### PR TITLE
Enable -Xjvm-default=all for the Kotlin DSL

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/util/KotlinSourceParser.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.JvmAnalysisFlags
+import org.jetbrains.kotlin.config.JvmDefaultMode
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
@@ -113,7 +114,8 @@ class KotlinSourceParser {
                 languageVersion = LanguageVersion.KOTLIN_1_4,
                 apiVersion = ApiVersion.KOTLIN_1_4,
                 analysisFlags = mapOf(
-                    JvmAnalysisFlags.javaTypeEnhancementState to JavaTypeEnhancementState.STRICT
+                    JvmAnalysisFlags.javaTypeEnhancementState to JavaTypeEnhancementState.STRICT,
+                    JvmAnalysisFlags.jvmDefaultMode to JvmDefaultMode.ENABLE
                 )
             )
         )

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepository
+import org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
+import org.junit.Test
+
+
+class KotlinDslJvmDefaultIntegrationTest : AbstractPluginIntegrationTest() {
+
+    @Test
+    fun `kotlin-dsl java and groovy consumers can use kotlin interface default methods directly`() {
+
+        withSettings(
+            """
+            include("kotlin-dsl-producer")
+            include("java-consumer")
+            include("groovy-consumer")
+            """
+        )
+        withBuildScript("subprojects { ${mavenCentralRepository(KOTLIN)} }")
+
+        withBuildScriptIn("kotlin-dsl-producer", "plugins { `kotlin-dsl` }")
+        withFile(
+            "kotlin-dsl-producer/src/main/kotlin/some/Some.kt",
+            """
+            package some
+            interface Some { fun some() = Unit }
+            """
+        )
+
+        withBuildScriptIn(
+            "java-consumer",
+            """
+            plugins { `java-library` }
+            dependencies { implementation(project(":kotlin-dsl-producer")) }
+            """
+        )
+        withFile(
+            "java-consumer/src/main/java/jc/SomeJava.java",
+            """
+            package jc;
+            class SomeJava implements some.Some {
+                public static void main(String[] args) {
+                    new SomeJava().some();
+                }
+            }
+            """
+        )
+
+        withBuildScriptIn(
+            "groovy-consumer",
+            """
+            plugins { `groovy` }
+            dependencies { implementation(project(":kotlin-dsl-producer")) }
+            """
+        )
+        withFile(
+            "java-consumer/src/main/groovy/gc/SomeGroovy.groovy",
+            """
+            package gc;
+            class SomeGroovy implements some.Some {
+                public static void main(String[] args) {
+                    new SomeGroovy().some();
+                }
+            }
+            """
+        )
+
+        build("classes")
+    }
+}

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinDslJvmDefaultIntegrationTest.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.integration
 
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepository
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 import org.hamcrest.MatcherAssert.assertThat
@@ -26,6 +27,7 @@ import org.junit.Test
 class KotlinDslJvmDefaultIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `kotlin-dsl scripts can call and override java default methods`() {
         withKotlinBuildSrc()
         withFile(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -44,6 +44,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-language-version", "1.4",
         "-api-version", "1.4",
         "-jvm-target", "1.8",
+        "-Xjvm-default=all",
         "-Xjsr305=strict",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinInitScript.kt
@@ -64,6 +64,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-language-version", "1.4",
         "-api-version", "1.4",
         "-jvm-target", "1.8",
+        "-Xjvm-default=all",
         "-Xjsr305=strict",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinSettingsScript.kt
@@ -70,6 +70,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
         "-language-version", "1.4",
         "-api-version", "1.4",
         "-jvm-target", "1.8",
+        "-Xjvm-default=all",
         "-Xjsr305=strict",
         "-XXLanguage:+DisableCompatibilityModeForNewInference",
     ]

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslPluginSupport.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinDslPluginSupport.kt
@@ -22,6 +22,7 @@ object KotlinDslPluginSupport {
     val kotlinCompilerArgs: List<String>
         get() = listOf(
             "-java-parameters",
+            "-Xjvm-default=all",
             "-Xjsr305=strict",
             "-XXLanguage:+DisableCompatibilityModeForNewInference",
         )

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/KotlinCompiler.kt
@@ -50,6 +50,8 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.JVM_TARGET
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.OUTPUT_DIRECTORY
 import org.jetbrains.kotlin.config.JVMConfigurationKeys.RETAIN_OUTPUT_IN_MEMORY
+import org.jetbrains.kotlin.config.JvmAnalysisFlags
+import org.jetbrains.kotlin.config.JvmDefaultMode
 import org.jetbrains.kotlin.config.JvmTarget.JVM_1_8
 import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -341,7 +343,8 @@ val gradleKotlinDslLanguageVersionSettings = LanguageVersionSettingsImpl(
     languageVersion = LanguageVersion.KOTLIN_1_4,
     apiVersion = ApiVersion.KOTLIN_1_4,
     analysisFlags = mapOf(
-        AnalysisFlags.skipMetadataVersionCheck to true
+        AnalysisFlags.skipMetadataVersionCheck to true,
+        JvmAnalysisFlags.jvmDefaultMode to JvmDefaultMode.ENABLE,
     ),
     specificFeatures = mapOf(
         LanguageFeature.DisableCompatibilityModeForNewInference to LanguageFeature.State.ENABLED


### PR DESCRIPTION
See https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/

Issue https://github.com/gradle/gradle/issues/14875