### PR TITLE
Use token from command in exception

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DefaultIncomingConnectionHandler.java
@@ -157,7 +157,7 @@ public class DefaultIncomingConnectionHandler implements IncomingConnectionHandl
             try {
                 if (!Arrays.equals(command.getToken(), token)) {
                     throw new BadlyFormedRequestException(String.format("Unexpected authentication token in command %s received from %s, expected: %s, incoming: %s.",
-                        command, connection, Arrays.toString(token), Arrays.toString(token)));
+                        command, connection, Arrays.toString(token), Arrays.toString(command.getToken())));
                 }
                 commandExecuter.executeCommand(daemonConnection, command, daemonContext, daemonStateControl);
             } catch (Throwable e) {


### PR DESCRIPTION
instead of accidentally logging the daemon token twice.

See https://github.com/gradle/gradle/commit/b810473f2bd9df34872c36cba313a829dbff7bba#r46962987