### PR TITLE
Name precompiled script plugin accessors package after classpath fingerprint

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -261,6 +261,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
+    @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors are available after registering plugin`() {
         withSettings(
             """

--- a/subprojects/kotlin-dsl-provider-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-provider-plugins/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":plugins"))
     implementation(project(":plugin-development"))
+    implementation(project(":snapshots"))
     implementation(project(":tooling-api"))
 
     implementation(libs.futureKotlin("scripting-compiler-impl-embeddable")) {


### PR DESCRIPTION
Instead of classpath hash to match task input snapshotting behaviour.