### PR TITLE
Make executing 'undefined builds' an error

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/ProjectCacheDir.java
@@ -22,16 +22,21 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 
 public class ProjectCacheDir implements Stoppable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProjectCacheDir.class);
 
     private static final long MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS = 7;
 
     private final File dir;
     private final ProgressLoggerFactory progressLoggerFactory;
     private final Deleter deleter;
+    private boolean deleteOnStop = false;
 
     public ProjectCacheDir(File dir, ProgressLoggerFactory progressLoggerFactory, Deleter deleter) {
         this.dir = dir;
@@ -43,8 +48,20 @@ public class ProjectCacheDir implements Stoppable {
         return dir;
     }
 
+    public void delete() {
+        deleteOnStop = true;
+    }
+
     @Override
     public void stop() {
+        if (deleteOnStop) {
+            try {
+                deleter.deleteRecursively(dir);
+            } catch (IOException e) {
+                LOGGER.debug("Failed to delete unused project cache dir " + dir.getAbsolutePath(), e);
+            }
+            return;
+        }
         VersionSpecificCacheCleanupAction cleanupAction = new VersionSpecificCacheCleanupAction(
             dir,
             MAX_UNUSED_DAYS_FOR_RELEASES_AND_SNAPSHOTS,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -54,7 +54,7 @@ import org.gradle.execution.CompositeAwareTaskSelector;
 import org.gradle.execution.DefaultBuildConfigurationActionExecuter;
 import org.gradle.execution.DefaultBuildWorkExecutor;
 import org.gradle.execution.DefaultTasksBuildExecutionAction;
-import org.gradle.execution.DeprecateUndefinedBuildWorkExecutor;
+import org.gradle.execution.UndefinedBuildWorkExecutor;
 import org.gradle.execution.DryRunBuildExecutionAction;
 import org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction;
 import org.gradle.execution.IncludedBuildLifecycleBuildWorkExecutor;
@@ -84,6 +84,7 @@ import org.gradle.execution.taskgraph.TaskListenerInternal;
 import org.gradle.initialization.BuildOperationFiringTaskExecutionPreparer;
 import org.gradle.initialization.DefaultTaskExecutionPreparer;
 import org.gradle.initialization.TaskExecutionPreparer;
+import org.gradle.initialization.layout.ProjectCacheDir;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
@@ -144,14 +145,14 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new CommandLineTaskParser(new CommandLineTaskConfigurer(optionReader), taskSelector);
     }
 
-    BuildWorkExecutor createBuildExecuter(StyledTextOutputFactory textOutputFactory, IncludedBuildControllers includedBuildControllers, BuildOperationExecutor buildOperationExecutor) {
+    BuildWorkExecutor createBuildExecuter(StyledTextOutputFactory textOutputFactory, IncludedBuildControllers includedBuildControllers, BuildOperationExecutor buildOperationExecutor, ProjectCacheDir projectCacheDir) {
         return new BuildOperationFiringBuildWorkerExecutor(
-            new DeprecateUndefinedBuildWorkExecutor(
+            new UndefinedBuildWorkExecutor(
                 new IncludedBuildLifecycleBuildWorkExecutor(
                     new DefaultBuildWorkExecutor(
                         asList(new DryRunBuildExecutionAction(textOutputFactory),
                             new SelectedTaskExecutionAction())),
-                    includedBuildControllers)),
+                    includedBuildControllers), projectCacheDir),
             buildOperationExecutor);
     }
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -110,6 +110,14 @@ If you used these plugins despite their experimental nature, you may find suitab
 
 The `layout` method taking a configuration block has been removed and is replaced by link:{groovyDslPath}/org.gradle.api.artifacts.repositories.IvyArtifactRepository.html#org.gradle.api.artifacts.repositories.IvyArtifactRepository:patternLayout(org.gradle.api.Action)[patternLayout].
 
+==== Executing undefined builds is now an error
+
+A Gradle build is defined by a `settings.gradle(.kts)` file in the current or parent directory.
+Without a settings file, a Gradle build is undefined.
+Executing Gradle in such a directory is now an error.
+
+Exceptions to this are invoking Gradle with the `init` task or using diagnostic command line flags, such as `--version`.
+
 ==== Removal of `ProjectLayout#configurableFiles`
 
 Please use `ObjectFactory#fileCollection()` instead.


### PR DESCRIPTION
Also delete the project cache dir in the folder that turned out not to be a Gradle project.

See also #13793
