### PR TITLE
Default to no buildId in Gradle module metadata

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
@@ -124,26 +124,21 @@ The following rules are enforced:
 These rules ensure the quality of the metadata produced, and help confirm that consumption will not be problematic.
 
 [[sub:gmm-reproducible]]
-== Making Gradle Module Metadata reproducible
+== Gradle Module Metadata reproducibility
 
-By default, the Gradle Module Metadata file contains a unique id from the build that generated it.
-This means that the file will always be different.
+The task generating the module metadata files is currently never marked `UP-TO-DATE` by Gradle due to the way it is implemented.
+However, if neither build inputs nor build scripts changed, the task result is effectively up-to-date: it always produces the same output.
 
-Users can choose to disable this unique identifier in their `publication`:
+If users desire to have a unique `module` file per build invocation, it is possible to link an identifier in the produced metadata to the build that created it.
+Users can choose to enable this unique identifier in their `publication`:
 
 .Configuring the build identifier of a publication
 ====
-include::sample[dir="snippets/publishing/javaLibrary/groovy",files="build.gradle[tags=disable-build-id]"]
-include::sample[dir="snippets/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=disable-build-id]"]
+include::sample[dir="snippets/publishing/javaLibrary/groovy",files="build.gradle[tags=enable-build-id]"]
+include::sample[dir="snippets/publishing/javaLibrary/kotlin",files="build.gradle.kts[tags=enable-build-id]"]
 ====
 
-With the changes above, the generated Gradle Module Metadata file will always be the same, allowing downstream tasks to consider it up-to-date.
-
-[NOTE]
-====
-The task generating the module metadata files is currently never marked `UP-TO-DATE` by Gradle due to the way it is implemented.
-However, if the build identifier is skipped, and no build inputs nor build scripts changed, the task is effectively up-to-date (it always produces the same output).
-====
+With the changes above, the generated Gradle Module Metadata file will always be different, forcing downstream tasks to consider it out-of-date.
 
 [[sub:disabling-gmm-publication]]
 == Disabling Gradle Module Metadata publication

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -42,6 +42,11 @@ Some plugins will break with this new version of Gradle, for example because the
 The `getGeneratedSourceDirectories()` and `getGeneratedTestDirectories()` methods are removed from the `IdeaContentRoot` interface.
 Clients should replace these invocations with `getSourceDirectories()` and `getTestDirectories()` and use the `isGenerated()` method on the returned instances.
 
+=== Gradle Module Metadata is now reproducible by default
+
+The `buildId` field will not be populated by default to ensure that the produced metadata file remains unchanged when no build inputs are changed.
+Users can still opt in to have this unique identifier part of the produced metadata if they want to, see <<publishing_gradle_module_metadata.adoc#sub:gmm-reproducible,the documentation>>.
+
 === Potential breaking changes
 
 ==== Removal of `compile` and `runtime` configurations

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/groovy/build.gradle
@@ -42,16 +42,16 @@ tasks.withType(GenerateMavenPom).all {
 }
 // end::configure-generate-task[]
 
-// tag::disable-build-id[]
+// tag::enable-build-id[]
 publishing {
     publications {
         main(MavenPublication) {
             from components.java
-            withoutBuildIdentifier()
+            withBuildIdentifier()
         }
     }
 }
-// end::disable-build-id[]
+// end::enable-build-id[]
 
 // tag::disable_validation[]
 tasks.withType(GenerateModuleMetadata).configureEach {

--- a/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/publishing/javaLibrary/kotlin/build.gradle.kts
@@ -42,16 +42,16 @@ tasks.withType<GenerateMavenPom>().configureEach {
 }
 // end::configure-generate-task[]
 
-// tag::disable-build-id[]
+// tag::enable-build-id[]
 publishing {
     publications {
         create<MavenPublication>("main") {
             from(components["java"])
-            withoutBuildIdentifier()
+            withBuildIdentifier()
         }
     }
 }
-// end::disable-build-id[]
+// end::enable-build-id[]
 
 // tag::disable_validation[]
 tasks.withType<GenerateModuleMetadata> {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -934,7 +934,7 @@ class TestCapability implements Capability {
     }
 
     @ToBeFixedForConfigurationCache
-    def 'can skip the build identifier'() {
+    def 'can add the build identifier'() {
         given:
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
@@ -957,7 +957,7 @@ class TestCapability implements Capability {
                 publications {
                     ivy(IvyPublication) {
                         from comp
-                        withoutBuildIdentifier()
+                        withBuildIdentifier()
                     }
                 }
             }
@@ -969,6 +969,6 @@ class TestCapability implements Capability {
         then:
         def module = ivyRepo.module('group', 'root', '1.0')
         module.assertPublished()
-        module.parsedModuleMetadata.createdBy.buildId == null
+        module.parsedModuleMetadata.createdBy.buildId != null
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -138,7 +138,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
     private boolean silenceAllPublicationWarnings;
-    private boolean withBuildIdentifier = true;
+    private boolean withBuildIdentifier = false;
 
     @Inject
     public DefaultIvyPublication(

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -873,7 +873,7 @@ class TestCapability implements Capability {
         variant.dependencyConstraints[0].rejectsVersion == []
     }
 
-    def 'can skip the build identifier'() {
+    def 'can add the build identifier'() {
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
             apply plugin: 'maven-publish'
@@ -894,7 +894,7 @@ class TestCapability implements Capability {
                 publications {
                     maven(MavenPublication) {
                         from comp
-                        withoutBuildIdentifier()
+                        withBuildIdentifier()
                     }
                 }
             }
@@ -906,6 +906,6 @@ class TestCapability implements Capability {
         then:
         def module = mavenRepo.module('group', 'root', '1.0')
         module.assertPublished()
-        module.parsedModuleMetadata.createdBy.buildId == null
+        module.parsedModuleMetadata.createdBy.buildId != null
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -163,7 +163,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private boolean artifactsOverridden;
     private boolean versionMappingInUse = false;
     private boolean silenceAllPublicationWarnings;
-    private boolean withBuildIdentifier = true;
+    private boolean withBuildIdentifier = false;
 
     @Inject
     public DefaultMavenPublication(

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/Publication.java
@@ -28,7 +28,7 @@ public interface Publication extends Named {
     /**
      * Disables publication of a unique build identifier in Gradle Module Metadata.
      * <p>
-     * The build identifier is published by default.
+     * The build identifier is not published by default.
      *
      * @since 6.6
      */
@@ -37,7 +37,7 @@ public interface Publication extends Named {
     /**
      * Enables publication of a unique build identifier in Gradle Module Metadata.
      * <p>
-     * The build identifier is published by default.
+     * The build identifier is not published by default.
      *
      * @since 6.6
      */


### PR DESCRIPTION
This changes moves the default to not include the build id in the
produced metadata.