### PR TITLE
Fix issue with file hash cache during runtime classpath normalization

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -30,7 +30,7 @@ import java.util.jar.Manifest
 @Unroll
 class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore files on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withFilesIgnored()
 
@@ -85,7 +85,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'nested in dir jars' | 'ignoredResourceInNestedInDirJar' | 'notIgnoredResourceInNestedInDirJar' | Api.ANNOTATION
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore manifest attributes in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestAttributesIgnored()
@@ -113,7 +113,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore entire manifest in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestIgnored()
@@ -141,7 +141,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore all meta-inf files in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withAllMetaInfIgnored()
@@ -170,7 +170,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore manifest properties on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestPropertiesIgnored()
 
@@ -191,7 +191,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         skipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can configure ignore rules per project (using runtime API: #api)"() {
         def projectWithIgnores = new ProjectWithRuntimeClasspathNormalization('a', api).withFilesIgnored()
         def projectWithoutIgnores = new ProjectWithRuntimeClasspathNormalization('b', api)
@@ -241,13 +241,13 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         change                      | config                                                    | api
         'ignore file'               | "ignore '**/some-other-file.txt'"                         | Api.RUNTIME
         'ignore file'               | "ignore '**/some-other-file.txt'"                         | Api.ANNOTATION
-        'ignore manifest attribute' | "metaInf { ignoreAttribute '${IMPLEMENTATION_VERSION}' }"    | Api.RUNTIME
-        'ignore manifest attribute' | "metaInf { ignoreAttribute '${IMPLEMENTATION_VERSION}' }"    | Api.ANNOTATION
+        'ignore manifest attribute' | "metaInf { ignoreAttribute '${IMPLEMENTATION_VERSION}' }" | Api.RUNTIME
+        'ignore manifest attribute' | "metaInf { ignoreAttribute '${IMPLEMENTATION_VERSION}' }" | Api.ANNOTATION
         'ignore property'           | "properties { ignoreProperty 'timestamp' }"               | Api.RUNTIME
         'ignore property'           | "properties { ignoreProperty 'timestamp' }"               | Api.ANNOTATION
     }
-
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withPropertiesIgnored()
 
@@ -287,7 +287,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'nested in dir jars' | 'propertiesFileInNestedInDirJar' | Api.ANNOTATION
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties in selected files"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME_TOO): 'this should not actually be ignored'])
@@ -324,7 +324,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties in selected files defined in multiple rules"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME_TOO): 'this should not actually be ignored'])
@@ -409,7 +409,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can add rules to the default properties rule"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME): 'this should not actually be ignored'])
@@ -472,11 +472,14 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization")
+    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Issue('https://github.com/gradle/gradle/issues/16144')
     def "changing normalization configuration rules changes build cache key (#description)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         project.propertiesFileInJar.changeProperty(ALSO_IGNORE_ME, 'some value')
+
+        // We implement this with a flag, rather than just changing the build script, because we don't want the change in build script to affect
+        // the cache hit. We want the only change to be in the normalization rules so we can be sure that's what's changing the cache key.
         project.buildFile << """
             normalization {
                 runtimeClasspath {

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceHasher.java
@@ -33,6 +33,8 @@ public class IgnoringResourceHasher implements ResourceHasher {
 
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
+        delegate.appendConfigurationToHasher(hasher);
+        hasher.putString(getClass().getName());
         resourceFilter.appendConfigurationToHasher(hasher);
     }
 

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasher.java
@@ -52,6 +52,7 @@ public class MetaInfAwareClasspathResourceHasher implements ResourceHasher {
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
         delegate.appendConfigurationToHasher(hasher);
+        hasher.putString(getClass().getName());
         attributeResourceFilter.appendConfigurationToHasher(hasher);
     }
 

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasher.java
@@ -58,6 +58,8 @@ public class PropertiesFileAwareClasspathResourceHasher implements ResourceHashe
 
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
+        delegate.appendConfigurationToHasher(hasher);
+        hasher.putString(getClass().getName());
         propertiesFilePatterns.forEach(hasher::putString);
         propertiesFileFilters.values().forEach(resourceEntryFilter -> resourceEntryFilter.appendConfigurationToHasher(hasher));
     }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/UnionResourceEntryFilter.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/UnionResourceEntryFilter.java
@@ -37,6 +37,7 @@ public class UnionResourceEntryFilter implements ResourceEntryFilter {
 
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
+        hasher.putString(getClass().getName());
         filters.forEach(resourceEntryFilter -> resourceEntryFilter.appendConfigurationToHasher(hasher));
     }
 }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.changedetection.state
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.Hasher
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -49,5 +50,15 @@ class IgnoringResourceHasherTest extends Specification {
 
         and:
         hash == null
+    }
+
+    def "delegate configuration is added to hasher"() {
+        def configurationHasher = Mock(Hasher)
+
+        when:
+        hasher.appendConfigurationToHasher(configurationHasher)
+
+        then:
+        1 * delegate.appendConfigurationToHasher(configurationHasher)
     }
 }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.archive.ZipEntry
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.Hasher
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -387,6 +388,18 @@ class MetaInfAwareClasspathResourceHasherTest extends Specification {
 
         and:
         hash3 == hash4
+    }
+
+    def "delegate configuration is added to hasher"() {
+        def configurationHasher = Mock(Hasher)
+        def delegate = Mock(ResourceHasher)
+        useDelegate(delegate)
+
+        when:
+        hasher.appendConfigurationToHasher(configurationHasher)
+
+        then:
+        1 * delegate.appendConfigurationToHasher(configurationHasher)
     }
 
     void populateAttributes(Attributes attributes, Map<String, Object> attributesMap) {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Maps
 import com.google.common.io.ByteStreams
 import org.gradle.api.internal.file.archive.ZipEntry
+import org.gradle.internal.hash.Hasher
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.hash.HashingOutputStream
 import org.gradle.internal.snapshot.RegularFileSnapshot
@@ -255,6 +256,17 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
         SnapshotContext.ZIP_ENTRY     | "key"    | 'keyWithBadEscapeSequence\\uxxxx=some value'
         SnapshotContext.FILE_SNAPSHOT | "value"  | 'someKey=a value with bad escape sequence \\uxxxx'
         SnapshotContext.FILE_SNAPSHOT | "key"    | 'keyWithBadEscapeSequence\\uxxxx=some value'
+    }
+
+    def "delegate configuration is added to hasher"() {
+        def configurationHasher = Mock(Hasher)
+        delegate = Mock(ResourceHasher)
+
+        when:
+        filteredHasher.appendConfigurationToHasher(configurationHasher)
+
+        then:
+        1 * delegate.appendConfigurationToHasher(configurationHasher)
     }
 
     enum SnapshotContext {


### PR DESCRIPTION
Normalization rules were not being properly captured when calculating the cache key for file hashes during runtime classpath normalization.  This was causing incorrect build cache misses under the right sequence of events.

Fixes #16144

