### PR TITLE
Use injection for obtaining FileSystemOperations

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -406,17 +406,18 @@ performanceTest.registerTestProject("uberMobileApp", RemoteProject) {
     subdirectory = 'mobile_app1'
     // Pinned from PR https://github.com/uber-common/android-build-eval/pull/17
     ref = '18ff193198010064e43e9244edde91ab54c2da70'
-    def fileSystemOperations = objects.newInstance(InjectFileSystemOperations).fileSystemOperations
-    doLast {
-        fileSystemOperations.delete {
-            delete(new File(outputDirectory, ".okbuck"))
-        }
-    }
+    doLast(objects.newInstance(DeleteOkBuckDirectory))
 }
 
-interface InjectFileSystemOperations {
+abstract class DeleteOkBuckDirectory implements Action<RemoteProject> {
     @Inject
-    FileSystemOperations getFileSystemOperations()
+    abstract FileSystemOperations getFileSystemOperations()
+
+    void execute(RemoteProject remoteProject) {
+        fileSystemOperations.delete {
+            delete(new File(remoteProject.outputDirectory, ".okbuck"))
+        }
+    }
 }
 
 private void setMaxWorkers(File projectDirectory, int maxWorkers) {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -406,12 +406,17 @@ performanceTest.registerTestProject("uberMobileApp", RemoteProject) {
     subdirectory = 'mobile_app1'
     // Pinned from PR https://github.com/uber-common/android-build-eval/pull/17
     ref = '18ff193198010064e43e9244edde91ab54c2da70'
-    def fileSystemOperations = gradle.services.get(FileSystemOperations)
+    def fileSystemOperations = objects.newInstance(InjectFileSystemOperations).fileSystemOperations
     doLast {
         fileSystemOperations.delete {
             delete(new File(outputDirectory, ".okbuck"))
         }
     }
+}
+
+interface InjectFileSystemOperations {
+    @Inject
+    FileSystemOperations getFileSystemOperations()
 }
 
 private void setMaxWorkers(File projectDirectory, int maxWorkers) {


### PR DESCRIPTION
instead of GradleInternal.services. This avoids using the internal API for the `uberMobileApp` task.