### PR TITLE
Remove non-dynamic constraint on plugin versions.

### DIFF
--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -130,7 +130,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         useCustomRepository("""
             resolutionStrategy.eachPlugin {
                 if(requested.id.name == 'plugin') {
-                    useVersion("+")
+                    useVersion("x")
                 }
             }
         """)
@@ -139,7 +139,35 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("pluginTask")
 
         then:
-        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '+'] was not found")
+        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: 'x'] was not found")
+    }
+
+    def 'when version range is specified, resolution succeeds'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1.2'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useVersion("1.+")
+                }
+            }
+        """)
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
     }
 
     def 'when invalid artifact version is specified, resolution fails'() {
@@ -158,7 +186,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         useCustomRepository("""
             resolutionStrategy.eachPlugin {
                 if(requested.id.name == 'plugin') {
-                    useModule("org.example.plugin:plugin:+")
+                    useModule("org.example.plugin:plugin:x")
                 }
             }
         """)
@@ -167,7 +195,35 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("pluginTask")
 
         then:
-        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '1.2', artifact: 'org.example.plugin:plugin:+'] was not found")
+        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '1.2', artifact: 'org.example.plugin:plugin:x'] was not found")
+    }
+
+    def 'when artifact version range is specified, resolution succeeds'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1.2'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useModule("org.example.plugin:plugin:1.+")
+                }
+            }
+        """)
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
     }
 
     def 'can specify an artifact to use'() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -71,11 +71,6 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
             return;
         }
 
-        if (versionSelectorScheme.parseSelector(markerVersion).isDynamic()) {
-            result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported");
-            return;
-        }
-
         if (exists(markerDependency)) {
             handleFound(result, pluginRequest, markerDependency);
         } else {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -84,11 +84,11 @@ class ArtifactRepositoriesPluginResolverTest extends Specification {
         1 * result.found(SOURCE_NAME, _)
     }
 
-    def "fail pluginRequests with dynamic versions"() {
+    def "accept pluginRequests with dynamic versions"() {
         when:
         resolver.resolve(request("plugin", "latest.revision"), result)
 
         then:
-        1 * result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported")
+        1 * result.found(SOURCE_NAME, _)
     }
 }


### PR DESCRIPTION
Fixes #14704

### Context
This is currently blocking us from adopting the new plugins notation. We have a large set of projects that utilizes a common toolchain of Gradle plugins. By using a version of '1.0.+', we are able to update all projects and their build tools in a single step by just pushing a new patch version. Each dependent project then gets these fixes on their next build.

We are currently using the buildscript configuration with classpath dependencies that do have version ranges, which does allow us to set version ranges, and solves this for us. However, we would like to update to the more modern plugins notation.

I also believe this will benefit others, and does not adversely affect the current state of the code. Its just a check that is removed, without any logic changes. So this constraint doesn't really provide any value.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
