### PR TITLE
Add more triggers for Teamcity

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -12,7 +12,7 @@ class FunctionalTest(
     id: String,
     name: String,
     description: String,
-    testCoverage: TestCoverage,
+    val testCoverage: TestCoverage,
     stage: Stage,
     subprojects: List<String> = listOf(),
     extraParameters: String = "",
@@ -22,7 +22,7 @@ class FunctionalTest(
     this.name = name
     this.description = description
     this.id(id)
-    val testTasks = getTestTaskName(testCoverage, stage, subprojects)
+    val testTasks = getTestTaskName(testCoverage, subprojects)
     val buildScanTags = listOf("FunctionalTest")
     val buildScanValues = mapOf(
         "coverageOs" to testCoverage.os.name.toLowerCase(),
@@ -82,7 +82,7 @@ class FunctionalTest(
 
 fun enableExperimentalTestDistribution(testCoverage: TestCoverage, subprojects: List<String>) = testCoverage.os == Os.LINUX && (subprojects == listOf("core") || subprojects == listOf("dependency-management"))
 
-fun getTestTaskName(testCoverage: TestCoverage, stage: Stage, subprojects: List<String>): String {
+fun getTestTaskName(testCoverage: TestCoverage, subprojects: List<String>): String {
     val testTaskName = "${testCoverage.testType.name}Test"
     return when {
         testCoverage.testDistribution -> {

--- a/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
+++ b/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configurations
+
+import common.applyDefaultSettings
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import model.CIBuildModel
+
+class PartialTrigger<T : BuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(model, init = {
+    id("${model.projectId}_${triggerId}_Trigger")
+    name = "$triggerName (Trigger)"
+    type = Type.COMPOSITE
+
+    applyDefaultSettings()
+
+    features {
+        publishBuildStatusToGithub(model)
+    }
+
+    dependencies {
+        snapshotDependencies(dependencies)
+    }
+})

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -25,7 +25,7 @@ class CheckProject(
 
     var prevStage: Stage? = null
     model.stages.forEach { stage ->
-        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage, uuid)
+        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)


### PR DESCRIPTION
This PR adds more triggers for the stages:
- all functional tests in a stage
- all smoke tests in a stage
- all specific builds in a stage
- all cross-version tests in a stage
- all performance tests in a stage

<!--- The issue this PR addresses -->
Fixes gradle/gradle-private#3259