### PR TITLE
Set ANDROID_SDK_ROOT on CI

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -61,6 +61,7 @@ class FunctionalTest(
 
         param("env.JAVA_HOME", "%${testCoverage.os.name.toLowerCase()}.${testCoverage.buildJvmVersion}.openjdk.64bit%")
         param("env.ANDROID_HOME", testCoverage.os.androidHome)
+        param("env.ANDROID_SDK_ROOT", testCoverage.os.androidHome)
         if (testCoverage.os == Os.MACOS) {
             // Use fewer parallel forks on macOs, since the agents are not very powerful.
             param("maxParallelForks", "2")

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -58,6 +58,7 @@ class PerformanceTest(
             param("performance.baselines", type.defaultBaselines)
             param("performance.channel", performanceTestBuildSpec.channel())
             param("env.ANDROID_HOME", os.androidHome)
+            param("env.ANDROID_SDK_ROOT", os.androidHome)
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             when (os) {
                 Os.WINDOWS -> param("env.PATH", "%env.PATH%;C:/Program Files/7-zip")

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -12,6 +12,7 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
 
     params {
         param("env.ANDROID_HOME", LINUX.androidHome)
+        param("env.ANDROID_SDK_ROOT", LINUX.androidHome)
         param("env.JAVA_HOME", LINUX.javaHomeForGradle())
     }
 

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -64,6 +64,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
         param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
         param("additional.gradle.parameters", "")
         param("env.ANDROID_HOME", os.androidHome)
+        param("env.ANDROID_SDK_ROOT", os.androidHome)
     }
 
     steps {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/android/AndroidHome.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/android/AndroidHome.groovy
@@ -23,7 +23,7 @@ import static org.junit.Assume.assumeThat
 
 class AndroidHome {
 
-    static final String ENV_VARIABLE_NAME = "ANDROID_HOME"
+    private static final String ENV_VARIABLE_NAME = "ANDROID_SDK_ROOT"
 
     static void assumeIsSet() {
         assumeThat(NO_ENV_MESSAGE, System.getenv(ENV_VARIABLE_NAME), notNullValue())
@@ -34,8 +34,8 @@ class AndroidHome {
     }
 
     private static final String NO_ENV_MESSAGE = """
-        In order to run these tests the ANDROID_HOME directory must be set.
-        It is not necessary to install the whole android SDK via Android Studio - it is enough if there is a ${'$'}ANDROID_HOME/licenses/android-sdk-license containing the license keys from an Android Studio installation.
+        In order to run these tests the ANDROID_SDK_ROOT directory must be set.
+        It is not necessary to install the whole android SDK via Android Studio - it is enough if there is a ${'$'}ANDROID_SDK_ROOT/licenses/android-sdk-license containing the license keys from an Android Studio installation.
         The Gradle Android plugin will then download the SDK by itself, see https://developer.android.com/studio/intro/update.html#download-with-gradle
     """.stripIndent()
 

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -86,6 +86,7 @@ tasks {
         classpath = smokeTestSourceSet.runtimeClasspath
         maxParallelForks = 1 // those tests are pretty expensive, we shouldn"t execute them concurrently
         inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
+        inputs.property("androidSdkRootIsSet", System.getenv("ANDROID_SDK_ROOT") != null)
         inputs.files(remoteProjects.map { it.map { it.outputDirectory } })
             .withPropertyName("remoteProjectsSource")
             .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.VersionNumber
 
 /**
- * For these tests to run you need to set ANDROID_HOME to your Android SDK directory
+ * For these tests to run you need to set ANDROID_SDK_ROOT to your Android SDK directory
  *
  * https://developer.android.com/studio/releases/build-tools.html
  * https://developer.android.com/studio/releases/gradle-plugin.html


### PR DESCRIPTION
ANDROID_HOME is deprecated and has been replaced by `ANDROID_SDK_ROOT`.