### PR TITLE
Defer removal of `File` as input of artifact transforms to 8.0

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -107,7 +107,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
 
         where:
         inputArtifactType              | convertToFile   | expectedDeprecation
-        'File'                         | ''              | "Injecting the input artifact of a transform as a File has been deprecated. This is scheduled to be removed in Gradle 7.0. Declare the input artifact as Provider<FileSystemLocation> instead. See https://docs.gradle.org/current/userguide/artifact_transforms.html#sec:implementing-artifact-transforms for more details."
+        'File'                         | ''              | "Injecting the input artifact of a transform as a File has been deprecated. This will fail with an error in Gradle 8.0. Declare the input artifact as Provider<FileSystemLocation> instead. See https://docs.gradle.org/current/userguide/artifact_transforms.html#sec:implementing-artifact-transforms for more details."
         'Provider<FileSystemLocation>' | '.get().asFile' | null
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -356,7 +356,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction<?>> 
                 DeprecationLogger
                     .deprecate("Injecting the input artifact of a transform as a File")
                     .withAdvice("Declare the input artifact as Provider<FileSystemLocation> instead.")
-                    .willBeRemovedInGradle7()
+                    .willBecomeAnErrorInGradle8()
                     .withUserManual("artifact_transforms", "sec:implementing-artifact-transforms")
                     .nagUser();
                 return inputFileProvider.get().getAsFile();


### PR DESCRIPTION
In particular the Kotlin plugin is not ready for this change,
so we decided to defer this removal to 8.0.

See #15546

Supercedes #15969