### PR TITLE
Never consider an included build with injected plugins as undefined

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -158,6 +158,11 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
     }
 
     @Override
+    public boolean hasInjectedSettingsPlugins() {
+        return !buildDefinition.getInjectedPluginRequests().isEmpty();
+    }
+
+    @Override
     public SettingsInternal loadSettings() {
         return gradleLauncher.getLoadedSettings();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/DeprecateUndefinedBuildWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DeprecateUndefinedBuildWorkExecutor.java
@@ -17,6 +17,8 @@
 package org.gradle.execution;
 
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.resource.EmptyFileTextResource;
 import org.gradle.internal.resource.TextResource;
@@ -43,6 +45,11 @@ public class DeprecateUndefinedBuildWorkExecutor implements BuildWorkExecutor {
     }
 
     private static boolean isUndefinedBuild(GradleInternal gradle) {
+        BuildState buildState = gradle.getOwner();
+        if (buildState instanceof IncludedBuildState && ((IncludedBuildState) buildState).hasInjectedSettingsPlugins()) {
+            // this included build may be completely configured through injected plugins
+            return false;
+        }
         return !gradle.getRootProject().getBuildFile().exists() && isUndefinedResource(gradle.getSettings().getSettingsScript().getResource());
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -34,6 +34,7 @@ public interface IncludedBuildState extends NestedBuildState, CompositeBuildPart
     IncludedBuild getModel();
     boolean isPluginBuild();
     Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions();
+    boolean hasInjectedSettingsPlugins();
 
     SettingsInternal loadSettings();
 


### PR DESCRIPTION
In this case, the build may be fully configured even without a 'settings.gradle' or 'build.gradle' file in the root project dir.

See also #13793