### PR TITLE
Check version rejector for project dependency

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -88,7 +88,11 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
             if (componentMetaData == null) {
                 result.failed(new ModuleVersionResolveException(selector, () -> projectId + " not found."));
             } else {
-                result.resolved(componentMetaData);
+                if (rejector != null && rejector.accept(componentMetaData.getModuleVersionId().getVersion())) {
+                    result.rejected(projectId, componentMetaData.getModuleVersionId());
+                } else {
+                    result.resolved(componentMetaData);
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -19,6 +19,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
@@ -29,7 +30,10 @@ class RejectedModuleMessageBuilder {
     String buildFailureMessage(ModuleResolveState module) {
         boolean hasRejectAll = false;
         for (SelectorState candidate : module.getSelectors()) {
-            hasRejectAll |= candidate.getVersionConstraint().isRejectAll();
+            ResolvedVersionConstraint versionConstraint = candidate.getVersionConstraint();
+            if (versionConstraint != null) {
+                hasRejectAll |= versionConstraint.isRejectAll();
+            }
         }
         StringBuilder sb = new StringBuilder();
         if (hasRejectAll) {


### PR DESCRIPTION
When a project selector was considered, we never looked at the
compatibility of its version with the constraints on accepted version.
This change introduces such a check, so that if the project version is a
rejected version it cannot be selected.