### PR TITLE
Don't use exceptions for validation errors

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -82,7 +82,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
 
         expect:
         fails('check')
-        failureCauseContains('specified for property \'configDirectory\' does not exist.')
+        failureDescriptionContains('specified for property \'configDirectory\' does not exist.')
     }
 
     @ToBeImplemented

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -135,14 +135,14 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
         configurationCacheFails "printString"
 
         then:
-        failureCauseContains "No value has been specified for property 'string'."
+        failureDescriptionContains "No value has been specified for property 'string'."
         configurationCache.assertStateStored()
 
         when:
         configurationCacheFails "printString"
 
         then:
-        failureCauseContains "No value has been specified for property 'string'."
+        failureDescriptionContains "No value has been specified for property 'string'."
         configurationCache.assertStateLoaded()
 
         where:

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     testImplementation(testFixtures(project(":base-services")))
     testImplementation(testFixtures(project(":diagnostics")))
     testImplementation(testFixtures(project(":snapshots")))
+    testImplementation(testFixtures(project(":execution")))
 
     integTestImplementation(project(":workers"))
     integTestImplementation(project(":dependency-management"))

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -374,7 +374,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec {
         when:
         fails 'brokenInput'
         then:
-        failure.assertHasCause("${inputName} '${brokenInputFile}' specified for property 'brokenInputFile' does not exist.")
+        failureDescriptionContains("${inputName} '${brokenInputFile}' specified for property 'brokenInputFile' does not exist.")
 
         where:
         inputName   | inputType

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -133,7 +133,7 @@ task work {
         expect:
         fails("work")
         failure.assertHasDescription("A problem was found with the configuration of task ':work' (type 'DefaultTask').")
-        failure.assertHasCause("File '$link' specified for property '\$1' does not exist.")
+        failureDescriptionContains("File '$link' specified for property '\$1' does not exist.")
     }
 
     def "can replace input file with symlink to file with same content"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -483,7 +483,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         expect:
         fails "myTask"
         failure.assertHasDescription("A problem was found with the configuration of task ':myTask' (type 'TaskWithAbsentNestedInput').")
-        failure.assertHasCause("No value has been specified for property 'nested'.")
+        failureDescriptionContains("No value has been specified for property 'nested'.")
     }
 
     def "null on optional nested bean is allowed"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -78,7 +78,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
