### PR TITLE
Move RC/Final release builds to release configuration only

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -3,11 +3,9 @@ package common
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
 data class VersionedSettingsBranch(val branchName: String) {
-    fun asBuildTypeId() = branchName.capitalize()
 
     companion object {
         val MASTER = VersionedSettingsBranch("master")
-        val RELEASE = VersionedSettingsBranch("release")
 
         fun fromDslContext(): VersionedSettingsBranch {
             val branch = DslContext.getParameter("Branch")

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -11,14 +11,15 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     buildType(PublishNightlySnapshot(branch))
     buildType(PublishNightlySnapshotFromQuickFeedback(branch))
     buildType(PublishBranchSnapshotFromQuickFeedback)
-    if (branch.branchName == "master") {
+    buildType(PublishMilestone(branch))
+
+    if (branch == VersionedSettingsBranch.MASTER) {
         buildType(StartReleaseCycle)
         buildType(StartReleaseCycleTest)
+    } else {
+        buildType(PublishReleaseCandidate(branch))
+        buildType(PublishFinalRelease(branch))
     }
-
-    buildType(PublishMilestone(branch))
-    buildType(PublishReleaseCandidate(branch))
-    buildType(PublishFinalRelease(branch))
 
     params {
         password("env.ORG_GRADLE_PROJECT_gradleS3SecretKey", "%gradleS3SecretKey%")

--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -16,12 +16,10 @@
 
 package promotion
 
-import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import vcsroots.gradlePromotionBranches
 
 object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistribution(
-    versionSettingsBranch = VersionedSettingsBranch.MASTER,
     promotedBranch = "%branch.to.promote%",
     triggerName = "QuickFeedback",
     task = "promoteSnapshot",

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
@@ -22,8 +22,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionMaster
 
 abstract class PublishGradleDistribution(
-    // The branch where the build pipeline comes from, usually Master/Release
-    versionSettingsBranch: VersionedSettingsBranch,
     // The branch to be promoted
     promotedBranch: String,
     task: String,
@@ -61,4 +59,7 @@ abstract class PublishGradleDistribution(
     }
 }
 
-fun VersionedSettingsBranch.promoteNightlyTaskName(): String = "promote${if (this == VersionedSettingsBranch.MASTER) "" else asBuildTypeId()}Nightly"
+fun VersionedSettingsBranch.promoteNightlyTaskName(): String = when (this) {
+    VersionedSettingsBranch.MASTER -> "promoteNightly"
+    else -> "promoteReleaseNightly"
+}

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -20,13 +20,12 @@ import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistribution(
-    versionSettingsBranch = branch,
     promotedBranch = branch.branchName,
     task = branch.promoteNightlyTaskName(),
     triggerName = "ReadyforNightly"
 ) {
     init {
-        id("Promotion_${branch.asBuildTypeId()}Nightly")
+        id("Promotion_Nightly")
         name = "Nightly Snapshot"
         description = "Promotes the latest successful changes on '${branch.branchName}' from Ready for Nightly as a new nightly snapshot"
 

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
@@ -19,13 +19,12 @@ package promotion
 import common.VersionedSettingsBranch
 
 class PublishNightlySnapshotFromQuickFeedback(branch: VersionedSettingsBranch) : PublishGradleDistribution(
-    versionSettingsBranch = branch,
     promotedBranch = branch.branchName,
     task = branch.promoteNightlyTaskName(),
     triggerName = "QuickFeedback"
 ) {
     init {
-        id("Promotion_${branch.asBuildTypeId()}SnapshotFromQuickFeedback")
+        id("Promotion_SnapshotFromQuickFeedback")
         name = "Nightly Snapshot (from QuickFeedback)"
         description = "Promotes the latest successful changes on '${branch.branchName}' from Quick Feedback as a new nightly snapshot"
     }

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -22,11 +22,9 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 abstract class PublishRelease(
     task: String,
     requiredConfirmationCode: String,
-    versionSettingsBranch: VersionedSettingsBranch = VersionedSettingsBranch.RELEASE,
-    promotedBranch: String = "release",
+    promotedBranch: String,
     init: PublishRelease.() -> Unit = {}
 ) : PublishGradleDistribution(
-    versionSettingsBranch = versionSettingsBranch,
     promotedBranch = promotedBranch,
     task = task,
     triggerName = "ReadyforRelease",
@@ -66,7 +64,6 @@ abstract class PublishRelease(
 }
 
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
-    versionSettingsBranch = branch,
     promotedBranch = branch.branchName,
     task = "promoteFinalRelease",
     requiredConfirmationCode = "final",
@@ -78,7 +75,6 @@ class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
 )
 
 class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
-    versionSettingsBranch = branch,
     promotedBranch = branch.branchName,
     task = "promoteRc",
     requiredConfirmationCode = "rc",
@@ -90,7 +86,6 @@ class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
 )
 
 class PublishMilestone(branch: VersionedSettingsBranch) : PublishRelease(
-    versionSettingsBranch = branch,
     promotedBranch = branch.branchName,
     task = "promoteMilestone",
     requiredConfirmationCode = "milestone",


### PR DESCRIPTION
So you cannot publish RCs or Final releases from the master
configuration.