### PR TITLE
Fix `GradleBuildExternalPluginsValidationSmokeTest`

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -22,12 +22,6 @@ tasks.configCacheIntegTest {
     enabled = false
 }
 
-// This is a workaround for the validate plugins task trying to inspect classes which have changed but are NOT tasks.
-// For the current project, we simply disable it since there are no tasks in there.
-tasks.withType<ValidatePlugins>().configureEach {
-    enabled = false
-}
-
 dependencies {
     implementation(project(":base-services"))
     implementation(project(":base-services-groovy"))

--- a/subprojects/dependency-management/build.gradle.kts
+++ b/subprojects/dependency-management/build.gradle.kts
@@ -109,15 +109,3 @@ tasks.clean {
         }.visit { this.file.setWritable(true) }
     }
 }
-
-// This is a workaround for the validate plugins task trying to inspect classes which
-// have changed but are NOT tasks
-tasks.withType<ValidatePlugins>().configureEach {
-    val main = sourceSets.main.get()
-    classes.setFrom(main.output.classesDirs.asFileTree.filter { !it.isInternal(main) })
-}
-
-fun File.isInternal(sourceSet: SourceSet) = isInternal(sourceSet.output.classesDirs.files)
-
-fun File.isInternal(roots: Set<File>): Boolean = name == "internal" ||
-    !roots.contains(parentFile) && parentFile.isInternal(roots)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
@@ -96,7 +96,8 @@ class GradleBuildExternalPluginsValidationSmokeTest extends AbstractGradleceptio
 
     void validatePlugins() {
         allPlugins.performValidation([
-            "-Dorg.gradle.internal.validate.external.plugins=true"
+            "-Dorg.gradle.internal.validate.external.plugins=true",
+            "--no-parallel" // make sure we have consistent execution ordering as we skip cached tasks
         ])
     }
 

--- a/subprojects/snapshots/build.gradle.kts
+++ b/subprojects/snapshots/build.gradle.kts
@@ -33,9 +33,3 @@ dependencies {
 
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
-
-// This is a workaround for the validate plugins task trying to inspect classes which have changed but are NOT tasks.
-// For the current project, we exclude all internal packages, since there are no tasks in there.
-tasks.withType<ValidatePlugins>().configureEach {
-    classes.setFrom(sourceSets.main.get().output.classesDirs.asFileTree.matching { exclude("**/internal/**") })
-}


### PR DESCRIPTION
This PR fixes a couple issues with `GradleBuildExternalPluginsValidationSmokeTest`:

- the Gradle build itself was incorrectly configuring _all_ `ValidatePlugins` tasks, including those for external plugins
- there was a potential race condition in verification

Closes #16084