### PR TITLE
Revert `InstrumentingClasspathFileTransformer` to its old behaviour

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -23,13 +23,11 @@ import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.api.internal.file.archive.ZipInput;
 import org.gradle.api.internal.file.archive.impl.FileZipInput;
 import org.gradle.internal.Pair;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.FileException;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
-import org.gradle.internal.io.ExponentialBackoff;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.util.GFileUtils;
 import org.objectweb.asm.ClassReader;
@@ -41,13 +39,9 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.format;
 
 class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentingClasspathFileTransformer.class);
-    private static final int CACHE_FORMAT = 1;
 
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
@@ -63,7 +57,6 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
 
     private HashCode configHashFor(CachedClasspathTransformer.Transform transform) {
         Hasher hasher = Hashing.defaultFunction().newHasher();
-        hasher.putInt(CACHE_FORMAT);
         transform.applyConfigurationTo(hasher);
         return hasher.hash();
     }
@@ -78,15 +71,8 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     }
 
     private File transformIfNeeded(File source, File cacheDir, String destFileName) {
-        File receipt = new File(cacheDir, destFileName + ".receipt");
         File transformed = new File(cacheDir, destFileName);
-        if (receipt.isFile()) {
-            return transformed;
-        }
         if (transformed.isFile()) {
-            // A concurrent writer has already started writing to the file.
-            // Just wait until the transformed file is ready for consumption.
-            waitForReceiptOf(destFileName, receipt);
             return transformed;
         }
         try {
@@ -99,41 +85,11 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
                 // the move is done.
                 // Just wait until the transformed file is ready for consumption.
                 LOGGER.debug("Instrumented classpath file '{}' already exists.", destFileName, e);
-                waitForReceiptOf(destFileName, receipt);
-                return transformed;
             } else {
                 throw e;
             }
         }
-        try {
-            receipt.createNewFile();
-        } catch (IOException e) {
-            LOGGER.debug("Failed to create receipt for instrumented classpath file '{}'.", destFileName, e);
-        }
         return transformed;
-    }
-
-    private void waitForReceiptOf(String destFileName, File receipt) {
-        if (!waitFor(receipt)) {
-            throw new IllegalStateException(
-                format("Timeout waiting for instrumented classpath file: '%s'.", destFileName)
-            );
-        }
-    }
-
-    /**
-     * Waits up to 60 seconds for the given file to appear.
-     *
-     * @return true when the file appears before the timeout, false otherwise.
-     */
-    private boolean waitFor(File file) {
-        try {
-            return ExponentialBackoff
-                .of(60, TimeUnit.SECONDS)
-                .retryUntil(() -> file.isFile() ? file : null) != null;
-        } catch (InterruptedException | IOException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
     }
 
     private HashCode hashOf(FileSystemLocationSnapshot sourceSnapshot) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -236,7 +236,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
+        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -264,7 +264,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
+        def cachedFile = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -294,8 +294,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
-        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
+        def cachedDir = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
+        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -352,8 +352,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/f524c514f947e91e62213d06a0aa44ff/thing.dir.jar")
-        def cachedFile = testDir.file("cached/f5f9fad7b44c0a1e957b9d27d508e341/thing.jar")
+        def cachedDir = testDir.file("cached/1726ae8bd0cffcd895ac2d3c7140c1bc/thing.dir.jar")
+        def cachedFile = testDir.file("cached/6cd68b4a2d29d65ffada96046d7d2fa4/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -373,7 +373,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/627a9975cd1bd37a9ca2247e75a0d173/thing.jar")
+        def cachedFile = testDir.file("cached/a3c0fbce9fb1525477bf88adc7b21f40/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)


### PR DESCRIPTION
And don't synchronize access to the transformed files via a 2nd receipt file.