### PR TITLE
Fix handling of excludes for missing task dependency detection

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -360,7 +360,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
     }
 
     @Issue("https://github.com/gradle/gradle/issues/16061")
-    def "excludes part of paths works with missing dependency detection"() {
+    def "missing dependency detection takes excludes into account"() {
         file("src/main/java/my/JavaClass.java").text = """
             package my;
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
@@ -83,12 +83,14 @@ public class ExecutionNodeAccessHierarchy {
             return false;
         }
         // All parent paths need to match the spec as well, since this is how we implement the file system walking for file tree.
-        File parentFile = element.getParentFile();
         RelativePath parentRelativePath = relativePath.getParent();
-        for (; parentRelativePath != null && parentRelativePath != RelativePath.EMPTY_ROOT; parentRelativePath = parentRelativePath.getParent(), parentFile = parentFile.getParentFile()) {
+        File parentFile = element.getParentFile();
+        while (parentRelativePath != null && parentRelativePath != RelativePath.EMPTY_ROOT) {
             if (!filter.isSatisfiedBy(new ReadOnlyFileTreeElement(parentFile, parentRelativePath, stat))) {
                 return false;
             }
+            parentRelativePath = parentRelativePath.getParent();
+            parentFile = parentFile.getParentFile();
         }
         return true;
     }
@@ -218,7 +220,7 @@ public class ExecutionNodeAccessHierarchy {
 
         @Override
         public boolean isDirectory() {
-            return file.isDirectory();
+            return !relativePath.isFile();
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
@@ -172,6 +173,31 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
         assertNodesAccessing("/other", root)
     }
 
+    def "can query for nodes accessing using excludes for parts of paths"() {
+        def childNode = Mock(Node)
+
+        hierarchy.recordNodeAccessingLocations(childNode, ["/some/root/child/relative/path"])
+        expect:
+        hierarchy.getNodesAccessing("/some/root", excludes("child")).empty
+        hierarchy.getNodesAccessing("/some/root", includes("child")).empty
+        hierarchy.getNodesAccessing("/some/root", includes("child/**")) == ImmutableSet.of(childNode)
+    }
+
+    def "can record file trees with excludes for parts of paths"() {
+        def excluding = Mock(Node)
+        def including = Mock(Node)
+        def includingWithChildren = Mock(Node)
+        def root = "/some/root/"
+
+        hierarchy.recordNodeAccessingFileTree(excluding, root, excludes("child"))
+        hierarchy.recordNodeAccessingFileTree(including, root, includes("child"))
+        hierarchy.recordNodeAccessingFileTree(includingWithChildren, root, includes("child/**"))
+        expect:
+        assertNodesAccessing(root, excluding, including, includingWithChildren)
+        assertNodesAccessing("${root}/child", including, includingWithChildren)
+        assertNodesAccessing("${root}/child/some/subdir", includingWithChildren)
+    }
+
     def nodesRelatedTo(TestFile location, String includePattern) {
         return hierarchy.getNodesAccessing(location.absolutePath, includes(includePattern))
     }
@@ -182,6 +208,10 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
 
     static Spec<FileTreeElement> includes(String include) {
         return new PatternSet().include(include).asSpec
+    }
+
+    static Spec<FileTreeElement> excludes(String exclude) {
+        return new PatternSet().exclude(exclude).asSpec
     }
 
     void assertNodesAccessing(String location, Node... expectedNodeList) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
@@ -173,7 +173,7 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
         assertNodesAccessing("/other", root)
     }
 
-    def "can query for nodes accessing using excludes for parts of paths"() {
+    def "can return nodes accessing some path taking includes and excludes into consideration"() {
         def childNode = Mock(Node)
 
         hierarchy.recordNodeAccessingLocations(childNode, ["/some/root/child/relative/path"])


### PR DESCRIPTION
Excludes on part of sub-trees already exclude the whole subtree. For example `exclude 'foo'` also excludes `foo/some/subdir`. We need to take this into account for missing task dependency detection as well.

Fixes #16160