### PR TITLE
Support camelCase shortcuts for configuration selection in dependencies/dependencyInsight task

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/AbstractDependencyReportTask.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.tasks.diagnostics.internal.ConfigurationFinder;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer;
@@ -96,7 +97,7 @@ public abstract class AbstractDependencyReportTask extends ProjectBasedReportTas
      */
     @Option(option = "configuration", description = "The configuration to generate the report for.")
     public void setConfiguration(String configurationName) {
-        this.configurations = Collections.singleton(getTaskConfigurations().getByName(configurationName));
+        this.configurations = Collections.singleton(ConfigurationFinder.find(getTaskConfigurations(), configurationName));
     }
 
     private Set<Configuration> getNonDeprecatedTaskConfigurations() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.diagnostics.internal.ConfigurationFinder;
 import org.gradle.api.tasks.diagnostics.internal.dsl.DependencyResultSpecNotationConverter;
 import org.gradle.api.tasks.diagnostics.internal.graph.DependencyGraphsRenderer;
 import org.gradle.api.tasks.diagnostics.internal.graph.NodeRenderer;
@@ -150,7 +151,7 @@ public class DependencyInsightReportTask extends DefaultTask {
      */
     @Option(option = "configuration", description = "Looks for the dependency in given configuration.")
     public void setConfiguration(String configurationName) {
-        this.configuration = getProject().getConfigurations().getByName(configurationName);
+        this.configuration = ConfigurationFinder.find(getProject().getConfigurations(), configurationName);
     }
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ConfigurationFinder.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/ConfigurationFinder.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.diagnostics.internal;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.util.internal.NameMatcher;
+
+public class ConfigurationFinder {
+    private ConfigurationFinder() {
+    }
+
+    public static Configuration find(ConfigurationContainer configurations, String configurationName) {
+        NameMatcher matcher = new NameMatcher();
+        Configuration configuration = matcher.find(configurationName, configurations.getAsMap());
+        if (configuration != null) {
+            return configuration;
+        }
+
+        throw new InvalidUserDataException(matcher.formatErrorMessage("configuration", configurations));
+    }
+}

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskSpec.groovy
@@ -88,4 +88,30 @@ class DependencyInsightReportTaskSpec extends AbstractProjectBuilderSpec {
         task.configuration.name == 'foo'
         task.showSinglePathToDependency == true
     }
+
+    def "configuration could be specified by camelCase shortcut"() {
+        given:
+        project.configurations.create("confAlpha")
+        def confB = project.configurations.create("confBravo")
+
+        when:
+        task.configuration = "coB"
+        task.dependencySpec = { true } as Spec
+
+        then:
+        task.configuration == confB
+    }
+
+    def "ambiguous configuration selection by camelCase shortcut fails"() {
+        given:
+        project.configurations.create("confAlpha")
+        project.configurations.create("confAlfa")
+
+        when:
+        task.configuration = "coA"
+        task.dependencySpec = { true } as Spec
+
+        then:
+        thrown InvalidUserDataException
+    }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.tasks.diagnostics
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer
 import org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer
@@ -84,5 +85,29 @@ class DependencyReportTaskTest extends AbstractProjectBuilderSpec {
 
         then:
         task.configurations == [bConf] as Set
+    }
+
+    def "configuration to render could be specified by camelCase shortcut"() {
+        given:
+        project.configurations.create("confAlpha")
+        def confB = project.configurations.create("confBravo")
+
+        when:
+        task.configuration = "coB"
+
+        then:
+        task.configurations == [confB] as Set
+    }
+
+    def "ambiguous configuration selection by camelCase shortcut fails"() {
+        given:
+        project.configurations.create("confAlpha")
+        project.configurations.create("confAlfa")
+
+        when:
+        task.configuration = "coA"
+
+        then:
+        thrown InvalidUserDataException
     }
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -54,7 +54,8 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
-
+## Support for camelCase shortcuts when selecting configuration `dependency`/`dependencyInsight` tasks
+When selecting configuration name using `--configuration` parameter from command line you can use camelCase notation like in subproject and task selection. This way `gradle dependencies --configuration tRC` could be used instead of `gradle dependencies --configuration testRuntimeClasspath` if `tRC` resolves to unique configuration within project where task is running.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -54,7 +54,7 @@ Example:
 ADD RELEASE FEATURES BELOW
 vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
-## Support for camelCase shortcuts when selecting configuration `dependency`/`dependencyInsight` tasks
+## Support name abbreviation when specifying configuration for `dependencies` and `dependencyInsight`
 When selecting configuration name using `--configuration` parameter from command line you can use camelCase notation like in subproject and task selection. This way `gradle dependencies --configuration tRC` could be used instead of `gradle dependencies --configuration testRuntimeClasspath` if `tRC` resolves to unique configuration within project where task is running.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -4,6 +4,7 @@ This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
  [Peter Runge](https://github.com/causalnet)
+ [Konstantin Gribov](https://github.com/grossws)
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -49,6 +49,8 @@ For example, to show dependencies that would be on the test runtime classpath in
 gradle -q dependencies --configuration testRuntimeClasspath
 ----
 
+TIP: You can use _camelCase_ shortcut to select configuration like `tRC` instead of `testRuntimeClasspath` if that shortcut points to unique configuration.
+
 TIP: To see a list of all the pre-defined configurations added by the `java` plugin, see <<java_plugin.adoc#sec:java_plugin_and_dependency_management,the documentation for the Java Plugin>>.
 
 .Declaring the JGit dependency with a custom configuration
@@ -103,7 +105,7 @@ Indicates which dependency to focus on.
 It can be a complete `group:name`, or part of it.
 If multiple dependencies match, they are all printed in the report.
 `--configuration <name>` (mandatory)::
-Indicates which configuration to resolve for showing the dpendency information.
+Indicates which configuration to resolve for showing the dependency information (_camelCase_ also supported like in `dependencies` task).
 Note that the <<java_plugin#java_plugin, Java plugin>> wires a convention with the value `compileClasspath`, making the parameter optional.
 `--singlepath` (optional)::
 Indicates to render only a single path to the dependency.

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -49,7 +49,7 @@ For example, to show dependencies that would be on the test runtime classpath in
 gradle -q dependencies --configuration testRuntimeClasspath
 ----
 
-TIP: You can use _camelCase_ shortcut to select configuration like `tRC` instead of `testRuntimeClasspath` if that shortcut points to unique configuration.
+TIP: Just like with <<command_line_interface#sec:name_abbreviation, project and task names>>, you can use abbreviated names to select a configuration. For example, you can specify `tRC` instead of `testRuntimeClasspath` if the pattern matches to a single configuration.
 
 TIP: To see a list of all the pre-defined configurations added by the `java` plugin, see <<java_plugin.adoc#sec:java_plugin_and_dependency_management,the documentation for the Java Plugin>>.
 


### PR DESCRIPTION
Fixes #16141

I'll add relevant docs for this feature if required.

Do I need to add some integration tests for such trivial change? I've added couple of tests into `DependencyReportTaskTest` which check relevant behavior change.

Also `sanityCheck` against master fails 'cause dependency verification failures in independent modules. So I checked relevant todo item below.

### Context
See #16141 and https://gradle-community.slack.com/archives/CA7UM03V3/p1611706682059700

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes