### PR TITLE
Update wrapper to latest nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210202060519+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210202135711+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With the fix for Kotlin DSL accessors line endings on Windows.