### PR TITLE
Segregate internal message rewriting API to `ContextAwareTaskLogger`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -235,11 +235,6 @@ public class DefaultTask implements TaskInternal, DynamicObjectAware {
     }
 
     @Override
-    public void setLoggerMessageRewriter(ContextAwareTaskLogger.MessageRewriter messageRewriter) {
-        logger.setMessageRewriter(messageRewriter);
-    }
-
-    @Override
     public List<Action<? super Task>> getActions() {
         if (observableActionList == null) {
             observableActionList = new ObservableActionWrapperList(getTaskActions());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -27,7 +27,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.internal.Factory;
 import org.gradle.internal.logging.StandardOutputCapture;
-import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Configurable;
 import org.gradle.util.Path;
@@ -89,11 +88,6 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     TaskIdentity<?> getTaskIdentity();
-
-    /**
-     * Sets the log message rewriter for this task's logger.
-     */
-    void setLoggerMessageRewriter(ContextAwareTaskLogger.MessageRewriter messageRewriter);
 
     @Internal
     Set<Provider<? extends BuildService<?>>> getRequiredServices();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -547,7 +547,7 @@ class DefaultTaskTest extends AbstractTaskTest {
         def rewriter = Mock(ContextAwareTaskLogger.MessageRewriter)
 
         when:
-        task.setLoggerMessageRewriter(rewriter)
+        task.logger.setMessageRewriter(rewriter)
         task.logger.warn("test")
 
         then:

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -19,7 +19,6 @@ package org.gradle.kotlin.dsl.plugins.dsl
 import org.gradle.api.HasImplicitReceiver
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.internal.TaskInternal
 import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.provider.KotlinDslPluginSupport
@@ -58,6 +57,6 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
 
     private
     fun KotlinCompile.setWarningRewriter(rewriter: ContextAwareTaskLogger.MessageRewriter) {
-        (this as TaskInternal).setLoggerMessageRewriter(rewriter)
+        (logger as ContextAwareTaskLogger).setMessageRewriter(rewriter)
     }
 }


### PR DESCRIPTION
To avoid leaking the API to `DefaultTask` subclasses.