+        failureDescriptionContains("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
 
         where:
         method | targetType
@@ -112,7 +112,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails "customTask"
         failure.assertHasDescription("A problem was found with the configuration of task ':customTask' (type 'CustomTask').")
-        failure.assertHasCause("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
+        failureDescriptionContains("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
 
         where:
         annotation     | targetType
@@ -196,6 +196,6 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         fails "foo"
 
         then:
-        failureCauseContains("No value has been specified for property 'bar'.")
+        failureDescriptionContains("No value has been specified for property 'bar'.")
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -564,7 +564,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("No value has been specified for property 'input'.")
+        failureDescriptionContains("No value has been specified for property 'input'.")
     }
 
     def "optional null input properties registered via TaskInputs.property are allowed"() {
@@ -589,7 +589,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("No value has been specified for property 'input'.")
+        failureDescriptionContains("No value has been specified for property 'input'.")
 
         where:
         method << ["file", "files", "dir"]
@@ -621,7 +621,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("No value has been specified for property 'output'.")
+        failureDescriptionContains("No value has been specified for property 'output'.")
 
         where:
         method << ["file", "files", "dir", "dirs"]
@@ -654,7 +654,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("$type '${file("missing")}' specified for property 'input' does not exist.")
+        failureDescriptionContains("$type '${file("missing")}' specified for property 'input' does not exist.")
 
         where:
         method | type
@@ -676,7 +676,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failure.assertHasCause("${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type.")
+        failureDescriptionContains("${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type.")
 
         where:
         method | path             | type
@@ -697,7 +697,7 @@ task someTask(type: SomeTask) {
 
         expect:
         fails "test"
-        failure.assertHasCause(message.replace("<PATH>", file(path).absolutePath))
+        failureDescriptionContains(message.replace("<PATH>", file(path).absolutePath))
 
         where:
         method  | path              | message

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -922,8 +922,11 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
 
     private static void validateException(TaskInternal task, WorkValidationException exception, String... causes) {
         def expectedMessage = causes.length > 1 ? "Some problems were found with the configuration of $task" : "A problem was found with the configuration of $task"
-        assert exception.message.contains(expectedMessage)
-        assert exception.causes.collect({ it.message }) as Set == causes as Set
+        def actualMessage = exception.message
+        assert actualMessage.contains(expectedMessage)
+        causes.each { cause ->
+            assert actualMessage.contains(cause)
+        }
     }
 
     private Map<String, Object> inputProperties(TaskInternal task) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.TaskPropertyTestUtils
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.execution.WorkValidationException
+import org.gradle.internal.execution.WorkValidationExceptionChecker
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.JavaReflectionUtil
 import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore
@@ -922,10 +923,11 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
 
     private static void validateException(TaskInternal task, WorkValidationException exception, String... causes) {
         def expectedMessage = causes.length > 1 ? "Some problems were found with the configuration of $task" : "A problem was found with the configuration of $task"
-        def actualMessage = exception.message
-        assert actualMessage.contains(expectedMessage)
-        causes.each { cause ->
-            assert actualMessage.contains(cause)
+        WorkValidationExceptionChecker.check(exception) {
+            messageContains(expectedMessage)
+            causes.each { cause ->
+                hasProblem(cause)
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -35,6 +35,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
+import static org.hamcrest.Matchers.containsString
 
 class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture {
     private final static long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES
@@ -197,7 +198,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         then:
         ['lib', 'app', 'util'].each {
             failure.assertHasDescription("A problem was found with the configuration of task ':${it}:badTask' (type 'DefaultTask').")
-            failure.assertHasCause("The output ${file("${it}/build/${forbiddenPath}")} must not be in a reserved location.")
+            failure.assertThatDescription(containsString("The output ${file("${it}/build/${forbiddenPath}")} must not be in a reserved location."))
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -46,6 +46,7 @@ import spock.lang.Unroll
 import java.util.concurrent.atomic.AtomicInteger
 
 import static org.gradle.util.Matchers.matchesRegexp
+import static org.hamcrest.Matchers.containsString
 
 class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
 
@@ -976,7 +977,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         expect:
         fails('broken')
         failure.assertHasDescription("A problem was found with the configuration of task ':broken' (type 'MyTask').")
-        failure.assertHasCause("Type 'MyTask': Cannot use @CacheableTransform on type. This annotation can only be used with TransformAction types.")
+        failure.assertThatDescription(containsString("Type 'MyTask': Cannot use @CacheableTransform on type. This annotation can only be used with TransformAction types."))
     }
 
     def "task @Nested bean cannot use cacheable annotations"() {
@@ -1009,8 +1010,8 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         // Probably should be eager
         fails('broken')
         failure.assertHasDescription("Some problems were found with the configuration of task ':broken' (type 'MyTask').")
-        failure.assertHasCause("Type 'Options': Cannot use @CacheableTask on type. This annotation can only be used with Task types.")
-        failure.assertHasCause("Type 'Options': Cannot use @CacheableTransform on type. This annotation can only be used with TransformAction types.")
+        failure.assertThatDescription(containsString("Type 'Options': Cannot use @CacheableTask on type. This annotation can only be used with Task types."))
+        failure.assertThatDescription(containsString("Type 'Options': Cannot use @CacheableTransform on type. This annotation can only be used with TransformAction types."))
     }
 
     @Unroll

--- a/subprojects/execution/build.gradle.kts
+++ b/subprojects/execution/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(project(":persistent-cache"))
     implementation(project(":build-cache"))
     implementation(project(":build-cache-packaging"))
+    implementation(project(":logging"))
 
     implementation(libs.slf4jApi)
     implementation(libs.guava)

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -591,7 +591,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
 
         then:
         def ex = thrown WorkValidationException
-        ex.causes*.message as List == ["Type '$Object.simpleName': Validation error."]
+        ex.message.contains "Type '$Object.simpleName': Validation error."
     }
 
     def "results are loaded from identity cache"() {

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -591,7 +591,9 @@ class IncrementalExecutionIntegrationTest extends Specification {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message.contains "Type '$Object.simpleName': Validation error."
+        WorkValidationExceptionChecker.check(ex) {
+            hasProblem "Type '$Object.simpleName': Validation error."
+        }
     }
 
     def "results are loaded from identity cache"() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
@@ -16,15 +16,97 @@
 
 package org.gradle.internal.execution;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.GradleException;
 import org.gradle.internal.exceptions.Contextual;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A {@code WorkValidationException} is thrown when there is some validation problem with a work item.
  */
 @Contextual
 public class WorkValidationException extends GradleException {
-    public WorkValidationException(String message) {
+    private final List<String> problems;
+
+    private WorkValidationException(String message, Collection<String> problems) {
         super(message);
+        this.problems = ImmutableList.copyOf(problems);
+    }
+
+    public List<String> getProblems() {
+        return problems;
+    }
+
+    public static Builder forProblems(Collection<String> problems) {
+        return new Builder(problems);
+    }
+
+    public static class Builder {
+        private final List<String> problems;
+        private final int size;
+
+        public Builder(Collection<String> problems) {
+            this.problems = ImmutableList.copyOf(problems);
+            this.size = problems.size();
+        }
+
+        public Builder limitTo(int maxProblems) {
+            return new Builder(problems.stream().limit(maxProblems).collect(Collectors.toList()));
+        }
+
+        public BuilderWithSummary withSummary(Function<SummaryHelper, String> summaryBuilder) {
+            return new BuilderWithSummary(problems, summaryBuilder.apply(new SummaryHelper()));
+        }
+
+        public class SummaryHelper  {
+            public int size() {
+                return size;
+            }
+
+            public String pluralize(String term) {
+                if (size > 1) {
+                    return term + "s";
+                }
+                return term;
+            }
+        }
+    }
+
+    public static class BuilderWithSummary {
+        private final List<String> problems;
+        private final String summary;
+
+        public BuilderWithSummary(List<String> problems, String summary) {
+            this.problems = problems;
+            this.summary = summary;
+        }
+
+        public WorkValidationException get() {
+            return build(null);
+        }
+
+        public WorkValidationException getWithExplanation(String explanation) {
+            return build(explanation);
+        }
+
+        private WorkValidationException build(@Nullable String explanation) {
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node(summary);
+            formatter.startChildren();
+            for (String problem : problems) {
+                formatter.node(problem);
+            }
+            formatter.endChildren();
+            if (explanation != null) {
+                formatter.node(explanation);
+            }
+            return new WorkValidationException(formatter.toString(), ImmutableList.copyOf(problems));
+        }
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
@@ -16,22 +16,15 @@
 
 package org.gradle.internal.execution;
 
-import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.GradleException;
 import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.exceptions.DefaultMultiCauseException;
-
-import java.util.List;
 
 /**
  * A {@code WorkValidationException} is thrown when there is some validation problem with a work item.
  */
 @Contextual
-public class WorkValidationException extends DefaultMultiCauseException {
+public class WorkValidationException extends GradleException {
     public WorkValidationException(String message) {
         super(message);
-    }
-
-    public WorkValidationException(String message, List<InvalidUserDataException> causes) {
-        super(message, causes);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationException.java
@@ -27,6 +27,10 @@ import java.util.List;
  */
 @Contextual
 public class WorkValidationException extends DefaultMultiCauseException {
+    public WorkValidationException(String message) {
+        super(message);
+    }
+
     public WorkValidationException(String message, List<InvalidUserDataException> causes) {
         super(message, causes);
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -20,13 +20,13 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.reflect.TypeValidationContext.Severity;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.vfs.VirtualFileSystem;
@@ -72,17 +72,7 @@ public class ValidateStep<R extends Result> implements Step<AfterPreviousExecuti
         if (!errors.isEmpty()) {
             ImmutableSortedSet<String> uniqueSortedErrors = ImmutableSortedSet.copyOf(errors);
             throw new WorkValidationException(
-                String.format("%s found with the configuration of %s (%s).",
-                    uniqueSortedErrors.size() == 1
-                        ? "A problem was"
-                        : "Some problems were",
-                    work.getDisplayName(),
-                    describeTypesChecked(validationContext.getValidatedTypes())
-                ),
-                uniqueSortedErrors.stream()
-                    .limit(5)
-                    .map(InvalidUserDataException::new)
-                    .collect(Collectors.toList())
+                buildValidationErrorMessage(work, validationContext, uniqueSortedErrors)
             );
         }
 
@@ -139,6 +129,24 @@ public class ValidateStep<R extends Result> implements Step<AfterPreviousExecuti
                 return context.getValidationContext();
             }
         });
+    }
+
+    private String buildValidationErrorMessage(UnitOfWork work,
+                                               WorkValidationContext validationContext,
+                                               ImmutableSortedSet<String> uniqueSortedErrors) {
+        TreeFormatter tf = new TreeFormatter();
+        tf.node(String.format("%s found with the configuration of %s (%s).",
+            uniqueSortedErrors.size() == 1
+                ? "A problem was"
+                : "Some problems were",
+            work.getDisplayName(),
+            describeTypesChecked(validationContext.getValidatedTypes())));
+        tf.startChildren();
+        uniqueSortedErrors.stream()
+            .limit(5)
+            .forEachOrdered(tf::node);
+        tf.endChildren();
+        return tf.toString();
     }
 
     private static String describeTypesChecked(ImmutableCollection<Class<?>> types) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.vfs.VirtualFileSystem
 
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.ERROR
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.WARNING
+import static org.gradle.util.TextUtil.normaliseLineSeparators
 
 class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
     def warningReporter = Mock(ValidateStep.ValidationWarningRecorder)
@@ -60,7 +61,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
+        normaliseLineSeparators(ex.message) == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
   - Type '$Object.simpleName': Validation error."""
 
         _ * work.validate(_ as  WorkValidationContext) >> {  WorkValidationContext validationContext ->
@@ -75,7 +76,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == """Some problems were found with the configuration of job ':test' (types 'ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType').
+        normaliseLineSeparators(ex.message) == """Some problems were found with the configuration of job ':test' (types 'ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType').
   - Type '$Object.simpleName': Validation error #1.
   - Type '$Object.simpleName': Validation error #2."""
 
@@ -121,7 +122,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
+        normaliseLineSeparators(ex.message) == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
   - Type '$Object.simpleName': Validation error."""
         0 * _
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -60,9 +60,8 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == "A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType')."
-        ex.causes.size() == 1
-        ex.causes[0].message == "Type '$Object.simpleName': Validation error."
+        ex.message == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
+  - Type '$Object.simpleName': Validation error."""
 
         _ * work.validate(_ as  WorkValidationContext) >> {  WorkValidationContext validationContext ->
             validationContext.forType(JobType, true).visitTypeProblem(ERROR, Object, "Validation error")
@@ -76,10 +75,9 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == "Some problems were found with the configuration of job ':test' (types 'ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType')."
-        ex.causes.size() == 2
-        ex.causes[0].message == "Type '$Object.simpleName': Validation error #1."
-        ex.causes[1].message == "Type '$Object.simpleName': Validation error #2."
+        ex.message == """Some problems were found with the configuration of job ':test' (types 'ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType').
+  - Type '$Object.simpleName': Validation error #1.
+  - Type '$Object.simpleName': Validation error #2."""
 
         _ * work.validate(_ as  WorkValidationContext) >> {  WorkValidationContext validationContext ->
             validationContext.forType(JobType, true).visitTypeProblem(ERROR, Object, "Validation error #1")
@@ -123,9 +121,8 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> {
 
         then:
         def ex = thrown WorkValidationException
-        ex.message == "A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType')."
-        ex.causes.size() == 1
-        ex.causes[0].message == "Type '$Object.simpleName': Validation error."
+        ex.message == """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
+  - Type '$Object.simpleName': Validation error."""
         0 * _
     }
 

--- a/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
+++ b/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
@@ -41,6 +41,12 @@ class WorkValidationExceptionChecker {
         problems = error.problems as Set
     }
 
+    void messageContains(String expected) {
+        String actualMessage = normaliseLineSeparators(error.message.trim())
+        String expectedMessage = normaliseLineSeparators(expected.trim())
+        assert actualMessage.contains(expectedMessage)
+    }
+
     void hasMessage(String expected) {
         String actualError = normaliseLineSeparators(error.message.trim())
         String expectedError = normaliseLineSeparators(expected.trim())

--- a/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
+++ b/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.execution
+
+import groovy.transform.CompileStatic
+
+import static org.gradle.util.TextUtil.normaliseLineSeparators
+
+@CompileStatic
+class WorkValidationExceptionChecker {
+    private final WorkValidationException error
+    private final Set<String> verified
+    private final Set<String> problems
+
+    static void check(Exception exception, @DelegatesTo(value = WorkValidationExceptionChecker, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        assert exception instanceof WorkValidationException
+        def checker = new WorkValidationExceptionChecker(exception)
+        spec.delegate = checker
+        spec.resolveStrategy = Closure.DELEGATE_FIRST
+        spec()
+        checker.done()
+    }
+
+    private WorkValidationExceptionChecker(WorkValidationException ex) {
+        error = ex
+        verified = [] as Set
+        problems = error.problems as Set
+    }
+
+    void hasMessage(String expected) {
+        String actualError = normaliseLineSeparators(error.message.trim())
+        String expectedError = normaliseLineSeparators(expected.trim())
+        assert actualError == expectedError
+    }
+
+    void hasProblem(String problem) {
+        assert problems.contains(problem)
+        verified.add(problem)
+    }
+
+    private void done() {
+        if (verified && !(verified == problems as Set)) {
+            throw new AssertionError("Expected ${problems.size()} problems but you only checked ${verified.size()}")
+        }
+    }
+}

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
@@ -784,7 +784,7 @@ class SomeTask extends DefaultTask {
 
         then:
         failure.assertHasDescription("A problem was found with the configuration of task ':consumer' (type 'ConsumerTask').")
-        failure.assertHasCause("No value has been specified for property 'bean.inputFile'.")
+        failureDescriptionContains("No value has been specified for property 'bean.inputFile'.")
         failure.assertTasksExecuted(':consumer')
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -106,19 +106,19 @@ class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec {
             class CustomTask extends DefaultTask {
                 @InputFile File srcFile
                 @OutputFile File destFile
-                
+
                 @TaskAction
                 void action() {}
             }
-            
+
             task custom(type: CustomTask)
         '''
         expect:
         fails "custom"
 
-        failure.assertHasDescription("Some problems were found with the configuration of task ':custom' (type 'CustomTask').")
-        failure.assertHasCause("No value has been specified for property 'srcFile'.")
-        failure.assertHasCause("No value has been specified for property 'destFile'.")
+        failureDescriptionContains("Some problems were found with the configuration of task ':custom' (type 'CustomTask').")
+        failureDescriptionContains("No value has been specified for property 'srcFile'.")
+        failureDescriptionContains("No value has been specified for property 'destFile'.")
     }
 
     def reportsUnknownTask() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
@@ -42,7 +42,7 @@ class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec {
         fails TASK_NAME
 
         then:
-        failure.assertHasCause("No value has been specified for property 'outputDirectory'.")
+        failureDescriptionContains("No value has been specified for property 'outputDirectory'.")
     }
 
     def "implementation-classpath entry in metadata is empty if there is no classpath"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationIntegrationTest.groovy
@@ -85,7 +85,7 @@ class RuntimePluginValidationIntegrationTest extends AbstractPluginValidationInt
                 break
         }
         expectedFailures.forEach { error ->
-            failureHasCause(error)
+            failureDescriptionContains(error)
         }
     }
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
@@ -24,6 +24,7 @@ import spock.lang.Unroll
 
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.ERROR
 import static org.gradle.internal.reflect.TypeValidationContext.Severity.WARNING
+import static org.hamcrest.Matchers.containsString
 
 class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegrationSpec {
 
@@ -56,9 +57,9 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         def report = new TaskValidationReportFixture(file("build/reports/plugin-development/validation-report.txt"))
         report.verify(messages)
 
-        failure.assertHasCause "Plugin validation failed"
+        failure.assertHasCause "Plugin validation failed with ${messages.size()} problem${messages.size()>1?'s':''}"
         messages.forEach { message, severity ->
-            failure.assertHasCause("$severity: $message")
+            failure.assertThatCause(containsString("$severity: $message"))
         }
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -31,7 +31,6 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.execution.WorkValidationException;
-import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.plugin.devel.tasks.internal.ValidateAction;
 import org.gradle.workers.WorkerExecutor;
 
@@ -80,7 +79,10 @@ public abstract class ValidatePlugins extends DefaultTask {
                         getDocumentationRegistry().getDocumentationFor("more_about_tasks", "sec:task_input_output_annotations"),
                         toMessageList(problemMessages));
                 } else {
-                    throw new WorkValidationException(buildValidationErrorMessage(problemMessages));
+                    throw WorkValidationException.forProblems(problemMessages)
+                        .withSummary(helper -> "Plugin validation failed with " + helper.size() + helper.pluralize(" problem"))
+                        .getWithExplanation(String.format("See %s for more information on how to annotate task properties.",
+                            getDocumentationRegistry().getDocumentationFor("more_about_tasks", "sec:task_input_output_annotations")));
                 }
             } else {
                 getLogger().warn("Plugin validation finished with warnings:{}",
@@ -95,20 +97,6 @@ public abstract class ValidatePlugins extends DefaultTask {
             builder.append(String.format("%n  - %s", problemMessage));
         }
         return builder;
-    }
-
-    private String buildValidationErrorMessage(List<String> problemMessages) {
-        TreeFormatter tf = new TreeFormatter();
-        int size = problemMessages.size();
-        tf.node("Plugin validation failed with " + size + " problem" + (size > 1 ? "s" : ""));
-        tf.startChildren();
-        for (String message : problemMessages) {
-            tf.node(message);
-        }
-        tf.endChildren();
-        tf.node(String.format("See %s for more information on how to annotate task properties.",
-            getDocumentationRegistry().getDocumentationFor("more_about_tasks", "sec:task_input_output_annotations")));
-        return tf.toString();
     }
 
     /**

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -670,7 +670,7 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         fails('jar')
 
         then:
-        failureCauseContains('No value has been specified for property \'archiveFile\'.')
+        failureDescriptionContains('No value has been specified for property \'archiveFile\'.')
     }
 
     def "can use Provider values in manifest attribute"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -381,7 +381,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
 
         expect:
         fails("compileGroovy")
-        failure.assertHasCause("File '${file('groovycompilerconfig.groovy')}' specified for property 'groovyOptions.configurationScript' does not exist.")
+        failureDescriptionContains("File '${file('groovycompilerconfig.groovy')}' specified for property 'groovyOptions.configurationScript' does not exist.")
     }
 
     def "failsBecauseOfInvalidConfigFile"() {


### PR DESCRIPTION
Validation previously generated one exception per validation problem.
This causes a LOT of noise when using `--stacktrace` without bringing
any kind of user facing value. Exceptions shouldn't be used for
reporting "normal" problems: the user doesn't care where, in our
codebase, the problem is thrown. The only useful information to them
is the validation issue itself.

For us, we _might_ want to know where the validation error is thrown,
which is why in this commit we end up throwing a _single_ validation
exception, which, in turn, contains a rich description (using the
tree formatter).
