### PR TITLE
Update JVM vendor to match our CI configuration

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -18,6 +18,6 @@ package common
 
 enum class JvmCategory(val vendor: JvmVendor, val version: JvmVersion) {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.oracle, JvmVersion.java15),
+    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java15),
     EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java16)
 }


### PR DESCRIPTION
We've deployed AdoptOpenJdk 15.0.2 on our infrastructure to the standard location. This PR adjusts the related TeamCity configuration. 