### PR TITLE
Fix bug when matching locations for missing task dependencies

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -336,20 +336,20 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
                 builtBy(prepareBuild)
             }
 
-            task generateA {
+            task consumesResultOfPrepareBuildAndGeneratesAInSameDirectory {
                 inputs.files(sources)
                 outputs.file("app/src/generatedA.txt")
                 doLast {}
             }
 
-            task generateB {
+            task consumesResultOfPrepareBuildAndGeneratesBInSameDirectory {
                 inputs.files(sources)
                 outputs.file("app/src/generatedB.txt")
                 doLast {}
             }
 
             task assemble {
-                dependsOn(generateA, generateB)
+                dependsOn(consumesResultOfPrepareBuildAndGeneratesAInSameDirectory, consumesResultOfPrepareBuildAndGeneratesBInSameDirectory)
             }
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.MissingTaskDependenciesFixture
+import spock.lang.Issue
 import spock.lang.Unroll
 
 @Unroll
@@ -319,6 +320,43 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
         run("consumer", "producer")
         then:
         executed(":producer", ":consumer")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/16061")
+    def "does not detect missing dependencies even for complicated filters"() {
+        buildFile """
+            task prepareBuild {
+                outputs.file("app/foo.txt")
+                doLast {}
+            }
+
+            def sources = fileTree("app") {
+                include("**/*.txt")
+                exclude("**/*generated*")
+                builtBy(prepareBuild)
+            }
+
+            task generateA {
+                inputs.files(sources)
+                outputs.file("app/src/generatedA.txt")
+                doLast {}
+            }
+
+            task generateB {
+                inputs.files(sources)
+                outputs.file("app/src/generatedB.txt")
+                doLast {}
+            }
+
+            task assemble {
+                dependsOn(generateA, generateB)
+            }
+        """
+
+        when:
+        run("assemble")
+        then:
+        executedAndNotSkipped(":assemble")
     }
 
     def "emits a deprecation warning when an input file collection can't be resolved"() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
@@ -168,7 +168,7 @@ public final class ValuedVfsHierarchy<T> {
                 child.getValues(),
                 () -> childPath
             );
-            child.visitAllChildren((grandChildren, relativePath) -> childConsumer.accept(grandChildren, () -> childPath + "/" + relativePath));
+            child.visitAllChildren((grandChildren, relativePath) -> childConsumer.accept(grandChildren, () -> childPath + "/" + relativePath.get()));
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
@@ -70,7 +70,10 @@ public final class ValuedVfsHierarchy<T> {
                     child.getValues(),
                     () -> childPathFromAncestor.substring(location.length() + 1));
                 child.visitAllChildren((nodes, relativePath) ->
-                    visitor.visitChildren(nodes, () -> childPathFromAncestor.substring(location.length() + 1) + "/" + relativePath.get()));
+                    visitor.visitChildren(nodes, () -> joinRelativePaths(
+                        childPathFromAncestor.substring(location.length() + 1),
+                        relativePath.get())
+                    ));
                 return "";
             }
 
@@ -168,11 +171,18 @@ public final class ValuedVfsHierarchy<T> {
                 child.getValues(),
                 () -> childPath
             );
-            child.visitAllChildren((grandChildren, relativePath) -> childConsumer.accept(grandChildren, () -> childPath + "/" + relativePath.get()));
+            child.visitAllChildren((grandChildren, relativePath) -> childConsumer.accept(grandChildren, () -> joinRelativePaths(
+                childPath,
+                relativePath.get())
+            ));
         });
     }
 
     private ChildMap<ValuedVfsHierarchy<T>> getChildren() {
         return children;
+    }
+
+    private static String joinRelativePaths(String first, String second) {
+        return first + "/" + second;
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
@@ -101,18 +101,20 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
         def node4 = Mock(Node)
         def node5 = Mock(Node)
         def node6 = Mock(Node)
+        def node7 = Mock(Node)
 
         hierarchy.recordNodeAccessingLocations(rootNode, [root.absolutePath])
         hierarchy.recordNodeAccessingLocations(node1, [root.file("location").absolutePath])
         hierarchy.recordNodeAccessingLocations(node2, [root.file("sub/location").absolutePath])
         hierarchy.recordNodeAccessingLocations(node3, [root.file("third/within").absolutePath])
-        hierarchy.recordNodeAccessingLocations(node4, [root.file("included/within").absolutePath])
+        hierarchy.recordNodeAccessingLocations(node4, [root.file("included/without").absolutePath])
+        hierarchy.recordNodeAccessingLocations(node7, [root.file("included/within").absolutePath])
         hierarchy.recordNodeAccessingLocations(node5, [root.file("excluded/within").absolutePath])
         hierarchy.recordNodeAccessingLocations(node6, [temporaryFolder.createDir("other").file("third").absolutePath])
 
         expect:
         nodesRelatedTo(root, "*/within") == ([rootNode, node1, node3, node4, node5] as Set)
-        nodesRelatedTo(root, "included/*") == ([rootNode, node4] as Set)
+        nodesRelatedTo(root, "included/*") == ([rootNode, node4, node7] as Set)
         nodesRelatedTo(root, "included/within") == ([rootNode, node4] as Set)
     }
 


### PR DESCRIPTION
This caused the wrong path to be matched which caused arbitrary results.

Fixes #16061