### PR TITLE
Direct access to task providers in Groovy DSL without breaking configuration avoidance

### DIFF
--- a/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
+++ b/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/AntlrPluginTest.groovy
@@ -68,11 +68,11 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         project.pluginManager.apply(AntlrPlugin)
 
         then:
-        def main = project.tasks.generateGrammarSource
+        def main = project.tasks.generateGrammarSource.get()
         main instanceof AntlrTask
         project.tasks.compileJava.taskDependencies.getDependencies(null).contains(main)
 
-        def test = project.tasks.generateTestGrammarSource
+        def test = project.tasks.generateTestGrammarSource.get()
         test instanceof AntlrTask
         project.tasks.compileTestJava.taskDependencies.getDependencies(null).contains(test)
 
@@ -80,7 +80,7 @@ class AntlrPluginTest extends AbstractProjectBuilderSpec {
         project.sourceSets.create('custom')
 
         then:
-        def custom = project.tasks.generateCustomGrammarSource
+        def custom = project.tasks.generateCustomGrammarSource.get()
         custom instanceof AntlrTask
         project.tasks.compileCustomJava.taskDependencies.getDependencies(null).contains(custom)
     }

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/BuildInitPluginSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/BuildInitPluginSpec.groovy
@@ -29,8 +29,8 @@ class BuildInitPluginSpec extends AbstractProjectBuilderSpec {
         and:
         project.evaluate()
         then:
-        project.tasks.wrapper instanceof Wrapper
-        TaskDependencyMatchers.dependsOn("wrapper").matches(project.tasks.init)
+        project.tasks.wrapper.get() instanceof Wrapper
+        TaskDependencyMatchers.dependsOn("wrapper").matches(project.tasks.init.get())
     }
 
     def "no wrapper task configured if build file already exists"() {

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/WrapperPluginSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/WrapperPluginSpec.groovy
@@ -35,7 +35,7 @@ class WrapperPluginSpec extends Specification {
         project.pluginManager.apply WrapperPlugin
 
         then:
-        project.tasks.wrapper instanceof Wrapper
+        project.tasks.wrapper.get() instanceof Wrapper
         project.tasks.wrapper.group == "Build Setup"
     }
 }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/CheckstylePluginTest.groovy
