### PR TITLE
Temporarily capture `:build-logic-commons:code-quality` `compileClasspath`

### DIFF
--- a/.teamcity/common/extensions.kt
+++ b/.teamcity/common/extensions.kt
@@ -76,6 +76,8 @@ fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, timeout: Int = 30, vcsRoot
         build/errorLogs/** => $failedTestArtifactDestination/errorLogs
         subprojects/internal-build-reports/build/reports/incubation/all-incubating.html => incubation-reports
         build/reports/dependency-verification/** => dependency-verification-reports
+        build/reports/dependency-verification/** => dependency-verification-reports
+        build-logic-commons/code-quality/build/distributions/code-quality-compile-classpath.zip => debugging
     """.trimIndent()
 
     vcs {

--- a/build-logic-commons/code-quality/build.gradle.kts
+++ b/build-logic-commons/code-quality/build.gradle.kts
@@ -13,3 +13,19 @@ dependencies {
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:1.4.4")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.6.0")
 }
+
+tasks {
+
+    // Temporarily capture the compileClasspath so we can investigate
+    // what's going on with generateExternalPluginSpecBuilders.
+    val zipCompileClasspath by registering(Zip::class) {
+        archiveBaseName.set("code-quality-compile-classpath")
+        from(sourceSets.main.map { it.compileClasspath })
+        duplicatesStrategy = DuplicatesStrategy.WARN
+    }
+
+    generateExternalPluginSpecBuilders {
+        require(this is Task)
+        dependsOn(zipCompileClasspath)
+    }
+}


### PR DESCRIPTION
So we can debug what's going on with `generateExternalPluginSpecBuilders`.
