### PR TITLE
Remove GRADLE_METADATA feature preview

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -26,7 +26,6 @@ public class FeaturePreviews {
      * A feature that is no longer relevant will have the {@code active} flag set to {@code false}.
      */
     public enum Feature {
-        GRADLE_METADATA(false),
         GROOVY_COMPILATION_AVOIDANCE(true),
         ONE_LOCKFILE_PER_PROJECT(false),
         VERSION_ORDERING_V2(false),

--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
@@ -31,7 +31,9 @@ class GradleMetadataJavaLibraryCrossVersionIntegrationTest extends CrossVersionI
     def setup() {
         settingsFile << """
             rootProject.name = 'test'
-            enableFeaturePreview('GRADLE_METADATA')
+            if (org.gradle.util.GradleVersion.current().nextMajor == '6.0') {
+                enableFeaturePreview('GRADLE_METADATA')
+            }
             include 'consumer'
             include 'producer'
         """


### PR DESCRIPTION
It has been inactive and deprecated since 6.0.