### PR TITLE
Keep 'Using mustRunAfter/shouldRunAfter/finalizedBy to reference tasks from another build' deprecated until 8.0

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskLifecycleIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildTaskLifecycleIntegrationTest.groovy
@@ -65,7 +65,7 @@ class CompositeBuildTaskLifecycleIntegrationTest extends AbstractCompositeBuildI
         includedBuilds << buildB
 
         when:
-        executer.expectDocumentedDeprecationWarning("Using mustRunAfter to reference tasks from another build has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
+        executer.expectDocumentedDeprecationWarning("Using mustRunAfter to reference tasks from another build has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
         fails(buildA, 'a')
 
         then:
@@ -89,7 +89,7 @@ class CompositeBuildTaskLifecycleIntegrationTest extends AbstractCompositeBuildI
         includedBuilds << buildB
 
         when:
-        executer.expectDocumentedDeprecationWarning("Using shouldRunAfter to reference tasks from another build has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
+        executer.expectDocumentedDeprecationWarning("Using shouldRunAfter to reference tasks from another build has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
         fails(buildA, 'a')
 
         then:
@@ -143,7 +143,7 @@ class CompositeBuildTaskLifecycleIntegrationTest extends AbstractCompositeBuildI
                 }
             """
         }
-        executer.expectDocumentedDeprecationWarning("Using finalizedBy to reference tasks from another build has been deprecated. This will fail with an error in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
+        executer.expectDocumentedDeprecationWarning("Using finalizedBy to reference tasks from another build has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#referencing_tasks_from_included_builds")
         includedBuilds << buildB
 
         when:

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -169,7 +169,7 @@ public abstract class TaskNode extends Node {
     private void deprecateLifecycleHookReferencingNonLocalTask(String hookName, Node taskNode) {
         if (taskNode instanceof TaskInAnotherBuild) {
             DeprecationLogger.deprecateAction("Using " + hookName + " to reference tasks from another build")
-                .willBecomeAnErrorInGradle7()
+                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(6, "referencing_tasks_from_included_builds")
                 .nagUser();
         }


### PR DESCRIPTION
See #15875

The deprecation was only introduced in 6.8