### PR TITLE
Replace jcenter() with mavenCentral() in samples and documentation snippets

### DIFF
--- a/subprojects/docs/src/samples/android-application/groovy/app/build.gradle
+++ b/subprojects/docs/src/samples/android-application/groovy/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {

--- a/subprojects/docs/src/samples/android-application/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/android-application/kotlin/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 android {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-app/app/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-app/app/build.gradle
@@ -17,5 +17,5 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-utils/number-utils/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-utils/number-utils/build.gradle
@@ -6,5 +6,5 @@ group 'org.sample'
 version '1.0'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-utils/string-utils/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/groovy/my-utils/string-utils/build.gradle
@@ -6,7 +6,7 @@ group 'org.sample'
 version '1.0'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-app/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-app/app/build.gradle.kts
@@ -17,5 +17,5 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-utils/number-utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-utils/number-utils/build.gradle.kts
@@ -6,5 +6,5 @@ group = "org.sample"
 version = "1.0"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-utils/string-utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/basic/kotlin/my-utils/string-utils/build.gradle.kts
@@ -6,7 +6,7 @@ group = "org.sample"
 version = "1.0"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/build.gradle
@@ -18,5 +18,5 @@ repositories {
     maven {
         url project.file("../../local-repo")
     }
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/string-utils/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/string-utils/build.gradle
@@ -15,7 +15,7 @@ repositories {
         name 'localrepo'
         url file("../../../local-repo")
     }
-    jcenter()
+    mavenCentral()
 }
 
 publishing {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/build.gradle.kts
@@ -18,5 +18,5 @@ repositories {
     maven {
         url = uri(project.file("../../local-repo"))
     }
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/string-utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/string-utils/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
         name = "localrepo"
         url = uri(file("../../../local-repo"))
     }
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/subprojects/docs/src/samples/build-organization/gradle-plugin/groovy/greeting-plugin/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/gradle-plugin/groovy/greeting-plugin/build.gradle
@@ -5,9 +5,9 @@ plugins {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies.
+    // Use Maven Central for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/build-organization/gradle-plugin/kotlin/greeting-plugin/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/gradle-plugin/kotlin/greeting-plugin/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 repositories {
-    // Use jcenter for resolving dependencies
-    jcenter()
+    // Use Maven Central for resolving dependencies
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -11,10 +11,10 @@ plugins {
 }
 // end::apply-external-plugin[]
 
-// Projects should use JCenter for external dependencies
+// Projects should use Maven Central for external dependencies
 // This could be the organization's private repository
 repositories {
-    jcenter() 
+    mavenCentral()
 }
 
 // Use the Checkstyle rules provided by the convention plugin

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 }
 // end::apply-external-plugin[]
 
-// Projects should use JCenter for external dependencies
+// Projects should use Maven Central for external dependencies
 // This could be the organization's private repository
 repositories {
-    jcenter() 
+    mavenCentral()
 }
 
 // Use the Checkstyle rules provided by the convention plugin

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/main/groovy/com.myorg.java-conventions.gradle
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/main/groovy/com.myorg.java-conventions.gradle
@@ -11,10 +11,10 @@ plugins {
 }
 // end::apply-external-plugin[]
 
-// Projects should use JCenter for external dependencies
+// Projects should use Maven Central for external dependencies
 // This could be the organization's private repository
 repositories {
-    jcenter() 
+    mavenCentral()
 }
 
 // Use the Checkstyle rules provided by the convention plugin

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/kotlin/convention-plugins/src/main/kotlin/com.myorg.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/kotlin/convention-plugins/src/main/kotlin/com.myorg.java-conventions.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 }
 // end::apply-external-plugin[]
 
-// Projects should use JCenter for external dependencies
+// Projects should use Maven Central for external dependencies
 // This could be the organization's private repository
 repositories {
-    jcenter() 
+    mavenCentral()
 }
 
 // Use the Checkstyle rules provided by the convention plugin

--- a/subprojects/docs/src/samples/build-organization/sharing-convention-plugins-with-build-logic/groovy/build-conventions/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/build-organization/sharing-convention-plugins-with-build-logic/groovy/build-conventions/src/main/groovy/myproject.java-conventions.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/subprojects/docs/src/samples/build-organization/sharing-convention-plugins-with-build-logic/kotlin/build-conventions/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/sharing-convention-plugins-with-build-logic/kotlin/build-conventions/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/android-app/settings.gradle
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/android-app/settings.gradle
@@ -13,7 +13,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 }
 includeBuild('../user-feature')

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/android-app/settings.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/android-app/settings.gradle.kts
@@ -13,7 +13,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 }
 includeBuild("../user-feature")

