### PR TITLE
Collect coverage from all test tasks in multi-project example.

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -15,6 +15,7 @@ We would like to thank the following community members for their contributions t
 [Björn Kautler](https://github.com/Vampire),
 [Sebastian Schuberth](https://github.com/sschuberth),
 [Kejn](https://github.com/kejn),
+[Anuraag Agrawal](https://github.com/anuraaga),
 [Florian Schmitt](https://github.com/florianschmitt).
 
 ## Upgrade Instructions

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -55,5 +55,9 @@ configurations.create('coverageDataElements') {
     outgoing.artifact(tasks.named("test").map { task ->
         task.extensions.getByType(JacocoTaskExtension).destinationFile
     })
-}
 
+    // Request coverage data from all test tasks (note: this realizes all Test tasks)
+    // outgoing.artifact(tasks.withType(Test).map { task ->
+    //     task.extensions.getByType(JacocoTaskExtension).destinationFile
+    // })
+}

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -55,5 +55,9 @@ configurations.create("coverageDataElements") {
     outgoing.artifact(tasks.test.map { task ->
         task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
     })
-}
 
+    // Request coverage data from all test tasks (note: this realizes all Test tasks)
+    // outgoing.artifact(tasks.withType<Test>().map { task ->
+    //     task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
+    // })
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Many users will copy-paste this sample to enable multi-project jacoco collection. So it's nice if this sample can default to satisfying as many use cases as possible. It seems more common for all test tasks (e.g., generated by `test-sets` gradle plugin) to need to be reflected in coverage report.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
