### PR TITLE
Add input/output location to missing task dependency message

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -26,7 +26,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             task producer {
                 def outputFile = file("${producedLocation}")
-                outputs.${producerOutput}
+                outputs.${outputType}(${producerOutput == null ? 'outputFile' : "'${producerOutput}'"})
                 doLast {
                     outputFile.parentFile.mkdirs()
                     outputFile.text = "produced"
@@ -45,20 +45,20 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", file(consumedLocation))
         then:
         succeeds("producer", "consumer")
 
         when:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", file(producerOutput ?: producedLocation))
         then:
         succeeds("consumer", "producer")
 
         where:
-        description            | producerOutput     | producedLocation           | consumedLocation
-        "same location"        | "file(outputFile)" | "output.txt"               | "output.txt"
-        "consuming ancestor"   | "file(outputFile)" | "build/dir/sub/output.txt" | "build/dir"
-        "consuming descendant" | "dir('build/dir')" | "build/dir/sub/output.txt" | "build/dir/sub/output.txt"
+        description            | producerOutput | outputType | producedLocation           | consumedLocation
+        "same location"        | null           | "file"     | "output.txt"               | "output.txt"
+        "consuming ancestor"   | null           | "file"     | "build/dir/sub/output.txt" | "build/dir"
+        "consuming descendant" | 'build/dir'    | "dir"      | "build/dir/sub/output.txt" | "build/dir/sub/output.txt"
     }
 
     def "ignores missing dependency if there is an #relation relation in the other direction"() {
@@ -193,7 +193,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", file("output.txt"))
         succeeds("producer", "consumer")
     }
 
@@ -217,7 +217,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", file("output.txt"))
         succeeds("producer", "consumer")
     }
 
@@ -270,13 +270,13 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", testDirectory)
         run("producer", "consumer")
         then:
         executedAndNotSkipped(":producer", ":consumer")
 
         when:
-        expectMissingDependencyDeprecation(":producer", ":consumer")
+        expectMissingDependencyDeprecation(":producer", ":consumer", file("build/problematic/output.txt"))
         run("consumer", "producer")
         then:
         executed(":producer", ":consumer")