@@ -145,8 +145,8 @@ class CheckstylePluginTest extends AbstractProjectBuilderSpec {
         hasCustomizedSettings("checkstyleMain", project.sourceSets.main)
         hasCustomizedSettings("checkstyleTest", project.sourceSets.test)
         hasCustomizedSettings("checkstyleOther", project.sourceSets.other)
-        that(project.check, dependsOn(hasItem('checkstyleMain')))
-        that(project.check, dependsOn(not(hasItems('checkstyleTest', 'checkstyleOther'))))
+        that(project.check.get(), dependsOn(hasItem('checkstyleMain')))
+        that(project.check.get(), dependsOn(not(hasItems('checkstyleTest', 'checkstyleOther'))))
     }
 
     private void hasCustomizedSettings(String taskName, SourceSet sourceSet) {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -168,8 +168,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         hasCustomizedSettings("pmdMain", project.sourceSets.main)
         hasCustomizedSettings("pmdTest", project.sourceSets.test)
         hasCustomizedSettings("pmdOther", project.sourceSets.other)
-        that(project.check, dependsOn(hasItem('pmdMain')))
-        that(project.check, dependsOn(not(hasItems('pmdTest', 'pmdOther'))))
+        that(project.check.get(), dependsOn(hasItem('pmdMain')))
+        that(project.check.get(), dependsOn(not(hasItems('pmdTest', 'pmdOther'))))
     }
 
     private void hasCustomizedSettings(String taskName, SourceSet sourceSet) {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -187,7 +187,7 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         DefaultSettings                       | Settings                       | "project.gradle.settings"
         DefaultProject                        | Project                        | "project"
         DefaultTaskContainer                  | TaskContainer                  | "project.tasks"
-        DefaultTask                           | Task                           | "project.tasks.other"
+        DefaultTask                           | Task                           | "project.tasks.other.get()"
         DefaultSourceSetContainer             | SourceSetContainer             | "project.sourceSets"
         DefaultSourceSet                      | SourceSet                      | "project.sourceSets['main']"
         // Dependency Resolution Types

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DynamicObjectIntegrationTest.groovy
@@ -208,7 +208,7 @@ assert 'overridden value' == global
             javaTask.custom = 'another value'
             groovyTask.custom = 'another value'
             assert !project.hasProperty('custom')
-            assert defaultTask.hasProperty('custom')
+            assert defaultTask.get().hasProperty('custom')
             assert defaultTask.custom == 'another value'
             assert javaTask.custom == 'another value'
             assert groovyTask.custom == 'another value'
@@ -624,8 +624,8 @@ task print(type: MyTask) {
     def failsWhenGettingUnknownPropertyOnTask() {
         buildFile """
             task p
-            assert !tasks.p.hasProperty("p1")
-            println tasks.p.p1
+            assert !tasks.p.get().hasProperty("p1")
+            println tasks.p.get().p1
         """
 
         expect:
@@ -698,8 +698,8 @@ task print(type: MyTask) {
     def failsWhenSettingUnknownPropertyOnTask() {
         buildFile """
             task p
-            assert !tasks.p.hasProperty("p1")
-            tasks.p.p1 = 1
+            assert !tasks.p.get().hasProperty("p1")
+            tasks.p.get().p1 = 1
         """
 
         expect:
@@ -742,7 +742,7 @@ task print(type: MyTask) {
     def failsWhenInvokingUnknownMethodOnDecoratedObject() {
         buildFile """
             task p
-            tasks.p.unknown(12, "things")
+            tasks.p.get().unknown(12, "things")
         """
 
         expect:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -106,6 +106,7 @@ tasks.help {
         prop = "value 3"
     }
 }
+tasks.help // realize the task
 assert prop == "value 3"
 """
 
@@ -303,6 +304,7 @@ tasks.configure {
         }
     }
 }
+tasks.help // realize the task
 assert prop == "value 4"
 """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -304,7 +304,7 @@ tasks.configure {
         }
     }
 }
-tasks.help.get() = "help" // realize the task
+tasks.help.get() // realize the task
 assert prop == "value 4"
 """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -106,7 +106,7 @@ tasks.help {
         prop = "value 3"
     }
 }
-tasks.help // realize the task
+tasks.help.get() // realize the task
 assert prop == "value 3"
 """
 
@@ -304,7 +304,7 @@ tasks.configure {
         }
     }
 }
-tasks.help // realize the task
+tasks.help.get() = "help" // realize the task
 assert prop == "value 4"
 """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -400,10 +400,10 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
 
             class PrintInputsAndOutputs extends DefaultTask {
                 @Internal
-                Task task
+                TaskProvider task
                 @TaskAction
                 void printInputsAndOutputs() {
-                    TaskPropertyUtils.visitProperties(project.services.get(PropertyWalker), task, new PropertyVisitor.Adapter() {
+                    TaskPropertyUtils.visitProperties(project.services.get(PropertyWalker), task.get(), new PropertyVisitor.Adapter() {
                         @Override
                         void visitInputProperty(String propertyName, PropertyValue value, boolean optional) {
                             println "Input property '\${propertyName}'"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -2088,7 +2088,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
             task copy(type: Copy) {
                 from 'src'
                 into 'dest'
-                with tasks.war
+                with tasks.war.get()
             }
         '''.stripIndent()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -171,7 +171,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             // Eager
             tasks.create("task2", SomeTask) {
                 println "Configure ${path}"
-                dependsOn task1
+                dependsOn task1.get() // without 'get()' this would not eageryl create the task
             }
             tasks.create("other")
         '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GroovyDSLTaskConfigurationAvoidanceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GroovyDSLTaskConfigurationAvoidanceIntegrationTest.groovy
@@ -55,6 +55,17 @@ class GroovyDSLTaskConfigurationAvoidanceIntegrationTest extends AbstractIntegra
         outputContains('help task created')
     }
 
+    def "can access task property through provider if task was already created"() {
+        buildFile << """
+            tasks.help.get() // realize the task
+            tasks.help.taskPath = 'projects'
+        """
+
+        expect:
+        succeeds('projects')
+        outputContains('help task created')
+    }
+
     def "task is not eagerly created when a detail of the provider is accessed"() {
         buildFile << """
             tasks.help.name
@@ -63,6 +74,29 @@ class GroovyDSLTaskConfigurationAvoidanceIntegrationTest extends AbstractIntegra
         expect:
         succeeds('projects')
         outputDoesNotContain('help task created')
+    }
+
+    def "task provider can be stored and used"() {
+        buildFile << """
+            def helpTaskProvider = tasks.help
+            assert helpTaskProvider instanceof TaskProvider
+            helpTaskProvider {
+                println("help task configured")
+            }
+        """
+
+        when:
+        succeeds('projects')
+
+        then:
+        outputDoesNotContain('help task created')
+        outputDoesNotContain('help task configured')
+
+        and:
+        succeeds('help')
+
+        then:
+        outputContains('help task created\nhelp task configured')
     }
 
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GroovyDSLTaskConfigurationAvoidanceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/GroovyDSLTaskConfigurationAvoidanceIntegrationTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GroovyDSLTaskConfigurationAvoidanceIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            tasks.help { t ->
+                println('help task created')
+            }
+        """
+    }
+
+    def "task is not eagerly created"() {
+        expect:
+        succeeds('projects')
+        outputDoesNotContain('help task created')
+    }
+
+    def "task is not eagerly created when accessed as property"() {
+        buildFile << """
+            def helpTask = tasks.help
+            assert helpTask instanceof TaskProvider
+        """
+
+        expect:
+        succeeds('projects')
+        outputDoesNotContain('help task created')
+    }
+
+    def "task is created on demand when task property is accessed"() {
+        buildFile << """
+            tasks.help.taskPath = 'projects'
+        """
+
+        expect:
+        succeeds('projects')
+        outputContains('help task created')
+    }
+
+    def "task is not eagerly created when a detail of the provider is accessed"() {
+        buildFile << """
+            tasks.help.name
+        """
+
+        expect:
+        succeeds('projects')
+        outputDoesNotContain('help task created')
+    }
+
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -666,7 +666,7 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             }
             task explodedZip(type: Copy) {
                 into 'build/exploded'
-                with zip
+                with zip.get()
             }
             task copyFromRootSpec(type: Copy) {
                 into 'build/copy'

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -529,9 +529,10 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public DynamicInvokeResult tryGetProperty(String name) {
-            if (avoidConfigurationInDynamicMemberLookup()) {
-                return !getNames().contains(name) ? DynamicInvokeResult.notFound() : DynamicInvokeResult.found(named(name));
+            if (avoidConfigurationInDynamicMemberLookup() && getNames().contains(name)) {
+                return DynamicInvokeResult.found(named(name));
             }
+            // even if we do avoidConfigurationInDynamicMemberLookup(), we need to fall back to 'findByName()', as rules applied on tasks might create additional elements
             T t = findByName(name);
             return t == null ? DynamicInvokeResult.notFound() : DynamicInvokeResult.found(t);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -529,6 +529,9 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public DynamicInvokeResult tryGetProperty(String name) {
+            if (avoidConfigurationInDynamicMemberLookup()) {
+                return !getNames().contains(name) ? DynamicInvokeResult.notFound() : DynamicInvokeResult.found(named(name));
+            }
             T t = findByName(name);
             return t == null ? DynamicInvokeResult.notFound() : DynamicInvokeResult.found(t);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -112,6 +112,10 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         this.buildOperationExecutor = buildOperationExecutor;
     }
 
+    protected boolean avoidConfiguration() {
+        return true;
+    }
+
     @Override
     public Task create(Map<String, ?> options) {
         assertMutable("create(Map<String, ?>)");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
@@ -106,17 +106,17 @@ class DefaultAntBuilderTest extends AbstractProjectBuilderSpec {
         ant.importBuild(buildFile)
 
         then:
-        def task = project.tasks.target1
+        def task = project.tasks.target1.get()
         task instanceof AntTarget
         task.target.name == 'target1'
 
         and:
-        def task2 = project.tasks.target2
+        def task2 = project.tasks.target2.get()
         task2 instanceof AntTarget
         task2.target.name == 'target2'
 
         and:
-        def task3 = project.tasks.target3
+        def task3 = project.tasks.target3.get()
         task3 instanceof AntTarget
         task3.target.name == 'target3'
     }
@@ -192,7 +192,7 @@ class DefaultAntBuilderTest extends AbstractProjectBuilderSpec {
         }
 
         then:
-        def task = project.tasks.'a-target1'
+        def task = project.tasks.'a-target1'.get()
         task instanceof AntTarget
         task.target.name == 'target1'
         task.taskDependencies.getDependencies(task).name.sort() == ["a-target2", "a-target3"]

--- a/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/testfixtures/ProjectBuilderTest.groovy
@@ -90,7 +90,7 @@ class ProjectBuilderTest extends Specification {
         project.apply plugin: CustomPlugin
 
         then:
-        project.tasks.hello instanceof DefaultTask
+        project.tasks.hello.get() instanceof DefaultTask
     }
 
     def canApplyACustomPluginById() {
@@ -99,7 +99,7 @@ class ProjectBuilderTest extends Specification {
         project.apply plugin: 'custom-plugin'
 
         then:
-        project.tasks.hello instanceof DefaultTask
+        project.tasks.hello.get() instanceof DefaultTask
     }
 
     def canApplyACustomPluginByType() {
@@ -108,7 +108,7 @@ class ProjectBuilderTest extends Specification {
         project.pluginManager.apply(CustomPlugin)
 
         then:
-        project.tasks.hello instanceof DefaultTask
+        project.tasks.hello.get() instanceof DefaultTask
     }
 
     def canCreateAndExecuteACustomTask() {
@@ -128,7 +128,7 @@ class ProjectBuilderTest extends Specification {
         project.apply from: resources.getResource('ProjectBuilderTest.gradle')
 
         then:
-        project.tasks.hello instanceof DefaultTask
+        project.tasks.hello.get() instanceof DefaultTask
     }
 
     def "Can trigger afterEvaluate programmatically"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -665,7 +665,7 @@ class LoggingRule implements ComponentMetadataRule {
 configurations {
     ruleDownloader.incoming.afterResolve {
         println "Adding rules"
-        dependencies {
+        project.dependencies {
             components {
                 all(LoggingRule)
             }

--- a/subprojects/docs/src/snippets/ivy-publish/conditional-publishing/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/conditional-publishing/groovy/build.gradle
@@ -19,7 +19,7 @@ publishing {
         }
         binaryAndSources(IvyPublication) {
             from components.java
-            artifact sourcesJar
+            artifact sourcesJar.get()
         }
     }
     repositories {

--- a/subprojects/docs/src/snippets/ivy-publish/distribution/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/ivy-publish/distribution/groovy/build.gradle
@@ -28,8 +28,8 @@ distributions {
 publishing {
     publications {
         myDistribution(IvyPublication) {
-            artifact distZip
-            artifact customDistTar
+            artifact distZip.get()
+            artifact customDistTar.get()
         }
     }
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ import ratpack.gradle.RatpackExtension
 // tag::root[]
 plugins {
     id("com.github.johnrengelman.shadow") version "4.0.1" apply false
-    id("io.ratpack.ratpack-java") version "1.8.0" apply false
+    id("io.ratpack.ratpack-java") version "1.8.2" apply false
 }
 // end::root[]
 

--- a/subprojects/docs/src/snippets/native-binaries/idl/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/native-binaries/idl/groovy/build.gradle
@@ -14,7 +14,7 @@ model {
         main(NativeExecutableSpec) {
             sources {
                 idlOutput(CSourceSet) {
-                    generatedBy tasks.idl
+                    generatedBy tasks.idl.get()
                 }
                 c.lib sources.idlOutput
             }

--- a/subprojects/docs/src/snippets/signing/in-memory-subkey/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/signing/in-memory-subkey/groovy/build.gradle
@@ -13,6 +13,6 @@ signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign stuffZip
+    sign stuffZip.get()
 }
 // end::signing[]

--- a/subprojects/docs/src/snippets/signing/in-memory/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/signing/in-memory/groovy/build.gradle
@@ -12,6 +12,6 @@ signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign stuffZip
+    sign stuffZip.get()
 }
 // end::signing[]

--- a/subprojects/docs/src/snippets/signing/tasks/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/signing/tasks/groovy/build.gradle
@@ -14,6 +14,6 @@ task stuffZip(type: Zip) {
 }
 
 signing {
-    sign stuffZip
+    sign stuffZip.get()
 }
 // end::sign-task[]

--- a/subprojects/docs/src/snippets/testing/jacoco-application/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/jacoco-application/groovy/build.gradle
@@ -9,11 +9,11 @@ application {
 }
 
 jacoco {
-    applyTo run
+    applyTo run.get()
 }
 
 task applicationCodeCoverageReport(type:JacocoReport) {
-    executionData run
+    executionData run.get()
     sourceSets sourceSets.main
 }
 // end::application-configuration[]

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipsePluginTest.groovy
@@ -37,7 +37,7 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
 
         then:
         project.tasks.findByPath(':eclipseClasspath') == null
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject)
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject.get())
         checkEclipseProjectTask([], [])
     }
 
@@ -47,8 +47,8 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'java-base')
         project.evaluate()
         then:
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject)
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath)
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject.get())
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath.get())
         checkEclipseProjectTask([new BuildCommand('org.eclipse.jdt.core.javabuilder')], ['org.eclipse.jdt.core.javanature'])
         checkEclipseClasspath([])
         checkEclipseJdt()
@@ -69,8 +69,8 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.evaluate()
 
         then:
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject)
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath)
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject.get())
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath.get())
         checkEclipseProjectTask([new BuildCommand('org.scala-ide.sdt.core.scalabuilder')],
                 ['org.scala-ide.sdt.core.scalanature', 'org.eclipse.jdt.core.javanature'])
         checkEclipseClasspath([], scalaIdeContainer)
@@ -89,8 +89,8 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
         project.evaluate()
 
         then:
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject)
-        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath)
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseProject.get())
+        assertThatCleanEclipseDependsOn(project, project.cleanEclipseClasspath.get())
         checkEclipseProjectTask([new BuildCommand('org.eclipse.jdt.core.javabuilder')], ['org.eclipse.jdt.groovy.core.groovyNature',
                 'org.eclipse.jdt.core.javanature'])
         checkEclipseClasspath([])
@@ -141,9 +141,9 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
     }
 
     private void checkEclipseProjectTask(List buildCommands, List natures) {
-        GenerateEclipseProject eclipseProjectTask = project.eclipseProject
+        GenerateEclipseProject eclipseProjectTask = project.eclipseProject.get()
         assert eclipseProjectTask instanceof GenerateEclipseProject
-        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse).contains(eclipseProjectTask)
+        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse.get()).contains(eclipseProjectTask)
         assert eclipseProjectTask.outputFile == project.file('.project')
 
         assert project.eclipse.project.buildCommands == buildCommands
@@ -152,12 +152,12 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
 
     private void checkEclipseClasspath(def configurations, def additionalContainers = []) {
         def classpath = project.eclipse.classpath
-        def classpathTask = project.tasks.eclipseClasspath
+        def classpathTask = project.tasks.eclipseClasspath.get()
 
         assert classpathTask instanceof GenerateEclipseClasspath
         assert classpathTask.classpath == classpath
         assert classpathTask.outputFile == project.file('.classpath')
-        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse).contains(classpathTask)
+        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse.get()).contains(classpathTask)
 
         assert classpath.sourceSets == project.sourceSets
         assert classpath.plusConfigurations == configurations
@@ -168,14 +168,14 @@ class EclipsePluginTest extends AbstractProjectBuilderSpec {
     }
 
     private void checkEclipseJdt() {
-        GenerateEclipseJdt eclipseJdt = project.eclipseJdt
-        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse).contains(eclipseJdt)
+        GenerateEclipseJdt eclipseJdt = project.eclipseJdt.get()
+        assert project.tasks.eclipse.taskDependencies.getDependencies(project.tasks.eclipse.get()).contains(eclipseJdt)
         assert eclipseJdt.outputFile == project.file('.settings/org.eclipse.jdt.core.prefs')
     }
 
     void assertThatCleanEclipseDependsOn(Project project, Task dependsOnTask) {
         assert dependsOnTask instanceof Delete
-        assert project.cleanEclipse.taskDependencies.getDependencies(project.cleanEclipse).contains(dependsOnTask)
+        assert project.cleanEclipse.taskDependencies.getDependencies(project.cleanEclipse.get()).contains(dependsOnTask)
     }
 }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -53,8 +53,8 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         wtpPlugin.apply(project)
 
         then:
-        project.tasks.eclipse.taskDependencies.getDependencies(null).contains(project.eclipseWtp)
-        project.tasks.cleanEclipse.taskDependencies.getDependencies(null).contains(project.cleanEclipseWtp)
+        project.tasks.eclipse.taskDependencies.getDependencies(null).contains(project.eclipseWtp.get())
+        project.tasks.cleanEclipse.taskDependencies.getDependencies(null).contains(project.cleanEclipseWtp.get())
     }
 
     def applyToJavaProject_shouldHaveWebProjectAndClasspathTask() {
@@ -64,7 +64,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         wtpPlugin.apply(project)
 
         then:
-        [project.tasks.cleanEclipseWtpComponent, project.tasks.cleanEclipseWtpFacet].each {
+        [project.tasks.cleanEclipseWtpComponent.get(), project.tasks.cleanEclipseWtpFacet.get()].each {
             assert project.tasks.cleanEclipseWtp.dependsOn*.get().contains(it)
         }
         checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
@@ -82,7 +82,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         project.sourceCompatibility = 1.7
 
         then:
-        [project.tasks.cleanEclipseWtpComponent, project.tasks.cleanEclipseWtpFacet].each {
+        [project.tasks.cleanEclipseWtpComponent.get(), project.tasks.cleanEclipseWtpFacet.get()].each {
             assert project.tasks.cleanEclipseWtp.dependsOn*.get().contains(it)
         }
         checkEclipseClasspath([project.configurations.compileClasspath, project.configurations.runtimeClasspath, project.configurations.testCompileClasspath, project.configurations.testRuntimeClasspath])
@@ -120,7 +120,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         project.apply(plugin: 'eclipse-wtp')
 
         then:
-        [project.cleanEclipseWtpComponent, project.cleanEclipseWtpFacet].each {
+        [project.cleanEclipseWtpComponent.get(), project.cleanEclipseWtpFacet.get()].each {
             assert project.tasks.cleanEclipseWtp.dependsOn*.get().contains(it)
         }
 
@@ -140,7 +140,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         project.sourceCompatibility = 1.8
 
         then:
-        [project.cleanEclipseWtpComponent, project.cleanEclipseWtpFacet].each {
+        [project.cleanEclipseWtpComponent.get(), project.cleanEclipseWtpFacet.get()].each {
             assert project.tasks.cleanEclipseWtp.dependsOn*.get().contains(it)
         }
 
@@ -213,7 +213,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         }
 
         then:
-        [project.cleanEclipseWtpComponent, project.cleanEclipseWtpFacet].each {
+        [project.cleanEclipseWtpComponent.get(), project.cleanEclipseWtpFacet.get()].each {
             assert project.cleanEclipseWtp.dependsOn*.get().contains(it)
         }
 
@@ -303,10 +303,10 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
 
     private void checkEclipseWtpFacet(def expectedFacets) {
         def wtp = project.eclipse.wtp.facet
-        def eclipseWtpFacet = project.eclipseWtpFacet
+        def eclipseWtpFacet = project.eclipseWtpFacet.get()
         assert eclipseWtpFacet instanceof GenerateEclipseWtpFacet
         assert eclipseWtpFacet.facet == wtp
-        assert project.tasks.eclipseWtp.taskDependencies.getDependencies(project.tasks.eclipseWtp).contains(eclipseWtpFacet)
+        assert project.tasks.eclipseWtp.taskDependencies.getDependencies(project.tasks.eclipseWtp.get()).contains(eclipseWtpFacet)
         assert eclipseWtpFacet.inputFile == project.file('.settings/org.eclipse.wst.common.project.facet.core.xml')
         assert eclipseWtpFacet.outputFile == project.file('.settings/org.eclipse.wst.common.project.facet.core.xml')
         assert wtp.facets.sort() == expectedFacets.sort()
@@ -344,9 +344,9 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
 
     private def checkAndGetEclipseWtpComponent() {
         def wtp = project.eclipse.wtp.component
-        def eclipseWtpComponent = project.eclipseWtpComponent
+        def eclipseWtpComponent = project.eclipseWtpComponent.get()
         assert eclipseWtpComponent instanceof GenerateEclipseWtpComponent
-        assert project.tasks.eclipseWtp.taskDependencies.getDependencies(project.tasks.eclipseWtp).contains(eclipseWtpComponent)
+        assert project.tasks.eclipseWtp.taskDependencies.getDependencies(project.tasks.eclipseWtp.get()).contains(eclipseWtpComponent)
         assert eclipseWtpComponent.component == wtp
         assert eclipseWtpComponent.inputFile == project.file('.settings/org.eclipse.wst.common.component')
         assert eclipseWtpComponent.outputFile == project.file('.settings/org.eclipse.wst.common.component')

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -65,8 +65,8 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
 
         then:
-        assertThatCleanIdeaDependsOnDeleteTask(project, project.cleanIdeaProject)
-        GenerateIdeaProject ideaProjectTask = project.ideaProject
+        assertThatCleanIdeaDependsOnDeleteTask(project, project.cleanIdeaProject.get())
+        GenerateIdeaProject ideaProjectTask = project.ideaProject.get()
         ideaProjectTask instanceof GenerateIdeaProject
         ideaProjectTask.outputFile == new File(project.projectDir, project.name + ".ipr")
         ideaProjectTask.ideaProject.modules == [project.idea.module, childProject.idea.module, anotherChildProject.idea.module]
@@ -99,9 +99,9 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
 
         then:
-        project.ideaWorkspace instanceof GenerateIdeaWorkspace
-        assert project.cleanIdeaWorkspace instanceof Delete
-        assert !project.cleanIdea.taskDependencies.getDependencies(project.cleanIdea).contains(project.cleanIdeaWorkspace)
+        project.ideaWorkspace.get() instanceof GenerateIdeaWorkspace
+        assert project.cleanIdeaWorkspace.get() instanceof Delete
+        assert !project.cleanIdea.taskDependencies.getDependencies(project.cleanIdea.get()).contains(project.cleanIdeaWorkspace.get())
 
 
         childProject.tasks.findByName('ideaWorkspace') == null
@@ -148,8 +148,8 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         applyPluginToProjects()
 
         then:
-        project.cleanIdea instanceof Task
-        childProject.cleanIdea instanceof Task
+        project.cleanIdea.get() instanceof Task
+        childProject.cleanIdea.get() instanceof Task
     }
 
      def "adds single entry libraries from source sets"() {
@@ -180,9 +180,9 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         childProject.pluginManager.apply(ScalaPlugin)
 
         then:
-        def parentIdeaProject = project.tasks.ideaProject
-        def parentIdeaModule = project.tasks.ideaModule
-        def childIdeaModule = childProject.tasks.ideaModule
+        def parentIdeaProject = project.tasks.ideaProject.get()
+        def parentIdeaModule = project.tasks.ideaModule.get()
+        def childIdeaModule = childProject.tasks.ideaModule.get()
 
         childIdeaModule.taskDependencies.getDependencies(childIdeaModule).contains(parentIdeaProject)
         !parentIdeaModule.taskDependencies.getDependencies(parentIdeaModule).contains(parentIdeaProject)
@@ -218,15 +218,15 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
     }
 
     private void assertThatIdeaModuleIsProperlyConfigured(Project project) {
-        GenerateIdeaModule ideaModuleTask = project.ideaModule
+        GenerateIdeaModule ideaModuleTask = project.ideaModule.get()
         assert ideaModuleTask instanceof GenerateIdeaModule
         assert ideaModuleTask.outputFile == new File(project.projectDir, project.name + ".iml")
-        assertThatCleanIdeaDependsOnDeleteTask(project, project.cleanIdeaModule)
+        assertThatCleanIdeaDependsOnDeleteTask(project, project.cleanIdeaModule.get())
     }
 
     private void assertThatCleanIdeaDependsOnDeleteTask(Project project, Task dependsOnTask) {
         assert dependsOnTask instanceof Delete
-        assert project.cleanIdea.taskDependencies.getDependencies(project.cleanIdea).contains(dependsOnTask)
+        assert project.cleanIdea.taskDependencies.getDependencies(project.cleanIdea.get()).contains(dependsOnTask)
     }
 
     private applyPluginToProjects() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -39,9 +39,9 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
             assert notified
             assert gradle.taskGraph.hasTask(task)
             assert gradle.taskGraph.hasTask(':a')
-            assert gradle.taskGraph.hasTask(a)
+            assert gradle.taskGraph.hasTask(a.get())
             assert gradle.taskGraph.hasTask(':b')
-            assert gradle.taskGraph.hasTask(b)
+            assert gradle.taskGraph.hasTask(b.get())
             assert gradle.taskGraph.allTasks.contains(task)
             assert gradle.taskGraph.allTasks.contains(tasks.getByName('b'))
         }
@@ -49,11 +49,11 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
     task b
     gradle.taskGraph.whenReady { graph ->
         assert graph.hasTask(':a')
-        assert graph.hasTask(a)
+        assert graph.hasTask(a.get())
         assert graph.hasTask(':b')
-        assert graph.hasTask(b)
-        assert graph.allTasks.contains(a)
-        assert graph.allTasks.contains(b)
+        assert graph.hasTask(b.get())
+        assert graph.allTasks.contains(a.get())
+        assert graph.allTasks.contains(b.get())
         notified = true
     }
 """
@@ -75,7 +75,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
     task b {
         doLast {
-            assert a == project.executedA
+            assert a.get() == project.executedA
             assert gradle.taskGraph.hasTask(':a')
         }
     }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
@@ -35,7 +35,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
                     artifact "customFile.txt"
                     artifact customDocsTask.outputFile
                     artifact regularFileTask.outputFile
-                    artifact customJar
+                    artifact customJar.get()
                     artifact provider { file("customFile.foo") }
                     artifact provider { "customFile.bar" }
                 }
