### PR TITLE
Remove more jcenter references from the docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
@@ -332,7 +332,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 ```
 

--- a/subprojects/docs/src/samples/readme-templates/multi-common-body.adoc.template
+++ b/subprojects/docs/src/samples/readme-templates/multi-common-body.adoc.template
@@ -227,7 +227,7 @@ include::sample[dir="kotlin",files="buildSrc/src/main/kotlin/demo.${languageLC.r
 
 The `${languageLC.raw}-common-conventions` defines some configuration that should be shared by all our ${language.raw} project -- independent of whether they represent a library or the actual application.
 First, we apply the ${languagePluginDocsLink.raw} *(1)* to have all functionality for building ${language.raw} projects available.
-Then, we declare a repository -- `jcenter()` -- as source for external dependencies *(2)*, define dependency constraints *(3)* as well as standard dependencies that are shared by all subprojects and set JUnit 5 as testing framework *(4...)*.
+Then, we declare a repository -- `mavenCentral()` -- as source for external dependencies *(2)*, define dependency constraints *(3)* as well as standard dependencies that are shared by all subprojects and set JUnit 5 as testing framework *(4...)*.
 Other shared settings, like compiler flags or JVM version compatibilities, could also be set here.
 
 ====

--- a/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
@@ -1,9 +1,7 @@
 // tag::buildscript_block[]
 buildscript {
     repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'

--- a/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/plugins/buildscript/groovy/build.gradle
@@ -1,7 +1,9 @@
 // tag::buildscript_block[]
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
@@ -10,5 +12,3 @@ buildscript {
 
 apply plugin: 'com.jfrog.bintray'
 // end::buildscript_block[]
-
-

--- a/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
@@ -1,7 +1,9 @@
 // tag::buildscript_block[]
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
     dependencies {
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")
@@ -10,5 +12,3 @@ buildscript {
 
 apply(plugin = "com.jfrog.bintray")
 // end::buildscript_block[]
-
-

--- a/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/plugins/buildscript/kotlin/build.gradle.kts
@@ -1,9 +1,7 @@
 // tag::buildscript_block[]
 buildscript {
     repositories {
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
-        }
+        gradlePluginPortal()
     }
     dependencies {
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/16035

This should only leave the `declaring_repositories` page talking about jcenter, which I will handle separately.