@@ -313,9 +313,10 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec {
             Consider using Task.dependsOn instead of an input file collection.""".stripIndent())
     }
 
-    void expectMissingDependencyDeprecation(String producer, String consumer) {
+    void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using Task.dependsOn() or Task.mustRunAfter()) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "The location which is an input/output is '${producedConsumedLocation.absolutePath}'. " +
                 "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -469,8 +469,8 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         }
 
         when:
-        expectMissingDependencyDeprecation(":restore", ":backup")
-        expectMissingDependencyDeprecation(":backup", ":restore")
+        expectMissingDependencyDeprecation(":restore", ":backup", file('build/original'))
+        expectMissingDependencyDeprecation(":backup", ":restore", file('backup'))
         run 'backup', 'restore'
 
         then:
@@ -487,8 +487,8 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         //
         // If cleaning up stale output files does not invalidate the file system mirror, then the restore task would be up-to-date.
         invalidateBuildOutputCleanupState()
-        expectMissingDependencyDeprecation(":restore", ":backup")
-        expectMissingDependencyDeprecation(":backup", ":restore")
+        expectMissingDependencyDeprecation(":restore", ":backup", file('build/original'))
+        expectMissingDependencyDeprecation(":backup", ":restore", file('backup'))
         run 'backup', 'restore', '--info'
 
         then:
@@ -732,9 +732,10 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
-    void expectMissingDependencyDeprecation(String producer, String consumer) {
+    void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using Task.dependsOn() or Task.mustRunAfter()) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "The location which is an input/output is '${producedConsumedLocation.absolutePath}'. " +
                 "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -108,8 +108,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         }
         // Generate external jar with entries in alphabetical order
         def externalJar = file('build/libs/external.jar')
-        expectMissingDependencyDeprecation(":alphabetic", ":a:compileJava")
-        expectMissingDependencyDeprecation(":alphabetic", ":a:javadoc")
+        expectMissingDependencyDeprecation(":alphabetic", ":a:compileJava", file("build/libs/external.jar"))
+        expectMissingDependencyDeprecation(":alphabetic", ":a:javadoc", file("build/libs/external.jar"))
         succeeds("alphabetic", ":a:javadoc")
         new ZipTestFixture(externalJar).hasDescendantsInOrder('META-INF/MANIFEST.MF', 'a', 'b', 'c', 'd')
 
@@ -156,8 +156,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
             file("external/$it").touch()
         }
         // Generate external jar with entries with a current timestamp
-        expectMissingDependencyDeprecation(":currentTime", ":a:compileJava")
-        expectMissingDependencyDeprecation(":currentTime", ":a:javadoc")
+        expectMissingDependencyDeprecation(":currentTime", ":a:compileJava", file("build/libs/external.jar"))
+        expectMissingDependencyDeprecation(":currentTime", ":a:javadoc", file("build/libs/external.jar"))
         succeeds("currentTime", ":a:javadoc")
         def oldHash = externalJar.md5Hash
         when:
@@ -199,8 +199,8 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         duplicate.text = "duplicate"
 
         // Generate external jar with entries with a duplicate 'a' file
-        expectMissingDependencyDeprecation(":duplicate", ":a:compileJava")
-        expectMissingDependencyDeprecation(":duplicate", ":a:javadoc")
+        expectMissingDependencyDeprecation(":duplicate", ":a:compileJava", file("build/libs/external.jar"))
+        expectMissingDependencyDeprecation(":duplicate", ":a:javadoc", file("build/libs/external.jar"))
         succeeds("duplicate", ":a:javadoc")
         def oldHash = externalJar.md5Hash
 
@@ -259,9 +259,10 @@ class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec {
         !file("a/build/docs/javadoc/AA.html").isFile()
     }
 
-    void expectMissingDependencyDeprecation(String producer, String consumer) {
+    void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using Task.dependsOn() or Task.mustRunAfter()) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "The location which is an input/output is '${producedConsumedLocation.absolutePath}'. " +
                 "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
@@ -58,7 +58,7 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
         executer.inDirectory(dslDir)
 
         when:
-        def result = succeeds('retrieveRuntimeDependencies')
+        succeeds('retrieveRuntimeDependencies')
 
         then: "The JARs are copied to the destination directory"
         dslDir.file('build/libs/our-custom.jar').isFile()
@@ -78,8 +78,8 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
 
         when:
         // FIXME: Infer dependencies for zipTree(Provider<>)
-        expectMissingDependencyDeprecation(":javadocJarArchive", ":unpackJavadocs")
-        def result = succeeds('javadocJar', 'unpackJavadocs')
+        expectMissingDependencyDeprecation(":javadocJarArchive", ":unpackJavadocs", dslDir.file("build/libs/ant-file-deps-sample-javadoc.jar"))
+        succeeds('javadocJar', 'unpackJavadocs')
 
         then: "The HTML Javadoc files are unpacked to the 'dist' directory"
         dslDir.file('build/dist/org/example/app/HelloApp.html').isFile()
@@ -88,9 +88,10 @@ class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest {
         dsl << ['groovy', 'kotlin']
     }
 
-    void expectMissingDependencyDeprecation(String producer, String consumer) {
+    void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
         executer.expectDocumentedDeprecationWarning(
             "Task '${consumer}' uses the output of task '${producer}', without declaring an explicit dependency (using Task.dependsOn() or Task.mustRunAfter()) or an implicit dependency (declaring task '${producer}' as an input). " +
+                "The location which is an input/output is '${producedConsumedLocation.absolutePath}'. " +
                 "This can lead to incorrect results being produced, depending on what order the tasks are executed. " +
                 "This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. " +
                 "Execution optimizations are disabled due to the failed validation. " +


### PR DESCRIPTION
So it is easier to understand what is going on.

Fixes #16062 