@@ -103,7 +103,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
                         name "regular"
                         extension "txt"
                     }
-                    artifact(customJar) {
+                    artifact(customJar.get()) {
                         extension "war"
                         type "web-archive"
                         conf "*"
@@ -152,7 +152,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
                     artifact source: "customFile.txt", name: "customFile", classifier: "classified", conf: "foo,bar"
                     artifact source: customDocsTask.outputFile, name: "docs", extension: "htm", builtBy: customDocsTask
                     artifact source: regularFileTask.outputFile, name: "regular", extension: "txt"
-                    artifact source: customJar, extension: "war", type: "web-archive", conf: "*"
+                    artifact source: customJar.get(), extension: "war", type: "web-archive", conf: "*"
                 }
             }
 """)
@@ -188,7 +188,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
             publications {
                 ivy(IvyPublication) {
                     from components.java
-                    artifacts = ["customFile.txt", customDocsTask.outputFile, customJar]
+                    artifacts = ["customFile.txt", customDocsTask.outputFile, customJar.get()]
                 }
             }
 """, """
@@ -219,7 +219,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
                     }
                     artifact source: "customFile.txt", name: "customFile"
                     artifact source: customDocsTask.outputFile, name: "docs", builtBy: customDocsTask
-                    artifact source: customJar
+                    artifact source: customJar.get()
                 }
             }
 """, """
@@ -277,7 +277,7 @@ class IvyPublishArtifactCustomizationIntegTest extends AbstractIvyPublishIntegTe
         createBuildScripts("""
             publications {
                 ivy(IvyPublication) {
-                    artifact source: customJar, classifier: "classy"
+                    artifact source: customJar.get(), classifier: "classy"
                 }
             }
 """)
@@ -400,7 +400,7 @@ The following types/formats are supported:
         given:
         createBuildScripts("""
             publications.create("ivyCustom", IvyPublication) {
-                artifact customJar
+                artifact customJar.get()
             }
         """, "version = 2.0")
         when:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishCoordinatesIntegTest.groovy
@@ -107,7 +107,7 @@ class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
                                 extend "compile"
                             }
                         }
-                        artifact(apiJar) {
+                        artifact(apiJar.get()) {
                             conf "compile,runtime"
                         }
                     }
@@ -173,7 +173,7 @@ class IvyPublishCoordinatesIntegTest extends AbstractIvyPublishIntegTest {
                         from components.java
                     }
                     other(IvyPublication) {
-                        artifact(otherJar)
+                        artifact(otherJar.get())
                     }
                 }
             }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishEarIntegTest.groovy
@@ -55,7 +55,7 @@ class IvyPublishEarIntegTest extends AbstractIvyPublishIntegTest {
                                 extend "master"
                             }
                         }
-                        artifact source: ear, conf: "master"
+                        artifact source: ear.get(), conf: "master"
                     }
                 }
             }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -187,7 +187,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 publications {
                     ivy(IvyPublication) {
                         from components.java
-                        artifact(sourceJar) {
+                        artifact(sourceJar.get()) {
                             classifier "source"
                             type "sources"
                             conf "runtime"
@@ -1156,7 +1156,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         publishing {
             publications {
                 java(IvyPublication) {
-                    artifact jar
+                    artifact jar.get()
                 }
             }
         }

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -52,7 +52,7 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << '''
             assert project.test.extensions.getByType(JacocoTaskExtension) != null
-            assert project.jacocoTestReport instanceof JacocoReport
+            assert project.jacocoTestReport.get() instanceof JacocoReport
             assert project.jacocoTestReport.sourceDirectories*.absolutePath == project.layout.files("src/main/java")*.absolutePath
             assert project.jacocoTestReport.classDirectories*.absolutePath == project.sourceSets.main.output*.absolutePath
         '''.stripIndent()

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -218,7 +218,7 @@ public class ThingTest {
                 csv.enabled false
                 html.destination file("\${buildDir}/reports/jacoco/integ")
             }
-            executionData test
+            executionData test.get()
         }
         """.stripIndent()
 

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JavaProjectUnderTest.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JavaProjectUnderTest.groovy
@@ -72,12 +72,12 @@ class JavaProjectUnderTest {
             }
 
             task jacocoIntegrationTestReport(type: JacocoReport) {
-                executionData integrationTest
+                executionData integrationTest.get()
                 sourceSets sourceSets.main
             }
 
             task jacocoIntegrationTestCoverageVerification(type: JacocoCoverageVerification) {
-                executionData integrationTest
+                executionData integrationTest.get()
                 sourceSets sourceSets.main
             }
         """

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -137,7 +137,7 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
             publishing {
                 publications {
                     headers(${repoType.capitalize()}Publication) {
-                        artifact zipHeaders
+                        artifact zipHeaders.get()
                         ${group(repoType)} = "org.gradle.test"
                         ${version(repoType)} = "1.0"
                     }

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
@@ -75,7 +75,7 @@ class CppApplicationPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileDebugCpp = project.tasks.compileDebugCpp
+        def compileDebugCpp = project.tasks.compileDebugCpp.get()
         compileDebugCpp instanceof CppCompile
         compileDebugCpp.includes.files.first() == project.file("src/main/headers")
         compileDebugCpp.source.files == [src] as Set
@@ -83,17 +83,17 @@ class CppApplicationPluginTest extends Specification {
         compileDebugCpp.debuggable
         !compileDebugCpp.optimized
 
-        def linkDebug = project.tasks.linkDebug
+        def linkDebug = project.tasks.linkDebug.get()
         linkDebug instanceof LinkExecutable
         linkDebug.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("testApp"))
         linkDebug.debuggable
 
-        def installDebug = project.tasks.installDebug
+        def installDebug = project.tasks.installDebug.get()
         installDebug instanceof InstallExecutable
         installDebug.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
         installDebug.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("testApp")
 
-        def compileReleaseCpp = project.tasks.compileReleaseCpp
+        def compileReleaseCpp = project.tasks.compileReleaseCpp.get()
         compileReleaseCpp instanceof CppCompile
         compileReleaseCpp.includes.files.first() == project.file("src/main/headers")
         compileReleaseCpp.source.files == [src] as Set
@@ -101,12 +101,12 @@ class CppApplicationPluginTest extends Specification {
         compileReleaseCpp.debuggable
         compileReleaseCpp.optimized
 
-        def linkRelease = project.tasks.linkRelease
+        def linkRelease = project.tasks.linkRelease.get()
         linkRelease instanceof LinkExecutable
         linkRelease.linkedFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("testApp"))
         linkRelease.debuggable
 
-        def installRelease = project.tasks.installRelease
+        def installRelease = project.tasks.installRelease.get()
         installRelease instanceof InstallExecutable
         installRelease.installDirectory.get().asFile == projectDir.file("build/install/main/release")
         installRelease.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("testApp")

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppLibraryPluginTest.groovy
@@ -125,7 +125,7 @@ class CppLibraryPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileDebugCpp = project.tasks.compileDebugCpp
+        def compileDebugCpp = project.tasks.compileDebugCpp.get()
         compileDebugCpp instanceof CppCompile
         compileDebugCpp.includes.files.take(2) as List == [publicHeaders, privateHeaders]
         compileDebugCpp.source.files as List == [src]
@@ -133,12 +133,12 @@ class CppLibraryPluginTest extends Specification {
         compileDebugCpp.debuggable
         !compileDebugCpp.optimized
 
-        def linkDebug = project.tasks.linkDebug
+        def linkDebug = project.tasks.linkDebug.get()
         linkDebug instanceof LinkSharedLibrary
         linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkDebug.debuggable
 
-        def compileReleaseCpp = project.tasks.compileReleaseCpp
+        def compileReleaseCpp = project.tasks.compileReleaseCpp.get()
         compileReleaseCpp instanceof CppCompile
         compileReleaseCpp.includes.files.take(2) as List == [publicHeaders, privateHeaders]
         compileReleaseCpp.source.files as List == [src]
@@ -146,7 +146,7 @@ class CppLibraryPluginTest extends Specification {
         compileReleaseCpp.debuggable
         compileReleaseCpp.optimized
 
-        def linkRelease = project.tasks.linkRelease
+        def linkRelease = project.tasks.linkRelease.get()
         linkRelease instanceof LinkSharedLibrary
         linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkRelease.debuggable
@@ -162,50 +162,50 @@ class CppLibraryPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileDebug = project.tasks.compileDebugSharedCpp
+        def compileDebug = project.tasks.compileDebugSharedCpp.get()
         compileDebug instanceof CppCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug/shared")
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def linkDebug = project.tasks.linkDebugShared
+        def linkDebug = project.tasks.linkDebugShared.get()
         linkDebug instanceof LinkSharedLibrary
         linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkDebug.debuggable
 
-        def compileRelease = project.tasks.compileReleaseSharedCpp
+        def compileRelease = project.tasks.compileReleaseSharedCpp.get()
         compileRelease instanceof CppCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release/shared")
         compileRelease.debuggable
         compileRelease.optimized
 
-        def linkRelease = project.tasks.linkReleaseShared
+        def linkRelease = project.tasks.linkReleaseShared.get()
         linkRelease instanceof LinkSharedLibrary
         linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("testLib"))
         linkRelease.debuggable
 
         and:
-        def compileDebugStatic = project.tasks.compileDebugStaticCpp
+        def compileDebugStatic = project.tasks.compileDebugStaticCpp.get()
         compileDebugStatic instanceof CppCompile
         compileDebugStatic.source.files == [src] as Set
         compileDebugStatic.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug/static")
         compileDebugStatic.debuggable
         !compileDebugStatic.optimized
 
-        def createDebugStatic = project.tasks.createDebugStatic
+        def createDebugStatic = project.tasks.createDebugStatic.get()
         createDebugStatic instanceof CreateStaticLibrary
         createDebugStatic.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/static/" + OperatingSystem.current().getStaticLibraryName("testLib"))
 
-        def compileReleaseStatic = project.tasks.compileReleaseStaticCpp
+        def compileReleaseStatic = project.tasks.compileReleaseStaticCpp.get()
         compileReleaseStatic instanceof CppCompile
         compileReleaseStatic.source.files == [src] as Set
         compileReleaseStatic.objectFileDir.get().asFile == projectDir.file("build/obj/main/release/static")
         compileReleaseStatic.debuggable
         compileReleaseStatic.optimized
 
-        def createReleaseStatic = project.tasks.createReleaseStatic
+        def createReleaseStatic = project.tasks.createReleaseStatic.get()
         createReleaseStatic instanceof CreateStaticLibrary
         createReleaseStatic.binaryFile.get().asFile == projectDir.file("build/lib/main/release/static/" + OperatingSystem.current().getStaticLibraryName("testLib"))
     }
@@ -224,25 +224,25 @@ class CppLibraryPluginTest extends Specification {
         project.tasks.withType(LinkSharedLibrary).empty
 
         and:
-        def compileDebug = project.tasks.compileDebugCpp
+        def compileDebug = project.tasks.compileDebugCpp.get()
         compileDebug instanceof CppCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug")
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def createDebug = project.tasks.createDebug
+        def createDebug = project.tasks.createDebug.get()
         createDebug instanceof CreateStaticLibrary
         createDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getStaticLibraryName("testLib"))
 
-        def compileRelease = project.tasks.compileReleaseCpp
+        def compileRelease = project.tasks.compileReleaseCpp.get()
         compileRelease instanceof CppCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release")
         compileRelease.debuggable
         compileRelease.optimized
 
-        def createRelease = project.tasks.createRelease
+        def createRelease = project.tasks.createRelease.get()
         createRelease instanceof CreateStaticLibrary
         createRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getStaticLibraryName("testLib"))
     }
@@ -298,7 +298,7 @@ class CppLibraryPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def zip = project.tasks.cppHeaders
+        def zip = project.tasks.cppHeaders.get()
         zip instanceof Zip
     }
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftApplicationPluginTest.groovy
@@ -78,7 +78,7 @@ class SwiftApplicationPluginTest extends Specification {
         project.tasks.withType(SwiftCompile)*.name == ['compileDebugSwift', 'compileReleaseSwift']
 
         and:
-        def compileDebug = project.tasks.compileDebugSwift
+        def compileDebug = project.tasks.compileDebugSwift.get()
         compileDebug instanceof SwiftCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug")
@@ -86,17 +86,17 @@ class SwiftApplicationPluginTest extends Specification {
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def linkDebug = project.tasks.linkDebug
+        def linkDebug = project.tasks.linkDebug.get()
         linkDebug instanceof LinkExecutable
         linkDebug.linkedFile.get().asFile == projectDir.file("build/exe/main/debug/" + OperatingSystem.current().getExecutableName("TestApp"))
         linkDebug.debuggable
 
-        def installDebug = project.tasks.installDebug
+        def installDebug = project.tasks.installDebug.get()
         installDebug instanceof InstallExecutable
         installDebug.installDirectory.get().asFile == projectDir.file("build/install/main/debug")
         installDebug.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("TestApp")
 
-        def compileRelease = project.tasks.compileReleaseSwift
+        def compileRelease = project.tasks.compileReleaseSwift.get()
         compileRelease instanceof SwiftCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release")
@@ -104,12 +104,12 @@ class SwiftApplicationPluginTest extends Specification {
         compileRelease.debuggable
         compileRelease.optimized
 
-        def linkRelease = project.tasks.linkRelease
+        def linkRelease = project.tasks.linkRelease.get()
         linkRelease instanceof LinkExecutable
         linkRelease.linkedFile.get().asFile == projectDir.file("build/exe/main/release/" + OperatingSystem.current().getExecutableName("TestApp"))
         linkRelease.debuggable
 
-        def installRelease = project.tasks.installRelease
+        def installRelease = project.tasks.installRelease.get()
         installRelease instanceof InstallExecutable
         installRelease.installDirectory.get().asFile == projectDir.file("build/install/main/release")
         installRelease.runScriptFile.get().getAsFile().name == OperatingSystem.current().getScriptName("TestApp")

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftLibraryPluginTest.groovy
@@ -124,7 +124,7 @@ class SwiftLibraryPluginTest extends Specification {
         project.tasks.withType(CreateStaticLibrary).empty
 
         and:
-        def compileDebug = project.tasks.compileDebugSwift
+        def compileDebug = project.tasks.compileDebugSwift.get()
         compileDebug instanceof SwiftCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug")
@@ -132,12 +132,12 @@ class SwiftLibraryPluginTest extends Specification {
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def linkDebug = project.tasks.linkDebug
+        def linkDebug = project.tasks.linkDebug.get()
         linkDebug instanceof LinkSharedLibrary
         linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkDebug.debuggable
 
-        def compileRelease = project.tasks.compileReleaseSwift
+        def compileRelease = project.tasks.compileReleaseSwift.get()
         compileRelease instanceof SwiftCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release")
@@ -145,7 +145,7 @@ class SwiftLibraryPluginTest extends Specification {
         compileRelease.debuggable
         compileRelease.optimized
 
-        def linkRelease = project.tasks.linkRelease
+        def linkRelease = project.tasks.linkRelease.get()
         linkRelease instanceof LinkSharedLibrary
         linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkRelease.debuggable
@@ -161,7 +161,7 @@ class SwiftLibraryPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileDebug = project.tasks.compileDebugSharedSwift
+        def compileDebug = project.tasks.compileDebugSharedSwift.get()
         compileDebug instanceof SwiftCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug/shared")
@@ -169,12 +169,12 @@ class SwiftLibraryPluginTest extends Specification {
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def linkDebug = project.tasks.linkDebugShared
+        def linkDebug = project.tasks.linkDebugShared.get()
         linkDebug instanceof LinkSharedLibrary
         linkDebug.linkedFile.get().asFile == projectDir.file("build/lib/main/debug/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkDebug.debuggable
 
-        def compileRelease = project.tasks.compileReleaseSharedSwift
+        def compileRelease = project.tasks.compileReleaseSharedSwift.get()
         compileRelease instanceof SwiftCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release/shared")
@@ -182,13 +182,13 @@ class SwiftLibraryPluginTest extends Specification {
         compileRelease.debuggable
         compileRelease.optimized
 
-        def linkRelease = project.tasks.linkReleaseShared
+        def linkRelease = project.tasks.linkReleaseShared.get()
         linkRelease instanceof LinkSharedLibrary
         linkRelease.linkedFile.get().asFile == projectDir.file("build/lib/main/release/shared/" + OperatingSystem.current().getSharedLibraryName("TestLib"))
         linkRelease.debuggable
 
         and:
-        def compileDebugStatic = project.tasks.compileDebugStaticSwift
+        def compileDebugStatic = project.tasks.compileDebugStaticSwift.get()
         compileDebugStatic instanceof SwiftCompile
         compileDebugStatic.source.files == [src] as Set
         compileDebugStatic.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug/static")
@@ -196,11 +196,11 @@ class SwiftLibraryPluginTest extends Specification {
         compileDebugStatic.debuggable
         !compileDebugStatic.optimized
 
-        def createDebugStatic = project.tasks.createDebugStatic
+        def createDebugStatic = project.tasks.createDebugStatic.get()
         createDebugStatic instanceof CreateStaticLibrary
         createDebugStatic.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/static/" + OperatingSystem.current().getStaticLibraryName("TestLib"))
 
-        def compileReleaseStatic = project.tasks.compileReleaseStaticSwift
+        def compileReleaseStatic = project.tasks.compileReleaseStaticSwift.get()
         compileReleaseStatic instanceof SwiftCompile
         compileReleaseStatic.source.files == [src] as Set
         compileReleaseStatic.objectFileDir.get().asFile == projectDir.file("build/obj/main/release/static")
@@ -208,7 +208,7 @@ class SwiftLibraryPluginTest extends Specification {
         compileReleaseStatic.debuggable
         compileReleaseStatic.optimized
 
-        def createReleaseStatic = project.tasks.createReleaseStatic
+        def createReleaseStatic = project.tasks.createReleaseStatic.get()
         createReleaseStatic instanceof CreateStaticLibrary
         createReleaseStatic.binaryFile.get().asFile == projectDir.file("build/lib/main/release/static/" + OperatingSystem.current().getStaticLibraryName("TestLib"))
     }
@@ -227,7 +227,7 @@ class SwiftLibraryPluginTest extends Specification {
         project.tasks.withType(LinkSharedLibrary).empty
 
         and:
-        def compileDebug = project.tasks.compileDebugSwift
+        def compileDebug = project.tasks.compileDebugSwift.get()
         compileDebug instanceof SwiftCompile
         compileDebug.source.files == [src] as Set
         compileDebug.objectFileDir.get().asFile == projectDir.file("build/obj/main/debug")
@@ -235,11 +235,11 @@ class SwiftLibraryPluginTest extends Specification {
         compileDebug.debuggable
         !compileDebug.optimized
 
-        def createDebug = project.tasks.createDebug
+        def createDebug = project.tasks.createDebug.get()
         createDebug instanceof CreateStaticLibrary
         createDebug.binaryFile.get().asFile == projectDir.file("build/lib/main/debug/" + OperatingSystem.current().getStaticLibraryName("TestLib"))
 
-        def compileRelease = project.tasks.compileReleaseSwift
+        def compileRelease = project.tasks.compileReleaseSwift.get()
         compileRelease instanceof SwiftCompile
         compileRelease.source.files == [src] as Set
         compileRelease.objectFileDir.get().asFile == projectDir.file("build/obj/main/release")
@@ -247,7 +247,7 @@ class SwiftLibraryPluginTest extends Specification {
         compileRelease.debuggable
         compileRelease.optimized
 
-        def createRelease = project.tasks.createRelease
+        def createRelease = project.tasks.createRelease.get()
         createRelease instanceof CreateStaticLibrary
         createRelease.binaryFile.get().asFile == projectDir.file("build/lib/main/release/" + OperatingSystem.current().getStaticLibraryName("TestLib"))
     }

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/GeneratedSourcesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/sourceset/GeneratedSourcesIntegrationTest.groovy
@@ -79,7 +79,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                c.generatedBy tasks.generateCSources
+                c.generatedBy tasks.generateCSources.get()
             }
         }
     }
@@ -108,7 +108,7 @@ model {
     components { comp ->
         headersOnly(NativeLibrarySpec) {
             sources {
-                c.generatedBy tasks.generateCSources
+                c.generatedBy tasks.generateCSources.get()
             }
         }
         main(NativeExecutableSpec) {
@@ -141,7 +141,7 @@ model {
         main(NativeExecutableSpec) {
             sources {
                 generatedC(CSourceSet) {
-                    generatedBy tasks.generateCSources
+                    generatedBy tasks.generateCSources.get()
                 }
                 c.lib sources.generatedC
             }
@@ -176,7 +176,7 @@ model {
         hello(NativeLibrarySpec) {
             sources {
                 c {
-                    generatedBy tasks.generateCSources
+                    generatedBy tasks.generateCSources.get()
                 }
             }
         }
@@ -214,7 +214,7 @@ model {
         hello(NativeLibrarySpec) {
             sources {
                 c {
-                    generatedBy tasks.generateCSources
+                    generatedBy tasks.generateCSources.get()
                 }
             }
         }
@@ -247,7 +247,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                cpp.generatedBy tasks.generateCppSources
+                cpp.generatedBy tasks.generateCppSources.get()
             }
         }
     }
@@ -283,7 +283,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                asm.generatedBy tasks.generateAsmSources
+                asm.generatedBy tasks.generateAsmSources.get()
             }
         }
     }
@@ -318,7 +318,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                rc.generatedBy tasks.generateRcSources
+                rc.generatedBy tasks.generateRcSources.get()
             }
         }
     }
@@ -341,7 +341,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                c.generatedBy tasks.generateSources
+                c.generatedBy tasks.generateSources.get()
             }
         }
     }
@@ -407,7 +407,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                c.generatedBy tasks.lateConfiguredGenerator
+                c.generatedBy tasks.lateConfiguredGenerator.get()
             }
         }
     }
@@ -440,7 +440,7 @@ model {
     components {
         main(NativeExecutableSpec) {
             sources {
-                c.generatedBy tasks.generateCSources
+                c.generatedBy tasks.generateCSources.get()
             }
         }
     }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/plugins/NativeComponentPluginTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/plugins/NativeComponentPluginTest.groovy
@@ -58,7 +58,7 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def testExecutable = binaries.testExecutable
-        with(project.tasks.linkTestExecutable) {
+        with(project.tasks.linkTestExecutable.get()) {
             it instanceof LinkExecutable
             it == testExecutable.tasks.link
             it.toolChain.get() == testExecutable.toolChain
@@ -67,11 +67,11 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         }
 
         and:
-        def lifecycleTask = project.tasks.testExecutable
+        def lifecycleTask = project.tasks.testExecutable.get()
         lifecycleTask TaskDependencyMatchers.dependsOn("linkTestExecutable")
 
         and:
-        project.tasks.installTestExecutable instanceof InstallExecutable
+        project.tasks.installTestExecutable.get() instanceof InstallExecutable
     }
 
     def "creates link task and static archive task for library"() {
@@ -88,7 +88,7 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         def sharedLibraryBinary = binaries.testSharedLibrary
-        with(project.tasks.linkTestSharedLibrary) {
+        with(project.tasks.linkTestSharedLibrary.get()) {
             it instanceof LinkSharedLibrary
             it == sharedLibraryBinary.tasks.link
             it.toolChain.get() == sharedLibraryBinary.toolChain
@@ -97,12 +97,12 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         }
 
         and:
-        def sharedLibTask = project.tasks.testSharedLibrary
+        def sharedLibTask = project.tasks.testSharedLibrary.get()
         sharedLibTask TaskDependencyMatchers.dependsOn("linkTestSharedLibrary")
 
         and:
         def staticLibraryBinary = binaries.testStaticLibrary
-        with(project.tasks.createTestStaticLibrary) {
+        with(project.tasks.createTestStaticLibrary.get()) {
             it instanceof CreateStaticLibrary
             it == staticLibraryBinary.tasks.createStaticLib
             it.toolChain.get() == staticLibraryBinary.toolChain
@@ -111,7 +111,7 @@ class NativeComponentPluginTest extends AbstractProjectBuilderSpec {
         }
 
         and:
-        def staticLibTask = project.tasks.testStaticLibrary
+        def staticLibTask = project.tasks.testStaticLibrary.get()
         staticLibTask TaskDependencyMatchers.dependsOn("createTestStaticLibrary")
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginPublishingIntegrationTest.groovy
@@ -168,10 +168,10 @@ class JavaGradlePluginPluginPublishingIntegrationTest extends AbstractIntegratio
             publishing {
                 publications {
                     pluginMaven(MavenPublication) {
-                        artifact sourceJar
+                        artifact sourceJar.get()
                     }
                     pluginIvy(IvyPublication) {
-                        artifact sourceJar
+                        artifact sourceJar.get()
                     }
                 }
             }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
@@ -56,7 +56,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.pluginManager.apply(DistributionPlugin)
 
         then:
-        def task = project.tasks.distZip
+        def task = project.tasks.distZip.get()
         task instanceof Zip
         task.archivePath == project.file("build/distributions/test-project.zip")
     }
@@ -67,7 +67,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.distributions.create('custom')
 
         then:
-        def task = project.tasks.customDistZip
+        def task = project.tasks.customDistZip.get()
         task instanceof Zip
         task.archivePath == project.file("build/distributions/test-project-custom.zip")
     }
@@ -77,7 +77,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.pluginManager.apply(DistributionPlugin)
 
         then:
-        def task = project.tasks.distTar
+        def task = project.tasks.distTar.get()
         task instanceof Tar
         task.archivePath == project.file("build/distributions/test-project.tar")
     }
@@ -88,7 +88,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.distributions.create('custom')
 
         then:
-        def task = project.tasks.customDistTar
+        def task = project.tasks.customDistTar.get()
         task instanceof Tar
         task.archivePath == project.file("build/distributions/test-project-custom.tar")
     }
@@ -99,7 +99,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.distributions.create('custom')
 
         then:
-        def task = project.tasks.assembleCustomDist
+        def task = project.tasks.assembleCustomDist.get()
         task instanceof DefaultTask
         task TaskDependencyMatchers.dependsOn ("customDistZip","customDistTar")
     }
@@ -121,7 +121,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.pluginManager.apply(DistributionPlugin)
 
         then:
-        def task = project.installDist
+        def task = project.installDist.get()
         task instanceof Sync
         task.destinationDir == project.file("build/install/test-project")
     }
@@ -132,7 +132,7 @@ class DistributionPluginTest extends AbstractProjectBuilderSpec {
         project.distributions.create('custom')
 
         then:
-        def task = project.installCustomDist
+        def task = project.installCustomDist.get()
         task instanceof Sync
         task.destinationDir == project.file("build/install/test-project-custom")
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -174,15 +174,15 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
         set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
 
-        def processResources = project.tasks.processResources
+        def processResources = project.tasks.processResources.get()
         processResources.description == "Processes main resources."
         processResources instanceof Copy
 
-        def compileJava = project.tasks.compileJava
+        def compileJava = project.tasks.compileJava.get()
         compileJava.description == "Compiles main Java source."
         compileJava instanceof JavaCompile
 
-        def classes = project.tasks.classes
+        def classes = project.tasks.classes.get()
         classes.description == "Assembles main classes."
         TaskDependencyMatchers.dependsOn('processResources', 'compileJava').matches(classes)
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
@@ -41,7 +41,7 @@ class JavaLibraryDistributionPluginTest extends AbstractProjectBuilderSpec {
         project.pluginManager.apply(JavaLibraryDistributionPlugin)
 
         then:
-        def task = project.tasks.distZip
+        def task = project.tasks.distZip.get()
         task instanceof Zip
         task.archiveName == "test-project.zip"
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryPluginTest.groovy
@@ -189,13 +189,13 @@ class JavaLibraryPluginTest extends AbstractProjectBuilderSpec {
             implementation internalProject
         }
 
-        def task = project.tasks.compileJava
+        def task = project.tasks.compileJava.get()
 
         then:
         task.taskDependencies.getDependencies(task)*.path as Set == [":common:$producingTask", ":tools:$producingTask"] as Set<String>
 
         when:
-        task = commonProject.tasks.compileJava
+        task = commonProject.tasks.compileJava.get()
 
         then:
         task.taskDependencies.getDependencies(task)*.path as Set == [":tools:$producingTask", ":internal:$producingTask"] as Set<String>

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/InMemoryPgpSignatoryProviderIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/InMemoryPgpSignatoryProviderIntegrationSpec.groovy
@@ -26,7 +26,7 @@ class InMemoryPgpSignatoryProviderIntegrationSpec extends SigningIntegrationSpec
         buildFile << """
             signing {
                 useInMemoryPgpKeys(project.properties['secretKey'], project.properties['password'])
-                sign(jar)
+                sign(jar.get())
             }
         """
 
@@ -51,7 +51,7 @@ class InMemoryPgpSignatoryProviderIntegrationSpec extends SigningIntegrationSpec
                 signatories {
                     custom(project.properties['secretKey'], project.properties['password'])
                 }
-                sign(jar)*.signatory = signatories.custom
+                sign(jar.get())*.signatory = signatories.custom
             }
         """
 
