### PR TITLE
Correct version ordering example in documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/single_versions.adoc
@@ -54,7 +54,7 @@ Versions are ordered based on the following rules:
 * Certain string values have special meaning for the purposes of ordering:
 ** The string `dev` is consider **lower** than any other string part: `1.0-dev` < `1.0-alpha` < `1.0-rc`.
 ** The strings `rc`, `release` and `final` are considered **higher** than any other string part (sorted in that order): `1.0-zeta` < `1.0-rc` < `1.0-release` < `1.0-final` < `1.0`.
-** The string `SNAPSHOT` has **no special meaning**, and is sorted alphabetically like any other string part: `1.0-alpha` < `1.0-SNAPSHOT` < `1.0-zeta` < `1.0-rc` < `1.0`.
+** The string `SNAPSHOT` has **no special meaning**, and is sorted alphabetically like any other string part: `1.0-SNAPSHOT` < `1.0-alpha` < `1.0-zeta` < `1.0-rc` < `1.0`.
 ** Numeric snapshot versions have **no special meaning**, and are sorted like any other numeric part: `1.0` < `1.0-20150201.121010-123` < `1.1`.
 
 [NOTE]


### PR DESCRIPTION
Signed-off-by: Will Boulter <willboulter@quantexa.com>

<!--- The issue this PR addresses -->
I noticed that one of the examples of Version ordering appeared to be wrong in the documentation. I posted in the forum about it here https://discuss.gradle.org/t/case-sensitive-version-ordering/38924 and someone else seemed to agree, so I thought I'd just raise a PR rather than go through the effort of raising an issue etc (raising a bug seemed overkill and I didn't see any issue type relating to documentation - happy to do this though).

I'm not familiar with the project as a contributor, so I didn't really know which branch to raise this to, but master appears to not have the mistake any longer because it's probably for v7 now which uses the new ordering. Happy to update the target branch etc as I've probably got it wrong.
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
