### PR TITLE
Remove internal `org.gradle.kotlin.dsl.caching.buildcache` property

### DIFF
--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 kotlin.parallel.tasks.in.project=true
-systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ org.gradle.parallel=true
 kotlin.parallel.tasks.in.project=true
 org.gradle.caching=true
 
-systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
 systemProp.gradle.publish.skip.namespace.check=true
 
 # Temporarily force IDEs to produce build scans

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -34,7 +34,6 @@ import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
 import org.gradle.internal.execution.caching.CachingDisabledReason
-import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 import org.gradle.internal.execution.history.OverlappingOutputs
 import org.gradle.internal.execution.workspace.WorkspaceProvider
 import org.gradle.internal.file.TreeType
@@ -328,17 +327,8 @@ class CompileKotlinScript(
     private val fileCollectionFactory: FileCollectionFactory
 ) : UnitOfWork {
 
-    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> {
-        return when {
-            System.getProperty(kotlinDslBuildCacheSystemProperty, null) == "false" -> Optional.of(
-                CachingDisabledReason(
-                    CachingDisabledReasonCategory.DISABLE_CONDITION_SATISFIED,
-                    "$kotlinDslBuildCacheSystemProperty == false"
-                )
-            )
-            else -> Optional.empty()
-        }
-    }
+    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> =
+        Optional.empty()
 
     override fun visitInputs(
         visitor: UnitOfWork.InputVisitor
@@ -408,7 +398,3 @@ class CompileKotlinScript(
         }
     }
 }
-
-
-private
-const val kotlinDslBuildCacheSystemProperty = "org.gradle.kotlin.dsl.caching.buildcache"

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -33,8 +33,6 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.execution.ExecutionEngine
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.UnitOfWork.IdentityKind.IDENTITY
-import org.gradle.internal.execution.caching.CachingDisabledReason
-import org.gradle.internal.execution.history.OverlappingOutputs
 import org.gradle.internal.execution.workspace.WorkspaceProvider
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
@@ -64,7 +62,6 @@ import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.plugin.management.internal.PluginRequests
 import org.gradle.plugin.use.internal.PluginRequestApplicator
 import java.io.File
-import java.util.Optional
 
 
 interface KotlinScriptEvaluator {
@@ -326,9 +323,6 @@ class CompileKotlinScript(
     private val workspaceProvider: KotlinDslWorkspaceProvider,
     private val fileCollectionFactory: FileCollectionFactory
 ) : UnitOfWork {
-
-    override fun shouldDisableCaching(detectedOverlappingOutputs: OverlappingOutputs?): Optional<CachingDisabledReason> =
-        Optional.empty()
 
     override fun visitInputs(
         visitor: UnitOfWork.InputVisitor

--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
@@ -16,10 +16,6 @@
 
 package org.gradle.kotlin.dsl.caching
 
-import org.gradle.kotlin.dsl.caching.fixtures.CachedScript
-import org.gradle.kotlin.dsl.caching.fixtures.cachedBuildFile
-import org.gradle.kotlin.dsl.caching.fixtures.cachedSettingsFile
-import org.gradle.kotlin.dsl.caching.fixtures.compilationCache
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
 
 import org.hamcrest.CoreMatchers.containsString
@@ -55,84 +51,6 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
         build("--scan", "--build-cache", "-Dscan.dump").apply {
             assertThat(output, containsString("Build scan written to"))
-        }
-    }
-
-    @Test
-    fun `build cache integration can be disabled via system property`() {
-
-        val buildCacheDir = existing("build-cache")
-
-        val expectedOutput = "***42***"
-
-        fun cloneProject(): Pair<CachedScript.WholeFile, CachedScript.WholeFile> {
-
-            val settingsFile =
-                withLocalBuildCacheSettings(buildCacheDir)
-
-            val buildFile = withBuildScript(
-                """
-                    plugins {
-                        java // force the generation of accessors
-                    }
-
-                    println("$expectedOutput")
-                """
-            )
-
-            return cachedSettingsFile(settingsFile, hasBody = true) to cachedBuildFile(buildFile, hasBody = true)
-        }
-
-        withProjectRoot(newDir("clone-a")) {
-
-            val (settingsFile, buildFile) = cloneProject()
-
-            // Cache miss with a fresh Gradle home, script cache will be pushed to build cache
-            executer.withGradleUserHomeDir(newDir("guh-1"))
-            buildForCacheInspection("--build-cache").apply {
-
-                compilationCache {
-                    misses(settingsFile)
-                    misses(buildFile)
-                }
-
-                assertThat(output, containsString(expectedOutput))
-            }
-        }
-
-        withProjectRoot(newDir("clone-b")) {
-
-            val (settingsFile, buildFile) = cloneProject()
-
-            // Cache hit from build cache
-            executer.withGradleUserHomeDir(newDir("guh-2"))
-            buildForCacheInspection("--build-cache").apply {
-
-                compilationCache {
-                    misses(settingsFile)
-                    hits(buildFile)
-                }
-
-                assertThat(output, containsString(expectedOutput))
-            }
-
-            // Cache miss without build cache integration (disabled via system property)
-            executer.withGradleUserHomeDir(
-                newDir("guh-3").apply {
-                    resolve("gradle.properties").writeText(
-                        "systemProp.org.gradle.kotlin.dsl.caching.buildcache=false"
-                    )
-                }
-            )
-            buildForCacheInspection("--build-cache").apply {
-
-                compilationCache {
-                    misses(settingsFile)
-                    misses(buildFile)
-                }
-
-                assertThat(output, containsString(expectedOutput))
-            }
         }
     }
 


### PR DESCRIPTION
The build cache for kotlin script compilation has been enabled by default for a while and is now considered stable.
This internal property isn't needed anymore.
