### PR TITLE
WIP Propose more comprehensible terminology for “disable optimizations”

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
@@ -71,7 +71,7 @@ public enum TaskOutputCachingDisabledReasonCategory {
      * </ul>
      */
     NON_CACHEABLE_TASK_IMPLEMENTATION,
-    
+
     /**
      * One of the task actions is not cacheable. Reasons for non-cacheable task action:
      * <ul>
@@ -88,5 +88,13 @@ public enum TaskOutputCachingDisabledReasonCategory {
      *     <li>a Java lambda was used as an input (see https://github.com/gradle/gradle/issues/5510).</li>
      * </ul>
      */
-    NON_CACHEABLE_INPUTS
+    NON_CACHEABLE_INPUTS,
+
+    /**
+     * A generic catch-all for problems with the implementation or configuration of the work that prevents it being cached.
+     *
+     * For example, its declaration has invalid annotation combinations or it consumes the output of another
+     * work unit without declaring a dependency.
+     */
+    UNSAFE_IMPLEMENTATION_OR_CONFIGURATION
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationResult.java
@@ -102,10 +102,8 @@ public class ExecuteTaskBuildOperationResult implements ExecuteTaskBuildOperatio
                 return TaskOutputCachingDisabledReasonCategory.NON_CACHEABLE_TREE_OUTPUT;
             case OVERLAPPING_OUTPUTS:
                 return TaskOutputCachingDisabledReasonCategory.OVERLAPPING_OUTPUTS;
-            case VALIDATION_FAILURE:
-                // TODO Introduce new category or reuse an existing one
-                //noinspection DuplicateBranchesInSwitch
-                return TaskOutputCachingDisabledReasonCategory.UNKNOWN;
+            case UNSAFE_IMPLEMENTATION_OR_CONFIGURATION:
+                return TaskOutputCachingDisabledReasonCategory.UNSAFE_IMPLEMENTATION_OR_CONFIGURATION;
             case NON_CACHEABLE_IMPLEMENTATION:
                 return TaskOutputCachingDisabledReasonCategory.NON_CACHEABLE_TASK_IMPLEMENTATION;
             case NON_CACHEABLE_ADDITIONAL_IMPLEMENTATION:

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -37,13 +37,12 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
     public void recordValidationWarnings(UnitOfWork work, Collection<String> warnings) {
         workWithFailuresCount.incrementAndGet();
         Set<String> uniqueSortedWarnings = ImmutableSortedSet.copyOf(warnings);
-        LOGGER.warn("Validation failed for {}, disabling optimizations:{}",
+        LOGGER.warn("Avoidance and parallel execution have been disabled for {} in order to ensure correctness, due to the following reasons:{}",
             work.getDisplayName(),
             uniqueSortedWarnings.stream()
                 .map(warning -> "\n  - " + warning)
                 .collect(Collectors.joining()));
         uniqueSortedWarnings.forEach(warning -> DeprecationLogger.deprecateBehaviour(warning)
-            .withContext("Execution optimizations are disabled due to the failed validation.")
             .willBeRemovedInGradle7()
             .withUserManual("more_about_tasks", "sec:up_to_date_checks")
             .nagUser());
@@ -53,7 +52,8 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
     public void reportWorkValidationWarningsAtEndOfBuild() {
         int workWithFailures = workWithFailuresCount.getAndSet(0);
         if (workWithFailures > 0) {
-            LOGGER.warn("\nExecution optimizations have been disabled for {} invalid unit(s) of work during the build. Consult deprecation warnings for more information.", workWithFailures);
+            LOGGER.warn("\nAvoidance and parallel execution were disabled for {} unit(s) of work during this build in order to ensure correctness, which potentially increased the build time.", workWithFailures);
+            LOGGER.warn("Please consult the build log and deprecation warnings for more details.");
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -34,7 +34,6 @@ public class DefaultNodeValidator implements NodeValidator {
             taskNode.getTaskProperties().validateType(taskValidationContext);
             ImmutableCollection<String> problems = validationContext.getProblems().values();
             problems.forEach(warning -> DeprecationLogger.deprecateBehaviour(warning)
-                .withContext("Execution optimizations are disabled due to the failed validation.")
                 .willBeRemovedInGradle7()
                 .withUserManual("more_about_tasks", "sec:up_to_date_checks")
                 .nagUser());

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/caching/CachingDisabledReasonCategory.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/caching/CachingDisabledReasonCategory.java
@@ -58,9 +58,12 @@ public enum CachingDisabledReasonCategory {
     OVERLAPPING_OUTPUTS,
 
     /**
-     * The work has failed validation.
+     * A generic catch-all for problems with the implementation or configuration of the work that prevents it being cached.
+     *
+     * For example, its declaration has invalid annotation combinations or it consumes the output of another
+     * work unit without declaring a dependency.
      */
-    VALIDATION_FAILURE,
+    UNSAFE_IMPLEMENTATION_OR_CONFIGURATION,
 
     /**
      * The work's implementation is not cacheable.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -50,8 +50,8 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveCachingStateStep.class);
     private static final CachingDisabledReason BUILD_CACHE_DISABLED_REASON = new CachingDisabledReason(CachingDisabledReasonCategory.BUILD_CACHE_DISABLED, "Build cache is disabled");
     private static final CachingState BUILD_CACHE_DISABLED_STATE = CachingState.disabledWithoutInputs(BUILD_CACHE_DISABLED_REASON);
-    private static final CachingDisabledReason VALIDATION_FAILED_REASON = new CachingDisabledReason(CachingDisabledReasonCategory.VALIDATION_FAILURE, "Validation failed");
-    private static final CachingState VALIDATION_FAILED_STATE = CachingState.disabledWithoutInputs(VALIDATION_FAILED_REASON);
+    private static final CachingDisabledReason UNSAFE_IMPLEMENTATION_OR_CONFIGURATION_REASON = new CachingDisabledReason(CachingDisabledReasonCategory.UNSAFE_IMPLEMENTATION_OR_CONFIGURATION, "The implementation or configuration is unsafe for caching");
+    private static final CachingState UNSAFE_IMPLEMENTATION_OR_CONFIGURATION_STATE = CachingState.disabledWithoutInputs(UNSAFE_IMPLEMENTATION_OR_CONFIGURATION_REASON);
 
     private final BuildCacheController buildCache;
     private final boolean buildScansEnabled;
@@ -73,7 +73,7 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
         if (!buildCache.isEnabled() && !buildScansEnabled) {
             cachingState = BUILD_CACHE_DISABLED_STATE;
         } else if (context.getValidationProblems().isPresent()) {
-            cachingState = VALIDATION_FAILED_STATE;
+            cachingState = UNSAFE_IMPLEMENTATION_OR_CONFIGURATION_STATE;
         } else {
             cachingState = context.getBeforeExecutionState()
                 .map(beforeExecutionState -> calculateCachingState(beforeExecutionState, work))

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 
 public class ResolveChangesStep<R extends Result> implements Step<CachingContext, R> {
     private static final String NO_HISTORY = "No history is available.";
-    private static final String VALIDATION_FAILED = "Validation failed.";
+    private static final String UNSAFE_FOR_REUSING_OUTPUTS = "Implementation or configuration is unsafe for reusing outputs.";
 
     private final ExecutionStateChangeDetector changeDetector;
 
@@ -68,7 +68,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
                 beforeExecutionState
                     .map(beforeExecution -> context.getAfterPreviousExecutionState()
                         .map(afterPreviousExecution -> context.getValidationProblems()
-                            .map(__ -> rebuildChanges(work, beforeExecution, VALIDATION_FAILED))
+                            .map(__ -> rebuildChanges(work, beforeExecution, UNSAFE_FOR_REUSING_OUTPUTS))
                             .orElseGet(() ->
                                 changeDetector.detectChanges(
                                     afterPreviousExecution,

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -51,7 +51,7 @@ class ResolveCachingStateStepTest extends StepSpec<BeforeExecutionContext> {
         _ * context.beforeExecutionState >> Optional.empty()
         _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationContext)
         1 * delegate.execute(work, { CachingContext context ->
-            context.cachingState.disabledReasons*.category == [CachingDisabledReasonCategory.VALIDATION_FAILURE]
+            context.cachingState.disabledReasons*.category == [CachingDisabledReasonCategory.UNSAFE_IMPLEMENTATION_OR_CONFIGURATION]
             context.cachingState.disabledReasons*.message == ["Validation failed"]
         })
     }


### PR DESCRIPTION
This is a strawman for discussing options for improving the user feedback when unsafe/incomplete implementation or configuration of a work unit causes “optimizations” to be disabled.

Tests have not been updated to reflect the proposal.

For the common case of not using `--info`, before:

Before:
```
Property 'myPrivateInput' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. Execution optimizations are disabled due to the failed validation. See https://docs.gradle.org/7.0-20210201140000+0000/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
> Task :myTask
Validation failed for task ':myTask', disabling optimizations:
  - Property 'myPrivateInput' is private and annotated with @Input.
Execution optimizations have been disabled for 1 invalid unit(s) of work during the build. Consult deprecation warnings for more information.
BUILD SUCCESSFUL in 60ms
1 actionable task: 1 executed
```

After: 
```
Property 'myPrivateInput' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/7.0-20210201140000+0000/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

> Task :myTask
Avoidance and parallel execution have been disabled for task ':myTask' in order to ensure correctness, due to the following reasons:
  - Property 'myPrivateInput' is private and annotated with @Input.

Avoidance and parallel execution were disabled for 1 unit(s) of work during this build in order to ensure correctness, which potentially increased the build time.
Please consult the build log and deprecation warnings for more details.
```

Both are problematic, with the most problematic probably being that the given documentation link will do very little to help any non-expert comprehend what is going on here.

Regardless, I propose that the `after` is better in that:

- It does not using potentially confusing concept of “validation”, which makes sense to us but not to users
- It avoids the ambiguous (for a user) concept of “disabling optimizations”
- It gives some indication that this is actually benefiting a user
- It makes it clearer that this has a negative build time impact and is different in that manner
- It is generally more human oriented
