### PR TITLE
Split docs subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /*/docs/src/samples/**/build
 /*/docs/src/snippets/**/build
 /*/internal-android-performance-testing/build-android-libs
+test-splits/
 
 # IDEA
 # ----

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.split-docs.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.split-docs.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gradlebuild.integrationtests.getBucketProvider
+import org.gradle.api.tasks.testing.Test
+
+afterEvaluate {
+    tasks.named<Test>("docsTest") {
+        getBucketProvider().get().bucketProvider.configureTest(this, "docsTest")
+    }
+}

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.split-docs.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.split-docs.gradle.kts
@@ -17,8 +17,6 @@
 import gradlebuild.integrationtests.getBucketProvider
 import org.gradle.api.tasks.testing.Test
 
-afterEvaluate {
-    tasks.named<Test>("docsTest") {
-        getBucketProvider().get().bucketProvider.configureTest(this, "docsTest")
-    }
+tasks.named<Test>("docsTest") {
+    getBucketProvider().get().bucketProvider.configureTest(this, "docsTest")
 }

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -532,6 +532,7 @@ tasks.named("docsTest") { task ->
         excludeTestsMatching '*java-modules-multi-project-with-integration-tests_kotlin_testTask*'
         excludeTestsMatching '*structuring-software-projects*'
     }
+    project.getBucketProvider().get().bucketProvider.configureTest(task, "docsTest")
 }
 
 // Publications for the docs subproject:

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'org.asciidoctor.jvm.convert'
     id 'gradlebuild.documentation'
     id 'gradlebuild.generate-samples'
+    id 'gradlebuild.split-docs'
 }
 
 repositories { handler ->
@@ -532,7 +533,6 @@ tasks.named("docsTest") { task ->
         excludeTestsMatching '*java-modules-multi-project-with-integration-tests_kotlin_testTask*'
         excludeTestsMatching '*structuring-software-projects*'
     }
-    project.getBucketProvider().get().bucketProvider.configureTest(task, "docsTest")
 }
 
 // Publications for the docs subproject:


### PR DESCRIPTION
`docs` takes too long time, so we manually split `docs` subproject into 4 buckets.
