### PR TITLE
Upgradlew to latest nightly following the Kotlin upgrade to 1.4.30

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -12,6 +12,6 @@ kotlinDslPluginOptions.experimentalWarning.set(false)
 dependencies {
     implementation(project(":code-quality"))
 
-    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.0.0")
+    implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.1.0")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.6.0")
 }

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
@@ -28,26 +28,20 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.config.AnalysisFlag
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.JvmAnalysisFlags
 import org.jetbrains.kotlin.config.JvmTarget
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.utils.JavaTypeEnhancementState
 import org.jetbrains.kotlin.utils.PathUtil
 
 
 import java.io.File
-
-import kotlin.reflect.KProperty1
-import kotlin.reflect.full.companionObject
-import kotlin.reflect.full.companionObjectInstance
-import kotlin.reflect.full.memberProperties
 
 
 class KotlinSourceParser {
@@ -118,7 +112,9 @@ class KotlinSourceParser {
             LanguageVersionSettingsImpl(
                 languageVersion = LanguageVersion.KOTLIN_1_4,
                 apiVersion = ApiVersion.KOTLIN_1_4,
-                analysisFlags = mapOf(strictJsr305AnalysisFlag)
+                analysisFlags = mapOf(
+                    JvmAnalysisFlags.javaTypeEnhancementState to JavaTypeEnhancementState.STRICT
+                )
             )
         )
 
@@ -126,25 +122,6 @@ class KotlinSourceParser {
         put(JVMConfigurationKeys.SKIP_RUNTIME_VERSION_CHECK, true)
         put(JVMConfigurationKeys.JVM_TARGET, JvmTarget.JVM_1_8)
     }
-
-    /**
-     * Temporary compatibility with Kotlin 1.4.20 / 1.4.30.
-     */
-    private
-    val strictJsr305AnalysisFlag: Pair<AnalysisFlag<*>, Any?>
-        get() {
-            val kotlinOneDotThirty = KotlinCompilerVersion.VERSION.startsWith("1.4.3")
-            val (flagName, valueTypeName) = when {
-                kotlinOneDotThirty -> "javaTypeEnhancementState" to "org.jetbrains.kotlin.utils.JavaTypeEnhancementState"
-                else -> "jsr305" to "org.jetbrains.kotlin.utils.Jsr305State"
-            }
-            val flags = JvmAnalysisFlags::class.objectInstance!!
-            val flag = JvmAnalysisFlags::class.memberProperties.single { it.name == flagName }.get(flags) as AnalysisFlag<*>
-            val valueType = Class.forName(valueTypeName).kotlin
-            @Suppress("UNCHECKED_CAST") val valueProperty = valueType.companionObject!!.memberProperties.single { it.name == "STRICT" } as KProperty1<Any, *>
-            val value = valueProperty.getValue(valueType.companionObjectInstance!!, valueProperty)
-            return flag to value
-        }
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210202135711+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210204175406+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
@@ -536,7 +536,7 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         // workaround to use Kotlin precompiled script plugin because Groovy version does not support pluginManagement {} in settings plugins (https://github.com/gradle/gradle/issues/15416)
         settingsPluginBuild.buildFile.setText("""
             plugins {
-                id("org.gradle.kotlin.kotlin-dsl") version "2.0.0"
+                id("org.gradle.kotlin.kotlin-dsl") version "2.1.0"
             }
             repositories {
                 gradlePluginPortal()


### PR DESCRIPTION
Upgrade the wrapper.
Update the `kotlin-dsl` plugin version used in `:build-logic`.
Remove temporary hacky backwards compatibility with 1.4.20 on internal kotlin compiler usage in `:build-logic`.