@@ -73,7 +73,7 @@ class InMemoryPgpSignatoryProviderIntegrationSpec extends SigningIntegrationSpec
         buildFile << """
             signing {
                 useInMemoryPgpKeys(project.properties['secretKey'], '')
-                sign(jar)
+                sign(jar.get())
             }
         """
 
@@ -95,7 +95,7 @@ class InMemoryPgpSignatoryProviderIntegrationSpec extends SigningIntegrationSpec
         buildFile << """
             signing {
                 useInMemoryPgpKeys(project.properties['keyId'], project.properties['secretKey'], project.properties['password'])
-                sign(jar)
+                sign(jar.get())
             }
         """
 

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/NoSigningCredentialsIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class NoSigningCredentialsIntegrationSpec extends SigningIntegrationSpec {
         when:
         buildFile << """
             signing {
-                sign jar
+                sign jar.get()
             }
         """
 

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsWithGpgCmdIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsWithGpgCmdIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class SigningConfigurationsWithGpgCmdIntegrationSpec extends SigningConfiguratio
             ${keyInfo.addAsPropertiesScript()}
             signing {
                 useGpgCmd()
-                sign(jar)
+                sign(jar.get())
                 signatories = new ${GnupgSignatoryProvider.name}()
             }
         """

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -132,14 +132,14 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
             ${keyInfo.addAsPropertiesScript()}
 
             task customJar(type:Jar) {
-                with jar
+                with jar.get()
                 archiveClassifier = 'custom'
             }
 
             publishing {
                 publications {
                     custom(MavenPublication) {
-                        artifact customJar
+                        artifact customJar.get()
                     }
                 }
             }
@@ -329,7 +329,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
                     ivyJava(IvyPublication) {
                         from components.java
                         module '$artifactId'
-                        artifact(sourceJar) {
+                        artifact(sourceJar.get()) {
                             type "source"
                             conf "compile"
                         }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
             signing {
                 ${signingConfiguration()}
-                sign jar
+                sign jar.get()
             }
         """
 
@@ -63,7 +63,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
             signing {
                 ${signingConfiguration()}
-                sign jar, javadocJar, sourcesJar
+                sign jar.get(), javadocJar.get(), sourcesJar.get()
             }
         """
 
@@ -94,7 +94,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
             ${keyInfo.addAsPropertiesScript()}
             signing {
                 ${signingConfiguration()}
-                sign(jar)
+                sign(jar.get())
             }
         """
 
@@ -134,7 +134,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
             ${keyInfo.addAsPropertiesScript()}
             signing {
                 ${signingConfiguration()}
-                sign(jar)
+                sign(jar.get())
             }
         """
 
@@ -274,7 +274,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
         buildFile << """
             signing {
                 ${signingConfiguration()}
-                sign clean
+                sign clean.get()
             }
         """
 
@@ -293,7 +293,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
             signing {
                 ${signingConfiguration()}
-                sign jar
+                sign jar.get()
             }
 
             jar {
@@ -320,7 +320,7 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
             ${getKeyInfo("subkey").addAsPropertiesScript()}
 
             signing {
-                sign jar
+                sign jar.get()
             }
         """
 

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningPublicationsSpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningPublicationsSpec.groovy
@@ -53,7 +53,7 @@ class SigningPublicationsSpec extends SigningProjectSpec {
         tasks.findByName('signAnotherPublication') != null
 
         and:
-        signTasks == [signMavenPublication, signAnotherPublication]
+        signTasks == [signMavenPublication.get(), signAnotherPublication.get()]
     }
 
     def "publication removed from container after signing is specified"() {

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
@@ -28,17 +28,17 @@ class SigningTasksSpec extends SigningProjectSpec {
 
         when:
         signing {
-            sign jar
-            sign sourcesJar, javadocJar
+            sign jar.get()
+            sign sourcesJar.get(), javadocJar.get()
         }
 
         then:
         def signingTasks = [signJar, signSourcesJar, signJavadocJar]
 
         and:
-        jar in signJar.dependsOn
-        sourcesJar in signSourcesJar.dependsOn
-        javadocJar in signJavadocJar.dependsOn
+        jar.get() in signJar.dependsOn
+        sourcesJar.get() in signSourcesJar.dependsOn
+        javadocJar.get() in signJavadocJar.dependsOn
 
         and:
         signingTasks.every { it.singleSignature in configurations.signatures.artifacts }
@@ -52,13 +52,13 @@ class SigningTasksSpec extends SigningProjectSpec {
         useJavadocAndSourceJars()
 
         when:
-        def signJarTask = signing.sign(jar).first()
+        def signJarTask = signing.sign(jar.get()).first()
 
         then:
         signJarTask.name == "signJar"
 
         when:
-        def (signSourcesJarTask, signJavadocJarTask) = signing.sign(sourcesJar, javadocJar)
+        def (signSourcesJarTask, signJavadocJarTask) = signing.sign(sourcesJar.get(), javadocJar.get())
 
         then:
         [signSourcesJarTask, signJavadocJarTask]*.name == ["signSourcesJar", "signJavadocJar"]
@@ -72,7 +72,7 @@ class SigningTasksSpec extends SigningProjectSpec {
         createJarTaskOutputFile('jar')
 
         when:
-        Sign signTask = signing.sign(jar).first()
+        Sign signTask = signing.sign(jar.get()).first()
 
         then:
         def libsDir = jar.outputs.files.singleFile.parentFile
@@ -86,7 +86,7 @@ class SigningTasksSpec extends SigningProjectSpec {
         addSigningProperties()
 
         when:
-        Sign signTask = signing.sign(jar).first()
+        Sign signTask = signing.sign(jar.get()).first()
         jar.enabled = false
 
         then:
@@ -101,7 +101,7 @@ class SigningTasksSpec extends SigningProjectSpec {
         createJarTaskOutputFile('jar')
 
         when:
-        Sign signTask = signing.sign(jar).first()
+        Sign signTask = signing.sign(jar.get()).first()
         signTask.sign('', jar.outputs.files.singleFile) // add jar task output again, this time directly as File
 
         then:
@@ -116,7 +116,7 @@ class SigningTasksSpec extends SigningProjectSpec {
 
         when:
         signing {
-            sign jar, sourcesJar
+            sign jar.get(), sourcesJar.get()
         }
 
         then:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -41,6 +41,7 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
                 println "Property from task again: $name"
               }
             }
+            tasks.test // realize the task
         '''
 
         when:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGSuiteIntegrationTest.groovy
@@ -41,7 +41,7 @@ class TestNGSuiteIntegrationTest extends MultiVersionIntegrationSpec {
                 println "Property from task again: $name"
               }
             }
-            tasks.test // realize the task
+            tasks.test.get() // realize the task
         '''
 
         when:

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPluginTest.groovy
@@ -109,19 +109,19 @@ class CppUnitTestPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileCpp = project.tasks.compileTestCpp
+        def compileCpp = project.tasks.compileTestCpp.get()
         compileCpp instanceof CppCompile
         compileCpp.source.files == [src] as Set
         compileCpp.objectFileDir.get().asFile == projectDir.file("build/obj/test")
         compileCpp.debuggable
         !compileCpp.optimized
 
-        def link = project.tasks.linkTest
+        def link = project.tasks.linkTest.get()
         link instanceof LinkExecutable
         link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("someAppTest"))
         link.debuggable
 
-        def install = project.tasks.installTest
+        def install = project.tasks.installTest.get()
         install instanceof InstallExecutable
         install.installDirectory.get().asFile == project.file("build/install/test")
         install.runScriptFile.get().asFile.name == OperatingSystem.current().getScriptName("someAppTest")

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPluginTest.groovy
@@ -135,24 +135,24 @@ class XCTestConventionPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileSwift = project.tasks.compileTestSwift
+        def compileSwift = project.tasks.compileTestSwift.get()
         compileSwift instanceof SwiftCompile
         compileSwift.source.files == [src] as Set
         compileSwift.objectFileDir.get().asFile == projectDir.file("build/obj/test")
         compileSwift.debuggable
         !compileSwift.optimized
 
-        def link = project.tasks.linkTest
+        def link = project.tasks.linkTest.get()
         link instanceof LinkMachOBundle
         link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
-        def install = project.tasks.installTest
+        def install = project.tasks.installTest.get()
         install instanceof InstallXCTestBundle
         install.installDirectory.get().asFile == project.file("build/install/test")
         install.runScriptFile.get().asFile.name == OperatingSystem.current().getScriptName("TestAppTest")
 
-        def test = project.tasks.xcTest
+        def test = project.tasks.xcTest.get()
         test instanceof XCTest
         test.workingDirectory.get().asFile == projectDir.file("build/install/test")
     }
@@ -167,24 +167,24 @@ class XCTestConventionPluginTest extends Specification {
         project.evaluate()
 
         then:
-        def compileSwift = project.tasks.compileTestSwift
+        def compileSwift = project.tasks.compileTestSwift.get()
         compileSwift instanceof SwiftCompile
         compileSwift.source.files == [src] as Set
         compileSwift.objectFileDir.get().asFile == projectDir.file("build/obj/test")
         compileSwift.debuggable
         !compileSwift.optimized
 
-        def link = project.tasks.linkTest
+        def link = project.tasks.linkTest.get()
         link instanceof LinkExecutable
         link.linkedFile.get().asFile == projectDir.file("build/exe/test/" + OperatingSystem.current().getExecutableName("TestAppTest"))
         link.debuggable
 
-        def install = project.tasks.installTest
+        def install = project.tasks.installTest.get()
         install instanceof InstallExecutable
         install.installDirectory.get().asFile == project.file("build/install/test")
         install.runScriptFile.get().asFile.name == OperatingSystem.current().getScriptName("TestAppTest")
 
-        def test = project.tasks.xcTest
+        def test = project.tasks.xcTest.get()
         test instanceof XCTest
         test.workingDirectory.get().asFile == projectDir.file("build/install/test")
     }


### PR DESCRIPTION
(Proposal, WiP)

See: #15720

These four options could be consider to address  #15720:

## Options

1. Do nothing
2. Only make configuration with closure - `tasks.a { }` - respect configuration avoidance
3. In addition, make property access - `task.a` - respect configuration avoidance (return task provider)
4. In addition, make `task.a.taskPropertyOrMethod` automatically realize the task and delegate to the property (for backwards compatibility) 

This draft PR does (2) in the first (3) in the second and (4) in the third commit. Doing only (1), did require almost no adjustment to any test to [pass the pipeline](https://builds.gradle.org/buildConfiguration/Gradle_Check_Stage_ReadyforMerge_Trigger/41091285).

## How/why does the proposals solve the issues we currently have?

- Groovy and Kotlin DSL are not aligned:
   With (1) we'll keep this for at least another year. With (2) we'll make it slightly more aligned, but not completely. (3) or (4) would make for a nice alignment.
- Using task configuration avoidance in Groovy is clunky because you need to use `tasks.named('a') {}` instead of the shorter notation `tasks.a {}`. This is solved with (2) already. (3) or (4) is not that important in this context as the most common way is to access and configure the task (provider) directly.

## What do the proposals break?

- If going with (2), the only thing that changes is the evaluation order of tasks. Which only plays a role if you do things you shouldn't do. And also won't be able to do anymore if you use configuration cache. For example:

 ```
def a = 0
tasks.test {
   a = 1
}
println(a) // after the change, this prints '0', before it would print '1'
```

- If going with (4), in addition to the above, all places would break that, in dynamic Groovy, still strongly rely on the type `Task`. E.g.:

```
Task t = tasks.test // breaks, now of type TaskProvider; replace with tasks.test.get()

(Test) tasks.test // breaks,  now of type TaskProvider; replace with tasks.test.get()

signing.sign(jar) // breaks as method expects a Task, replace with signing.sign(jar.get()) 
```

- If we would _only_ go with (3) accessing task details through a provider would also break:

```
tasks.test.useJUnitPlatform()
```

Since the change only affects dynamic Groovy, statically compiled plugins (Groovy or other languages) are not affected as they were never able to use these "task accessors" in the first place.

Other methods to access the task will stay eager. As they are also eager in Kotlin DSL. So if we do this change, a Groovy DSL user that actually needs the realized task object, has a couple of options to replace `tasks.a` with:
- tasks["a"]
- tasks.getByName["a"]
- tasks.a.get()

