### PR TITLE
Revert parts of the removal of the search upwards logic

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.hamcrest.Matcher
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
@@ -321,7 +320,6 @@ include("child")
         succeeds "init"
     }
 
-    @Ignore("Broken by https://github.com/gradle/gradle/pull/15879 - investigating")
     def "ignores gradle properties for existing build when initializing inside another project"() {
         given:
         def sub = file("sub")

--- a/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
@@ -29,6 +29,7 @@ public class BuildLayoutParameters {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = "gradle.user.home";
     private static final File DEFAULT_GRADLE_USER_HOME = new File(SystemProperties.getInstance().getUserHome() + "/.gradle");
 
+    private boolean searchUpwards = true;
     private File currentDir = canonicalize(SystemProperties.getInstance().getCurrentDir());
     private File projectDir;
     private File gradleUserHomeDir;
@@ -57,6 +58,11 @@ public class BuildLayoutParameters {
             return gradleInstallation.getGradleHome();
         }
         return null;
+    }
+
+    public BuildLayoutParameters setSearchUpwards(boolean searchUpwards) {
+        this.searchUpwards = searchUpwards;
+        return this;
     }
 
     public BuildLayoutParameters setProjectDir(File projectDir) {
@@ -99,6 +105,10 @@ public class BuildLayoutParameters {
     @Nullable
     public File getGradleInstallationHomeDir() {
         return gradleInstallationHomeDir;
+    }
+
+    public boolean isSearchUpwards() {
+        return searchUpwards;
     }
 
 }

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
@@ -38,6 +38,7 @@ class BuildLayoutParametersTest extends Specification {
     def "has reasonable defaults"() {
         expect:
         def params = new BuildLayoutParameters()
+        params.searchUpwards
         params.gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
         params.currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         params.projectDir == null

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -22,12 +22,23 @@ import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 
+import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
+
 public class LayoutCommandLineConverter extends AbstractCommandLineConverter<BuildLayoutParameters> {
     private final CommandLineConverter<BuildLayoutParameters> converter = new BuildLayoutParametersBuildOptions().commandLineConverter();
 
     @Override
     public BuildLayoutParameters convert(ParsedCommandLine options, BuildLayoutParameters target) throws CommandLineArgumentException {
         converter.convert(options, target);
+
+        if (options.getExtraArguments().contains("init")) {
+            target.setSearchUpwards(false);
+        }
+
+        if (target.getSearchDir().getName().equals(BUILD_SRC)) {
+            target.setSearchUpwards(false);
+        }
+
         return target;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
@@ -42,12 +42,23 @@ class LayoutCommandLineConverterTest extends Specification {
         convert().currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         convert().projectDir == null
         convert().gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
+        convert().searchUpwards
     }
 
     def "converts"() {
         expect:
         convert("-p", "foo").projectDir.name == "foo"
         convert("-g", "bar").gradleUserHomeDir.name == "bar"
+    }
+
+    def "doesn't search upwards when building buildSrc"() {
+        expect:
+        !convert("-p", "buildSrc").searchUpwards
+    }
+
+    def "doesn't search upwards when running init task"() {
+        expect:
+        !convert("init").searchUpwards
     }
 
     def "converts relatively to the target dir"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -58,11 +58,15 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     @Override
     protected List<String> getAllArgs() {
         List<String> args = new ArrayList<String>(super.getAllArgs());
-
         if(!isQuiet() && isAllowExtraLogging()) {
             if (!containsLoggingArgument(args)) {
                 args.add(0, "-i");
             }
+        }
+
+        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
+        if (getUserHomeDir() != null) {
+            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
         }
 
         return args;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -119,12 +119,6 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         List<String> args = new ArrayList<String>();
         args.addAll(super.getAllArgs());
         addPropagatedSystemProperties(args);
-
-        // Workaround for https://issues.gradle.org/browse/GRADLE-2625
-        if (getUserHomeDir() != null) {
-            args.add(String.format("-Duser.home=%s", getUserHomeDir().getPath()));
-        }
-
         return args;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -97,6 +97,7 @@ public class BuildActionSerializer {
             nullableFileSerializer.write(encoder, startParameter.getGradleHomeDir());
             nullableFileSerializer.write(encoder, startParameter.getProjectCacheDir());
             fileListSerializer.write(encoder, startParameter.getIncludedBuilds());
+            encoder.writeBoolean(startParameter.isSearchUpwards());
 
             // Other stuff
             NO_NULL_STRING_MAP_SERIALIZER.write(encoder, startParameter.getProjectProperties());
@@ -172,6 +173,9 @@ public class BuildActionSerializer {
             startParameter.setGradleHomeDir(nullableFileSerializer.read(decoder));
             startParameter.setProjectCacheDir(nullableFileSerializer.read(decoder));
             startParameter.setIncludedBuilds(fileListSerializer.read(decoder));
+            if (!decoder.readBoolean()) {
+                startParameter.doNotSearchUpwards();
+            }
 
             // Other stuff
             startParameter.setProjectProperties(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
@@ -70,6 +70,7 @@ public class BuildLayoutConverter {
         public void applyTo(BuildLayoutParameters buildLayout) {
             buildLayout.setCurrentDir(this.buildLayout.getCurrentDir());
             buildLayout.setProjectDir(this.buildLayout.getProjectDir());
+            buildLayout.setSearchUpwards(this.buildLayout.isSearchUpwards());
             buildLayout.setGradleUserHomeDir(this.buildLayout.getGradleUserHomeDir());
             buildLayout.setGradleInstallationHomeDir(this.buildLayout.getGradleInstallationHomeDir());
         }
@@ -78,6 +79,9 @@ public class BuildLayoutConverter {
         public void applyTo(StartParameterInternal startParameter) {
             startParameter.setProjectDir(buildLayout.getProjectDir());
             startParameter.setCurrentDir(buildLayout.getCurrentDir());
+            if (!buildLayout.isSearchUpwards()) {
+                startParameter.doNotSearchUpwards();
+            }
             startParameter.setGradleUserHomeDir(buildLayout.getGradleUserHomeDir());
         }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -65,7 +65,7 @@ public class LayoutToPropertiesConverter {
         layout.applyTo(layoutParameters);
         Map<String, String> properties = new HashMap<>();
         configureFromHomeDir(layoutParameters.getGradleInstallationHomeDir(), properties);
-        configureFromBuildDir(layoutParameters.getSearchDir(), properties);
+        configureFromBuildDir(layoutParameters.getSearchDir(), layoutParameters.isSearchUpwards(), properties);
         configureFromHomeDir(layout.getGradleUserHomeDir(), properties);
         configureFromSystemPropertiesOfThisJvm(Cast.uncheckedNonnullCast(properties));
         properties.putAll(initialProperties.getRequestedSystemProperties());
@@ -86,8 +86,8 @@ public class LayoutToPropertiesConverter {
         maybeConfigureFrom(new File(gradleUserHomeDir, Project.GRADLE_PROPERTIES), result);
     }
 
-    private void configureFromBuildDir(File currentDir, Map<String, String> result) {
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, true);
+    private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, searchUpwards);
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
@@ -89,11 +89,13 @@ class BuildLayoutConverterTest extends Specification {
         def parameters = convert(["--gradle-user-home", "dir"]) {
             gradleUserHomeDir = new File("ignore-me")
             projectDir = dir
+            searchUpwards = true
         }
 
         then:
         parameters.gradleUserHomeDir == dir
         parameters.projectDir == dir
+        parameters.searchUpwards
     }
 
     BuildLayoutParameters convert(List<String> args, @DelegatesTo(BuildLayoutParameters) Closure overrides = {}) {
@@ -110,6 +112,7 @@ class BuildLayoutConverterTest extends Specification {
         assert startParameters.gradleUserHomeDir == parameters.gradleUserHomeDir
         assert startParameters.currentDir == parameters.currentDir
         assert startParameters.projectDir == parameters.projectDir
+        assert startParameters.searchUpwards == parameters.searchUpwards
 
         return parameters
     }


### PR DESCRIPTION
It is still needed to not search upwards for the `init` task and for `buildSrc` builds