### PR TITLE
Avoid replacing instrumented classpath files

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -30,6 +30,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
@@ -46,17 +47,28 @@ public class ClasspathBuilder {
     }
 
     /**
-     * Creates a Jar file using the given action to add entries to the file.
+     * Creates a Jar file using the given action to add entries to the file. If the file already exists it will be replaced.
      */
     public void jar(File jarFile, Action action) {
+        tryToBuildJar(jarFile, action, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    /**
+     * Creates a Jar file using the given action to add entries to the file. Fails if the file already exists.
+     */
+    public void nonReplacingJar(File jarFile, Action action) {
+        tryToBuildJar(jarFile, action);
+    }
+
+    private void tryToBuildJar(File jarFile, Action action, CopyOption... moveOptions) {
         try {
-            buildJar(jarFile, action);
+            buildJar(jarFile, action, moveOptions);
         } catch (Exception e) {
             throw new GradleException(String.format("Failed to create Jar file %s.", jarFile), e);
         }
     }
 
-    private void buildJar(File jarFile, Action action) throws IOException {
+    private void buildJar(File jarFile, Action action, CopyOption... moveOptions) throws IOException {
         File parentDir = jarFile.getParentFile();
         File tmpFile = temporaryFileProvider.createTemporaryFile(jarFile.getName(), ".tmp");
         try {
@@ -65,7 +77,7 @@ public class ClasspathBuilder {
                 outputStream.setLevel(0);
                 action.execute(new ZipEntryBuilder(outputStream));
             }
-            Files.move(tmpFile.toPath(), jarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.move(tmpFile.toPath(), jarFile.toPath(), moveOptions);
         } finally {
             Files.deleteIfExists(tmpFile.toPath());
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -100,7 +100,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     }
 
     private void instrument(File source, File dest) {
-        classpathBuilder.jar(dest, builder -> {
+        classpathBuilder.nonReplacingJar(dest, builder -> {
             try {
                 visitEntries(source, builder);
             } catch (FileException e) {


### PR DESCRIPTION
To avoid a race condition where a process could try to read an instrumented classpath file while another process would be replacing it.