### PR TITLE
Promote API additions introduced before 6.7

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.ArtifactRepositoryContainer;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.ExclusiveContentRepository;
@@ -336,6 +335,5 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * @since 6.2
      */
-    @Incubating
     void exclusiveContent(Action<? super ExclusiveContentRepository> action);
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -323,6 +323,9 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.artifacts.ModuleDependency.isEndorsingStrictVersions
         - org.gradle.api.artifacts.ComponentMetadataDetails.maybeAddVariant
     - [Repositories](userguide/declaring_repositories.html#declaring-repositories)
+        - org.gradle.api.artifacts.dsl.RepositoryHandler.exclusiveContent
+        - org.gradle.api.artifacts.repositories.ExclusiveContentRepository
+        - org.gradle.api.artifacts.repositories.InclusiveRepositoryContentDescriptor
         - org.gradle.api.artifacts.repositories.IvyArtifactRepository.getMetadataSources
         - org.gradle.api.artifacts.repositories.IvyArtifactRepository.MetadataSources.isGradleMetadataEnabled
         - org.gradle.api.artifacts.repositories.IvyArtifactRepository.MetadataSources.isIvyDescriptorEnabled
@@ -418,7 +421,8 @@ In Gradle 7.0 we moved the following classes or methods out of incubation phase.
         - org.gradle.api.tasks.SourceSetOutput.getGeneratedSourcesDirs()
         - org.gradle.api.tasks.compile.CompileOptions.getGeneratedSourceOutputDirectory()
         - org.gradle.api.tasks.compile.CompileOptions.getRelease()
-        - org.gradle.api.tasks.compile.JavaCompile.getStableSources
+        - org.gradle.api.tasks.compile.JavaCompile.getStableSources()
+        - org.gradle.api.tasks.compile.JavaCompile.getSourceClassesMappingFile()
         - org.gradle.api.tasks.compile.JavaCompile.compile(org.gradle.work.InputChanges)
     - Java Module System
         - org.gradle.api.jvm.ModularitySpec

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
-import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -288,7 +287,6 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      * @since 6.5
      */
     @LocalState
-    @Incubating
     protected File getSourceClassesMappingFile() {
         if (sourceClassesMappingFile == null) {
             File tmpDir = getServices().get(TemporaryFileProvider.class).newTemporaryFile(getName());


### PR DESCRIPTION
This is a follow up to #15694 and #15809 which just missed these two methods.