--- a/subprojects/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
+++ b/subprojects/docs/src/samples/groovy/library-publishing/groovy/my-library/build.gradle
@@ -7,7 +7,7 @@ version = '1.0.2'
 group = 'org.gradle.sample'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
+++ b/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
@@ -7,7 +7,7 @@ version = "1.0.2"
 group = "org.gradle.sample"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -6,7 +6,7 @@ version = '1.0.2'
 group = 'org.gradle.sample'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 def integrationTest = sourceSets.create('integrationTest')

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-additional-test-types/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -6,7 +6,7 @@ version = "1.0.2"
 group = "org.gradle.sample"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val integrationTest by sourceSets.creating

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // A resolvable configuration to collect source code

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -7,7 +7,7 @@ version = '1.0.2'
 group = 'org.gradle.sample'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.named("test") {

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.jacoco-aggregation.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.jacoco-aggregation.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // A resolvable configuration to collect source code

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -7,7 +7,7 @@ version = "1.0.2"
 group = "org.gradle.sample"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.test {

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -6,7 +6,7 @@ version = '1.0.2'
 group = 'com.example'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::toolchain[]

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -6,7 +6,7 @@ version = "1.0.2"
 group = "com.example"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::toolchain[]

--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -6,7 +6,7 @@ version = '1.0.2'
 group = 'org.gradle.sample'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 def integrationTest = sourceSets.create('integrationTest')

--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-multi-project-with-integration-tests/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -6,7 +6,7 @@ version = "1.0.2"
 group = "org.gradle.sample"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val integrationTest by sourceSets.creating

--- a/subprojects/docs/src/samples/java/modules-multi-project/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/modules-multi-project/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -6,7 +6,7 @@ version = '1.0.2'
 group = 'org.gradle.sample'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.named("test") {

--- a/subprojects/docs/src/samples/java/modules-multi-project/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-multi-project/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/samples/java/modules-multi-project/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-multi-project/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -6,7 +6,7 @@ version = "1.0.2"
 group = "org.gradle.sample"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 tasks.test {

--- a/subprojects/docs/src/samples/java/modules-with-transform/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/java/modules-with-transform/groovy/buildSrc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/samples/java/modules-with-transform/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/modules-with-transform/kotlin/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::config-logic[]

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-do/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::config-logic[]

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations.all {

--- a/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/bestPractices/logicDuringConfiguration-dont/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 

--- a/subprojects/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/caching-android-projects/kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::cacheKapt[]

--- a/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/customModel/languageType/groovy/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/groovy/buildSrc/src/main/groovy/myproject.java-library-conventions.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-classifierSubstitutionRule/kotlin/buildSrc/src/main/kotlin/myproject.java-library-conventions.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/groovy/build.gradle
@@ -7,7 +7,7 @@ repositories {
             includeGroup "my.company"
         }
     }
-    jcenter {
+    mavenCentral {
         content {
             // this repository contains everything BUT artifacts with group starting with "my.company"
             excludeGroupByRegex "my\\.company.*"
@@ -20,7 +20,7 @@ repositories {
 repositories {
     // This repository will _not_ be searched for artifacts in my.company
     // despite being declared first
-    jcenter()
+    mavenCentral()
     exclusiveContent {
         forRepository {
             maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-filtering/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
             includeGroup("my.company")
         }
     }
-    jcenter {
+    mavenCentral {
         content {
             // this repository contains everything BUT artifacts with group starting with "my.company"
             excludeGroupByRegex("my\\.company.*")
@@ -20,7 +20,7 @@ repositories {
 repositories {
     // This repository will _not_ be searched for artifacts in my.company
     // despite being declared first
-    jcenter()
+    mavenCentral()
     exclusiveContent {
         forRepository {
             maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-multipleRepositories/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-multipleRepositories/groovy/build.gradle
@@ -1,6 +1,6 @@
 // tag::multiple-repositories[]
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url "https://maven.springframework.org/release"
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-multipleRepositories/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/declaringRepositories-multipleRepositories/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::multiple-repositories[]
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url = uri("https://maven.springframework.org/release")
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependenciesReport/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependenciesReport/groovy/build.gradle
@@ -1,6 +1,6 @@
 // tag::dependency-declaration[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependenciesReport/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependenciesReport/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::dependency-declaration[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyInsightReport/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyInsightReport/groovy/build.gradle
@@ -1,6 +1,6 @@
 // tag::dependency-declaration[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyInsightReport/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyInsightReport/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 // tag::dependency-declaration[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/kotlin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::dependencies[]

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::dependencies[]

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/groovy/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateArtifacts/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val scm by configurations.creating

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/groovy/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-iterateDependencies/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val scm by configurations.creating

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-walkGraph/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-walkGraph/groovy/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-walkGraph/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/workingWithDependencies-walkGraph/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val scm by configurations.creating

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
@@ -44,7 +44,7 @@ tasks.named('check') {
 
 // tag::test-framework[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -44,7 +44,7 @@ tasks.check {
 
 // tag::test-framework[]
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/consumer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/groovy/producer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 group = 'org.gradle.demo'

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/consumer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/incompatible-variants/kotlin/producer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 group = "org.gradle.demo"

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 group = 'org.gradle.demo'

--- a/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer-separate-sourceset/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 group = "org.gradle.demo"

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/groovy/build.gradle
@@ -7,7 +7,7 @@ plugins {
 // end::plugins[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::register_variant[]

--- a/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/producer/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 // end::plugins[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::register_variant[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/groovy/project/build.gradle
@@ -6,7 +6,7 @@ repositories {
     maven {
         url '../repo'
     }
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/kotlin/project/build.gradle.kts
@@ -6,7 +6,7 @@ repositories {
     maven {
         setUrl(uri("../repo"))
     }
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/consumer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/groovy/producer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::producer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/consumer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::consumer[]

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/kotlin/producer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::producer[]

--- a/subprojects/docs/src/snippets/java-platform/recommender/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/java-platform/recommender/groovy/consumer/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::get-recommendations[]

--- a/subprojects/docs/src/snippets/java-platform/recommender/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java-platform/recommender/kotlin/consumer/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::get-recommendations[]

--- a/subprojects/docs/src/snippets/java/apt/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/apt/groovy/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::annotation-processing[]

--- a/subprojects/docs/src/snippets/java/apt/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/apt/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::annotation-processing[]

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
@@ -7,7 +7,7 @@ targetCompatibility = '1.8'
 version = '1.2.1'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ java {
 version = "1.2.1"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/java/toolchain-kotlin/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-kotlin/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::compiler-kotlin[]

--- a/subprojects/docs/src/snippets/java/toolchain-kotlin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-kotlin/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::compiler-kotlin[]

--- a/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/accessors/kotlin/build.gradle.kts
@@ -34,5 +34,5 @@ tasks {
 // end::accessors[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/androidBuild/kotlin/settings.gradle.kts
@@ -7,6 +7,6 @@ rootProject.name = "android-build"
 gradle.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/androidSingleBuild/kotlin/settings.gradle.kts
@@ -19,6 +19,6 @@ rootProject.name = "android-single-build"
 gradle.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/interoperability-static-extensions/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/interoperability-static-extensions/kotlin/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/kotlinDslPlugin/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/kotlinDslPlugin/kotlin/buildSrc/build.gradle.kts
@@ -6,6 +6,6 @@ plugins {
 repositories {
     // The org.jetbrains.kotlin.jvm plugin requires a repository
     // where to download the Kotlin compiler dependencies from.
-    jcenter()
+    mavenCentral()
 }
 // end::apply[]

--- a/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/build.gradle.kts
@@ -32,7 +32,7 @@ project(":infra") {
 project(":http") {
     apply(plugin = "java")
     apply(plugin = "io.ratpack.ratpack-java")
-    repositories { jcenter() }
+    repositories { mavenCentral() }
     val ratpack = the<RatpackExtension>()
     dependencies {
         "implementation"(project(":domain"))

--- a/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/multiProjectBuild/kotlin/settings.gradle.kts
@@ -1,7 +1,7 @@
 // tag::repositories[]
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/noAccessors/kotlin/build.gradle.kts
@@ -46,5 +46,5 @@ tasks {
 // end::no-accessors[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/subprojects/docs/src/snippets/mavenMigration/importBom/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/mavenMigration/importBom/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 // end::plugins[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::bom[]

--- a/subprojects/docs/src/snippets/mavenMigration/importBom/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/mavenMigration/importBom/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 // end::plugins[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 // tag::bom[]

--- a/subprojects/docs/src/snippets/organizingGradleProjects/customGradleDistribution/groovy/src/init.d/repositories.gradle
+++ b/subprojects/docs/src/snippets/organizingGradleProjects/customGradleDistribution/groovy/src/init.d/repositories.gradle
@@ -3,7 +3,7 @@ logger.lifecycle ("Hello from the custom Gradle distribution")
 gradle.projectsLoaded { Gradle gradle ->
     gradle.allprojects {
         repositories {
-            jcenter()
+            mavenCentral()
         }
     }
 }

--- a/subprojects/docs/src/snippets/plugins/buildService/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildService/groovy/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/buildService/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildService/kotlin/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainer/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainer/groovy/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainer/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainer/kotlin/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/groovy/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/namedDomainObjectContainerInterfaces/kotlin/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/nestedObjects/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/nestedObjects/groovy/buildSrc/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 gradlePlugin {

--- a/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-externalPlugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-externalPlugins/groovy/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-externalPlugins/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-externalPlugins/kotlin/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-inBuildSrc/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/precompiledScriptPlugins-inBuildSrc/kotlin/buildSrc/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 // end::apply[]

--- a/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/build.gradle
@@ -10,7 +10,7 @@ plugins {
 // end::failed-inferred-task-dep[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/kotlin/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 // end::failed-inferred-task-dep[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/webApplication/customized/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/webApplication/customized/groovy/build.gradle
@@ -13,7 +13,7 @@ configurations {
 
 repositories {
    flatDir { dirs "lib" }
-   jcenter()
+   mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/webApplication/customized/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/webApplication/customized/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ val moreLibs = configurations.create("moreLibs")
 
 repositories {
     flatDir { dir("lib") }
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/webApplication/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/webApplication/quickstart/groovy/build.gradle
@@ -5,7 +5,7 @@ plugins {
 // end::use-war-plugin[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/webApplication/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/webApplication/quickstart/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 // end::use-war-plugin[]
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/groovy/build.gradle
@@ -1,7 +1,7 @@
 plugins { id 'base' }
 
 repositories {
-    jcenter() // <1>
+    mavenCentral() // <1>
 }
 
 configurations.create('codec') { // <2>

--- a/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/groovy/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins { id("base") }
 
 repositories {
-    jcenter() // <1>
+    mavenCentral() // <1>
 }
 
 val codec = configurations.create("codec") { // <2>

--- a/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/md5ClassloaderIsolation/kotlin/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5CustomTask/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5CustomTask/groovy/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5CustomTask/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/md5CustomTask/kotlin/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5NoIsolation/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5NoIsolation/groovy/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5NoIsolation/kotlin/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5NoIsolation/kotlin/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/build.gradle
@@ -1,7 +1,7 @@
 plugins { id 'base' }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations.create('codec') {

--- a/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/groovy/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins { id("base") }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 val codec = configurations.create("codec") {

--- a/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/buildSrc/build.gradle.kts
+++ b/subprojects/docs/src/snippets/workerApi/md5ProcessIsolation/kotlin/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Update snippets and samples to use `mavenCentral()` instead of `jcenter()` for the majority of cases that "just work" with this switch.
Will sort out remaining bits and documentation page updates in separate changes.