### PR TITLE
Decide if current directory is the project root only where needed

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
+++ b/subprojects/core-api/src/main/java/org/gradle/initialization/BuildLayoutParameters.java
@@ -29,7 +29,6 @@ public class BuildLayoutParameters {
     public static final String GRADLE_USER_HOME_PROPERTY_KEY = "gradle.user.home";
     private static final File DEFAULT_GRADLE_USER_HOME = new File(SystemProperties.getInstance().getUserHome() + "/.gradle");
 
-    private boolean searchUpwards = true;
     private File currentDir = canonicalize(SystemProperties.getInstance().getCurrentDir());
     private File projectDir;
     private File gradleUserHomeDir;
@@ -58,11 +57,6 @@ public class BuildLayoutParameters {
             return gradleInstallation.getGradleHome();
         }
         return null;
-    }
-
-    public BuildLayoutParameters setSearchUpwards(boolean searchUpwards) {
-        this.searchUpwards = searchUpwards;
-        return this;
     }
 
     public BuildLayoutParameters setProjectDir(File projectDir) {
@@ -105,10 +99,6 @@ public class BuildLayoutParameters {
     @Nullable
     public File getGradleInstallationHomeDir() {
         return gradleInstallationHomeDir;
-    }
-
-    public boolean isSearchUpwards() {
-        return searchUpwards;
     }
 
 }

--- a/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/initialization/BuildLayoutParametersTest.groovy
@@ -38,7 +38,6 @@ class BuildLayoutParametersTest extends Specification {
     def "has reasonable defaults"() {
         expect:
         def params = new BuildLayoutParameters()
-        params.searchUpwards
         params.gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
         params.currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         params.projectDir == null

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcLocationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcLocationIntegrationTest.groovy
@@ -37,6 +37,18 @@ class BuildSrcLocationIntegrationTest extends AbstractIntegrationSpec {
         executed(":buildSrc:compileGroovy")
     }
 
+    def "buildSrc without settings file can execute standalone"() {
+        given:
+        def buildSrc = file("buildSrc")
+        buildSrc.file("build.gradle") << ''
+
+        when:
+        executer.usingProjectDirectory(buildSrc)
+
+        then:
+        succeeds("help")
+    }
+
     def "empty buildSrc directory is ignored"() {
         file("buildSrc").createDir()
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -20,12 +20,15 @@ import org.gradle.StartParameter;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
 import org.gradle.internal.watch.vfs.WatchMode;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newLinkedHashSet;
+import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
 import static org.gradle.internal.Cast.uncheckedCast;
 
 public class StartParameterInternal extends StartParameter {
@@ -76,7 +79,7 @@ public class StartParameterInternal extends StartParameter {
     }
 
     public boolean isSearchUpwards() {
-        return searchUpwards;
+        return searchUpwards && !useLocationAsProjectRoot(getProjectDir(), getTaskNames());
     }
 
     public void doNotSearchUpwards() {
@@ -166,5 +169,17 @@ public class StartParameterInternal extends StartParameter {
             setTaskNames(allTasks);
         }
         return added;
+    }
+
+    /**
+     * The following special behavior wrt. how the build root is discovered, is implemented:
+     * - If the current folder is called 'buildSrc', we do not search upwards for a settings file
+     * - If the build runs the 'init' task, we do not search upwards for a settings file
+     *
+     * This has an influence on deciding which 'gradle.properties' to load (in the launcher) and which 'settings.gradle(.kts)' to use (in the daemon)
+     */
+    public static boolean useLocationAsProjectRoot(@Nullable File potentialProjectLocation, List<String> requestedTaskNames) {
+        return requestedTaskNames.contains("init")
+            || (potentialProjectLocation != null && potentialProjectLocation.getName().equals(BUILD_SRC));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/LayoutCommandLineConverter.java
@@ -22,23 +22,12 @@ import org.gradle.cli.CommandLineConverter;
 import org.gradle.cli.CommandLineParser;
 import org.gradle.cli.ParsedCommandLine;
 
-import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
-
 public class LayoutCommandLineConverter extends AbstractCommandLineConverter<BuildLayoutParameters> {
     private final CommandLineConverter<BuildLayoutParameters> converter = new BuildLayoutParametersBuildOptions().commandLineConverter();
 
     @Override
     public BuildLayoutParameters convert(ParsedCommandLine options, BuildLayoutParameters target) throws CommandLineArgumentException {
         converter.convert(options, target);
-
-        if (options.getExtraArguments().contains("init")) {
-            target.setSearchUpwards(false);
-        }
-
-        if (target.getSearchDir().getName().equals(BUILD_SRC)) {
-            target.setSearchUpwards(false);
-        }
-
         return target;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -16,7 +16,6 @@
 package org.gradle.initialization.layout;
 
 import org.gradle.StartParameter;
-import org.gradle.TaskExecutionRequest;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -34,21 +33,9 @@ public class BuildLayoutConfiguration {
 
     public BuildLayoutConfiguration(StartParameter startParameter) {
         currentDir = startParameter.getCurrentDir();
-        searchUpwards = ((StartParameterInternal)startParameter).isSearchUpwards() && !isInitTaskRequested(startParameter);
+        searchUpwards = ((StartParameterInternal)startParameter).isSearchUpwards();
         settingsFile = startParameter.getSettingsFile();
         useEmptySettings = ((StartParameterInternal)startParameter).isUseEmptySettings();
-    }
-
-    private boolean isInitTaskRequested(StartParameter startParameter) {
-        if (startParameter.getTaskNames().contains("init")) {
-            return true;
-        }
-        for (TaskExecutionRequest request : startParameter.getTaskRequests()) {
-            if (request.getArgs().contains("init")) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public File getCurrentDir() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/LayoutCommandLineConverterTest.groovy
@@ -42,23 +42,12 @@ class LayoutCommandLineConverterTest extends Specification {
         convert().currentDir == canonicalize(SystemProperties.instance.getCurrentDir())
         convert().projectDir == null
         convert().gradleUserHomeDir == canonicalize(BuildLayoutParameters.DEFAULT_GRADLE_USER_HOME)
-        convert().searchUpwards
     }
 
     def "converts"() {
         expect:
         convert("-p", "foo").projectDir.name == "foo"
         convert("-g", "bar").gradleUserHomeDir.name == "bar"
-    }
-
-    def "doesn't search upwards when building buildSrc"() {
-        expect:
-        !convert("-p", "buildSrc").searchUpwards
-    }
-
-    def "doesn't search upwards when running init task"() {
-        expect:
-        !convert("init").searchUpwards
     }
 
     def "converts relatively to the target dir"() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -97,7 +97,6 @@ public class BuildActionSerializer {
             nullableFileSerializer.write(encoder, startParameter.getGradleHomeDir());
             nullableFileSerializer.write(encoder, startParameter.getProjectCacheDir());
             fileListSerializer.write(encoder, startParameter.getIncludedBuilds());
-            encoder.writeBoolean(startParameter.isSearchUpwards());
 
             // Other stuff
             NO_NULL_STRING_MAP_SERIALIZER.write(encoder, startParameter.getProjectProperties());
@@ -173,9 +172,6 @@ public class BuildActionSerializer {
             startParameter.setGradleHomeDir(nullableFileSerializer.read(decoder));
             startParameter.setProjectCacheDir(nullableFileSerializer.read(decoder));
             startParameter.setIncludedBuilds(fileListSerializer.read(decoder));
-            if (!decoder.readBoolean()) {
-                startParameter.doNotSearchUpwards();
-            }
 
             // Other stuff
             startParameter.setProjectProperties(NO_NULL_STRING_MAP_SERIALIZER.read(decoder));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/BuildLayoutConverter.java
@@ -70,7 +70,6 @@ public class BuildLayoutConverter {
         public void applyTo(BuildLayoutParameters buildLayout) {
             buildLayout.setCurrentDir(this.buildLayout.getCurrentDir());
             buildLayout.setProjectDir(this.buildLayout.getProjectDir());
-            buildLayout.setSearchUpwards(this.buildLayout.isSearchUpwards());
             buildLayout.setGradleUserHomeDir(this.buildLayout.getGradleUserHomeDir());
             buildLayout.setGradleInstallationHomeDir(this.buildLayout.getGradleInstallationHomeDir());
         }
@@ -79,9 +78,6 @@ public class BuildLayoutConverter {
         public void applyTo(StartParameterInternal startParameter) {
             startParameter.setProjectDir(buildLayout.getProjectDir());
             startParameter.setCurrentDir(buildLayout.getCurrentDir());
-            if (!buildLayout.isSearchUpwards()) {
-                startParameter.doNotSearchUpwards();
-            }
             startParameter.setGradleUserHomeDir(buildLayout.getGradleUserHomeDir());
         }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.gradle.api.internal.StartParameterInternal.useLocationAsProjectRoot;
+
 public class LayoutToPropertiesConverter {
 
     private final List<BuildOption<?>> allBuildOptions = new ArrayList<>();
@@ -65,7 +67,7 @@ public class LayoutToPropertiesConverter {
         layout.applyTo(layoutParameters);
         Map<String, String> properties = new HashMap<>();
         configureFromHomeDir(layoutParameters.getGradleInstallationHomeDir(), properties);
-        configureFromBuildDir(layoutParameters.getSearchDir(), layoutParameters.isSearchUpwards(), properties);
+        configureFromBuildDir(layoutParameters.getSearchDir(), properties);
         configureFromHomeDir(layout.getGradleUserHomeDir(), properties);
         configureFromSystemPropertiesOfThisJvm(Cast.uncheckedNonnullCast(properties));
         properties.putAll(initialProperties.getRequestedSystemProperties());
@@ -86,8 +88,8 @@ public class LayoutToPropertiesConverter {
         maybeConfigureFrom(new File(gradleUserHomeDir, Project.GRADLE_PROPERTIES), result);
     }
 
-    private void configureFromBuildDir(File currentDir, boolean searchUpwards, Map<String, String> result) {
-        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, searchUpwards);
+    private void configureFromBuildDir(File currentDir, Map<String, String> result) {
+        BuildLayout layout = buildLayoutFactory.getLayoutFor(currentDir, !useLocationAsProjectRoot(currentDir, Collections.emptyList()));
         maybeConfigureFrom(new File(layout.getRootDirectory(), Project.GRADLE_PROPERTIES), result);
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -284,11 +284,6 @@ public class ProviderConnection {
             if (operationParameters.getGradleUserHomeDir() != null) {
                 layout.setGradleUserHomeDir(operationParameters.getGradleUserHomeDir());
             }
-            @SuppressWarnings("deprecation")
-            Boolean searchUpwards = operationParameters.isSearchUpwards();
-            if (searchUpwards != null) {
-                layout.setSearchUpwards(searchUpwards);
-            }
             layout.setProjectDir(operationParameters.getProjectDir());
         });
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/BuildLayoutConverterTest.groovy
@@ -89,13 +89,11 @@ class BuildLayoutConverterTest extends Specification {
         def parameters = convert(["--gradle-user-home", "dir"]) {
             gradleUserHomeDir = new File("ignore-me")
             projectDir = dir
-            searchUpwards = true
         }
 
         then:
         parameters.gradleUserHomeDir == dir
         parameters.projectDir == dir
-        parameters.searchUpwards
     }
 
     BuildLayoutParameters convert(List<String> args, @DelegatesTo(BuildLayoutParameters) Closure overrides = {}) {
@@ -112,7 +110,6 @@ class BuildLayoutConverterTest extends Specification {
         assert startParameters.gradleUserHomeDir == parameters.gradleUserHomeDir
         assert startParameters.currentDir == parameters.currentDir
         assert startParameters.projectDir == parameters.projectDir
-        assert startParameters.searchUpwards == parameters.searchUpwards
 
         return parameters
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/BuildSrcCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/BuildSrcCrossVersionSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r26
+
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+
+class BuildSrcCrossVersionSpec extends ToolingApiSpecification {
+
+    def "buildSrc without settings file can execute standalone"() {
+        given:
+        def buildSrc = file("buildSrc")
+        buildSrc.file("build.gradle") << ''
+
+        when:
+        def connection = toolingApi.connector(buildSrc).connect()
+        buildSrc.file("settings.gradle").delete()
+
+        then:
+        connection.newBuild().forTasks("help").run()
+    }
+}


### PR DESCRIPTION
This restores most of what was already done in #15879, but fixes the following cases that were broken:

- Running a 'buildSrc' build directly in the 'buildSrc' folder where no settings file exists in that folder.
- Doing the above through the Tooling API.
- Not reading a property file further up the folder hierarchy when running 'gradle init'.

Basically, what was missed is that the launcher also needs to know the location of the root project to pick up the right 'gradle.properties'.

The decision of whether the current project folder is used as root, even if it does not contain a settings file, is now located in a single place -- StartParameterInternal. useLocationAsProjectRoot(). This is used in all three places where this decision needs to be made:
- StartParameterInternal.isSearchUpwards() - needed to determine the actual root (settings file)
- DeprecateUndefinedBuildWorkExecutor. execute() - Check if one of the special cases apply or if there is a settings file at all (which will become an error soon)
- LayoutToPropertiesConverter.configureFromBuildDir() - Find the location of `gradle.properties` (used in Launcher and Tooling API) 

Another special case is an included build that runs as part of a parent. In this cases, the included build is allowed to *not* have a settings file. To handle this case, `StartParameterInternal.doNotSearchUpwards()` is still required.