### PR TITLE
Synchronize access to instrumented classpath file via receipt file

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/ExponentialBackoff.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/ExponentialBackoff.java
@@ -18,6 +18,7 @@ package org.gradle.internal.io;
 import org.gradle.internal.time.CountdownTimer;
 import org.gradle.internal.time.Time;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,17 @@ public class ExponentialBackoff<S extends ExponentialBackoff.Signal> {
         timer = Time.startCountdownTimer(timeoutMs);
     }
 
+    /**
+     * Retries the given query until it returns a non-null value.
+     *
+     * @param query which returns non-null value when successful.
+     * @param <T> the result type.
+     *
+     * @return the last value returned by the query.
+     * @throws IOException thrown by the query.
+     * @throws InterruptedException if interrupted while waiting.
+     */
+    @Nullable
     public <T> T retryUntil(IOQuery<T> query) throws IOException, InterruptedException {
         int iteration = 0;
         T result;

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -236,7 +236,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
+        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -264,7 +264,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
+        def cachedFile = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -294,8 +294,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
-        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
+        def cachedDir = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
+        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -352,8 +352,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
-        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
+        def cachedDir = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
+        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -373,7 +373,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/a3c0fbce9fb1525477bf88adc7b21f40/thing.jar")
+        def cachedFile = testDir.file("cached/627a9975cd1bd37a9ca2247e75a0d173/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)


### PR DESCRIPTION
To prevent concurrent readers from accessing the instrumented file before it has been fully written to, particularly on Windows.