### PR TITLE
Remove deprecated usage of KotlinDslPluginOptions.experimentalWarning

### DIFF
--- a/build-logic-commons/code-quality/build.gradle.kts
+++ b/build-logic-commons/code-quality/build.gradle.kts
@@ -9,8 +9,6 @@ java {
 
 group = "gradlebuild"
 
-kotlinDslPluginOptions.experimentalWarning.set(false)
-
 dependencies {
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:1.4.4")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.6.0")

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -7,8 +7,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-kotlinDslPluginOptions.experimentalWarning.set(false)
-
 dependencies {
     implementation(project(":code-quality"))
 


### PR DESCRIPTION
This has no effect now.
