### PR TITLE
Fix links without anchor

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Gradle" />
+    <inspection_tool class="AsciiDocLinkResolve" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CatchMayIgnoreException" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="Convert2streamapi" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/FindBrokenInternalLinks.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/FindBrokenInternalLinks.java
@@ -97,7 +97,7 @@ public abstract class FindBrokenInternalLinks extends DefaultTask {
     private void writeHeader(PrintWriter fw) {
         fw.println("# Valid links are:");
         fw.println("# * Inside the same file: <<(#)section-name(,text)>>");
-        fw.println("# * To a different file: <<other-file(.adoc)#(section-name),text>> - Note that the # is mandatory, otherwise the link is considered to be inside the file!");
+        fw.println("# * To a different file: <<other-file(.adoc)#section-name,text>> - Note that the # and section are mandatory, otherwise the link is invalid in the single page output");
         fw.println("#");
         fw.println("# The checker does not handle implicit section names, so they must be explicit and declared as: [[section-name]]");
     }
@@ -124,7 +124,9 @@ public abstract class FindBrokenInternalLinks extends DefaultTask {
                                 errorsForFile.add(new Error(lineNumber, line, "Looking for file named " + fileName));
                             } else {
                                 String idName = result.group(2);
-                                if (!idName.isEmpty()) {
+                                if (idName.isEmpty()) {
+                                    errorsForFile.add(new Error(lineNumber, line, "Missing section reference for link to " + fileName));
+                                } else {
                                     if (!fileContainsText(referencedFile, "[[" + idName + "]]")) {
                                         errorsForFile.add(new Error(lineNumber, line, "Looking for section named " + idName + " in " + fileName));
                                     }

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -25,7 +25,7 @@ This chapter provides details of the main Kotlin DSL constructs and how to use i
 
 [TIP]
 ====
-If you are interested in migrating an existing Gradle build to the Kotlin DSL, please also check out the dedicated <<migrating_from_groovy_to_kotlin_dsl.adoc#,migration section>>.
+If you are interested in migrating an existing Gradle build to the Kotlin DSL, please also check out the dedicated <<migrating_from_groovy_to_kotlin_dsl.adoc#migrating_groovy_kotlin,migration section>>.
 ====
 
 
@@ -90,7 +90,7 @@ The Kotlin DSL is fully supported by IntelliJ IDEA and Android Studio. Other IDE
 As mentioned in the limitations, you must link:https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import your project from the Gradle model] to get content-assist and refactoring tools for Kotlin DSL scripts in IntelliJ IDEA.
 
 In addition, IntelliJ IDEA and Android Studio might spawn up to 3 Gradle daemons when editing Gradle scripts — one for each type of script: build scripts, settings files and initialization scripts.
-Builds with slow configuration time might affect the IDE responsiveness, so please check out the <<performance.adoc#,performance section>> to help resolve such issues.
+Builds with slow configuration time might affect the IDE responsiveness, so please check out the <<performance.adoc#performance_gradle,performance section>> to help resolve such issues.
 
 === Automatic build import vs. automatic reloading of script dependencies
 
@@ -706,7 +706,7 @@ tasks.create("myTask") {
 == The Kotlin DSL Plugin
 
 The Kotlin DSL Plugin provides a convenient way to develop Kotlin-based projects that contribute build logic.
-That includes <<organizing_gradle_projects#sec:build_sources,buildSrc projects>>, <<composite_builds#,included builds>> and <<custom_plugins#,Gradle plugins>>.
+That includes <<organizing_gradle_projects#sec:build_sources,buildSrc projects>>, <<composite_builds#composite_builds,included builds>> and <<custom_plugins#custom_plugins,Gradle plugins>>.
 
 The plugin achieves this by doing the following:
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/build_lifecycle.adoc
@@ -65,7 +65,7 @@ For a build script, the property access and method calls are delegated to a proj
 
 How does Gradle know whether to do a single or multi-project build?
 If you trigger a multi-project build from a directory with a `settings.gradle` file, Gradle uses it to configure the build.
-Gradle also allows you to execute the build from within any subproject taking part in the build.footnote:[Gradle supports partial multi-project builds (see <<intro_multi_project_builds.adoc#,Executing Multi-Project Builds>>).]
+Gradle also allows you to execute the build from within any subproject taking part in the build.footnote:[Gradle supports partial multi-project builds (see <<intro_multi_project_builds.adoc#intro_multi_project_builds,Executing Multi-Project Builds>>).]
 If you execute Gradle from within a project with no `settings.gradle` file, Gradle looks for a `settings.gradle` file in the following way:
 
 * It looks for `settings.gradle` in parent directories.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -61,7 +61,7 @@ We have already seen how to define tasks using strings for task names in <<tutor
 
 [NOTE]
 ====
-The task configuration APIs are described in more detail in the <<task_configuration_avoidance#,task configuration avoidance chapter>>.
+The task configuration APIs are described in more detail in the <<task_configuration_avoidance#task_configuration_avoidance,task configuration avoidance chapter>>.
 ====
 
 .Defining tasks using strings for task names
@@ -85,7 +85,7 @@ include::sample[dir="snippets/tasks/defineAsKotlinDelegatedProperty/kotlin",file
 ====
 If you look at the API of the _tasks_ container you may notice that there are additional methods to _create_ tasks.
 The use of these methods is discouraged and will be deprecated in future versions.
-These methods only exist for backward compatibility as they were introduced before <<task_configuration_avoidance#,task configuration avoidance>> was added to Gradle.
+These methods only exist for backward compatibility as they were introduced before <<task_configuration_avoidance#task_configuration_avoidance,task configuration avoidance>> was added to Gradle.
 ====
 
 [[sec:locating_tasks]]
@@ -95,7 +95,7 @@ You often need to locate the tasks that you have defined in the build file, for 
 There are a number of ways of doing this. Firstly, just like with defining tasks there are language specific syntaxes for the Groovy and Kotlin DSL:
 
 In general, tasks are available through the `tasks` collection.
-You should use of the methods that return a _task provider_ – `register()` or `named()` – to make sure you do not break <<task_configuration_avoidance#,task configuration avoidance>>.
+You should use of the methods that return a _task provider_ – `register()` or `named()` – to make sure you do not break <<task_configuration_avoidance#task_configuration_avoidance,task configuration avoidance>>.
 
 .Accessing tasks via tasks collection
 ====
@@ -115,8 +115,8 @@ include::sample[dir="snippets/tasks/accessUsingType/kotlin",files="build.gradle.
 [WARNING]
 ====
 The following shows how to access a task by path.
-This is not a recommended practice anymore as it breaks <<task_configuration_avoidance#,task configuration avoidance>> and project isolation.
-Dependencies between projects <<declaring_dependencies_between_subprojects.adoc#,should be declared as dependencies>>.
+This is not a recommended practice anymore as it breaks <<task_configuration_avoidance#task_configuration_avoidance,task configuration avoidance>> and project isolation.
+Dependencies between projects <<declaring_dependencies_between_subprojects.adoc#declaring_dependencies_between_subprojects,should be declared as dependencies>>.
 ====
 
 You can access tasks from any project using the task's path using the `tasks.getByPath()` method.
@@ -214,7 +214,7 @@ include::sample[dir="snippets/tasks/taskConstructorArgs-onTaskContainer/kotlin",
 
 [NOTE]
 ====
-It's recommended to use the <<task_configuration_avoidance.adoc#,Task Configuration Avoidance>> APIs to improve configuration time.
+It's recommended to use the <<task_configuration_avoidance.adoc#task_configuration_avoidance,Task Configuration Avoidance>> APIs to improve configuration time.
 ====
 
 In all circumstances, the values passed as constructor arguments must be non-null.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/multi_project_builds.adoc
@@ -18,7 +18,7 @@ If you are building a software of a certain size with Gradle, you have two basic
 First, this chapter describes how to structure your software project using a Gradle multi-project.
 In this documentation, we consider this to be a single _software component_ which is structured internally.
 Second, you may regard your software as a _software product_ that is composed of multiple _software components_ where each component is represented by a separate Gradle build.
-This is described in detail in the chapter on <<structuring_software_products.adoc#,structuring software products with Gradle>>
+This is described in detail in the chapter on <<structuring_software_products.adoc#structure_large_projects,structuring software products with Gradle>>
 
 [[sec:creating_multi_project_builds]]
 == Creating a multi-project build
@@ -57,7 +57,7 @@ This is a structure of a multi-project build that contains a single subproject c
 ====
 
 This is the recommended project structure for starting any Gradle project.
-The <<build_init_plugin#,build init plugin>> also generates skeleton projects that follow this structure - a root project with a single subproject.
+The <<build_init_plugin#build_init_plugin,build init plugin>> also generates skeleton projects that follow this structure - a root project with a single subproject.
 
 Note that the root project does not have a Gradle build file, only a settings file that defines the subprojects to include.
 ====
@@ -73,7 +73,7 @@ We can view the structure of a multi-project build by running the `gradle projec
 include::{snippetsPath}/multiproject/basic-multiproject/tests/projects.out[]
 ----
 
-Let's say the `app` subproject is a Java application by applying the <<application_plugin#,application plugin>> and configuring the main class:
+Let's say the `app` subproject is a Java application by applying the <<application_plugin#application_plugin,application plugin>> and configuring the main class:
 ====
 include::sample[dir="snippets/multiproject/basic-multiproject/groovy",files="app/build.gradle[]"]
 include::sample[dir="snippets/multiproject/basic-multiproject/kotlin",files="app/build.gradle.kts[]"]
@@ -84,7 +84,7 @@ include::{snippetsPath}/multiproject/basic-multiproject/groovy/app/src/main/java
 ----
 ====
 
-We can then run the application by executing the `run` task from the <<application_plugin#,application plugin>>.
+We can then run the application by executing the `run` task from the <<application_plugin#application_plugin,application plugin>>.
 ----
 > gradle -q run
 include::{snippetsPath}/multiproject/basic-multiproject/tests/run.out[]
@@ -139,8 +139,8 @@ Gradle will then look for the build file for the new subproject in the `lib/` su
 ====
 
 
-Next, will explore how build logic can be <<sharing_build_logic_between_subprojects#,shared between subprojects>>
-and how subprojects can <<declaring_dependencies_between_subprojects#,depend on one another>>.
+Next, will explore how build logic can be <<sharing_build_logic_between_subprojects#sharing_build_logic_between_subprojects,shared between subprojects>>
+and how subprojects can <<declaring_dependencies_between_subprojects#declaring_dependencies_between_subprojects,depend on one another>>.
 
 == Naming recommendations
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/sharing_build_logic_between_subprojects.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/sharing_build_logic_between_subprojects.adoc
@@ -36,9 +36,9 @@ Or in other words, a subproject's _type_ tells us what traits the project has.
 
 Gradle's recommended way of organizing build logic is to use its plugin system.
 A plugin should define the _type_ of a subproject.
-In fact, <<plugin_reference#,Gradle core plugins>> are modeled in the same way - for example, the <<java_plugin#,Java Plugin>> configures a generic `java` project,
-while <<java_library_plugin#,Java Library Plugin>> internally applies the <<java_plugin#,Java Plugin>> and configures aspects specific to a Java library in addition.
-Similarly, the <<application_plugin#,Application Plugin>> applies and configures the <<java_plugin#,Java Plugin>> and the <<distribution_plugin#,Distribution Plugin>>.
+In fact, <<plugin_reference#plugin_reference,Gradle core plugins>> are modeled in the same way - for example, the <<java_plugin#java_plugin,Java Plugin>> configures a generic `java` project,
+while <<java_library_plugin#java_library_plugin,Java Library Plugin>> internally applies the <<java_plugin#java_plugin,Java Plugin>> and configures aspects specific to a Java library in addition.
+Similarly, the <<application_plugin#application_plugin,Application Plugin>> applies and configures the <<java_plugin#java_plugin,Java Plugin>> and the <<distribution_plugin#distribution_plugin,Distribution Plugin>>.
 
 You can compose custom build logic by applying and configuring both core and external plugins and create custom plugins
 that define new project _types_ and configure conventions specific to your project or organization.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/structuring_software_products.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/structuring_software_products.adoc
@@ -1,3 +1,4 @@
+[[structure_large_projects]]
 = Structuring Large Projects
 
 As software projects grow, it is common to organize large systems into components that are connected following a certain software architecture.
@@ -40,7 +41,7 @@ Apart from the production code, there are also components that deal with buildin
 
 - The _build-logic_ component contains the configuration details about building the software.
 For example, defining a Java version to use or configuring a test framework.
-It may also contain additional build logic for Gradle (<<custom_plugins.adoc#,custom plugins>> with <<custom_tasks.adoc#,custom tasks>>) that is not covered by commonly available Gradle plugins.
+It may also contain additional build logic for Gradle (<<custom_plugins.adoc#custom_plugins,custom plugins>> with <<custom_tasks.adoc#custom_tasks,custom tasks>>) that is not covered by commonly available Gradle plugins.
 - The _platforms_ component is a central place to define which versions of external components are to be used in all of our own components.
 By that, it defines the constraints for the environments – that is, _the platforms_ – to build, test and run the software product.
 - The _aggregation_ component contains the setup of the delivery pipeline that is required to push the product to production and
@@ -147,7 +148,7 @@ include::sample[dir="samples/build-organization/structuring-software-projects/ko
 ====
 
 Once included, you may create a folder matching the project name and create a `build.gradle(.kts)` file in it to configure that part of the component.
-You can find more information in the chapter about <<multi_project_builds.adoc#,structuring Gradle builds for a single software component>>.
+You can find more information in the chapter about <<multi_project_builds.adoc#multi_project_builds,structuring Gradle builds for a single software component>>.
 
 == Assigning types to components
 
@@ -174,7 +175,7 @@ The project is of no specific type and does not offer any useful content.
 If we add more files to the `domain-model/release` folder now, for example Java source files, Gradle won't know what to do with these files and just ignore them.
 We need to assign a type to the project to make Gradle aware of the purpose of such files in the project.
 
-In Gradle, you assgn a type to a project by <<plugins.adoc#,applying a plugin>>.
+In Gradle, you assign a type to a project by <<plugins.adoc#plugins,applying a plugin>>.
 The simplest thing you can do is applying one of Gradle's core plugins, like `base` or `java-library`.
 
 However, usually you have additional configuration to do in the context of the product you are building.
@@ -255,8 +256,8 @@ Furthermore, we add two dependencies that Spring Boot projects should always hav
 Similarly, we define convention plugins for "Java Libraries", "Kotlin Libraries" and "Android Applications".
 With that, we have four different project types defined that we assign to the projects of our production code components.
 
-You can find more information about writing convention plugins in section on <<sharing_build_logic_between_subprojects.adoc#,sharing build logic>> and the link:../samples/sample_convention_plugins.html[associated sample].
-For using classes to implement plugins, and for writing more advanced custom build logic, consult the chapter on <<custom_plugins.adoc#,Gradle plugin developmet>>.
+You can find more information about writing convention plugins in section on <<sharing_build_logic_between_subprojects.adoc#sharing_build_logic_between_subprojects,sharing build logic>> and the link:../samples/sample_convention_plugins.html[associated sample].
+For using classes to implement plugins, and for writing more advanced custom build logic, consult the chapter on <<custom_plugins.adoc#custom_plugins,Gradle plugin developmet>>.
 
 == Connecting components
 
@@ -274,7 +275,7 @@ It just makes the physical location of one component known to another.
 In that sense it is similar to repository declarations to discover binary components.
 Consult <<composite_builds.adoc#defining_composite_builds,the section on defining composite builds>> for more information about how to include builds.
 2. _Declare dependencies between (projects of) components._
-This is done similarly to <<declaring_dependencies.adoc#,declaring dependencies to binary components>> by using GA (_group_ and _artifact_) coordinates in the `dependencies { }` block of a `build.gradle(.kts)` file:
+This is done similarly to <<declaring_dependencies.adoc#declaring-dependencies,declaring dependencies to binary components>> by using GA (_group_ and _artifact_) coordinates in the `dependencies { }` block of a `build.gradle(.kts)` file:
 `implementation("com.example.platform:product-platform")`.
 Or, if the included component provides a plugin, you <<plugins.adoc#sec:plugins_block,apply the plugin by ID>> similar to how you would apply a plugin from the plugin portal:
 `plugins { id("com.example.java-library") }`
@@ -301,8 +302,8 @@ include::sample[dir="samples/build-organization/structuring-software-projects/ko
 That's it.
 This chapter gave an overview of which techniques to use to structure a software project into components with Gradle by following a sample.
 Download link:../samples/sample_structuring_software_projects.html[the full sample] to explore further details.
-The <<structuring_software_products_details.adoc#,next chapter>> covers more details about how to work with and evolve this kind of project structure.
-The <<composite_builds.adoc#,chapter on composite builds>> gives you more technical background about the capabilities build composition offers.
+The <<structuring_software_products_details.adoc#tweaking_structure,next chapter>> covers more details about how to work with and evolve this kind of project structure.
+The <<composite_builds.adoc#composite_builds,chapter on composite builds>> gives you more technical background about the capabilities build composition offers.
 
 To summarize, if you follow the suggestions from this chapter, your setup should clearly separate the following concerns to give you a flexible and clean model of your software product:
 
@@ -322,5 +323,5 @@ To summarize, if you follow the suggestions from this chapter, your setup should
    Note that <<structuring_software_products_details.adoc#settings_convention_plugins,there are different strategies to avoid duplicating this information>> in each `settings.gradle(.kts)` of each of your components.
 4. _Declare platforms in a central place._
    Having a platform component as in the example is optional.
-   You could do things without, e.g. by declaring <<dependency_constraints.adoc#,dependency constraints>> directly in your convention plugins.
-   However, <<platforms.adoc#,platforms>> are a good option to have all the boundaries for the environment in which your software operates defined in a central place.
+   You could do things without, e.g. by declaring <<dependency_constraints.adoc#dependency-constraints,dependency constraints>> directly in your convention plugins.
+   However, <<platforms.adoc#sec:sharing-dep-versions-between-projects,platforms>> are a good option to have all the boundaries for the environment in which your software operates defined in a central place.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/structuring_software_products_details.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/structuring_software_products_details.adoc
@@ -1,6 +1,7 @@
+[[tweaking_structure]]
 = Tweaking Project Structure
 
-This chapter covers more details on selected topics related to <<structuring_software_products.adoc#,structuring and building a software product with Gradle>>.
+This chapter covers more details on selected topics related to <<structuring_software_products.adoc#structure_large_projects,structuring and building a software product with Gradle>>.
 
 == Working with the software project
 
@@ -88,11 +89,11 @@ This is described next.
 [[binary_vs_source_components]]
 == Publishing and using binary components
 
-You can also decide to <<publishing_setup.adoc#,publish your components to a binary repository>>.
+You can also decide to <<publishing_setup.adoc#publishing_components,publish your components to a binary repository>>.
 If you make the decision to do so at some point and you want to work with binary versions of certain components instead of the source versions, you can do that by
 <<declaring_repositories.adoc#sub:centralized-repository-declaration,adding the repository to which you published>> instead of the corresponding `includeBuild("...")` statements in your `settings.gradle(.kts)` file.
 If the components keep their coordinates, you do not need to adjust any dependencies.
-You just need to define versions for the components, ideally in a <<platforms.adoc#,platform project>>.
+You just need to define versions for the components, ideally in a <<platforms.adoc#sec:sharing-dep-versions-between-projects,platform project>>.
 
 [[publish-convention-plugins]]
 === Publishing components with convention plugins

--- a/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/tutorial_using_tasks.adoc
@@ -265,8 +265,8 @@ This is equivalent to running `gradle clean run`. In a multi-project build every
 [[sec:build_script_external_dependencies]]
 == External dependencies for the build script
 
-NOTE: Instead of manipulating the script classpath directly, it is recommended to <<plugins.adoc#,apply plugins>> that come with their own classpath.
-For custom build logic, the recommendation is to <<sharing_build_logic_between_subprojects.adoc#,use a custom plugin>>.
+NOTE: Instead of manipulating the script classpath directly, it is recommended to <<plugins.adoc#plugins,apply plugins>> that come with their own classpath.
+For custom build logic, the recommendation is to <<sharing_build_logic_between_subprojects.adoc#sharing_build_logic_between_subprojects,use a custom plugin>>.
 
 If your build script needs to use external libraries, you can add them to the script's classpath in the build script itself. You do this using the `buildscript()` method, passing in a block which declares the build script classpath.
 

--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
@@ -32,7 +32,7 @@ When using a shared build cache for task output caching this even works across d
 
 Apart from tasks, <<artifact_transforms.adoc#sec:abm_artifact_transforms,artifact transforms>> can also leverage the build cache and re-use their outputs similarly to task output caching.
 
-TIP: For a hands-on approach to learning how to use the build cache, start with reading through the <<build_cache_use_cases.adoc#,use cases for the build cache>> and the follow up sections.
+TIP: For a hands-on approach to learning how to use the build cache, start with reading through the <<build_cache_use_cases.adoc#use_cases_cache,use cases for the build cache>> and the follow up sections.
 It covers the different scenarios that caching can improve and has detailed discussions of the different caveats you need to be aware of when enabling caching for a build.
 
 [[sec:build_cache_enable]]

--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache_debugging.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache_debugging.adoc
@@ -37,7 +37,7 @@ BUILD SUCCESSFUL
 
 NOTE: Tasks that have no outputs or no inputs will always be executed, but that shouldn't be a problem.
 
-Use the methods as described below to <<#diagnosing_cache_miss,diagnose>> and <<common_caching_problems.adoc#,fix>> tasks that should be up-to-date but aren't.
+Use the methods as described below to <<#diagnosing_cache_miss,diagnose>> and <<common_caching_problems.adoc#common-problems,fix>> tasks that should be up-to-date but aren't.
 If you find a task which is out of date, but no cacheable tasks depends on its outcome, then you don't have to do anything about it.
 The goal is to achieve <<build_cache_concepts.adoc#stable_task_inputs,stable task inputs>> for cacheable tasks.
 
@@ -81,7 +81,7 @@ You should see all cacheable tasks loaded from cache, while non-cacheable tasks 
 [.screenshot]
 image::build-cache/fully-cached-task-execution.png[]
 
-Again, use the below methods to <<#diagnosing_cache_miss,diagnose>> and <<common_caching_problems.adoc#,fix>> cacheability issues.
+Again, use the below methods to <<#diagnosing_cache_miss,diagnose>> and <<common_caching_problems.adoc#common-problems,fix>> cacheability issues.
 
 [[caching_relocation_test]]
 === Testing cache relocatability

--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache_use_cases.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache_use_cases.adoc
@@ -1,3 +1,4 @@
+[[use_cases_cache]]
 = Use cases for the build cache
 
 This section covers the different use cases for Gradle’s build cache, from local-only development to caching task outputs across large teams.

--- a/subprojects/docs/src/docs/userguide/build-cache/common_caching_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/common_caching_problems.adoc
@@ -143,7 +143,7 @@ Never re-release a non-changing binary dependency with the same version number b
 
 Using ``SNAPSHOT``s or other changing dependencies in your build by design violates the <<build_cache_concepts.adoc#stable_task_inputs,stable task inputs>> principle.
 To use the build cache effectively, you should depend on fixed dependencies.
-You may want to look into <<dependency_locking.adoc#,dependency locking>> or switch to using <<composite_builds.adoc#,composite builds>> instead.
+You may want to look into <<dependency_locking.adoc#dependency-locking,dependency locking>> or switch to using <<composite_builds.adoc#composite_builds,composite builds>> instead.
 
 The same is true for depending on volatile external resources, for example a list of released versions.
 One way of locking the changes would be to check the volatile resource into source control whenever it changes so that the builds only depend on the state in source control and not on the volatile resource itself.

--- a/subprojects/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/build_init_plugin.adoc
@@ -99,7 +99,7 @@ The conversion process has the following features:
 * Supports both single module and multimodule projects
 * Supports custom module names (that differ from directory names)
 * Generates general metadata - id, description and version
-* Applies <<publishing_maven.adoc#,Maven Publish>>, <<java_plugin.adoc#,Java>> and <<war_plugin.adoc#,War>> Plugins (as needed)
+* Applies <<publishing_maven.adoc#publishing_maven,Maven Publish>>, <<java_plugin.adoc#java_plugin,Java>> and <<war_plugin.adoc#war_plugin,War>> Plugins (as needed)
 * Supports packaging war projects as jars if needed
 * Generates dependencies (both external and inter-module)
 * Generates download repositories (inc. local Maven repository)

--- a/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -17,7 +17,7 @@
 
 The Ear plugin adds support for assembling web application EAR files.
 It adds a default EAR archive task.
-It doesn't require the <<java_plugin.adoc#,Java plugin>>, but for projects that also use the Java plugin it disables the default JAR archive generation.
+It doesn't require the <<java_plugin.adoc#java_plugin,Java plugin>>, but for projects that also use the Java plugin it disables the default JAR archive generation.
 
 
 [[sec:ear_usage]]

--- a/subprojects/docs/src/docs/userguide/core-plugins/java_gradle_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/java_gradle_plugin.adoc
@@ -15,7 +15,7 @@
 [[java_gradle_plugin]]
 = Gradle Plugin Development Plugin
 
-The Java Gradle Plugin development plugin can be used to assist in the development of Gradle plugins. It automatically applies the <<java_library_plugin.adoc#,Java Library>> plugin, adds the `gradleApi()` dependency to the `api` configuration and performs validation of plugin metadata during `jar` task execution.
+The Java Gradle Plugin development plugin can be used to assist in the development of Gradle plugins. It automatically applies the <<java_library_plugin.adoc#java_library_plugin,Java Library>> plugin, adds the `gradleApi()` dependency to the `api` configuration and performs validation of plugin metadata during `jar` task execution.
 
 The plugin also integrates with <<test_kit.adoc#test_kit,TestKit>>, a library that aids in writing and executing functional tests for plugin code. It automatically adds the `gradleTestKit()` dependency to the `testImplementation` configuration and generates a plugin classpath manifest file consumed by a `GradleRunner` instance if found. Please refer to <<test_kit.adoc#sub:test-kit-automatic-classpath-injection,Automatic classpath injection with the Plugin Development Plugin>> for more on its usage, configuration options and samples.
 
@@ -31,7 +31,7 @@ include::sample[dir="snippets/java/javaGradlePlugin/groovy",files="build.gradle[
 include::sample[dir="snippets/java/javaGradlePlugin/kotlin",files="build.gradle.kts[tags=use-java-gradle-plugin-plugin]"]
 ====
 
-Applying the plugin automatically applies the <<java_library_plugin.adoc#,Java Library>> plugin and adds the `gradleApi()` dependency to the `api` configuration. It also adds some validations to the build.
+Applying the plugin automatically applies the <<java_library_plugin.adoc#java_library_plugin,Java Library>> plugin and adds the `gradleApi()` dependency to the `api` configuration. It also adds some validations to the build.
 
 The following validations are performed:
 
@@ -54,4 +54,4 @@ The `gradlePlugin {}` block defines the plugins being built by the project inclu
 
 * Generate the plugin descriptor in the `jar` file's `META-INF` directory.
 * Configure the <<publishing_maven.adoc#publishing_maven,Maven>> or <<publishing_ivy.adoc#publishing_ivy,Ivy Publish Plugins>> publishing plugins to publish a <<plugins.adoc#sec:plugin_markers,Plugin Marker Artifact>> for each plugin.
-* Moreover, if the link:https://plugins.gradle.org/docs/publish-plugin[Plugin Publishing Plugin] is applied, it will publish each plugin using the same name, plugin id, display name, and description to the Gradle Plugin Portal (see <<publishing_gradle_plugins.adoc#,Publishing Plugins to Gradle Plugin Portal>> for details).
+* Moreover, if the link:https://plugins.gradle.org/docs/publish-plugin[Plugin Publishing Plugin] is applied, it will publish each plugin using the same name, plugin id, display name, and description to the Gradle Plugin Portal (see <<publishing_gradle_plugins.adoc#publishing_portal,Publishing Plugins to Gradle Plugin Portal>> for details).

--- a/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/plugin_reference.adoc
@@ -19,109 +19,109 @@ This page contains links and short descriptions for all the core plugins provide
 
 == JVM languages and frameworks
 
-<<java_plugin.adoc#,Java>>::
+<<java_plugin.adoc#java_plugin,Java>>::
 Provides support for building any type of Java project.
 
-<<java_library_plugin.adoc#,Java Library>>::
+<<java_library_plugin.adoc#java_library_plugin,Java Library>>::
 Provides support for building a Java library.
 
-<<java_platform_plugin.adoc#,Java Platform>>::
+<<java_platform_plugin.adoc#java_platform_plugin,Java Platform>>::
 Provides support for building a Java platform.
 
-<<groovy_plugin.adoc#,Groovy>>::
+<<groovy_plugin.adoc#groovy_plugin,Groovy>>::
 Provides support for building any type of https://groovy-lang.org/[Groovy] project.
 
-<<scala_plugin.adoc#,Scala>>::
+<<scala_plugin.adoc#scala_plugin,Scala>>::
 Provides support for building any type of https://www.scala-lang.org/[Scala] project.
 
-<<antlr_plugin.adoc#,ANTLR>>::
+<<antlr_plugin.adoc#antlr_plugin,ANTLR>>::
 Provides support for generating parsers using http://www.antlr.org/[ANTLR].
 
 [[native_languages]]
 == Native languages
 
-<<cpp_application_plugin.adoc#,C++ Application>>::
+<<cpp_application_plugin.adoc#cpp_application_plugin,C++ Application>>::
 Provides support for building C++ applications on Windows, Linux, and macOS.
 
-<<cpp_library_plugin.adoc#,C++ Library>>::
+<<cpp_library_plugin.adoc#cpp_library_plugin,C++ Library>>::
 Provides support for building C++ libraries on Windows, Linux, and macOS.
 
-<<cpp_unit_test_plugin.adoc#,C++ Unit Test>>::
+<<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,C++ Unit Test>>::
 Provides support for building and running C++ executable-based tests on Windows, Linux, and macOS.
 
-<<swift_application_plugin.adoc#,Swift Application>>::
+<<swift_application_plugin.adoc#swift_application_plugin,Swift Application>>::
 Provides support for building Swift applications on Linux and macOS.
 
-<<swift_library_plugin.adoc#,Swift Library>>::
+<<swift_library_plugin.adoc#swift_library_plugin,Swift Library>>::
 Provides support for building Swift libraries on Linux and macOS.
 
-<<xctest_plugin.adoc#,XCTest>>::
+<<xctest_plugin.adoc#xctest_plugin,XCTest>>::
 Provides support for building and running XCTest-based tests on Linux and macOS.
 
 == Packaging and distribution
 
-<<application_plugin.adoc#,Application>>::
+<<application_plugin.adoc#application_plugin,Application>>::
 Provides support for building JVM-based, runnable applications.
 
-<<war_plugin.adoc#,WAR>>::
+<<war_plugin.adoc#war_plugin,WAR>>::
 Provides support for building and packaging WAR-based Java web applications.
 
-<<ear_plugin.adoc#,EAR>>::
+<<ear_plugin.adoc#ear_plugin,EAR>>::
 Provides support for building and packaging Java EE applications.
 
-<<publishing_maven.adoc#,Maven Publish>>::
-Provides support for <<publishing_setup.adoc#,publishing artifacts>> to Maven-compatible repositories.
+<<publishing_maven.adoc#publishing_maven,Maven Publish>>::
+Provides support for <<publishing_setup.adoc#publishing_components,publishing artifacts>> to Maven-compatible repositories.
 
-<<publishing_ivy.adoc#,Ivy Publish>>::
-Provides support for <<publishing_setup.adoc#,publishing artifacts>> to Ivy-compatible repositories.
+<<publishing_ivy.adoc#publishing_ivy,Ivy Publish>>::
+Provides support for <<publishing_setup.adoc#publishing_components,publishing artifacts>> to Ivy-compatible repositories.
 
-<<distribution_plugin.adoc#,Distribution>>::
+<<distribution_plugin.adoc#distribution_plugin,Distribution>>::
 Makes it easy to create ZIP and tarball distributions of your project.
 
-<<java_library_distribution_plugin.adoc#,Java Library Distribution>>::
+<<java_library_distribution_plugin.adoc#java_library_distribution_plugin,Java Library Distribution>>::
 Provides support for creating a ZIP distribution of a Java library project that includes its runtime dependencies.
 
 == Code analysis
 
-<<checkstyle_plugin.adoc#,Checkstyle>>::
+<<checkstyle_plugin.adoc#checkstyle_plugin,Checkstyle>>::
 Performs quality checks on your project’s Java source files using https://checkstyle.org/index.html[Checkstyle] and generates associated reports.
 
-<<pmd_plugin.adoc#,PMD>>::
+<<pmd_plugin.adoc#pmd_plugin,PMD>>::
 Performs quality checks on your project’s Java source files using http://pmd.github.io/[PMD] and generates associated reports.
 
-<<jacoco_plugin.adoc#,JaCoCo>>::
+<<jacoco_plugin.adoc#jacoco_plugin,JaCoCo>>::
 Provides code coverage metrics for your Java project using http://www.eclemma.org/jacoco/[JaCoCo].
 
-<<codenarc_plugin.adoc#,CodeNarc>>::
+<<codenarc_plugin.adoc#codenarc_plugin,CodeNarc>>::
 Performs quality checks on your Groovy source files using http://codenarc.sourceforge.net/index.html[CodeNarc] and generates associated reports.
 
 == IDE integration
 
-<<eclipse_plugin.adoc#,Eclipse>>::
+<<eclipse_plugin.adoc#eclipse_plugin,Eclipse>>::
 Generates Eclipse project files for the build that can be opened by the IDE. This set of plugins can also be used to fine tune http://projects.eclipse.org/projects/tools.buildship[Buildship's] import process for Gradle builds.
 
-<<idea_plugin.adoc#,IntelliJ IDEA>>::
+<<idea_plugin.adoc#idea_plugin,IntelliJ IDEA>>::
 Generates IDEA project files for the build that can be opened by the IDE. It can also be used to fine tune IDEA's import process for Gradle builds.
 
-<<visual_studio_plugin.adoc#,Visual Studio>>::
+<<visual_studio_plugin.adoc#visual_studio_plugin,Visual Studio>>::
 Generates Visual Studio solution and project files for build that can be opened by the IDE.
 
-<<xcode_plugin.adoc#,Xcode>>::
+<<xcode_plugin.adoc#xcode_plugin,Xcode>>::
 Generates Xcode workspace and project files for the build that can be opened by the IDE.
 
 == Utility
 
-<<base_plugin.adoc#,Base>>::
+<<base_plugin.adoc#base_plugin,Base>>::
 Provides common lifecycle tasks, such as `clean`, and other features common to most builds.
 
-<<build_init_plugin.adoc#,Build Init>>::
-Generates a new Gradle build of a specified type, such as a Java library. It can also generate a build script from a Maven POM — see <<migrating_from_maven.adoc#,Migrating from Maven to Gradle>> for more details.
+<<build_init_plugin.adoc#build_init_plugin,Build Init>>::
+Generates a new Gradle build of a specified type, such as a Java library. It can also generate a build script from a Maven POM — see <<migrating_from_maven.adoc#migrating_from_maven,Migrating from Maven to Gradle>> for more details.
 
-<<signing_plugin.adoc#,Signing>>::
+<<signing_plugin.adoc#signing_plugin,Signing>>::
 Provides support for digitally signing generated files and artifacts.
 
-<<java_gradle_plugin.adoc#,Plugin Development>>::
+<<java_gradle_plugin.adoc#java_gradle_plugin,Plugin Development>>::
 Makes it easier to develop and publish a Gradle plugin.
 
-<<project_report_plugin.adoc#,Project Report Plugin>>::
+<<project_report_plugin.adoc#project_report_plugin,Project Report Plugin>>::
 Helps to generate reports containing useful information about your build.

--- a/subprojects/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/visual_studio_plugin.adoc
@@ -27,10 +27,10 @@ What exactly the `visual-studio` plugin generates depends on which other plugins
 | None
 | Generates minimal solution file.
 
-| <<cpp_application_plugin.adoc#,{cpp} Application>>
+| <<cpp_application_plugin.adoc#cpp_application_plugin,{cpp} Application>>
 | Adds a project representing the {cpp} application to the solution file.
 
-| <<cpp_library_plugin.adoc#,{cpp} Library>>
+| <<cpp_library_plugin.adoc#cpp_library_plugin,{cpp} Library>>
 | Adds a project for each specified linkage representing the shared and/or static library to the solution file.
 |===
 

--- a/subprojects/docs/src/docs/userguide/core-plugins/war_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/war_plugin.adoc
@@ -15,7 +15,7 @@
 [[war_plugin]]
 = The War Plugin
 
-The War plugin extends the <<java_plugin.adoc#,Java plugin>> to add support for assembling web application WAR files.
+The War plugin extends the <<java_plugin.adoc#java_plugin,Java plugin>> to add support for assembling web application WAR files.
 It disables the default JAR archive generation of the Java plugin and adds a default WAR archive task.
 
 [[sec:war_usage]]

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/core_dependency_management.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/core_dependency_management.adoc
@@ -1,3 +1,4 @@
+[[dependency_management_in_gradle]]
 = Dependency management in Gradle
 
 == What is dependency management?
@@ -6,7 +7,7 @@ Software projects rarely work in isolation. In most cases, a project relies on r
 
 [NOTE]
 ====
-For a general overview on the terms used throughout the user guide, refer to <<dependency_management_terminology.adoc#,Dependency Management Terminology>>.
+For a general overview on the terms used throughout the user guide, refer to <<dependency_management_terminology.adoc#dependency_management_terminology,Dependency Management Terminology>>.
 ====
 
 [[sec:dependency-mgmt-in-gradle]]
@@ -49,7 +50,7 @@ Metadata is the data that describes the module in more detail e.g. the coordinat
 As part of the metadata, a module can define that other modules are needed for it to work properly.
 For example, the JUnit 5 platform module also requires the platform commons module.
 Gradle automatically resolves those additional modules, so called _transitive dependencies_.
-If needed, you can <<dependency_constraints.adoc#,customize the behavior the handling of transitive dependencies>> to your project's requirements.
+If needed, you can <<dependency_constraints.adoc#dependency-constraints,customize the behavior the handling of transitive dependencies>> to your project's requirements.
 
 Projects with tens or hundreds of declared dependencies can easily suffer from dependency hell.
 Gradle provides sufficient tooling to visualize, navigate and analyze the dependency graph of a project either with the help of a link:https://scans.gradle.com/get-started[build scan] or built-in tasks.

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
@@ -57,7 +57,7 @@ In the context of dependency resolution, it is useful to distinguish between a _
 1. to declare dependencies
 2. as a _consumer_, to resolve a set of dependencies to files
 3. as a _producer_, to expose artifacts and their dependencies for consumption by other projects
-   (such _consumable_ configurations usually represent the <<variant_model.adoc#,variants>> the producer offers to its consumers)
+   (such _consumable_ configurations usually represent the <<variant_model.adoc#understanding-variant-selection,variants>> the producer offers to its consumers)
 
 For example, to express that an application `app` _depends on_ library `lib`, _at least_ one configuration is required:
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -351,7 +351,7 @@ By default, repositories include everything and exclude nothing:
 * If you declare both includes and excludes, then it includes only what is explicitly included and not excluded.
 
 It is possible to filter either by explicit _group_, _module_ or _version_, either strictly or using regular expressions.
-When using a strict version, it is possible to use a version range, using <<single_versions.adoc#,the format supported>> by Gradle.
+When using a strict version, it is possible to use a version range, using <<single_versions.adoc#single-version-declarations,the format supported>> by Gradle.
 In addition, there are filtering options by resolution context: configuration name or even configuration attributes.
 See link:{javadocPath}/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html[RepositoryContentDescriptor] for details.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -1,7 +1,8 @@
+[[understanding_dependency_resolution]]
 = Understanding dependency resolution
 
 This chapter covers the way dependency resolution works _inside_ Gradle.
-After covering how you can declare <<declaring_repositories.adoc#,repositories>> and <<declaring_dependencies.adoc#,dependencies>>, it makes sense to explain how these declarations come together during dependency resolution.
+After covering how you can declare <<declaring_repositories.adoc#declaring-repositories,repositories>> and <<declaring_dependencies.adoc#declaring-dependencies,dependencies>>, it makes sense to explain how these declarations come together during dependency resolution.
 
 Dependency resolution is a process that consists of two phases, which are repeated until the dependency graph is complete:
 
@@ -25,7 +26,7 @@ That is when the dependency graph contains module that provide the same implemen
 The following sections will explain in detail how Gradle attempts to resolve these conflicts.
 
 The dependency resolution process is highly customizable to meet enterprise requirements.
-For more information, see the chapter on <<dependency_constraints.adoc#,Controlling transitive dependencies>>.
+For more information, see the chapter on <<dependency_constraints.adoc#dependency-constraints,Controlling transitive dependencies>>.
 
 [[sec:version-conflict]]
 == Version conflict resolution
@@ -70,7 +71,7 @@ This flexibility comes with the price of making it hard to reason about.
 Gradle will consider _all_ requested versions, wherever they appear in the dependency graph.
 Out of these versions, it will select the _highest_ one.
 
-As you have seen, Gradle supports a concept of <<rich_versions.adoc#,rich version declaration>>, so what is the highest version depends on the way versions were declared:
+As you have seen, Gradle supports a concept of <<rich_versions.adoc#rich-version-constraints,rich version declaration>>, so what is the highest version depends on the way versions were declared:
 
 * If no ranges are involved, then the highest version that is not rejected will be selected.
 ** If a version declared as `strictly` is lower than that version, selection will fail.
@@ -87,7 +88,7 @@ This causes an intermediate lookup for metadata, as described in <<#sec:how-grad
 
 Gradle uses variants and capabilities to identify what a module _provides_.
 
-This is a unique feature that deserves its <<variant_model.adoc#,own chapter>> to understand what it means and enables.
+This is a unique feature that deserves its <<variant_model.adoc#understanding-variant-selection,own chapter>> to understand what it means and enables.
 
 A conflict occurs the moment two modules either:
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/library_vs_application.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/library_vs_application.adoc
@@ -26,7 +26,7 @@ Or, a project may produce artifacts which are for consumption by other projects 
 A typical example in the Java world is the Guava library which is published in different versions: one for Java projects, and one for Android projects.
 
 However, it's the consumer responsibility to tell what version to use, and it's the dependency management engine responsibility to ensure _consistency of the graph_ (for example making sure that you don't end up with both Java and Android versions of Guava on your classpath).
-This is where the <<variant_model.adoc#,variant model>> of Gradle comes into play.
+This is where the <<variant_model.adoc#understanding-variant-selection,variant model>> of Gradle comes into play.
 
 In Gradle, _producer variants_ are exposed via <<declaring_dependencies.adoc#sec:resolvable-consumable-configs,consumable configurations>>.
 
@@ -44,7 +44,7 @@ On the other hand, a dependency which is assigned to the `api` configuration of 
 At _runtime_, however, all dependencies are required.
 Gradle makes the difference between different kinds of consumer even within a single project: the Java compile task, for example, is a different consumer than the Java exec task.
 
-More details on the segregation of API and runtime dependencies in the Java world <<java_library_plugin.adoc#,can be found here>>.
+More details on the segregation of API and runtime dependencies in the Java world <<java_library_plugin.adoc#java_library_plugin,can be found here>>.
 
 [[sub:being-respectful-consumers]]
 == Being respectful of consumers

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/viewing_debugging_dependencies.adoc
@@ -104,7 +104,7 @@ It can be a complete `group:name`, or part of it.
 If multiple dependencies match, they are all printed in the report.
 `--configuration <name>` (mandatory)::
 Indicates which configuration to resolve for showing the dpendency information.
-Note that the <<java_plugin#, Java plugin>> wires a convention with the value `compileClasspath`, making the parameter optional.
+Note that the <<java_plugin#java_plugin, Java plugin>> wires a convention with the value `compileClasspath`, making the parameter optional.
 `--singlepath` (optional)::
 Indicates to render only a single path to the dependency.
 This might be useful to trim down the output in large graphs.
@@ -153,7 +153,7 @@ Have a look at the table below to understand the meaning of the different terms 
 This can also be followed by a `because` text.
 
 | Was requested : reject version <versions>
-| The dependency appears in the graph, with a <<rich_versions#, rich version>> containing one or more `reject`.
+| The dependency appears in the graph, with a <<rich_versions#rich-version-constraints, rich version>> containing one or more `reject`.
 This can also be followed by a `because` text.
 
 | By conflict resolution : between versions <version>
@@ -165,10 +165,10 @@ This resulted in <<dependency_resolution#sec:version-conflict, conflict resoluti
 This can also be followed by a `because` text.
 
 | By ancestor
-| There is a <<rich_versions#, rich version>> with a `strictly` in the graph which enforces the version of this dependency.
+| There is a <<rich_versions#rich-version-constraints, rich version>> with a `strictly` in the graph which enforces the version of this dependency.
 
 | Selected by rule
-| A <<resolution_rules#, dependency resolution rule>> overruled the default selection process.
+| A <<resolution_rules#resolution_rules, dependency resolution rule>> overruled the default selection process.
 This can also be followed by a `because` text.
 
 | Rejection : <version> by rule because <text>
@@ -187,12 +187,12 @@ Note that if multiple selection reasons exist in the graph, they will all be lis
 [[sec:resolving-version-conflict]]
 == Resolving version conflicts
 
-If the selected version does not match your expectation, Gradle offers a series of tools to help you <<dependency_constraints.adoc#,control transitive dependencies>>.
+If the selected version does not match your expectation, Gradle offers a series of tools to help you <<dependency_constraints.adoc#dependency-constraints,control transitive dependencies>>.
 
 [[sec:resolving-variant-aware-errors]]
 == Resolving variant selection errors
 
-Sometimes a selection error will happen at the <<variant_model.adoc#,variant selection level>>.
+Sometimes a selection error will happen at the <<variant_model.adoc#understanding-variant-selection,variant selection level>>.
 Have a look at the <<variant_model.adoc#sec:variant-select-errors,dedicated section>> to understand these errors and how to resolve them.
 
 [[sub:resolving-unsafe-configuration-resolution-errors]]

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/rich_versions.adoc
@@ -120,7 +120,7 @@ Overwrites versions from transitive dependencies. +
 🔒
 |===
 
-Lines annotated with a lock (🔒) indicate that leveraging <<dependency_locking.adoc#,dependency locking>> makes sense in this context.
+Lines annotated with a lock (🔒) indicate that leveraging <<dependency_locking.adoc#dependency-locking,dependency locking>> makes sense in this context.
 Another concept that relates with rich version declaration is the ability to publish <<publishing_maven.adoc#publishing_maven:resolved_dependencies,resolved versions>> instead of declared ones.
 
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/component_metadata_rules.adoc
@@ -96,8 +96,8 @@ The following details of each variant can be adjusted:
 
 - The <<variant_model.adoc#sec:abm_configuration_attributes,attributes>> that identify the variant — `attributes {}` block
 - The <<component_capabilities.adoc#declaring-component-capabilities,capabilities>> the variant provides — `withCapabilities { }` block
-- The <<declaring_dependencies.adoc#,dependencies>> of the variant, including <<rich_versions.adoc#,rich versions>> — `withDependencies {}` block
-- The <<dependency_constraints.adoc#sec:adding-constraints-transitive-deps,dependency constraints>> of the variant, including <<rich_versions.adoc#,rich versions>> — `withDependencyConstraints {}` block
+- The <<declaring_dependencies.adoc#declaring-dependencies,dependencies>> of the variant, including <<rich_versions.adoc#rich-version-constraints,rich versions>> — `withDependencies {}` block
+- The <<dependency_constraints.adoc#sec:adding-constraints-transitive-deps,dependency constraints>> of the variant, including <<rich_versions.adoc#rich-version-constraints,rich versions>> — `withDependencyConstraints {}` block
 - The location of the published files that make up the actual content of the variant — `withFiles { }` block
 
 There are also a few properties of the whole component that can be changed:
@@ -120,7 +120,7 @@ In general, if you consider using component metadata rules to adjust the metadat
 
 If a module was published with Gradle Module Metadata, the metadata is likely complete although there can still be cases where something is just plainly wrong.
 For these modules you should only use component metadata rules if you have clearly identified a problem with the metadata itself.
-If you have an issue with the dependency resolution result, you should first check if you can solve the issue by declaring <<rich_versions.adoc#,dependency constraints with rich versions>>.
+If you have an issue with the dependency resolution result, you should first check if you can solve the issue by declaring <<rich_versions.adoc#rich-version-constraints,dependency constraints with rich versions>>.
 In particular, if you are developing a library that you publish, you should remember that dependency constraints, in contrast to component metadata rules, are published as part of the metadata of your own library.
 So with dependency constraints, you automatically share the solution of dependency resolution issues with your consumers, while component metadata rules are only applied to your own build.
 
@@ -145,12 +145,12 @@ include::sample[dir="snippets/dependencyManagement/customizingResolution-metadat
 ====
 
 Within the `withDependencies` block you have access to the full list of dependencies and can use all methods available on the Java collection interface to inspect and modify that list.
-In addition, there are `add(notation, configureAction)` methods accepting the usual notations similar to <<declaring_dependencies.adoc#,declaring dependencies>> in the build script.
+In addition, there are `add(notation, configureAction)` methods accepting the usual notations similar to <<declaring_dependencies.adoc#declaring-dependencies,declaring dependencies>> in the build script.
 Dependency constraints can be inspected and modified the same way in the `withDependencyConstraints` block.
 
 If we take a closer look at the Jaxen 1.1.4 pom, we observe that the _dom4j_, _jdom_ and _xerces_ dependencies are still there but marked as _optional_.
 Optional dependencies in poms are not automatically processed by Gradle nor Maven.
-The reason is that they indicate that there are <<feature_variants.adoc#,optional feature variants>> provided by the Jaxen library which require one or more of these dependencies, but the information what these features are and which dependency belongs to which is missing.
+The reason is that they indicate that there are <<feature_variants.adoc#feature_variants,optional feature variants>> provided by the Jaxen library which require one or more of these dependencies, but the information what these features are and which dependency belongs to which is missing.
 Such information cannot be represented in pom files, but in Gradle Module Metadata through variants and <<component_capabilities.adoc#declaring-component-capabilities,capabilities>>.
 Hence, we can add this information in a rule as well.
 
@@ -261,7 +261,7 @@ This rule is quite similar to the Quasar library example above.
 Only this time we have five different runtime variants we add and nothing we need to change for the compile variant.
 The runtime variants are all based on the existing _runtime_ variant and we do not change any existing information.
 All Java ecosystem attributes, the dependencies and the main jar file stay part of each of the runtime variants.
-We only set the additional attributes `OPERATING_SYSTEM_ATTRIBUTE` and `ARCHITECTURE_ATTRIBUTE` which are defined as part of Gradle's <<building_cpp_projects.adoc#,native support>>.
+We only set the additional attributes `OPERATING_SYSTEM_ATTRIBUTE` and `ARCHITECTURE_ATTRIBUTE` which are defined as part of Gradle's <<building_cpp_projects.adoc#building_cpp_projects,native support>>.
 And we add the corresponding native jar file so that each runtime variant now carries two files: the main jar and the native jar.
 
 In the build script, we can now request a specific variant and Gradle will fail with a selection error if more information is needed to make a decision.
@@ -285,7 +285,7 @@ include::sample[dir="snippets/dependencyManagement/customizingResolution-metadat
 
 == Making different flavors of a library available through capabilities
 
-Because it is difficult to model <<feature_variants.adoc#,optional feature variants>> as separate jars with pom metadata, libraries sometimes compose different jars with a different feature set.
+Because it is difficult to model <<feature_variants.adoc#feature_variants,optional feature variants>> as separate jars with pom metadata, libraries sometimes compose different jars with a different feature set.
 That is, instead of composing your flavor of the library from different feature variants, you select one of the pre-composed variants (offering everything in one jar).
 One such library is the well-known dependency injection framework Guice, published on link:https://repo1.maven.org/maven2/com/google/inject/guice/4.2.2[Maven central], which offers a complete flavor (the main jar) and a reduced variant without aspect-oriented programming support (`guice-4.2.2-no_aop.jar`).
 That second variant with a classifier is not mentioned in the pom metadata.
@@ -345,7 +345,7 @@ include::sample[dir="snippets/dependencyManagement/customizingResolution-metadat
 == Modifying metadata on the component level for alignment
 
 While all the examples above made modifications to variants of a component, there is also a limited set of modifications that can be done to the metadata of the component itself.
-This information can influence the <<dependency_resolution.adoc#,version selection>> process for a module during dependency resolution, which is performed _before_ one or multiple variants of a component are selected.
+This information can influence the <<dependency_resolution.adoc#understanding_dependency_resolution,version selection>> process for a module during dependency resolution, which is performed _before_ one or multiple variants of a component are selected.
 
 The first API available on the component is `belongsTo()` to create virtual platforms for aligning versions of multiple modules without Gradle Module Metadata.
 It is explained in detail in the section on <<dependency_version_alignment.adoc#sec:align-versions-unpublished,aligning versions of modules not published with Gradle>>.
@@ -361,7 +361,7 @@ It is therefore recommended to only modify this attribute, if any, on the compon
 A dedicated API `setStatus(value)` is available for this.
 To modify another attribute for all variants of a component `withAllVariants { attributes {} }` should be utilised instead.
 
-A module's status is taken into consideration when a <<single_versions.adoc#,_latest_ version selector>> is resolved.
+A module's status is taken into consideration when a <<single_versions.adoc#single-version-declarations,_latest_ version selector>> is resolved.
 Specifically, `latest.someStatus` will resolve to the highest module version that has status `someStatus` or a more mature status.
 For example, `latest.integration` will select the highest module version regardless of its status (because `integration` is the least mature status as explained below), whereas `latest.release` will select the highest module version with status `release`.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_constraints.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_constraints.adoc
@@ -20,7 +20,7 @@ To avoid this, Gradle provides the concept of _dependency constraints_.
 
 Dependency constraints allow you to define the version or the version range of both dependencies declared in the build script and transitive dependencies.
 It is the preferred method to express constraints that should be applied to all dependencies of a configuration.
-When Gradle attempts to resolve a dependency to a module version, all <<rich_versions.adoc#,dependency declarations with version>>, all transitive dependencies and all dependency constraints for that module are taken into consideration.
+When Gradle attempts to resolve a dependency to a module version, all <<rich_versions.adoc#rich-version-constraints,dependency declarations with version>>, all transitive dependencies and all dependency constraints for that module are taken into consideration.
 The highest version that matches all conditions is selected.
 If no such version is found, Gradle fails with an error showing the conflicting declarations.
 If this happens you can adjust your dependencies or dependency constraints declarations, or make other adjustments to the transitive dependencies if needed.
@@ -37,7 +37,7 @@ In the example, all versions are omitted from the dependency declaration.
 Instead, the versions are defined in the constraints block.
 The version definition for `commons-codec:1.11` is only taken into account if `commons-codec` is brought in as transitive dependency, since `commons-codec` is not defined as dependency in the project.
 Otherwise, the constraint has no effect.
-Dependency constraints can also define a <<rich_versions.adoc#,rich version constraint>> and support <<rich_versions.adoc#sec:strict-version,strict versions>> to enforce a version even if it contradicts with the version defined by a transitive dependency (e.g. if the version needs to be downgraded).
+Dependency constraints can also define a <<rich_versions.adoc#rich-version-constraints,rich version constraint>> and support <<rich_versions.adoc#sec:strict-version,strict versions>> to enforce a version even if it contradicts with the version defined by a transitive dependency (e.g. if the version needs to be downgraded).
 
 [NOTE]
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_downgrade_and_exclude.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_downgrade_and_exclude.adoc
@@ -1,3 +1,4 @@
+[[downgrading_versions_and_excluding_dependencies]]
 = Downgrading versions and excluding dependencies
 
 [[sec:enforcing_dependency_version]]
@@ -71,7 +72,7 @@ Then if a consumer chooses 1.1 (or any other version in the range), the build wi
 Forcing dependencies via link:{javadocPath}/org/gradle/api/artifacts/ExternalDependency.html#setForce-boolean-[ExternalDependency.setForce(boolean)] is deprecated and no longer recommended:
 forced dependencies suffer an ordering issue which can be hard to diagnose and will not work well together with other rich version constraints.
 You should prefer <<#sec:enforcing_dependency_version,strict versions>> instead.
-If you are authoring and publishing a <<library_vs_application.adoc#,library>>, you also need to be aware that `force` is *not* published.
+If you are authoring and publishing a <<library_vs_application.adoc#sec:understanding-diff-libraries-and-apps,library>>, you also need to be aware that `force` is *not* published.
 ====
 
 If, for some reason, you can't use <<#sec:enforcing_dependency_version,strict versions>>, you can force a dependency doing this:
@@ -122,7 +123,7 @@ include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencie
 ====
 
 Effectively, we are expressing that we only use a _subset_ of the library, which does not require the `commons-collection` library.
-This can be seen as implicitly defining a <<feature_variants.adoc#,feature variant>> that has not been explicitly declared by `commons-beanutils` itself.
+This can be seen as implicitly defining a <<feature_variants.adoc#feature_variants,feature variant>> that has not been explicitly declared by `commons-beanutils` itself.
 However, the risk of breaking an untested code path increased by doing this.
 
 For example, here we use the `setSimpleProperty()` method to modify properties defined by setters in the `Person` class, which works fine.
@@ -159,11 +160,11 @@ You may consider to look into the following features:
 
 - <<#sec:enforcing_dependency_version,Update>> or <<#sec:enforcing_dependency_version,downgrade>> dependency versions:
   If versions of dependencies clash, it is usually better to adjust the version through a dependency constraint, instead of attempting to exclude the dependency with the undesired version.
-- <<component_metadata_rules.adoc#,Component Metadata Rules>>:
+- <<component_metadata_rules.adoc#sec:component_metadata_rules,Component Metadata Rules>>:
   If a library's metadata is clearly wrong, for example if it includes a compile time dependency which is never needed at compile time, a possible solution is to remove the dependency in a component metadata rule.
   By this, you tell Gradle that a dependency between two modules is never needed — i.e. the metadata was wrong — and therefore should *never* be considered.
   If you are developing a library, you have to be aware that this information is not published, and so sometimes an _exclude_ can be the better alternative.
-- <<dependency_capability_conflict.adoc#,Resolving mutually exclusive dependency conflicts>>:
+- <<dependency_capability_conflict.adoc#sec:handling-mutually-exclusive-deps,Resolving mutually exclusive dependency conflicts>>:
   Another situation that you often see solved by excludes is that two dependencies cannot be used together because they represent two implementations of the same thing (the same <<dependency_capability_conflict.adoc#sub:capabilities,capability>>).
   A popular example are clashing logging API implementations (like `log4j` and `log4j-over-slf4j`) or modules that have different coordinates in different versions (like `com.google.collections` and `guava`).
   In this case, if this information is not known to Gradle, it is recommended to add the missing capability information via component metadata rules as described in the <<dependency_capability_conflict.adoc#sub:declaring-component-capabilities,declaring component capabilities>> section.

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/dependency_version_alignment.adoc
@@ -31,7 +31,7 @@ Either because they are actually published as a whole (when one of the members o
 
 Gradle natively supports alignment of modules produced by Gradle.
 This is a direct consequence of the transitivity of <<dependency_constraints.adoc#sec:adding-constraints-transitive-deps, dependency constraints>>.
-So if you have a multi-project build, and you wish that consumers get the same version of all your modules, Gradle provides a simple way to do this using the <<java_platform_plugin.adoc#,Java Platform Plugin>>.
+So if you have a multi-project build, and you wish that consumers get the same version of all your modules, Gradle provides a simple way to do this using the <<java_platform_plugin.adoc#java_platform_plugin,Java Platform Plugin>>.
 
 For example, if you have a project that consists of 3 modules:
 
@@ -84,7 +84,7 @@ There are two options to express that a set of modules belong to a platform:
 2. No existing platform can be used. Instead, a **virtual platform** should be created by Gradle:
    In this case, Gradle builds up the platform itself based on all the members that are used.
 
-To provide the missing information to Gradle, you can define <<component_metadata_rules.adoc#,component metadata rules>> as explained in the following.
+To provide the missing information to Gradle, you can define <<component_metadata_rules.adoc#sec:component_metadata_rules,component metadata rules>> as explained in the following.
 
 [[sec:align_bom_platform]]
 === Align versions of modules using a published BOM
@@ -112,7 +112,7 @@ In that BOM, the following versions are defined and will be used:
 `jackson-annotation:2.9.0`.
 The lower versions of `jackson-annotation` here might be the desired result as it is what the BOM recommends.
 
-NOTE: This behavior is working reliable since Gradle 6.1. Effectively, it is similar to a <<component_metadata_rules.adoc#,component metadata rule>> that adds a platform dependency to all members of the platform using `withDependencies`.
+NOTE: This behavior is working reliable since Gradle 6.1. Effectively, it is similar to a <<component_metadata_rules.adoc#sec:component_metadata_rules,component metadata rule>> that adds a platform dependency to all members of the platform using `withDependencies`.
 
 [[sec:virtual_platform]]
 === Align versions of modules without a published platform

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -28,7 +28,8 @@ In this context, `libs` is a catalog and `groovy` represents a dependency availa
 
 Adding a dependency using the `libs.someLib` notation works exactly like if you had hardcoded the group, artifact and version directly in the build script.
 
-WARNING: A dependency catalog doesn't enforce the version of a dependency: like a regular dependency notation, it declares the requested version or a <<rich_versions.adoc#rich-version-constraints,rich version>>. That version is not necessarily the version that is selected during <<dependency_resolution#,conflict resolution>>.
+WARNING: A dependency catalog doesn't enforce the version of a dependency: like a regular dependency notation, it declares the requested version or a <<rich_versions.adoc#rich-version-constraints,rich version>>.
+That version is not necessarily the version that is selected during <<dependency_resolution#understanding_dependency_resolution,conflict resolution>>.
 
 [[sub:version-catalog-declaration]]
 === Declaring a version catalog

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/resolution_rules.adoc
@@ -4,10 +4,10 @@
 [WARNING]
 ====
 This section covers mechanisms Gradle offers to directly influence the behavior of the dependency resolution engine.
-In contrast to the other concepts covered in this chapter, like <<dependency_constraints.adoc#,dependency constraints>> or <<component_metadata_rules.adoc#,component metadata rules>>, which are all *inputs* to resolution, the following mechanisms allow you to write rules which are directly injected into the resolution engine.
+In contrast to the other concepts covered in this chapter, like <<dependency_constraints.adoc#dependency-constraints,dependency constraints>> or <<component_metadata_rules.adoc#sec:component_metadata_rules,component metadata rules>>, which are all *inputs* to resolution, the following mechanisms allow you to write rules which are directly injected into the resolution engine.
 Because of this, they can be seen as _brute force_ solutions, that may hide future problems (e.g. if new dependencies are added).
 Therefore, the general advice is to only use the following mechanisms if other means are not sufficient.
-If you are authoring a <<library_vs_application.adoc#,library>>, you should always prefer <<dependency_constraints.adoc#,dependency constraints>> as they are published for your consumers.
+If you are authoring a <<library_vs_application.adoc#sec:understanding-diff-libraries-and-apps,library>>, you should always prefer <<dependency_constraints.adoc#dependency-constraints,dependency constraints>> as they are published for your consumers.
 ====
 
 [[sec:dependency_resolve_rules]]

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/cross_project_publications.adoc
@@ -209,7 +209,7 @@ And that's it! Now we have:
 - explained that the consumer needs this variant _only for test runtime_
 
 Gradle therefore offers a powerful mechanism to select the right variants based on preferences and compatibility.
-More details can be found in the <<variant_attributes.adoc#, variant aware plugins section of the documentation>>.
+More details can be found in the <<variant_attributes.adoc#variant_attributes, variant aware plugins section of the documentation>>.
 
 [WARNING]
 ====

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_model.adoc
@@ -25,7 +25,7 @@ image::component-model-gradle.png[]
 This intermediate level, which associates artifacts and dependencies to variants instead of directly to the component, allows Gradle to model properly what each artifact is used for.
 
 However, this raises the question about how variants are selected: how does Gradle know which variant to choose when there's more than one?
-In practice, variants are selected thanks to the use of <<variant_attributes.adoc#,attributes>>, which provide semantics to the variants and help the engine in achieving a _consistent resolution result_.
+In practice, variants are selected thanks to the use of <<variant_attributes.adoc#variant_attributes,attributes>>, which provide semantics to the variants and help the engine in achieving a _consistent resolution result_.
 
 For historical reasons, Gradle differentiates between two kind of components:
 
@@ -342,10 +342,10 @@ As a consequence, Maven modules are derived into 6 distinct variants, which allo
 
 * 2 "library" variants (attribute `org.gradle.category` = `library`)
 ** the `compile` variant maps the `<scope>compile</scope>` dependencies.
-This variant is equivalent to the `apiElements` variant of the <<java_library_plugin.adoc#,Java Library plugin>>.
+This variant is equivalent to the `apiElements` variant of the <<java_library_plugin.adoc#java_library_plugin,Java Library plugin>>.
 All dependencies of this scope are considered _API dependencies_.
 ** the `runtime` variant maps both the `<scope>compile</scope>` and `<scope>runtime</scope>` dependencies.
-This variant is equivalent to the `runtimeElements` variant of the <<java_library_plugin.adoc#,Java Library plugin>>.
+This variant is equivalent to the `runtimeElements` variant of the <<java_library_plugin.adoc#java_library_plugin,Java Library plugin>>.
 All dependencies of those scopes are considered _runtime dependencies_.
 - in both cases, the `<dependencyManagement>` dependencies are _not converted to constraints_
 * 4 "platform" variants derived from the `<dependencyManagement>` block (attribute `org.gradle.category` = `platform`):

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_customization.adoc
@@ -64,7 +64,7 @@ Then we add a variant through the `addVariantsFromConfiguration` method, which i
 
 In simple cases, there's a one-to-one mapping between a `Configuration` and a variant, in which case you can publish all variants issued from a single `Configuration` because they are effectively the same thing.
 However, there are cases where a `Configuration` is associated with additional link:{javadocPath}/org/gradle/api/artifacts/ConfigurationPublications.html[configuration publications] that we also call _secondary variants_.
-Such configurations make sense in the <<cross_project_publications.adoc#,cross-project publications>> use case, but not when publishing externally.
+Such configurations make sense in the <<cross_project_publications.adoc#cross_project_publications,cross-project publications>> use case, but not when publishing externally.
 This is for example the case when between projects you share a _directory of files_, but there's no way you can publish a _directory_ directly on a Maven repository (only packaged things like jars or zips).
 Look at the link:{javadocPath}/org/gradle/api/component/ConfigurationVariantDetails.html[ConfigurationVariantDetails] class for details about how to skip publication of a particular variant.
 If `addVariantsFromConfiguration` has already been called for a configuration, further modification of the resulting variants can be performed using `withVariantsFromConfiguration`.
@@ -83,7 +83,7 @@ In practice, it means that components created this way can be consumed by Gradle
 ====
 Instead of thinking in terms of artifacts, you should embrace the variant aware model of Gradle.
 It is expected that a single module may need multiple artifacts.
-However this rarely stops there, if the additional artifacts represent an <<feature_variants.adoc#,optional feature>>, they might also have different dependencies and more.
+However this rarely stops there, if the additional artifacts represent an <<feature_variants.adoc#feature_variants,optional feature>>, they might also have different dependencies and more.
 
 Gradle, via _Gradle Module Metadata_, supports the publication of _additional variants_ which make those artifacts known to the dependency resolution engine.
 Please refer to the <<cross_project_publications.adoc#sec:variant-aware-sharing, variant-aware sharing>> section of the documentation to see how to declare such variants and <<#sec:publishing-custom-components, check out how to publish custom components>>.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_gradle_module_metadata.adoc
@@ -21,9 +21,9 @@ Publication of Gradle Module Metadata will enable better dependency management f
 - early discovery of problems by detecting <<component_capabilities.adoc#declaring-component-capabilities,incompatible modules>>
 - consistent selection of <<cross_project_publications.adoc#targeting-different-platforms,platform-specific dependencies>>
 - native <<dependency_version_alignment.adoc#version_alignment, dependency version alignment>>
-- automatically getting dependencies for specific <<feature_variants.adoc#,features of your library>>
+- automatically getting dependencies for specific <<feature_variants.adoc#feature_variants,features of your library>>
 
-Gradle Module Metadata is automatically published when using the <<publishing_maven.adoc#,Maven Publish plugin>> or the <<publishing_ivy.adoc#,Ivy Publish plugin>>.
+Gradle Module Metadata is automatically published when using the <<publishing_maven.adoc#publishing_maven,Maven Publish plugin>> or the <<publishing_ivy.adoc#publishing_ivy,Ivy Publish plugin>>.
 It is _not_ supported on the legacy `maven` and `ivy` plugins.
 
 The specification for Gradle Module Metadata can be found {metadata-file-spec}[here].
@@ -58,7 +58,7 @@ The table below summarizes how some Gradle specific features are mapped to Maven
 |Not published
 |Component capabilities are unique to Gradle
 
-|<<feature_variants.adoc#,Feature variants>>
+|<<feature_variants.adoc#feature_variants,Feature variants>>
 |Variant artifacts are uploaded, dependencies are published as _optional_ dependencies
 |Variant artifacts are uploaded, dependencies are not published
 |Feature variants are a good replacement for optional dependencies
@@ -117,9 +117,9 @@ Gradle Module Metadata is validated before being published.
 The following rules are enforced:
 
 * Variant names must be unique,
-* Each variant must have at least <<variant_attributes.adoc#,one attribute>>,
-* Two variants cannot have the <<variant_model.adoc#,exact same attributes and capabilities>>,
-* If there are dependencies, at least one, across all variants, must carry <<rich_versions.adoc#,version information>>.
+* Each variant must have at least <<variant_attributes.adoc#variant_attributes,one attribute>>,
+* Two variants cannot have the <<variant_model.adoc#understanding-variant-selection,exact same attributes and capabilities>>,
+* If there are dependencies, at least one, across all variants, must carry <<rich_versions.adoc#rich-version-constraints,version information>>.
 
 These rules ensure the quality of the metadata produced, and help confirm that consumption will not be problematic.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_ivy.adoc
@@ -115,7 +115,7 @@ Two strategies are supported for publishing dependencies:
 
 Declared versions (default)::
 This strategy publishes the versions that are defined by the build script author with the dependency declarations in the `dependencies` block.
-Any other kind of processing, for example through <<resolution_rules.adoc#,a rule changing the resolved version>>, will not be taken into account for the publication.
+Any other kind of processing, for example through <<resolution_rules.adoc#resolution_rules,a rule changing the resolved version>>, will not be taken into account for the publication.
 
 Resolved versions::
 This strategy publishes the versions that were resolved during the build, possibly by applying resolution rules and automatic conflict resolution.
@@ -124,7 +124,7 @@ This has the advantage that the published versions correspond to the ones the pu
 Example use cases for resolved versions:
 
 * A project uses dynamic versions for dependencies but prefers exposing the resolved version for a given release to its consumers.
-* In combination with <<dependency_locking.adoc#,dependency locking>>, you want to publish the locked versions.
+* In combination with <<dependency_locking.adoc#dependency-locking,dependency locking>>, you want to publish the locked versions.
 * A project leverages the rich versions constraints of Gradle, which have a lossy conversion to Ivy.
 Instead of relying on the conversion, it publishes the resolved versions.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -16,7 +16,7 @@
 = Maven Publish Plugin
 
 The Maven Publish Plugin provides the ability to publish build artifacts to an http://maven.apache.org/[Apache Maven] repository.
-A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies.adoc#,Declaring Dependencies>>) and other tools that understand the Maven repository format.
+A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies.adoc#declaring-dependencies,Declaring Dependencies>>) and other tools that understand the Maven repository format.
 You can learn about the fundamentals of publishing in <<publishing_setup.adoc#publishing_overview,Publishing Overview>>.
 
 
@@ -115,7 +115,7 @@ Two strategies are supported for publishing dependencies:
 
 Declared versions (default)::
 This strategy publishes the versions that are defined by the build script author with the dependency declarations in the `dependencies` block.
-Any other kind of processing, for example through <<resolution_rules.adoc#,a rule changing the resolved version>>, will not be taken into account for the publication.
+Any other kind of processing, for example through <<resolution_rules.adoc#resolution_rules,a rule changing the resolved version>>, will not be taken into account for the publication.
 
 Resolved versions::
 This strategy publishes the versions that were resolved during the build, possibly by applying resolution rules and automatic conflict resolution.
@@ -124,7 +124,7 @@ This has the advantage that the published versions correspond to the ones the pu
 Example use cases for resolved versions:
 
 * A project uses dynamic versions for dependencies but prefers exposing the resolved version for a given release to its consumers.
-* In combination with <<dependency_locking.adoc#,dependency locking>>, you want to publish the locked versions.
+* In combination with <<dependency_locking.adoc#dependency-locking,dependency locking>>, you want to publish the locked versions.
 * A project leverages the rich versions constraints of Gradle, which have a lossy conversion to Maven.
 Instead of relying on the conversion, it publishes the resolved versions.
 

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_setup.adoc
@@ -39,7 +39,7 @@ For example, a publication destined for a Maven repository includes:
 The primary artifact is typically the project's production JAR and secondary artifacts might consist of "-sources" and "-javadoc" JARs.
 
 +
-In addition, Gradle will publish checksums for all of the above, and <<publishing_signing.adoc#,signatures>> when configured to do so.
+In addition, Gradle will publish checksums for all of the above, and <<publishing_signing.adoc#publishing_maven:signing,signatures>> when configured to do so.
 From Gradle 6.0 onwards, this includes `SHA256` and `SHA512` checksums.
 
 [[publishing_overview:where]]

--- a/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/dependency_management_terminology.adoc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+[[dependency_management_terminology]]
 = Dependency Management Terminology
 
 Dependency management comes with a wealth of terminology.
@@ -33,7 +34,7 @@ A capability identifies a feature offered by one or multiple components.
 A capability is identified by coordinates similar to the coordinates used for <<sub:terminology_module_version,module versions>>.
 By default, each module version offers a capability that matches its coordinates, for example `com.google:guava:18.0`.
 Capabilities can be used to express that a component provides multiple <<sub:terminology_feature_variant,feature variants>> or that two different components implement the same feature (and thus cannot be used together).
-For more details, see the section on <<component_capabilities.adoc#,capabilities>>.
+For more details, see the section on <<component_capabilities.adoc#declaring-component-capabilities,capabilities>>.
 
 [[sub:terminology_component]]
 == Component
@@ -63,7 +64,7 @@ The word "configuration" is an overloaded term and has a different meaning outsi
 == Dependency
 
 A dependency is a pointer to another piece of software required to build, test or run a <<#sub:terminology_module,module>>.
-For more information, see the section on <<declaring_dependencies.adoc#,declaring dependencies>>.
+For more information, see the section on <<declaring_dependencies.adoc#declaring-dependencies,declaring dependencies>>.
 
 [[sub:terminology_dependency_constraint]]
 == Dependency constraint
@@ -71,14 +72,14 @@ For more information, see the section on <<declaring_dependencies.adoc#,declarin
 A dependency constraint defines requirements that need to be met by a module to make it a valid resolution result for the dependency.
 For example, a dependency constraint can narrow down the set of supported module versions.
 Dependency constraints can be used to express such requirements for transitive dependencies.
-For more information, see the sections on <<dependency_constraints.adoc#,upgrading>> and <<dependency_downgrade_and_exclude.adoc#,downgrading>> transitive dependencies.
+For more information, see the sections on <<dependency_constraints.adoc#dependency-constraints,upgrading>> and <<dependency_downgrade_and_exclude.adoc#downgrading_versions_and_excluding_dependencies,downgrading>> transitive dependencies.
 
 [[sub:terminology_feature_variant]]
 == Feature Variant
 
 A feature variant is a <<#sub:terminology_variant,variant>> representing a feature of a component that can be individually selected or not.
 A feature variant is identified by one or more <<#sub:terminology_capability,capabilities>>.
-For more information, see the sections on <<feature_variants.adoc#,modeling feature variants and optional dependencies>>.
+For more information, see the sections on <<feature_variants.adoc#feature_variants,modeling feature variants and optional dependencies>>.
 
 [[sub:terminology_module]]
 == Module
@@ -93,14 +94,14 @@ For convenient consumption, modules can be hosted in a <<#sub:terminology_reposi
 Releases of a <<#sub:terminology_module,module>> provide metadata.
 Metadata is the data that describes the module in more detail e.g. information about the location of artifacts or required <<#sub:terminology_transitive_dependency,transitive dependencies>>.
 Gradle offers its own metadata format called link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[Gradle Module Metadata] (`.module` file) but also supports Maven (`.pom`) and Ivy (`ivy.xml`) metadata.
-See the section on <<publishing_gradle_module_metadata.adoc#,understanding Gradle Module Metadata>> for more information on the supported metadata formats.
+See the section on <<publishing_gradle_module_metadata.adoc#sec:understanding-gradle-module-md,understanding Gradle Module Metadata>> for more information on the supported metadata formats.
 
 == Component metadata rule
 
 A component metadata rule is a rule that modifies a component's metadata after it was fetched from a repository, e.g. to add missing information or to correct wrong information.
 In contrast to <<#sub:terminology_resolution_rule,resolution rules>>, component metadata rules are applied *before* resolution starts.
 Component metadata rules are defined as part of the build logic and can be shared through plugins.
-For more information, see the section on <<component_metadata_rules.adoc#,fixing metadata with component metadata rules>>.
+For more information, see the section on <<component_metadata_rules.adoc#sec:component_metadata_rules,fixing metadata with component metadata rules>>.
 
 [[sub:terminology_module_version]]
 == Module version
@@ -139,14 +140,14 @@ A publication has a name and consists of one or more artifacts plus information 
 
 A repository hosts a set of <<#sub:terminology_module,modules>>, each of which may provide one or many releases (components) indicated by a <<#sub:terminology_module_version,module version>>.
 The repository can be based on a binary repository product (e.g. Artifactory or Nexus) or a directory structure in the filesystem.
-For more information, see <<declaring_repositories.adoc#,Declaring Repositories>>.
+For more information, see <<declaring_repositories.adoc#declaring-repositories,Declaring Repositories>>.
 
 [[sub:terminology_resolution_rule]]
 == Resolution rule
 
 A resolution rule influences the behavior of how a <<#sub:terminology_dependency,dependency>> is resolved directly.
 Resolution rules are defined as part of the build logic.
-For more information, see the section on <<resolution_rules.adoc#,customizing resolution of a dependency directly>>.
+For more information, see the section on <<resolution_rules.adoc#resolution_rules,customizing resolution of a dependency directly>>.
 
 [[sub:terminology_transitive_dependency]]
 == Transitive dependency
@@ -154,7 +155,7 @@ For more information, see the section on <<resolution_rules.adoc#,customizing re
 A variant of a <<#sub:terminology_component,component>> can have dependencies on other modules to work properly, so-called transitive dependencies.
 Releases of a module hosted on a <<#sub:terminology_repository,repository>> can provide <<#sub:terminology_module_metadata,metadata>> to declare those transitive dependencies.
 By default, Gradle resolves transitive dependencies automatically.
-The version selection for transitive dependencies can be influenced by declaring <<dependency_constraints.adoc#,dependency constraints>>.
+The version selection for transitive dependencies can be influenced by declaring <<dependency_constraints.adoc#dependency-constraints,dependency constraints>>.
 
 [[sub:terminology_variant]]
 == Variant (of a component)
@@ -168,7 +169,7 @@ It may also fail if the variant selection result is ambiguous, meaning that Grad
 In that case, more information can be provided through <<#sub:terminology_attribute,variant attributes>>.
 Examples of variants each Java components typically offers are _api_ and _runtime_ variants.
 Others examples are JDK8 and JDK11 variants.
-For more information, see the section on <<variant_model.adoc#,variant selection>>.
+For more information, see the section on <<variant_model.adoc#understanding-variant-selection,variant selection>>.
 
 [[sub:terminology_attribute]]
 == Variant Attribute
@@ -178,4 +179,4 @@ A variant has one or more attributes defined, for example `org.gradle.usage=java
 When dependencies are resolved, a set of attributes are requested and Gradle finds the best fitting variant(s) for each component in the dependency graph.
 Compatibility and disambiguation rules can be implemented for an attribute to express compatibility between values (e.g. Java 8 is compatible with Java 11, but Java 11 should be preferred if the requested version is 11 or higher).
 Such rules are typically provided by plugins.
-For more information, see the sections on <<variant_model.adoc#,variant selection>> and <<variant_attributes.adoc#,declaring attributes>>.
+For more information, see the sections on <<variant_model.adoc#understanding-variant-selection,variant selection>> and <<variant_attributes.adoc#variant_attributes,declaring attributes>>.

--- a/subprojects/docs/src/docs/userguide/developing-plugins/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/custom_plugins.adoc
@@ -192,7 +192,7 @@ See the <<publishing_ivy.adoc#publishing_ivy,Ivy>> and <<publishing_maven.adoc#p
 
 If you are interested in publishing your plugin to be used by the wider Gradle community, you can publish it to the http://plugins.gradle.org[Gradle Plugin Portal].
 This site provides the ability to search for and gather information about plugins contributed by the Gradle community.
-Please refer to the corresponding <<publishing_gradle_plugins.adoc#,section>> on how to make your plugin available on this site.
+Please refer to the corresponding <<publishing_gradle_plugins.adoc#publishing_portal,section>> on how to make your plugin available on this site.
 
 [[sec:using_your_plugin_in_another_project]]
 === Using your plugin in another project

--- a/subprojects/docs/src/docs/userguide/developing-plugins/designing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/designing_gradle_plugins.adoc
@@ -28,7 +28,7 @@ When designing Gradle plugins always be aware of the impact on the end user.
 Seemingly simple logic can have a considerable impact on the execution performance of a build.
 That’s especially the case when code of a plugin is executed during the <<build_lifecycle.adoc#sec:build_phases,configuration phase of the build lifecycle>> e.g.
 resolving dependencies by iterating over them, making HTTP calls or writing to files.
-The section on <<performance.adoc#,optimizing Gradle build performance>> will give you additional code examples, pitfalls and recommendations.
+The section on <<performance.adoc#performance_gradle,optimizing Gradle build performance>> will give you additional code examples, pitfalls and recommendations.
 
 As you write plugin code ask yourself whether the code shouldn’t rather be run during the execution phase.
 If you suspect issues with your plugin code, try creating a link:https://scans.gradle.com/[build scan] to identify bottlenecks.
@@ -38,7 +38,7 @@ The link:https://github.com/gradle/gradle-profiler[Gradle profiler] can help wit
 
 link:https://en.wikipedia.org/wiki/Convention_over_configuration[Convention over configuration] is a software engineering paradigm that allows a tool or framework to make an attempt at decreasing the number of decisions the user has to make without losing its flexibility.
 What does that mean for Gradle plugins? Gradle plugins can provide users with sensible defaults and standards (_conventions_) in a certain context.
-Let’s take the <<java_plugin.adoc#,Java plugin>> as an example.
+Let’s take the <<java_plugin.adoc#java_plugin,Java plugin>> as an example.
 
 - It defines the directory _src/main/java_ as the default source directory for compilation.
 - The output directory for compiled source code and other artifacts (like the JAR file) is _build_.
@@ -81,7 +81,7 @@ One way to provide these quality criteria is to separate capabilities from conve
 In practice that means separating general-purpose functionality from pre-configured, opinionated functionality.
 Let’s have a look at an example to explain this seemingly abstract concept.
 There are two Gradle core plugins that demonstrate the concept perfectly:
-the link:{javadocPath}/org/gradle/api/plugins/JavaBasePlugin.html[Java Base plugin] and the <<java_plugin.adoc#,Java plugin>>.
+the link:{javadocPath}/org/gradle/api/plugins/JavaBasePlugin.html[Java Base plugin] and the <<java_plugin.adoc#java_plugin,Java plugin>>.
 
 - The Java Base plugin just provided un-opinionated functionality and general purpose concepts.
   For example it formalized the concept of a SourceSet and introduces dependency management configurations.

--- a/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
@@ -1,3 +1,4 @@
+[[implemention_plugins]]
 = Implementing Gradle plugins
 
 Writing plugin code is a routine activity for advanced build authors.
@@ -14,7 +15,7 @@ This section assumes you have:
 == Using the Plugin Development plugin for writing plugins
 
 Setting up a Gradle plugin project should require as little boilerplate code as possible.
-The <<java_gradle_plugin.adoc#,Java Gradle Plugin Development plugin>> provides aid in this concern.
+The <<java_gradle_plugin.adoc#java_gradle_plugin,Java Gradle Plugin Development plugin>> provides aid in this concern.
 To get started add the following code to your _build.gradle_ file:
 
 ====
@@ -29,7 +30,7 @@ Every plugin project should apply this plugin.
 [[writing-and-using-custom-task-types]]
 == Prefer writing and using custom task types
 
-Gradle tasks can be defined as ad-hoc tasks, simple task definitions of type `DefaultTask` with one or many actions, or as <<custom_tasks.adoc#,enhanced tasks>>, the ones that use a custom task type and expose its configurability with the help of properties.
+Gradle tasks can be defined as ad-hoc tasks, simple task definitions of type `DefaultTask` with one or many actions, or as <<custom_tasks.adoc#custom_tasks,enhanced tasks>>, the ones that use a custom task type and expose its configurability with the help of properties.
 Generally speaking, custom tasks provide the means for reusability, maintainability, configurability and testability.
 The same principles hold true when providing tasks as part of plugins.
 Always prefer custom task types over ad-hoc tasks.
@@ -263,7 +264,7 @@ Optimally, the plugin implementation doesn’t need to ask the user for the coor
 
 Let’s have a look at an example.
 You wrote a plugin that downloads files containing data for further processing.
-The plugin implementation declares a custom configuration that allows for <<declaring_dependencies.adoc#,assigning those external dependencies with dependency coordinates>>.
+The plugin implementation declares a custom configuration that allows for <<declaring_dependencies.adoc#declaring-dependencies,assigning those external dependencies with dependency coordinates>>.
 
 .DataProcessingPlugin.java
 [source,java]

--- a/subprojects/docs/src/docs/userguide/developing-plugins/publishing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/publishing_gradle_plugins.adoc
@@ -1,3 +1,4 @@
+[[publishing_portal]]
 = Publishing Plugins to the Gradle Plugin Portal
 :portal: Gradle Plugin Portal
 :plugin: Greeting Plugin
@@ -57,8 +58,8 @@ Add the {publishplugin} to the `plugins` block.
 include::sample[dir="snippets/developingPlugins/publishingPlugins/groovy",files="build.gradle[tags=plugins_block]"]
 include::sample[dir="snippets/developingPlugins/publishingPlugins/kotlin",files="build.gradle.kts[tags=plugins_block]"]
 ====
-<1> Use the <<java_gradle_plugin.adoc#,Java Gradle Plugin Development Plugin>>, which comes with the Gradle distribution, to author your Gradle plugin.
-<2> Use the <<publishing_maven.adoc#, Maven Publish Plugin>> to generate the published metadata for your plugin
+<1> Use the <<java_gradle_plugin.adoc#java_gradle_plugin,Java Gradle Plugin Development Plugin>>, which comes with the Gradle distribution, to author your Gradle plugin.
+<2> Use the <<publishing_maven.adoc#publishing_maven, Maven Publish Plugin>> to generate the published metadata for your plugin
 <3> The latest version of the {publishplugin} can be found on the https://plugins.gradle.org/plugin/com.gradle.plugin-publish[{portal}].
 
 == Configure the {publishplugin}

--- a/subprojects/docs/src/docs/userguide/developing-plugins/testing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/testing_gradle_plugins.adoc
@@ -7,7 +7,7 @@ In this section you will learn effective techniques for testing plugin code.
 This section assumes you have:
 
 - Basic understanding of software engineering practices
-- Knowledge of <<implementing_gradle_plugins.adoc#,Gradle plugin implementation techniques>>
+- Knowledge of <<implementing_gradle_plugins.adoc#implemention_plugins,Gradle plugin implementation techniques>>
 - Working knowledge in writing Java code
 
 == The sample project
@@ -82,16 +82,16 @@ For a detailed discussion and code example please refer to the dedicated section
 [cols="20%,80%",options="header"]
 |======================
 |Test type                               |Tooling support
-|<<manual-tests,Manual tests>>           |<<composite_builds.adoc#,Gradle composite builds>>
+|<<manual-tests,Manual tests>>           |<<composite_builds.adoc#composite_builds,Gradle composite builds>>
 |<<unit-tests,Unit tests>>               |Any JVM-based test framework
 |<<integration-tests,Integration tests>> |Any JVM-based test framework
-|<<functional-tests,Functional tests>>   |Any JVM-based test framework and <<test_kit.adoc#,Gradle TestKit>>
+|<<functional-tests,Functional tests>>   |Any JVM-based test framework and <<test_kit.adoc#test_kit,Gradle TestKit>>
 |======================
 
 [[manual-tests]]
 == Setting up manual tests
 
-The <<composite_builds.adoc#,composite builds>> feature of Gradle makes it very easy to test a plugin manually.
+The <<composite_builds.adoc#composite_builds,composite builds>> feature of Gradle makes it very easy to test a plugin manually.
 The standalone plugin project and the consuming project can be combined together into a single unit making it much more straight forward to try out or debug changes without the hassle of re-publishing the binary file.
 
 ----
@@ -271,7 +271,7 @@ As you can see, the implementation exposes an extension and a task instance that
 include::{snippetsPath}/developingPlugins/testingPlugins/groovy/url-verifier-plugin/src/main/java/org/myorg/UrlVerifierPlugin.java[]
 ----
 
-Every Gradle plugin project should apply the <<java_gradle_plugin.adoc#,plugin development plugin>> to reduce boilerplate code.
+Every Gradle plugin project should apply the <<java_gradle_plugin.adoc#java_gradle_plugin,plugin development plugin>> to reduce boilerplate code.
 By applying the plugin development plugin, the test source set is preconfigured for the use with TestKit.
 If we want to use a custom source set for functional tests and leave the default test source set for only unit tests, we can configure the plugin development plugin to look for TestKit tests elsewhere.
 
@@ -283,7 +283,7 @@ include::sample[dir="snippets/developingPlugins/testingPlugins/kotlin/url-verifi
 Functional tests for Gradle plugins use an instance of `GradleRunner` to execute the build under test.
 `GradleRunner` is an API provided by TestKit which internally uses the Tooling API to execute the build.
 The following example applies the plugin to the build script under test, configures the extension and executes the build with the task `verifyUrl`.
-Please see the <<test_kit.adoc#,TestKit documentation>> to get more familiar with the functionality of TestKit.
+Please see the <<test_kit.adoc#test_kit,TestKit documentation>> to get more familiar with the functionality of TestKit.
 
 .UrlVerifierPluginFunctionalTest.groovy
 [source,groovy]

--- a/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/custom_tasks.adoc
@@ -449,7 +449,7 @@ The Worker API provides a mechanism for doing exactly this. It allows for safe, 
 
 [NOTE]
 ====
-A step-by-step description of converting a normal task action to use the worker API can be found in the section on <<worker_api.adoc#,developing parallel tasks>>.
+A step-by-step description of converting a normal task action to use the worker API can be found in the section on <<worker_api.adoc#tasks_parallel_worker,developing parallel tasks>>.
 ====
 
 In order to submit work to the Worker API, two things must be provided: an implementation of the unit of work, and the parameters for the unit of work.
@@ -560,4 +560,4 @@ It's often a good approach to package custom task types in a custom Gradle plugi
 The plugin can provide useful defaults and conventions for the task type, and provides a convenient way to use the task type from a build script or another plugin.
 Please see <<custom_plugins.adoc#custom_plugins,Developing Custom Gradle Plugins>> for more details.
 
-Gradle provides a number of features that are helpful when developing Gradle types, including tasks. Please see <<custom_gradle_types.adoc#,Developing Custom Gradle Types>> for more details.
+Gradle provides a number of features that are helpful when developing Gradle types, including tasks. Please see <<custom_gradle_types.adoc#custom_gradle_types,Developing Custom Gradle Types>> for more details.

--- a/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
@@ -1,3 +1,4 @@
+[[tasks_parallel_worker]]
 = Developing Parallel Tasks using the Worker API
 
 The Worker API provides the ability to break up the execution of a task action into discrete units of work and then to execute that work concurrently and asynchronously.
@@ -5,7 +6,7 @@ This allows Gradle to fully utilize the resources available and complete builds 
 This section will walk you through the process of converting an existing custom task to use the Worker API.
 
 This section assumes that you understand the basics of writing Gradle custom tasks.
-For more information on that topic, consult the <<custom_tasks.adoc#,section on custom tasks>>.
+For more information on that topic, consult the <<custom_tasks.adoc#custom_tasks,section on custom tasks>>.
 
 You'll start by creating a custom task class that generates MD5 hashes for a configurable set of files.
 Then, you'll convert this custom task to use the Worker API.

--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -38,7 +38,7 @@ link:../samples/index.html#kotlin[Kotlin]
 
 == Introduction
 
-The simplest build script for a Java project applies the <<java_library_plugin.adoc#,Java Library Plugin>> and optionally sets the project version and selects the <<toolchains.adoc#,Java toolchain>> to use:
+The simplest build script for a Java project applies the <<java_library_plugin.adoc#java_library_plugin,Java Library Plugin>> and optionally sets the project version and selects the <<toolchains.adoc#toolchains,Java toolchain>> to use:
 
 .Applying the Java Library Plugin
 ====
@@ -127,7 +127,7 @@ You'll learn more about source sets and the features they provide in:
 
 The vast majority of Java projects rely on libraries, so managing a project's dependencies is an important part of building a Java project.
 Dependency management is a big topic, so we will focus on the basics for Java projects here.
-If you'd like to dive into the detail, check out the <<core_dependency_management.adoc#,introduction to dependency management>>.
+If you'd like to dive into the detail, check out the <<core_dependency_management.adoc#dependency_management_in_gradle,introduction to dependency management>>.
 
 Specifying the dependencies for your Java project requires just three pieces of information:
 
@@ -149,7 +149,7 @@ The Gradle terminology for the three elements is as follows:
  * _Configuration_ (ex: `implementation`) — a named collection of dependencies, grouped together for a specific goal such as compiling or running a module — a more flexible form of Maven scopes
  * _Module coordinate_ (ex: `org.hibernate:hibernate-core-3.6.7.Final`) — the ID of the dependency, usually in the form '__<group>__:__<module>__:__<version>__' (or '__<groupId>__:__<artifactId>__:__<version>__' in Maven terminology)
 
-You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#,here>>.
+You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#dependency_management_terminology,here>>.
 
 As far as configurations go, the main ones of interest are:
 
@@ -178,7 +178,7 @@ We have only scratched the surface here, so we recommend that you read the dedic
  * Using dependencies from a <<declaring_repositories.adoc#sub:flat_dir_resolver,local filesystem directory>>
  * Declaring dependencies with <<dynamic_versions.adoc#sub:declaring_dependency_with_changing_version,changing>> (e.g. SNAPSHOT) and <<dynamic_versions.adoc#sub:declaring_dependency_with_dynamic_version,dynamic>> (range) versions
  * Declaring a sibling <<declaring_dependencies.adoc#sub:project_dependencies,project as a dependency>>
- * <<dependency_constraints.adoc#,Controlling transitive dependencies and their versions>>
+ * <<dependency_constraints.adoc#dependency-constraints,Controlling transitive dependencies and their versions>>
  * Testing your fixes to a 3rd-party dependency via <<composite_builds.adoc#composite_builds,composite builds>> (a better alternative to publishing to and consuming from <<declaring_repositories.adoc#sub:maven_local,Maven Local>>)
 
 You'll discover that Gradle has a rich API for working with dependencies — one that takes time to master, but is straightforward to use for common scenarios.
@@ -240,7 +240,7 @@ That's also how you can change the verbosity of the compiler, disable debug outp
 === Targeting a specific Java version
 
 By default, Gradle will compile Java code to the language level of the JVM running Gradle.
-With the usage of <<toolchains.adoc#,Java toolchains>>, you can break that link by making sure a given Java version, defined by the build, is used for compilation, execution and documentation.
+With the usage of <<toolchains.adoc#toolchains,Java toolchains>>, you can break that link by making sure a given Java version, defined by the build, is used for compilation, execution and documentation.
 It is however possible to override some compiler and execution options at the task level.
 
 Since version 9, the Java compiler can be configured to produce bytecode for an older Java version while making sure the code does not use any APIs from a more recent version.
@@ -489,7 +489,7 @@ The task is an instance of link:{groovyDslPath}/org.gradle.api.tasks.Delete.html
 [[sec:building_jvm_components]]
 == Building JVM components
 
-All of the specific JVM plugins are built on top of the <<java_plugin.adoc#,Java Plugin>>.
+All of the specific JVM plugins are built on top of the <<java_plugin.adoc#java_plugin,Java Plugin>>.
 The examples above only illustrated concepts provided by this base plugin and shared with all JVM plugins.
 
 Read on to understand which plugins fits which project type, as it is recommended to pick a specific plugin instead of applying the Java Plugin directly.
@@ -549,7 +549,7 @@ A Java platform represents a set of dependency declarations and constraints that
 The platform has no source and no artifact of its own.
 It maps in the Maven world to a https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management[BOM].
 
-The support comes via the <<java_platform_plugin.adoc#,Java Platform plugin>>, which sets up the different configurations and publication components.
+The support comes via the <<java_platform_plugin.adoc#java_platform_plugin,Java Platform plugin>>, which sets up the different configurations and publication components.
 
 [NOTE]
 ====
@@ -577,7 +577,7 @@ include::sample[dir="snippets/java/preview/kotlin",files="build.gradle.kts[tags=
 
 If you want to leverage the multi language aspect of the JVM, most of what was described here will still apply.
 
-Gradle itself provides <<groovy_plugin.adoc#,Groovy>> and <<scala_plugin.adoc#,Scala>> plugins.
+Gradle itself provides <<groovy_plugin.adoc#groovy_plugin,Groovy>> and <<scala_plugin.adoc#scala_plugin,Scala>> plugins.
 The plugins automatically apply support for compiling Java code and can be further enhanced by combining them with the `java-library` plugin.
 
 [[sub:compile_deps_jvm_lang]]
@@ -595,7 +595,7 @@ include::sample[dir="snippets/tutorial/compileTaskClasspath/kotlin",files="build
 1. By setting the `compileGroovy` classpath to be only `sourceSets.main.compileClasspath`, we effectively remove the previous dependency on `compileJava` that was declared by having the classpath also take into consideration `sourceSets.main.java.classesDirectory`
 2. By adding `sourceSets.main.groovy.classesDirectory` to the `compileJava` `classpath`, we effectively declare a dependency on the `compileGroovy` task
 
-All of this is possible through the use of <<lazy_configuration.adoc#,directory properties>>.
+All of this is possible through the use of <<lazy_configuration.adoc#lazy_configuration,directory properties>>.
 
 === Extra language support
 

--- a/subprojects/docs/src/docs/userguide/jvm/dependency_management_for_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/dependency_management_for_java_projects.adoc
@@ -16,7 +16,7 @@
 = Managing Dependencies of JVM Projects
 
 This chapter explains how to apply basic dependency management concepts to JVM-based projects.
-For a detailed introduction to dependency management, see <<core_dependency_management.adoc#,dependency management in Gradle>>.
+For a detailed introduction to dependency management, see <<core_dependency_management.adoc#dependency_management_in_gradle,dependency management in Gradle>>.
 
 [[sec:setting_up_a_standard_build_script_java_tutorial]]
 == Dissecting a typical build script
@@ -48,7 +48,7 @@ include::sample[dir="snippets/artifacts/externalDependencies/groovy",files="buil
 include::sample[dir="snippets/artifacts/externalDependencies/kotlin",files="build.gradle.kts[tags=define-dependency]"]
 ====
 
-To find out more about defining dependencies, have a look at <<declaring_dependencies.adoc#,Declaring Dependencies>>.
+To find out more about defining dependencies, have a look at <<declaring_dependencies.adoc#declaring-dependencies,Declaring Dependencies>>.
 
 [[sec:configurations_java_tutorial]]
 == Using dependency configurations
@@ -100,9 +100,9 @@ include::sample[dir="snippets/artifacts/defineRepository/kotlin",files="build.gr
 
 A project can have multiple repositories. Gradle will look for a dependency in each repository in the order they are specified, stopping at the first repository that contains the requested module.
 
-To find out more about defining repositories, have a look at <<declaring_repositories.adoc#,Declaring Repositories>>.
+To find out more about defining repositories, have a look at <<declaring_repositories.adoc#declaring-repositories,Declaring Repositories>>.
 
 [[sec:publishing_artifacts_java_tutorial]]
 == Publishing artifacts
 
-To learn more about publishing artifacts, have a look at <<publishing_setup.adoc#,publishing plugins>>.
+To learn more about publishing artifacts, have a look at <<publishing_setup.adoc#publishing_components,publishing plugins>>.

--- a/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -15,7 +15,7 @@
 [[groovy_plugin]]
 = The Groovy Plugin
 
-The Groovy plugin extends the <<java_plugin.adoc#,Java plugin>> to add support for https://groovy-lang.org/[Groovy] projects.
+The Groovy plugin extends the <<java_plugin.adoc#java_plugin,Java plugin>> to add support for https://groovy-lang.org/[Groovy] projects.
 It can deal with Groovy code, mixed Groovy and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter).
 The plugin supports _joint compilation_, which allows you to freely mix and match Groovy and Java code, with dependencies in both directions.
 For example, a Groovy class can extend a Java class that in turn extends a Groovy class.
@@ -205,7 +205,7 @@ The Groovy plugin also modifies some source set properties:
 The Groovy plugin adds a link:{groovyDslPath}/org.gradle.api.tasks.compile.GroovyCompile.html[GroovyCompile] task for each source set in the project.
 The task type shares much with the `JavaCompile` task by extending `AbstractCompile` (see <<building_java_projects.adoc#sec:compile, the relevant Java Plugin section>>).
 The `GroovyCompile` task supports most configuration options of the official Groovy compiler.
-The task can also leverage the <<toolchains.adoc#,Java toolchain support>>.
+The task can also leverage the <<toolchains.adoc#toolchains,Java toolchain support>>.
 
 .Groovy plugin - GroovyCompile properties
 [%header%autowidth,compact]
@@ -230,7 +230,7 @@ Can set using anything described in <<working_with_files.adoc#sec:specifying_mul
 | `groovy` configuration if non-empty; Groovy library found on `classpath` otherwise
 
 |  `javaLauncher`
-| `Property<JavaLauncher>`, see the <<toolchains.adoc#,toolchain documentation>>.
+| `Property<JavaLauncher>`, see the <<toolchains.adoc#toolchains,toolchain documentation>>.
 | None but will be configured if a toolchain is defined on the `java` extension.
 |===
 
@@ -313,7 +313,7 @@ Also see <<java_plugin.adoc#sec:incremental_compilation_known_issues,Known issue
 [[sec:groovy_cross_compilation]]
 == Compiling and testing for Java 6 or Java 7
 
-With <<toolchains.adoc#,toolchain support>> added to `GroovyCompile`, it is possible to compile Groovy code using a different Java version than the one running Gradle.
+With <<toolchains.adoc#toolchains,toolchain support>> added to `GroovyCompile`, it is possible to compile Groovy code using a different Java version than the one running Gradle.
 If you also have Java source files, this will also configure `JavaCompile` to use the right Java compiler is used, as can be seen in the <<building_java_projects.adoc#sec:java_cross_compilation,Java plugin>> documentation.
 
 === Example: Configure Java 7 build for Groovy

--- a/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_library_plugin.adoc
@@ -15,7 +15,7 @@
 [[java_library_plugin]]
 = The Java Library Plugin
 
-The Java Library plugin expands the capabilities of the <<java_plugin.adoc#,Java plugin>> by providing specific knowledge about Java libraries.
+The Java Library plugin expands the capabilities of the <<java_plugin.adoc#java_plugin,Java plugin>> by providing specific knowledge about Java libraries.
 In particular, a Java library exposes an API to consumers (i.e., other projects using the Java or the Java Library plugin).
 All the source sets, tasks and configurations exposed by the Java plugin are implicitly available when using this plugin.
 
@@ -357,7 +357,7 @@ While a real module cannot directly depend on the unnamed module (only by adding
 Thus, if you cannot avoid to rely on a library without module information, you can wrap that library in an automatic module as part of your project.
 How you do that is described in the next section.
 
-Another way to deal with non-modules is to enrich existing Jars with module descriptors yourself using <<artifact_transforms.adoc#,artifact transforms>>.
+Another way to deal with non-modules is to enrich existing Jars with module descriptors yourself using <<artifact_transforms.adoc#sec:abm_artifact_transforms,artifact transforms>>.
 link:../samples/sample_java_modules_with_transform.html[This sample] contains a small _buildSrc_ plugin registering such a transform which you may use and adjust to your needs.
 This can be interesting if you want to build a fully <<application_plugin.adoc#sec:application_modular,modular application>> and want the java runtime to treat everything as a real module.
 
@@ -430,5 +430,5 @@ Note, since this has other performance impacts and potentially side effects, by 
 [[sec:library_distribution]]
 == Distributing a library
 
-Aside from <<publishing_setup.adoc#,publishing>> a library to a component repository, you may sometimes need to package a library and its dependencies in a distribution deliverable.
-The <<java_library_distribution_plugin.adoc#,Java Library Distribution Plugin>> is there to help you do just that.
+Aside from <<publishing_setup.adoc#publishing_components,publishing>> a library to a component repository, you may sometimes need to package a library and its dependencies in a distribution deliverable.
+The <<java_library_distribution_plugin.adoc#java_library_distribution_plugin,Java Library Distribution Plugin>> is there to help you do just that.

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -792,5 +792,5 @@ include::sample[dir="snippets/java/apt/kotlin", files="build.gradle.kts[tags=ann
 
 == Variant aware selection
 
-The whole set of JVM plugins leverage <<variant_model.adoc#,variant aware resolution>> for the dependencies used.
+The whole set of JVM plugins leverage <<variant_model.adoc#understanding-variant-selection,variant aware resolution>> for the dependencies used.
 They also install a set of attributes compatibility and disambiguation rules to <<variant_attributes.adoc#sub:jvm_default_attributes,configure the Gradle attributes>> for the specifics of the JVM ecosystem.

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -226,7 +226,7 @@ include::sample[dir="snippets/testing/testReport/groovy",files="buildSrc/src/mai
 include::sample[dir="snippets/testing/testReport/kotlin",files="buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts[tags=test-report];build.gradle.kts[tags=test-report]"]
 ====
 
-In this example, we use a convention plugin `myproject.java-conventions` to expose the test results from a project to Gradle's <<variant_model.adoc#,variant aware dependency management engine>>.
+In this example, we use a convention plugin `myproject.java-conventions` to expose the test results from a project to Gradle's <<variant_model.adoc#understanding-variant-selection,variant aware dependency management engine>>.
 
 The plugin declares a consumable `binaryTestResultsElements` configuration that represents the binary test results of the `test` task.
 In the aggregation project's build file, we declare the `testReportData` configuration and depend on all of the projects that we want to aggregate the results from. Gradle will automatically select the binary test result variant from each of the subprojects instead of the project's jar file.
@@ -518,7 +518,7 @@ Users commonly want to run integration tests after the unit tests, because they 
 [[sec:java_testing_modular]]
 == Testing Java Modules
 
-If you are <<java_library_plugin.adoc#,developing Java Modules>>, everything described in this chapter still applies and any of the supported test frameworks can be used.
+If you are <<java_library_plugin.adoc#java_library_plugin,developing Java Modules>>, everything described in this chapter still applies and any of the supported test frameworks can be used.
 However, there are some things to consider depending on whether you need module information to be available, and module boundaries to be enforced, during test execution.
 In this context, the terms _whitebox testing_ (module boundaries are deactivated or relaxed) and _blackbox testing_ (module boundaries are in place) are often used.
 Whitebox testing is used/needed for unit testing and blackbox testing fits functional or integration test requirements.

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -15,7 +15,7 @@
 [[scala_plugin]]
 = The Scala Plugin
 
-The Scala plugin extends the <<java_plugin.adoc#,Java plugin>> to add support for https://www.scala-lang.org/[Scala] projects.
+The Scala plugin extends the <<java_plugin.adoc#java_plugin,Java plugin>> to add support for https://www.scala-lang.org/[Scala] projects.
 It can deal with Scala code, mixed Scala and Java code, and even pure Java code (although we don't necessarily recommend to use it for the latter).
 The plugin supports _joint compilation_, which allows you to freely mix and match Scala and Java code, with dependencies in both directions.
 For example, a Scala class can extend a Java class that in turn extends a Scala class.
@@ -163,7 +163,7 @@ The Zinc compiler itself needs a compatible version of `scala-library` that may 
 Gradle takes care of specifying a compatible version of `scala-library` for you.
 footnote:[Gradle does not support running the Zinc compiler v1.2.0 with Scala 2.11.]
 
-You can diagnose problems with the version of the Zinc compiler selected by running <<viewing_debugging_dependencies.adoc#,dependencyInsight>> for the `zinc` configuration.
+You can diagnose problems with the version of the Zinc compiler selected by running <<viewing_debugging_dependencies.adoc#viewing-debugging-dependencies,dependencyInsight>> for the `zinc` configuration.
 
 .Zinc compatibility table
 [%header%autowidth,compact]

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_ant.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_ant.adoc
@@ -252,7 +252,7 @@ Most of Gradle's dependency-related configuration is baked into the build script
 +
 Some Ivy configuration options have no equivalent in Gradle. For example, there are no lock strategies because Gradle ensures that its dependency cache is concurrency safe, period. Nor are there "latest strategies" because it's simpler to have a reliable, single strategy for conflict resolution. If the "wrong" version is picked, you can easily override it using forced versions or other resolution strategy options.
 +
-See the chapter on <<dependency_constraints.adoc#,controlling transitive dependencies>> for more information on this aspect of Gradle.
+See the chapter on <<dependency_constraints.adoc#dependency-constraints,controlling transitive dependencies>> for more information on this aspect of Gradle.
 
 Resolution::
 At the beginning of the build, Gradle will automatically resolve any dependencies that you have declared and download them to its cache.
@@ -260,7 +260,7 @@ It searches the repositories for those dependencies, with the search order defin
 +
 It's worth noting that Gradle supports the same dynamic version syntax as Ivy, so you can still use versions like `1.0.+`. You can also use the special `latest.integration` and `latest.release` labels if you wish. If you decide to use such <<dynamic_versions.adoc#sub:declaring_dependency_with_dynamic_version,dynamic>> and <<dynamic_versions.adoc#sub:declaring_dependency_with_changing_version,changing>> dependencies, you can configure the caching behavior for them via link:{groovyDslPath}/org.gradle.api.artifacts.ResolutionStrategy.html[resolutionStrategy].
 +
-You might also want to consider <<dependency_locking#,dependency locking>> if you're using dynamic and/or changing dependencies. It's a way to make the build more reliable and allows for https://reproducible-builds.org/[reproducible builds].
+You might also want to consider <<dependency_locking#dependency-locking,dependency locking>> if you're using dynamic and/or changing dependencies. It's a way to make the build more reliable and allows for https://reproducible-builds.org/[reproducible builds].
 
 Retrieval::
 As mentioned, Gradle does not automatically copy files from the dependency cache. Its standard tasks typically use the files directly. If you want to copy the dependencies to a local directory, you can use a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy] task like this in your build script:

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
@@ -1,3 +1,4 @@
+[[migrating_groovy_kotlin]]
 = Migrating build logic from Groovy to Kotlin
 :figure-caption!:
 :example-caption!:
@@ -14,10 +15,10 @@ image::intellij-idea-android-studio.png[IntelliJ IDEA and Android Studio]
 
 [TIP]
 --
-Please also read the <<kotlin_dsl.adoc#,Gradle Kotlin DSL Primer>> to learn the specificities, limitations and usage of the Gradle Kotlin DSL.
+Please also read the <<kotlin_dsl.adoc#kotlin_dsl,Gradle Kotlin DSL Primer>> to learn the specificities, limitations and usage of the Gradle Kotlin DSL.
 
 The rest of the user manual contain build script excerpts that demonstrate both the Groovy DSL and the Kotlin DSL.
-This is the best place where to find how to do this and what with each DSL ; and it covers all Gradle features from <<plugins.adoc#,using plugins>> to <<dependency_constraints.adoc#,customizing the dependency resolution behavior>>.
+This is the best place where to find how to do this and what with each DSL ; and it covers all Gradle features from <<plugins.adoc#plugins,using plugins>> to <<dependency_constraints.adoc#dependency-constraints,customizing the dependency resolution behavior>>.
 --
 
 
@@ -30,7 +31,7 @@ This is the best place where to find how to do this and what with each DSL ; and
 * In IntelliJ IDEA, you must link:https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import your project from the Gradle model] to get content-assist and refactoring tools for Kotlin DSL scripts.
 * There are some situations where the Kotlin DSL is slower. First use, on clean checkouts or ephemeral CI agents for example, link:{gradle-issues}15886[are known to be slower].
 The same applies to the scenario in which something in the _buildSrc_ directory changes, which invalidates build-script caching.
-Builds with slow configuration time might affect the IDE responsiveness, please check out the <<performance.adoc#,documentation on Gradle performance>>.
+Builds with slow configuration time might affect the IDE responsiveness, please check out the <<performance.adoc#performance_gradle,documentation on Gradle performance>>.
 * You must run Gradle with Java 8 or higher. Java 7 is not supported.
 * The embedded Kotlin compiler is known to work on Linux, macOS, Windows, Cygwin, FreeBSD and Solaris on x86-64 architectures.
 * Knowledge of Kotlin syntax and basic language features is very helpful. The link:{kotlin-reference}[Kotlin reference documentation] and link:https://kotlinlang.org/docs/tutorials/koans.html[Kotlin Koans] should be useful to you.
@@ -149,7 +150,7 @@ In a multi-project build, you can have some modules using the Groovy DSL (with `
 On top of that, apply the following conventions for better IDE support:
 
 * Name scripts that are applied to `Settings` according to the pattern `*.settings.gradle.kts`,
-* Name <<init_scripts.adoc#,init scripts>> according to the pattern `*.init.gradle.kts`.
+* Name <<init_scripts.adoc#init_scripts,init scripts>> according to the pattern `*.init.gradle.kts`.
 
 
 == Applying plugins
@@ -251,7 +252,7 @@ ____
 One of the major differences between the existing and new Gradle Tasks API is whether or not Gradle spends the time to create `Task` instances and run configuration code. The new API allows Gradle to delay or completely avoid configuring tasks that will never be executed in a build. For example, when compiling code, Gradle does not need to configure tasks that run tests.
 ____
 
-See the link:https://blog.gradle.org/preview-avoiding-task-configuration-time[_Evolving the Gradle API to reduce configuration time_] blog post and the <<task_configuration_avoidance.adoc#,Task Configuration Avoidance>> chapter in the user manual for more information.
+See the link:https://blog.gradle.org/preview-avoiding-task-configuration-time[_Evolving the Gradle API to reduce configuration time_] blog post and the <<task_configuration_avoidance.adoc#task_configuration_avoidance,Task Configuration Avoidance>> chapter in the user manual for more information.
 
 The Gradle Kotlin DSL embraces configuration avoidance by making the type-safe model accessors leverage the new APIs and providing DSL constructs to make them easier to use.
 Rest assured, the whole Gradle API remains available.

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
@@ -78,7 +78,7 @@ For Gradle builds, you'll be able to see the project structure, the dependencies
 Your build may fail at this point, but that's ok; the scan will still run. Compare the build scan for the Gradle build to the one for the Maven build and continue down this list to troubleshoot the failures.
 +
 We recommend that you regularly generate build scans during the migration to help you identify and troubleshoot problems.
-If you want, you can also use a Gradle build scan to identify opportunities to <<performance.adoc#,improve the performance of the build>>, after all performance is a big reason for switching to Gradle in the first place.
+If you want, you can also use a Gradle build scan to identify opportunities to <<performance.adoc#performance_gradle,improve the performance of the build>>, after all performance is a big reason for switching to Gradle in the first place.
  . <<migmvn:migrating_deps,Verify your dependencies and fix any problems>>
  . <<migmvn:integration_tests,Configure integration and functional tests>>
 +
@@ -127,7 +127,7 @@ If you want to include integration tests, you will have to <<migmvn:integration_
 `install`::
 Use the `publishToMavenLocal` task provided by the <<publishing_maven#publishing_maven:tasks,Maven Publish Plugin>>.
 +
-Note that Gradle builds don't require you to "install" artifacts as you have access to more appropriate features like <<declaring_dependencies.adoc#sub:project_dependencies,inter-project dependencies>> and <<composite_builds#,composite builds>>.
+Note that Gradle builds don't require you to "install" artifacts as you have access to more appropriate features like <<declaring_dependencies.adoc#sub:project_dependencies,inter-project dependencies>> and <<composite_builds#composite_builds,composite builds>>.
 You should only use `publishToMavenLocal` for interoperating with Maven builds.
 +
 Gradle also allows you to resolve dependencies against the local Maven cache, as described in the <<migmvn:declaring_repos,Declaring repositories>> section.
@@ -158,7 +158,7 @@ You'll find that the new Gradle build includes the following:
 
  * All the custom repositories that are specified in the POM
  * Your external and inter-project dependencies
- * The appropriate plugins to build the project (limited to one or more of the <<publishing_maven.adoc#,Maven Publish>>, <<java_plugin.adoc#,Java>> and <<war_plugin.adoc#,War>> Plugins)
+ * The appropriate plugins to build the project (limited to one or more of the <<publishing_maven.adoc#publishing_maven,Maven Publish>>, <<java_plugin.adoc#java_plugin,Java>> and <<war_plugin.adoc#war_plugin,War>> Plugins)
 
 See the <<build_init_plugin#sec:pom_maven_conversion,Build Init Plugin chapter>> for a complete list of the automatic conversion features.
 
@@ -189,7 +189,7 @@ Gradle's dependency management system is more flexible than Maven's, but it stil
 In fact, Gradle works perfectly with Maven-compatible repositories, which makes it easy to migrate your dependencies.
 
 NOTE: One notable difference between the two tools is in how they manage version conflicts. Maven uses a "closest" match algorithm, whereas Gradle picks the newest.
-Don't worry though, you have a lot of control over which versions are selected, as documented in <<dependency_constraints.adoc#,Managing Transitive Dependencies>>.
+Don't worry though, you have a lot of control over which versions are selected, as documented in <<dependency_constraints.adoc#dependency-constraints,Managing Transitive Dependencies>>.
 
 Over the following sections, we will show you how to migrate the most common elements of a Maven build's dependency management information.
 
@@ -198,7 +198,7 @@ Over the following sections, we will show you how to migrate the most common ele
 
 Gradle uses the same dependency identifier components as Maven: group ID, artifact ID and version.
 It also supports classifiers.
-So all you need to do is substitute the identifier information for a dependency into Gradle's syntax, which is described in the <<declaring_dependencies#,Declaring Dependencies>> chapter.
+So all you need to do is substitute the identifier information for a dependency into Gradle's syntax, which is described in the <<declaring_dependencies#declaring-dependencies,Declaring Dependencies>> chapter.
 
 For example, consider this Maven-style dependency on Log4J:
 
@@ -311,7 +311,7 @@ On a per-project basis, you can use:
  * <<migmvn:using_boms,Bills of materials>> (Maven BOMs)
  * <<dependency_downgrade_and_exclude.adoc#sec:enforcing_dependency_version,Overriding transitive versions>>
 
-There are even more, specialized options listed in the <<dependency_constraints.adoc#,controlling transitive dependencies>> chapter.
+There are even more, specialized options listed in the <<dependency_constraints.adoc#dependency-constraints,controlling transitive dependencies>> chapter.
 
 If you want to ensure consistency of versions across all projects in a multi-project build, similar to how the `<dependencyManagement>` block in Maven works, you can use the <<java_platform_plugin#java_platform_plugin,Java Platform Plugin>>.
 This allows you declare a set of dependency constraints that can be applied to multiple projects.
@@ -411,7 +411,7 @@ This basically involves creating a root project build script that injects shared
 
 If you want to replicate the Maven pattern of having dependency versions declared in the `dependencyManagement` section of the root POM file, the best approach is to leverage the `java-platform` plugin.
 You will need to add a dedicated project for this and consume it in the regular projects of your build.
-See <<java_platform_plugin.adoc#,the documentation>> for more details on this pattern.
+See <<java_platform_plugin.adoc#java_platform_plugin,the documentation>> for more details on this pattern.
 
 [[migmvn:profiles_and_properties]]
 == Migrating Maven profiles and properties

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_4.adoc
@@ -15,23 +15,30 @@
 [[upgrading_version_4]]
 = Upgrading your build from Gradle 4.x to 5.0
 
-This chapter provides the information you need to migrate your older Gradle 4.x builds to Gradle 5.0. In most cases, you will need to apply the changes from all versions that come after the one you're upgrading from. For example, if you're upgrading from Gradle 4.3 to 5.0, you will also need to apply the changes since 4.4, 4.5, etc up to 5.0.
+This chapter provides the information you need to migrate your older Gradle 4.x builds to Gradle 5.0.
+In most cases, you will need to apply the changes from all versions that come after the one you're upgrading from.
+For example, if you're upgrading from Gradle 4.3 to 5.0, you will also need to apply the changes since 4.4, 4.5, etc up to 5.0.
 
 TIP: If you are using Gradle for Android, you need to move to version 3.3 or higher of both the Android Gradle Plugin and Android Studio.
 
 == For all users
 
- . If you are not already on the latest 4.10.x release, read the sections <<#changes_4.10,below>> for help upgrading your project to the latest 4.10.x release. We recommend upgrading to the latest 4.10.x release to get the most useful warnings and deprecations information before moving to 5.0. Avoid upgrading Gradle and migrating to Kotlin DSL at the same time in order to ease troubleshooting in case of potential issues.
- . Try running `gradle help --scan` and view the https://gradle.com/enterprise/releases/2018.4/#identify-usages-of-deprecated-gradle-functionality[deprecations view] of the generated build scan. If there are no warnings, the Deprecations tab will not appear.
+ . If you are not already on the latest 4.10.x release, read the sections <<#changes_4.10,below>> for help upgrading your project to the latest 4.10.x release.
+We recommend upgrading to the latest 4.10.x release to get the most useful warnings and deprecations information before moving to 5.0.
+Avoid upgrading Gradle and migrating to Kotlin DSL at the same time in order to ease troubleshooting in case of potential issues.
+ . Try running `gradle help --scan` and view the https://gradle.com/enterprise/releases/2018.4/#identify-usages-of-deprecated-gradle-functionality[deprecations view] of the generated build scan.
+If there are no warnings, the Deprecations tab will not appear.
 +
 image::deprecations.png[Deprecations View of a Gradle Build Scan]
 +
-This is so that you can see any deprecation warnings that apply to your build. Gradle 5.x will generate (potentially less obvious) errors if you try to upgrade directly to it.
+This is so that you can see any deprecation warnings that apply to your build.
+Gradle 5.x will generate (potentially less obvious) errors if you try to upgrade directly to it.
 +
 Alternatively, you could run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
 . Update your plugins.
 +
-Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed. The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
+Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed.
+The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
 +
 In particular, you will need to use at least a 2.x version of the https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow[*Shadow Plugin*].
 . Run `gradle wrapper --gradle-version 5.0` to update the project to 5.0
@@ -68,7 +75,8 @@ If you are not already on version 4.10, skip down to the section that applies to
 
 === Potential breaking changes
 
-The changes in this section have the potential to break your build, but the vast majority have been deprecated for quite some time and few builds will be affected by a large number of them. We strongly recommend upgrading to Gradle 4.10 first to get a report on what deprecations affect your build.
+The changes in this section have the potential to break your build, but the vast majority have been deprecated for quite some time and few builds will be affected by a large number of them.
+We strongly recommend upgrading to Gradle 4.10 first to get a report on what deprecations affect your build.
 
 The following breaking changes are not from deprecations, but the result of changes in behavior:
 
@@ -76,9 +84,10 @@ The following breaking changes are not from deprecations, but the result of chan
  * The evaluation of the `publishing {}` block is no longer deferred until needed but behaves like any other block.
    Please use `afterEvaluate {}` if you need to defer evaluation.
  * The link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Javadoc.html[`Javadoc`] and link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Groovydoc.html[`Groovydoc`] tasks now delete the destination dir for the documentation before executing. This has been added to remove stale output files from the last task execution.
- * The <<java_library_distribution_plugin.adoc#, Java Library Distribution Plugin>> is now based on the <<java_library_plugin.adoc#, Java Library Plugin>> instead of the <<java_plugin.adoc#, Java Plugin>>.
+ * The <<java_library_distribution_plugin.adoc#java_library_distribution_plugin, Java Library Distribution Plugin>> is now based on the <<java_library_plugin.adoc#java_library_plugin, Java Library Plugin>> instead of the <<java_plugin.adoc#java_plugin, Java Plugin>>.
 +
-While it applies the Java Plugin, it behaves slightly different (e.g. it adds the `api` configuration). Thus, make sure to check whether your build behaves as expected after upgrading.
+While it applies the Java Plugin, it behaves slightly different (e.g. it adds the `api` configuration).
+Thus, make sure to check whether your build behaves as expected after upgrading.
  * The `html` property on `CheckstyleReport` and `FindBugsReport` now returns a link:{groovyDslPath}/org.gradle.api.reporting.CustomizableHtmlReport.html[`CustomizableHtmlReport`] instance that is easier to configure from statically typed languages like Java and Kotlin.
  * The <<#rel5.0:configuration_avoidance, Configuration Avoidance API>> has been updated to prevent the creation and configuration of tasks that are never used.
  * The <<#rel5.0:default_memory_settings,default memory settings>> for the command-line client, the Gradle daemon, and all workers including compilers and test executors, have been greatly reduced.
@@ -208,7 +217,7 @@ Follow the API links to learn how to deal with these deprecations (if no extra i
  * There have been several potentially breaking changes in Kotlin DSL — see the _Breaking changes_ section of https://github.com/gradle/kotlin-dsl/releases/tag/v1.0-RC3[that project's release notes].
  * You can no longer use any of the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:beforeEvaluate(org.gradle.api.Action)[Project.beforeEvaluate()] or link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:afterEvaluate(org.gradle.api.Action)[Project.afterEvaluate()] methods with lazy task configuration, for example inside a link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#register-java.lang.String-java.lang.Class-org.gradle.api.Action-[TaskContainer.register()] block.
  * <<#rel4.10:aws_s3_permissions,Publishing to AWS S3 requires new permissions>>.
- * Both link:{javadocPath}/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.html[PluginUnderTestMetadata] and link:{javadocPath}/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.html[GeneratePluginDescriptors] — classes used by the <<java_gradle_plugin#,Java Gradle Plugin Development Plugin>> — have been updated to use the Provider API.
+ * Both link:{javadocPath}/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.html[PluginUnderTestMetadata] and link:{javadocPath}/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.html[GeneratePluginDescriptors] — classes used by the <<java_gradle_plugin#java_gradle_plugin,Java Gradle Plugin Development Plugin>> — have been updated to use the Provider API.
 +
 Use the link:{javadocPath}/org/gradle/api/provider/Property.html#set-T-[Property.set()] method to modify their values rather than using standard property assignment syntax, unless you are doing so in a Groovy build script. Standard property assignment still works in that one case.
 
@@ -229,7 +238,7 @@ Use https://docs.groovy-lang.org/latest/html/documentation/#_spread_operator[Gro
  * <<#rel4.8:switch_to_publishing_plugins,Switch to the Maven Publish and Ivy Publish plugins>>
  * <<#rel4.8:deferred_configuration,Use deferred configuration with the publishing plugins>>
  * <<#rel4.8:configure_internal_tasks,Configure existing `wrapper` and `init` tasks>> rather than defining your own
- * Consider migrating to the built-in <<dependency_locking#,dependency locking mechanism>> if you are currently using a plugin or custom solution for this
+ * Consider migrating to the built-in <<dependency_locking#dependency-locking,dependency locking mechanism>> if you are currently using a plugin or custom solution for this
 
 
 === Potential breaking changes
@@ -289,7 +298,7 @@ They should be added to the `annotationProcessor` configuration instead. If you 
 == Upgrading from 4.4 and earlier
 
  * Make sure you have a _settings.gradle_ file: it avoids a performance penalty and allows you to set the root project's name.
- * Gradle now ignores the build cache configuration of included builds (<<composite_builds.adoc#,composite builds>>) and instead uses the root build's configuration for all the builds.
+ * Gradle now ignores the build cache configuration of included builds (<<composite_builds.adoc#composite_builds,composite builds>>) and instead uses the root build's configuration for all the builds.
 
 === Potential breaking changes
 
@@ -598,15 +607,15 @@ pluginManagement {
 [[rel5.0:java_library_distribution_plugin]]
 === Java Library Distribution Plugin utilizes Java Library Plugin
 
-The <<java_library_distribution_plugin.adoc#,Java Library Distribution Plugin>> is now based on the
-<<java_library_plugin.adoc#, Java Library Plugin>> instead of the <<java_plugin.adoc#, Java Plugin>>.
+The <<java_library_distribution_plugin.adoc#java_library_distribution_plugin,Java Library Distribution Plugin>> is now based on the
+<<java_library_plugin.adoc#java_library_plugin, Java Library Plugin>> instead of the <<java_plugin.adoc#java_plugin, Java Plugin>>.
 
 Additionally, the default distribution created by the plugin will contain all artifacts of the `runtimeClasspath` configuration instead of the deprecated `runtime` configuration.
 
 [[rel5.0:configuration_avoidance]]
 === Configuration Avoidance API disallows common configuration errors
 
-The <<task_configuration_avoidance.adoc#, configuration avoidance API>> introduced in Gradle 4.9 allows you to avoid creating and configuring tasks that are never used.
+The <<task_configuration_avoidance.adoc#task_configuration_avoidance, configuration avoidance API>> introduced in Gradle 4.9 allows you to avoid creating and configuring tasks that are never used.
 
 With the existing API, this example adds two tasks (`foo` and `bar`):
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_5.adoc
@@ -51,10 +51,10 @@ See <<java_library_plugin.adoc#sec:java_library_configurations_graph, the relati
 
 The `uploadArchives` task and the `maven` plugin are deprecated.
 
-Users should migrate to the <<publishing_setup.adoc#,publishing system>> of Gradle by using either the <<publishing_maven.adoc#,`maven-publish`>> or <<publishing_ivy.adoc#,`ivy-publish`>> plugins.
+Users should migrate to the <<publishing_setup.adoc#publishing_components,publishing system>> of Gradle by using either the <<publishing_maven.adoc#publishing_maven,`maven-publish`>> or <<publishing_ivy.adoc#publishing_ivy,`ivy-publish`>> plugins.
 These plugins have been stable since Gradle 4.8.
 
-The publishing system is also the only way to ensure the publication of <<publishing_gradle_module_metadata.adoc#,Gradle Module Metadata>>.
+The publishing system is also the only way to ensure the publication of <<publishing_gradle_module_metadata.adoc#sec:understanding-gradle-module-md,Gradle Module Metadata>>.
 
 ==== Problems with tasks emit deprecation warnings
 
@@ -240,7 +240,7 @@ Officially introduced in Gradle 5.3, https://blog.gradle.org/gradle-metadata-1.0
 
 With Gradle 6.0, Gradle Module Metadata is enabled by default.
 
-This means, if you are publishing libraries with Gradle and using the <<publishing_maven.adoc#,maven-publish>> or <<publishing_ivy.adoc#,ivy-publish>> plugin, the Gradle Module Metadata file is always published *in addition* to traditional metadata.
+This means, if you are publishing libraries with Gradle and using the <<publishing_maven.adoc#publishing_maven,maven-publish>> or <<publishing_ivy.adoc#publishing_ivy,ivy-publish>> plugin, the Gradle Module Metadata file is always published *in addition* to traditional metadata.
 
 The traditional metadata file will contain a marker so that Gradle knows that there is additional metadata to consume.
 
@@ -249,9 +249,9 @@ The traditional metadata file will contain a marker so that Gradle knows that th
 The following rules are verified when publishing Gradle Module Metadata:
 
 * Variant names must be unique,
-* Each variant must have at least <<variant_attributes.adoc#,one attribute>>,
-* Two variants cannot have the <<variant_model.adoc#,exact same attributes and capabilities>>,
-* If there are dependencies, at least one, across all variants, must carry <<rich_versions.adoc#,version information>>.
+* Each variant must have at least <<variant_attributes.adoc#variant_attributes,one attribute>>,
+* Two variants cannot have the <<variant_model.adoc#understanding-variant-selection,exact same attributes and capabilities>>,
+* If there are dependencies, at least one, across all variants, must carry <<rich_versions.adoc#rich-version-constraints,version information>>.
 
 These are documented in the link:https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-latest-specification.md[specification] as well.
 
@@ -508,7 +508,7 @@ This will become an error in Gradle 6.0.
 
 The `WorkerExecutor.submit()` method is now deprecated.
 The new `noIsolation()`, `classLoaderIsolation()` and `processIsolation()` methods should now be used to submit work.
-See <<worker_api.adoc#,the section on the Worker API>> for more information on using these methods.
+See <<worker_api.adoc#tasks_parallel_worker,the section on the Worker API>> for more information on using these methods.
 
 `WorkerExecutor.submit()` will be removed in Gradle 8.0.
 
@@ -762,14 +762,14 @@ Please pass files and directories as arguments instead. See examples in the <<cu
 
 ==== Changes to native linking tasks
 
-To expand our idiomatic <<lazy_configuration.adoc#, Provider API>> practices, the install name property from `org.gradle.nativeplatform.tasks.LinkSharedLibrary` is affected by this change.
+To expand our idiomatic <<lazy_configuration.adoc#lazy_configuration, Provider API>> practices, the install name property from `org.gradle.nativeplatform.tasks.LinkSharedLibrary` is affected by this change.
 
 - `getInstallName()` was changed to return a `Property`.
 - `setInstallName(String)` was removed. Use `Property.set()` instead.
 
 ==== Passing arguments to Windows Resource Compiler
 
-To expand our idiomatic <<lazy_configuration.adoc#, Provider API>> practices, the `WindowsResourceCompile` task has been converted to use the Provider API.
+To expand our idiomatic <<lazy_configuration.adoc#lazy_configuration, Provider API>> practices, the `WindowsResourceCompile` task has been converted to use the Provider API.
 
 Passing additional compiler arguments now follow the same pattern as the `CppCompile` and other tasks.
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -110,7 +110,7 @@ An external replacement, the link:https://gradle.github.io/playframework[Play Fr
 These unmaintained alternative JVM plugins have been removed:
 `java-lang`, `scala-lang`, `junit-test-suite`, `jvm-component`, `jvm-resources`.
 
-Please use the stable <<java_library_plugin.adoc#,Java Library>> and <<scala_plugin.adoc#,Scala>> plugins instead.
+Please use the stable <<java_library_plugin.adoc#java_library_plugin,Java Library>> and <<scala_plugin.adoc#scala_plugin,Scala>> plugins instead.
 
 ==== Removal of experimental JavaScript plugins
 
@@ -185,7 +185,7 @@ The following APIs, which were not usable via command line options anymore since
 
 Gradle no longer supports discovering the settings file in a directory named `master` in a sibling directory.
 If your build still uses this deprecated feature, consider refactoring the build to have the root directory match the physical root of the project hierarchy.
-You can find more information about <<multi_project_builds.adoc#,how to structure a Gradle build>> or a <<structuring_software_products.adoc#,composition of builds>> in the user manual.
+You can find more information about <<multi_project_builds.adoc#multi_project_builds,how to structure a Gradle build>> or a <<structuring_software_products.adoc#structure_large_projects,composition of builds>> in the user manual.
 Alternatively, you can still run tasks in builds like this by invoking the build from the `master` directory only using a
 <<intro_multi_project_builds.adoc#sec:executing_tasks_by_fully_qualified_name,fully qualified path to the task>>.
 
@@ -394,7 +394,7 @@ configurations.implementation.extendsFrom(configurations.myConfiguration)
 ==== Dependency substitutions and variant aware dependency resolution
 
 While adding support for expressing <<resolution_rules#sec:variant_aware_substitutions, variant support>> in dependency substitutions, a bug fix introduced a behaviour change that some builds may rely upon.
-Previously a substituted dependency would still use the <<variant_attributes#, attributes>> of the original selector instead of the ones from the replacement selector.
+Previously a substituted dependency would still use the <<variant_attributes#variant_attributes, attributes>> of the original selector instead of the ones from the replacement selector.
 
 With that change, existing substitutions around dependencies with richer selectors, such as for platform dependencies, will no longer work as they did.
 It becomes mandatory to define the variant aware part in the target selector.
@@ -403,7 +403,7 @@ You can be affected by this change if you:
 
 * have dependencies on platforms, like `implementation platform("org:platform:1.0")`
 * _or_ if you specify attributes on dependencies,
-* _and_ you use <<resolution_rules#, resolution rules>> on these dependencies.
+* _and_ you use <<resolution_rules#resolution_rules, resolution rules>> on these dependencies.
 
 See the <<resolution_rules#sec:variant_aware_substitutions, documentation>> for resolving issues if you are impacted.
 
@@ -536,7 +536,7 @@ Gradle will continue building projects on 32-bit systems but will no longer show
 ==== Using default and archives configurations
 
 Almost every Gradle project has the _default_ and _archives_ configurations which are added by the _base_ plugin.
-These configurations are no longer used in modern Gradle builds that use <<variant_model.adoc#,variant aware dependency management>> and the <<publishing_setup.adoc#,new publishing plugins>>.
+These configurations are no longer used in modern Gradle builds that use <<variant_model.adoc#understanding-variant-selection,variant aware dependency management>> and the <<publishing_setup.adoc#publishing_components,new publishing plugins>>.
 
 While the configurations will stay in Gradle for backwards compatibility for now, using them to declare dependencies or to resolve dependencies is now deprecated.
 
@@ -609,7 +609,9 @@ The following methods have been discontinued and should no longer be used. They 
 [[upgrading_jvm_plugins]]
 ==== Alternative JVM plugins (a.k.a "Software Model")
 
-A set of alternative plugins for Java and Scala development were introduced in Gradle 2.x as an experiment based on the "software model".  These plugins are now deprecated and will eventually be removed.  If you are still using one of these old plugins (`java-lang`, `scala-lang`, `jvm-component`, `jvm-resources`, `junit-test-suite`) please consult the documentation on <<building_java_projects.adoc#,Building Java & JVM projects>> to determine which of the stable JVM plugins are appropriate for your project.
+A set of alternative plugins for Java and Scala development were introduced in Gradle 2.x as an experiment based on the "software model".
+These plugins are now deprecated and will eventually be removed.
+If you are still using one of these old plugins (`java-lang`, `scala-lang`, `jvm-component`, `jvm-resources`, `junit-test-suite`) please consult the documentation on <<building_java_projects.adoc#building_java_projects,Building Java & JVM projects>> to determine which of the stable JVM plugins are appropriate for your project.
 
 === Potential breaking changes
 

--- a/subprojects/docs/src/docs/userguide/native/building_cpp_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/native/building_cpp_projects.adoc
@@ -21,7 +21,7 @@ If you are coming from another native build system, these concepts may be unfami
 We will look at {cpp} projects in detail in this chapter, but most of the topics will apply to other supported native languages as well.
 If you don’t have much experience with building native projects with Gradle, take a look at the {cpp} tutorials for step-by-step instructions on how to build various types of basic {cpp} projects as well as some common use cases.
 
-The {cpp} plugins covered in this chapter were https://blog.gradle.org/introducing-the-new-cpp-plugins[introduced in 2018] and we recommend users to use those plugins over <<native_software.adoc#,the older Native plugins>> that you may find references to.
+The {cpp} plugins covered in this chapter were https://blog.gradle.org/introducing-the-new-cpp-plugins[introduced in 2018] and we recommend users to use those plugins over <<native_software.adoc#native_software,the older Native plugins>> that you may find references to.
 
 [[sec:cpp_introduction]]
 == Introduction
@@ -74,14 +74,14 @@ You can also configure sources for each binary build for those cases where sourc
 .Sources and {cpp} compilation
 image::cpp-sourcesets-compilation.png[]
 
-Test sources are configured on each test suite script block. See <<cpp_testing.adoc#,Testing {cpp} projects>> chapter.
+Test sources are configured on each test suite script block. See <<cpp_testing.adoc#cpp_testing,Testing {cpp} projects>> chapter.
 
 [[sec:cpp_dependency_management_overview]]
 == Managing your dependencies
 
 The vast majority of projects rely on other projects, so managing your project's dependencies is an important part of building any project.
 Dependency management is a big topic, so we will only focus on the basics for {cpp} projects here.
-If you’d like to dive into the details, check out the <<core_dependency_management.adoc#,introduction to dependency management>>.
+If you’d like to dive into the details, check out the <<core_dependency_management.adoc#dependency_management_in_gradle,introduction to dependency management>>.
 
 Gradle provides support for consuming pre-built binaries from Maven repositories published by Gradle footnote:[Unfortunately, Conan and Nuget repositories aren’t yet supported as core features].
 
@@ -106,7 +106,7 @@ The Gradle terminology for the three elements is as follows:
  * _Configuration_ (ex: `implementation`) - a named collection of dependencies, grouped together for a specific goal such as compiling or linking a module
  * _Project reference_ (ex: `project(':common')`) - the project referenced by the specified path
 
-You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#,here>>.
+You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#dependency_management_terminology,here>>.
 
 As far as configurations go, the main ones of interest are:
 
@@ -117,16 +117,16 @@ As far as configurations go, the main ones of interest are:
 
 You can learn more about these and how they relate to one another in the <<plugin_reference.adoc#native_languages,native plugin reference chapter>>.
 
-Be aware that the <<cpp_library_plugin.adoc#,{cpp} Library Plugin>> creates an additional configuration — `api` — for dependencies that are required for compiling and linking both the module and any modules that depend on it.
+Be aware that the <<cpp_library_plugin.adoc#cpp_library_plugin,{cpp} Library Plugin>> creates an additional configuration — `api` — for dependencies that are required for compiling and linking both the module and any modules that depend on it.
 
-We have only scratched the surface here, so we recommend that you read the <<core_dependency_management.adoc#,dedicated dependency management chapters>> once you’re comfortable with the basics of building {cpp} projects with Gradle.
+We have only scratched the surface here, so we recommend that you read the <<core_dependency_management.adoc#dependency_management_in_gradle,dedicated dependency management chapters>> once you’re comfortable with the basics of building {cpp} projects with Gradle.
 
 Some common scenarios that require further reading include:
 
  * Defining a custom <<declaring_repositories.adoc#sec:maven_repo,Maven-compatible>> repository
  * Declaring dependencies with <<dynamic_versions.adoc#sub:declaring_dependency_with_changing_version,changing>> (e.g. SNAPSHOT) and <<dynamic_versions.adoc#sub:declaring_dependency_with_dynamic_version,dynamic>> (range) versions
  * Declaring a sibling <<declaring_dependencies.adoc#sub:project_dependencies,project as a dependency>>
- * <<dependency_constraints.adoc#,Controlling transitive dependencies and their versions>>
+ * <<dependency_constraints.adoc#dependency-constraints,Controlling transitive dependencies and their versions>>
  * Testing your fixes to 3rd-party dependency via <<composite_builds.adoc#composite_builds,composite builds>> (a better alternative to publishing to and consuming from <<declaring_repositories.adoc#sub:maven_local,Maven Local>>)
 
 You’ll discover that Gradle has a rich API for working with dependencies — one that takes time to master, but is straightforward to use for common scenarios.
@@ -245,7 +245,7 @@ Gradle comes with defaults, but custom packaging can be implemented without any 
 [[sec:cleaning_cpp_build]]
 == Cleaning the build
 
-The {cpp} Application and Library Plugins add a `clean` task to you project by using the <<base_plugin.adoc#,base plugin>>.
+The {cpp} Application and Library Plugins add a `clean` task to you project by using the <<base_plugin.adoc#base_plugin,base plugin>>.
 This task simply deletes everything in the `$buildDir` directory, hence why you should always put files generated by the build in there.
 The task is an instance of Delete and you can change what directory it deletes by setting its `dir` property.
 
@@ -256,7 +256,7 @@ The unique aspect of library projects is that they are used (or "consumed") by o
 That means the dependency metadata published with the binaries and headers — in the form of Gradle Module Metadata — is crucial.
 In particular, consumers of your library should be able to distinguish between two different types of dependencies: those that are only required to compile your library and those that are also required to compile the consumer.
 
-Gradle manages this distinction via the <<cpp_library_plugin.adoc#,{cpp} Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
+Gradle manages this distinction via the <<cpp_library_plugin.adoc#cpp_library_plugin,{cpp} Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
 If the types from a dependency appear as unresolved symbols of the static library or within the public headers then that dependency is exposed via your library’s public API and should, therefore, be added to the _api_ configuration.
 Otherwise, the dependency is an internal implementation detail and should be added to _implementation_.
 
@@ -266,7 +266,7 @@ In addition, you can see a basic, practical example of building a {cpp} library 
 [[sec:building_cpp_applications]]
 == Building {cpp} applications
 
-See the <<cpp_application_plugin.adoc#,{cpp} Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
+See the <<cpp_application_plugin.adoc#cpp_application_plugin,{cpp} Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
 
  * `install` create a directory containing everything needed to run it
  * Shell and Windows Batch scripts to start the application

--- a/subprojects/docs/src/docs/userguide/native/building_swift_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/native/building_swift_projects.adoc
@@ -78,14 +78,14 @@ You can also configure sources for each binary build for those cases where sourc
 image::swift-sourcesets-compilation.png[]
 
 // TODO once we have the testing chapter
-//Test sources are configured on each test suite script block. See <<swift_testing.adoc#,Testing Swift projects>> chapter.
+//Test sources are configured on each test suite script block. See <<swift_testing.adoc#swift_testing,Testing Swift projects>> chapter.
 
 [[sec:swift_dependency_management_overview]]
 == Managing your dependencies
 
 The vast majority of projects rely on other projects, so managing your project's dependencies is an important part of building any project.
 Dependency management is a big topic, so we will only focus on the basics for Swift projects here.
-If you’d like to dive into the details, check out the <<core_dependency_management.adoc#,introduction to dependency management>>.
+If you’d like to dive into the details, check out the <<core_dependency_management.adoc#dependency_management_in_gradle,introduction to dependency management>>.
 
 Gradle provides support for consuming pre-built binaries from Maven repositories published by Gradle footnote:[Unfortunately, Cocoapods repositories aren’t yet supported as core features].
 
@@ -110,7 +110,7 @@ The Gradle terminology for the three elements is as follows:
  * _Configuration_ (ex: `implementation`) - a named collection of dependencies, grouped together for a specific goal such as compiling or linking a module
  * _Project reference_ (ex: `project(':common')`) - the project referenced by the specified path
 
-You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#,here>>.
+You can find a more comprehensive glossary of dependency management terms <<dependency_management_terminology.adoc#dependency_management_terminology,here>>.
 
 As far as configurations go, the main ones of interest are:
 
@@ -121,17 +121,17 @@ As far as configurations go, the main ones of interest are:
 
 You can learn more about these and how they relate to one another in the <<plugin_reference.adoc#native_languages,native plugin reference chapter>>.
 
-Be aware that the <<swift_library_plugin.adoc#,Swift Library Plugin>> creates an additional configuration — `api` — for dependencies that are required for compiling and linking both the module and any modules that depend on it.
+Be aware that the <<swift_library_plugin.adoc#swift_library_plugin,Swift Library Plugin>> creates an additional configuration — `api` — for dependencies that are required for compiling and linking both the module and any modules that depend on it.
 
-We have only scratched the surface here, so we recommend that you read the <<core_dependency_management.adoc#,dedicated dependency management chapters>> once you’re comfortable with the basics of building Swift projects with Gradle.
+We have only scratched the surface here, so we recommend that you read the <<core_dependency_management.adoc#dependency_management_in_gradle,dedicated dependency management chapters>> once you’re comfortable with the basics of building Swift projects with Gradle.
 
 Some common scenarios that require further reading include:
 
  * Defining a custom <<declaring_repositories.adoc#sec:repository-types,Maven-compatible>> repository
  * Declaring dependencies with <<dynamic_versions.adoc#sub:declaring_dependency_with_changing_version,changing>> (e.g. SNAPSHOT) and <<dynamic_versions.adoc#sub:declaring_dependency_with_dynamic_version,dynamic>> (range) versions
  * Declaring a sibling <<declaring_dependencies.adoc#sub:project_dependencies,project as a dependency>>
- * <<dependency_constraints.adoc#,Controlling transitive dependencies and their versions>>
- * Testing your fixes to 3rd-party dependency via <<composite_builds.adoc#,composite builds>> (a better alternative to publishing to and consuming from <<declaring_repositories.adoc#sub:maven_local,Maven Local>>)
+ * <<dependency_constraints.adoc#dependency-constraints,Controlling transitive dependencies and their versions>>
+ * Testing your fixes to 3rd-party dependency via <<composite_builds.adoc#composite_builds,composite builds>> (a better alternative to publishing to and consuming from <<declaring_repositories.adoc#sub:maven_local,Maven Local>>)
 
 You’ll discover that Gradle has a rich API for working with dependencies — one that takes time to master, but is straightforward to use for common scenarios.
 
@@ -224,7 +224,7 @@ Gradle comes with defaults, but custom packaging can be implemented without any 
 [[sec:cleaning_swift_build]]
 == Cleaning the build
 
-The Swift Application and Library Plugins add a `clean` task to you project by using the <<base_plugin.adoc#,base plugin>>.
+The Swift Application and Library Plugins add a `clean` task to you project by using the <<base_plugin.adoc#base_plugin,base plugin>>.
 This task simply deletes everything in the `$buildDir` directory, hence why you should always put files generated by the build in there.
 The task is an instance of Delete and you can change what directory it deletes by setting its `dir` property.
 
@@ -235,7 +235,7 @@ The unique aspect of library projects is that they are used (or "consumed") by o
 That means the dependency metadata published with the binaries and headers — in the form of Gradle Module Metadata — is crucial.
 In particular, consumers of your library should be able to distinguish between two different types of dependencies: those that are only required to compile your library and those that are also required to compile the consumer.
 
-Gradle manages this distinction via the <<swift_library_plugin.adoc#,Swift Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
+Gradle manages this distinction via the <<swift_library_plugin.adoc#swift_library_plugin,Swift Library Plugin>>, which introduces an _api_ configuration in addition to the _implementation_ once covered in this chapter.
 If the types from a dependency appear as unresolved symbols of the static library or within the public headers then that dependency is exposed via your library’s public API and should, therefore, be added to the _api_ configuration.
 Otherwise, the dependency is an internal implementation detail and should be added to _implementation_.
 
@@ -245,7 +245,7 @@ In addition, you can see a basic, practical example of building a Swift library 
 [[sec:building_swift_applications]]
 == Building Swift applications
 
-See the <<swift_application_plugin.adoc#,Swift Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
+See the <<swift_application_plugin.adoc#swift_application_plugin,Swift Application Plugin>> chapter for more details, but here’s a quick summary of what you get:
 
  * `install` create a directory containing everything needed to run it
  * Shell and Windows Batch scripts to start the application

--- a/subprojects/docs/src/docs/userguide/native/cpp_application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_application_plugin.adoc
@@ -91,29 +91,29 @@ Aggregates tasks that assemble the specific variant of this application.
 [[sec:cpp_application_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The {cpp} Application Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> - which the {cpp} Application Plugin applies automatically:
+The {cpp} Application Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> - which the {cpp} Application Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Depends on: `linkDebug`
 ::
 Aggregate task that assembles the debug variant of the application for the current host (if present) in the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `check` - Task (lifecycle)::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
-For example, the <<cpp_unit_test_plugin.adoc#,{cpp} Unit Test Plugin>> attaches a task to this lifecycle task to run tests.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+For example, the <<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,{cpp} Unit Test Plugin>> attaches a task to this lifecycle task to run tests.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:cpp_application_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/native/cpp_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_library_plugin.adoc
@@ -109,29 +109,29 @@ Aggregates tasks that assemble the specific variant of this library.
 [[sec:cpp_library_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The {cpp} Library Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> — which the {cpp} Library Plugin applies automatically:
+The {cpp} Library Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> — which the {cpp} Library Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Depends on: `linkDebug` when linkage includes `shared` or `createDebug` otherwise.
 ::
 Aggregate task that assembles the debug variant of the shared library (if available) for the current host (if present) in the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `check` - Task (lifecycle)::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
-For example, the <<cpp_unit_test_plugin.adoc#,{cpp} Unit Test Plugin>> attach his test task to this lifecycle task.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+For example, the <<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,{cpp} Unit Test Plugin>> attach his test task to this lifecycle task.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:cpp_library_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/native/cpp_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_testing.adoc
@@ -36,7 +36,7 @@ In order to operate, the link:{groovyDslPath}/org.gradle.nativeplatform.test.tas
 
  * Where to find the built test executable (property: link:{groovyDslPath}/org.gradle.nativeplatform.test.tasks.RunTestExecutable.html#org.gradle.nativeplatform.test.tasks.RunTestExecutable:executable[RunTestExecutable.getExecutable()])
 
-When you’re using the <<cpp_unit_test_plugin.adoc#,{cpp} Unit Test Plugin>> you will automatically get the following:
+When you’re using the <<cpp_unit_test_plugin.adoc#cpp_unit_test_plugin,{cpp} Unit Test Plugin>> you will automatically get the following:
 
  * A dedicated link:{groovyDslPath}/org.gradle.nativeplatform.test.cpp.CppTestSuite.html[unitTest] extension for configuring test component and its variants
  * A `run` task of type link:{groovyDslPath}/org.gradle.nativeplatform.test.tasks.RunTestExecutable.html[RunTestExecutable] that runs the test executable

--- a/subprojects/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/cpp_unit_test_plugin.adoc
@@ -86,12 +86,12 @@ Run the installed executable.
 [[sec:cpp_unit_test_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The {cpp} Unit Test Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> — which the {cpp} Unit Test Plugin applies automatically:
+The {cpp} Unit Test Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> — which the {cpp} Unit Test Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Aggregate task that assembles the debug variant of the tested component for the current host (if present) in the project.
-For example, the <<cpp_application_plugin.adoc#,{cpp} Application Plugin>> and <<cpp_library_plugin.adoc#,{cpp} Library Plugin>> attach their link and create tasks to this lifecycle task.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+For example, the <<cpp_application_plugin.adoc#cpp_application_plugin,{cpp} Application Plugin>> and <<cpp_library_plugin.adoc#cpp_library_plugin,{cpp} Library Plugin>> attach their link and create tasks to this lifecycle task.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `test` - Task (lifecycle)::
 Depends on: `runTest__Variant__` that most closely matches the build host
@@ -103,17 +103,17 @@ Depends on: `test`
 ::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:cpp_unit_test_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/native/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native/native_software.adoc
@@ -19,7 +19,7 @@
 [CAUTION]
 ====
 The https://blog.gradle.org/state-and-future-of-the-gradle-software-model[software model] is being retired and the plugins mentioned in this chapter will eventually be deprecated and removed.
-We recommend new projects looking to build C++ applications and libraries use the newer <<building_cpp_projects.adoc#,replacement plugins>>.
+We recommend new projects looking to build C++ applications and libraries use the newer <<building_cpp_projects.adoc#building_cpp_projects,replacement plugins>>.
 ====
 
 The native software plugins add support for building native software components, such as executables or shared libraries, from code written in C++, C and other languages. While many excellent build tools exist for this space of software development, Gradle offers developers its trademark power and flexibility together with dependency management practices more traditionally found in the JVM development space.

--- a/subprojects/docs/src/docs/userguide/native/swift_application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_application_plugin.adoc
@@ -91,29 +91,29 @@ Aggregates tasks that assemble the specific variant of this application.
 [[sec:swift_application_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The Swift Application Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> — which the Swift Application Plugin applies automatically:
+The Swift Application Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> — which the Swift Application Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Depends on: `linkDebug`
 ::
 Aggregate task that assembles the debug variant of the application for the current host (if present) in the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `check` - Task (lifecycle)::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
- For example, the <<xctest_plugin.adoc#,XCTest Plugin>> attaches a task to this lifecycle task to run tests.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+ For example, the <<xctest_plugin.adoc#xctest_plugin,XCTest Plugin>> attaches a task to this lifecycle task to run tests.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:swift_application_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/native/swift_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_library_plugin.adoc
@@ -109,29 +109,29 @@ Aggregates tasks that assemble the specific variant of this library.
 [[sec:swift_library_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The Swift Library Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> — which the Swift Library Plugin applies automatically:
+The Swift Library Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> — which the Swift Library Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Depends on: `linkDebug` when linkage includes `shared` or `createDebug` otherwise.
 ::
 Aggregate task that assembles the debug variant of the shared library (if available) for the current host (if present) in the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `check` - Task (lifecycle)::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
- For example, the <<xctest_plugin.adoc#,XCTest Plugin>> attach his test task to this lifecycle task.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+ For example, the <<xctest_plugin.adoc#xctest_plugin,XCTest Plugin>> attach his test task to this lifecycle task.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:swift_library_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/native/swift_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/native/swift_testing.adoc
@@ -40,7 +40,7 @@ In order to operate, the link:{groovyDslPath}/org.gradle.nativeplatform.test.xct
 - The run script for executing the bundle or executable (property: link:{groovyDslPath}/org.gradle.nativeplatform.test.xctest.tasks.XCTest.html#org.gradle.nativeplatform.test.xctest.tasks.XCTest:runScriptFile[XCTest.getRunScriptFile()])
 - The working directory to execution the bundle or executable (property: link:{groovyDslPath}/org.gradle.nativeplatform.test.xctest.tasks.XCTest.html#org.gradle.nativeplatform.test.xctest.tasks.XCTest:workingDirectory[XCTest.getWorkingDirectory()])
 
-When you’re using the <<xctest_plugin.adoc#,XCTest Plugin>> you will automatically get the following:
+When you’re using the <<xctest_plugin.adoc#xctest_plugin,XCTest Plugin>> you will automatically get the following:
 - A dedicated `xctest` extension of type link:{groovyDslPath}/org.gradle.nativeplatform.test.xctest.SwiftXCTestSuite.html[SwiftXCTestSuite] for configuring test component and its variants
 - A `xcTest` task of type link:{groovyDslPath}/org.gradle.nativeplatform.test.xctest.tasks.XCTest.html[XCTest] that runs those unit tests
 - A testable bundle or executable linked with the main component’s object files
@@ -146,7 +146,7 @@ include::sample[dir="snippets/swift/testReport/groovy",files="buildSrc/src/main/
 include::sample[dir="snippets/swift/testReport/kotlin",files="buildSrc/src/main/kotlin/myproject.xctest-conventions.gradle.kts[tags=test-report];build.gradle.kts[tags=test-report]"]
 ====
 
-In this example, we use a convention plugin `myproject.xctest-conventions` to expose the test results from a project to Gradle's <<variant_model.adoc#,variant aware dependency management engine>>.
+In this example, we use a convention plugin `myproject.xctest-conventions` to expose the test results from a project to Gradle's <<variant_model.adoc#understanding-variant-selection,variant aware dependency management engine>>.
 
 The plugin declares a consumable `binaryTestResultsElements` configuration that represents the binary test results of the `test` task.
 In the aggregation project's build file, we declare the `testReportData` configuration and depend on all of the projects that we want to aggregate the results from. Gradle will automatically select the binary test result variant from each of the subprojects instead of the project's jar file.

--- a/subprojects/docs/src/docs/userguide/native/xcode_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/xcode_plugin.adoc
@@ -27,19 +27,19 @@ What exactly the `xcode` plugin generates depends on which other plugins are use
 | None
 | Generates minimal solution file.
 
-| <<cpp_application_plugin.adoc#,{cpp} Application>>
+| <<cpp_application_plugin.adoc#cpp_application_plugin,{cpp} Application>>
 | Adds a target representing the {cpp} application to the project file.
 
-| <<cpp_library_plugin.adoc#,{cpp} Library>>
+| <<cpp_library_plugin.adoc#cpp_library_plugin,{cpp} Library>>
 | Adds a target for each specified linkage representing the shared and/or static library to the project file.
 
-| <<swift_application_plugin.adoc#,Swift Application>>
+| <<swift_application_plugin.adoc#swift_application_plugin,Swift Application>>
 | Adds a target representing the Swift application to the project file.
 
-| <<swift_library_plugin.adoc#,Swift Library>>
+| <<swift_library_plugin.adoc#swift_library_plugin,Swift Library>>
 | Adds a target for each specified linkage representing the shared and/or static library to the project file.
 
-| <<xctest_plugin.adoc#,XCTest>>
+| <<xctest_plugin.adoc#xctest_plugin,XCTest>>
 | Adds a target representing the XCTest bundle to the project file.
 | The tested target is also configured to enable a seamless workflow from the IDE.
 |===

--- a/subprojects/docs/src/docs/userguide/native/xctest_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/native/xctest_plugin.adoc
@@ -86,12 +86,12 @@ Run the installed executable.
 [[sec:xctest_lifecycle_tasks]]
 === Lifecycle Tasks
 
-The XCTest Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#,Base Plugin chapter>> — which the XCTest Plugin applies automatically:
+The XCTest Plugin attaches some of its tasks to the standard lifecycle tasks documented in the <<base_plugin.adoc#base_plugin,Base Plugin chapter>> — which the XCTest Plugin applies automatically:
 
 `assemble` - Task (lifecycle)::
 Aggregate task that assembles the debug variant of the tested component for the current host (if present) in the project.
-For example, the <<swift_application_plugin.adoc#,Swift Application Plugin>> and <<swift_library_plugin.adoc#,Swift Library Plugin>> attach their link and create tasks to this lifecycle task.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+For example, the <<swift_application_plugin.adoc#swift_application_plugin,Swift Application Plugin>> and <<swift_library_plugin.adoc#swift_library_plugin,Swift Library Plugin>> attach their link and create tasks to this lifecycle task.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `test` - Task (lifecycle)::
 Depends on: `xcTest__Variant__` that most closely matches the build host
@@ -103,17 +103,17 @@ Depends on: `test`
 ::
 Aggregate task that performs verification tasks, such as running the tests.
 Some plugins add their own verification task to `check`.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `build` - Task (lifecycle)::
 Depends on: `check`, `assemble`
 ::
 Aggregate tasks that perform a full build of the project.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 `clean` - Delete::
 Deletes the build directory and everything in it, i.e. the path specified by the `Project.getBuildDir()` project property.
-This task is added by the <<base_plugin.adoc#,Base Plugin>>.
+This task is added by the <<base_plugin.adoc#base_plugin,Base Plugin>>.
 
 [[sec:xctest_dependency_management]]
 == Dependency management

--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/jenkins.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/jenkins.adoc
@@ -1,3 +1,4 @@
+[[build_jenkins]]
 = Executing Gradle builds on Jenkins
 
 TIP: Top engineering teams using Jenkins have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. https://gradle.com/training/build-cache-deep-dive/?bid=guides-execute-jenkins[Register here] for our Build Cache training session to learn how your team can achieve similar results.

--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/teamcity.adoc
@@ -1,3 +1,4 @@
+[[build_teamcity]]
 = Executing Gradle builds on TeamCity
 
 TIP: Top engineering teams using TeamCity have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. https://gradle.com/training/build-cache-deep-dive/?bid=guides-execute-teamcity[Register here] for our Build Cache training session to learn how your team can achieve similar results.

--- a/subprojects/docs/src/docs/userguide/reference/ci-systems/travis-ci.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/ci-systems/travis-ci.adoc
@@ -1,3 +1,4 @@
+[[build_travis]]
 = Executing Gradle builds on Travis CI
 
 TIP: Top engineering teams using Travis CI have been able to reduce CI build time by up to 90% by using the Gradle Build Cache. https://gradle.com/training/build-cache-deep-dive/?bid=guides-execute-travisci[Register here] for our Build Cache training session to learn how your team can achieve similar results.

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -254,7 +254,7 @@ This will give you a link to a web-based report, where you can find dependency i
 
 image::gradle-core-test-build-scan-dependencies.png[Build Scan dependencies report]
 
-Learn more in <<viewing_debugging_dependencies.adoc#,Viewing and debugging dependencies>>.
+Learn more in <<viewing_debugging_dependencies.adoc#viewing-debugging-dependencies,Viewing and debugging dependencies>>.
 
 === Listing project dependencies
 
@@ -264,7 +264,7 @@ Running `gradle dependencies` gives you a list of the dependencies of the select
 $ gradle dependencies
 ----
 
-Concrete examples of build scripts and output available in the <<viewing_debugging_dependencies.adoc#,Viewing and debugging dependencies>>.
+Concrete examples of build scripts and output available in the <<viewing_debugging_dependencies.adoc#viewing-debugging-dependencies,Viewing and debugging dependencies>>.
 
 Running `gradle buildEnvironment` visualises the buildscript dependencies of the selected project, similarly to how `gradle dependencies` visualizes the dependencies of the software being built.
 
@@ -325,7 +325,7 @@ Debug <<gradle_daemon.adoc#gradle_daemon, Gradle Daemon>> process.
 
 [[sec:command_line_performance]]
 == Performance options
-Try these options when optimizing build performance. Learn more about <<performance.adoc#,improving performance of Gradle builds here>>.
+Try these options when optimizing build performance. Learn more about <<performance.adoc#performance_gradle,improving performance of Gradle builds here>>.
 
 Many of these options can be specified in `gradle.properties` so command-line flags are not necessary. See the <<build_environment.adoc#sec:gradle_configuration_properties, configuring build environment guide>>.
 

--- a/subprojects/docs/src/docs/userguide/reference/third_party_integration.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/third_party_integration.adoc
@@ -7,24 +7,29 @@ Gradle can be integrated with many different third-party tools such as IDEs and 
 == IDEs
 
 Android Studio::
-As a variant of IntelliJ IDEA, https://developer.android.com/studio/[Android Studio] has built-in support for importing and building Gradle projects. You can also use the <<idea_plugin.adoc#,IDEA Plugin for Gradle>> to fine-tune the import process if that's necessary.
+As a variant of IntelliJ IDEA, https://developer.android.com/studio/[Android Studio] has built-in support for importing and building Gradle projects.
+You can also use the <<idea_plugin.adoc#idea_plugin,IDEA Plugin for Gradle>> to fine-tune the import process if that's necessary.
 +
 This IDE also has an https://developer.android.com/studio/intro/[extensive user guide] to help you get the most out of the IDE and Gradle.
 
 Eclipse::
-If you want to work on a project within Eclipse that has a Gradle build, you should use the https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship plugin]. This will allow you to import and run Gradle builds. If you need to fine tune the import process so that the project loads correctly, you can use the <<eclipse_plugin.adoc#,Eclipse Plugins for Gradle>>. See https://discuss.gradle.org/t/buildship-1-0-18-is-now-available/19012[the associated release announcement] for details on what fine tuning you can do.
+If you want to work on a project within Eclipse that has a Gradle build, you should use the https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship plugin].
+This will allow you to import and run Gradle builds.
+If you need to fine tune the import process so that the project loads correctly, you can use the <<eclipse_plugin.adoc#eclipse_plugin,Eclipse Plugins for Gradle>>.
+See https://discuss.gradle.org/t/buildship-1-0-18-is-now-available/19012[the associated release announcement] for details on what fine tuning you can do.
 
 IntelliJ IDEA::
-IDEA has built-in support for importing Gradle projects. If you need to fine tune the import process so that the project loads correctly, you can use the <<idea_plugin.adoc#,IDEA Plugin for Gradle>>.
+IDEA has built-in support for importing Gradle projects.
+If you need to fine tune the import process so that the project loads correctly, you can use the <<idea_plugin.adoc#idea_plugin,IDEA Plugin for Gradle>>.
 
 NetBeans::
 Add the http://plugins.netbeans.org/plugin/44510/gradle-support[Gradle Support] plugin to NetBeans in order to import and run projects with Gradle builds.
 
 Visual Studio::
-For developing C++ projects, Gradle comes with a <<visual_studio_plugin.adoc#,Visual Studio plugin>>.
+For developing C++ projects, Gradle comes with a <<visual_studio_plugin.adoc#visual_studio_plugin,Visual Studio plugin>>.
 
 Xcode::
-For developing C++ projects, Gradle comes with a <<xcode_plugin.adoc#,Xcode plugin>>.
+For developing C++ projects, Gradle comes with a <<xcode_plugin.adoc#xcode_plugin,Xcode plugin>>.
 
 CLion::
 JetBrains supports building https://blog.jetbrains.com/clion/2018/05/clion-starts-2018-2-eap-sanitizers-gradle-db-performance/[C++ projects with Gradle].
@@ -33,11 +38,11 @@ JetBrains supports building https://blog.jetbrains.com/clion/2018/05/clion-start
 
 We have dedicated guides showing you how to integrate a Gradle project with the following CI platforms:
 
- * <<jenkins.adoc#,Jenkins>>
- * <<teamcity.adoc#,TeamCity>>
- * <<travis-ci.adoc#,Travis CI>>
+ * <<jenkins.adoc#build_jenkins,Jenkins>>
+ * <<teamcity.adoc#build_teamcity,TeamCity>>
+ * <<travis-ci.adoc#build_travis,Travis CI>>
 
-Even if you don't use one of the above, you can almost certainly configure your CI platform to use the <<gradle_wrapper.adoc#,Gradle Wrapper>> scripts.
+Even if you don't use one of the above, you can almost certainly configure your CI platform to use the <<gradle_wrapper.adoc#gradle_wrapper,Gradle Wrapper>> scripts.
 
 == How to integrate with Gradle
 
@@ -46,7 +51,7 @@ There are two main ways to integrate a tool with Gradle:
  * The Gradle build uses the tool
  * The tool executes the Gradle build
 
-The former case is typically <<custom_plugins.adoc#,implemented as a Gradle plugin>>. The latter can be accomplished by embedding Gradle through the Tooling API as described below.
+The former case is typically <<custom_plugins.adoc#custom_plugins,implemented as a Gradle plugin>>. The latter can be accomplished by embedding Gradle through the Tooling API as described below.
 
 [[embedding]]
 == Embedding Gradle using the Tooling API
@@ -64,7 +69,9 @@ Gradle provides a programmatic API called the Tooling API, which you can use for
 [[sec:embedding_features]]
 === Tooling API Features
 
-A fundamental characteristic of the Tooling API is that it operates in a version independent way. This means that you can use the same API to work with builds that use different versions of Gradle, including versions that are newer or older than the version of the Tooling API that you are using. The Tooling API is Gradle wrapper aware and, by default, uses the same Gradle version as that used by the wrapper-powered build.
+A fundamental characteristic of the Tooling API is that it operates in a version independent way.
+This means that you can use the same API to work with builds that use different versions of Gradle, including versions that are newer or older than the version of the Tooling API that you are using.
+The Tooling API is Gradle wrapper aware and, by default, uses the same Gradle version as that used by the wrapper-powered build.
 
 Some features that the Tooling API provides:
 
@@ -75,13 +82,17 @@ Some features that the Tooling API provides:
 * Cancel a build that is running.
 * Combine multiple separate Gradle builds into a single composite build.
 * The Tooling API can download and install the appropriate Gradle version, similar to the wrapper.
-* The implementation is lightweight, with only a small number of dependencies. It is also a well-behaved library, and makes no assumptions about your classloader structure or logging configuration. This makes the API easy to embed in your application.
+* The implementation is lightweight, with only a small number of dependencies.
+It is also a well-behaved library, and makes no assumptions about your classloader structure or logging configuration.
+This makes the API easy to embed in your application.
 
 
 [[sec:embedding_daemon]]
 === Tooling API and the Gradle Build Daemon
 
-The Tooling API always uses the Gradle daemon. This means that subsequent calls to the Tooling API, be it model building requests or task executing requests will be executed in the same long-living process. <<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> contains more details about the daemon, specifically information on situations when new daemons are forked.
+The Tooling API always uses the Gradle daemon.
+This means that subsequent calls to the Tooling API, be it model building requests or task executing requests will be executed in the same long-living process.
+<<gradle_daemon.adoc#gradle_daemon,Gradle Daemon>> contains more details about the daemon, specifically information on situations when new daemons are forked.
 
 [[sec:embedding_quickstart]]
 === Quickstart
@@ -101,11 +112,14 @@ The main entry point to the Tooling API is the link:{javadocPath}/org/gradle/too
 [[sec:embedding_compatibility]]
 === Compatibility of Java and Gradle versions
 
-The Tooling API requires Java 8 or later. The Gradle version used by builds may impose <<compatibility.adoc#,additional Java version requirements>>.
+The Tooling API requires Java 8 or later.
+The Gradle version used by builds may impose <<compatibility.adoc#compatibility,additional Java version requirements>>.
 
-The Tooling API supports running builds using Gradle 2.6 and later. Gradle 5.0 and up require clients to use Tooling API version 3.0 or later.
+The Tooling API supports running builds using Gradle 2.6 and later.
+Gradle 5.0 and up require clients to use Tooling API version 3.0 or later.
 
-You should note that not all features of the Tooling API are available for all versions of Gradle. Refer to the documentation for each class and method for more details.
+You should note that not all features of the Tooling API are available for all versions of Gradle.
+Refer to the documentation for each class and method for more details.
 
 In general, the Tooling API client can run on a different version of Java than the build, but classes that are sent to the build via custom build actions need to be targeted to the lowest supported Java version.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/init_scripts.adoc
@@ -91,7 +91,7 @@ include::sample[dir="snippets/initScripts/externalDependency/kotlin",files="init
 The closure passed to the `initscript()` method configures a link:{javadocPath}/org/gradle/api/initialization/dsl/ScriptHandler.html[ScriptHandler] instance.
 You declare the init script classpath by adding dependencies to the `classpath` configuration.
 This is the same way you declare, for example, the Java compilation classpath.
-You can use any of the dependency types described in <<declaring_dependencies.adoc#,Declaring Dependencies>>, except project dependencies.
+You can use any of the dependency types described in <<declaring_dependencies.adoc#declaring-dependencies,Declaring Dependencies>>, except project dependencies.
 
 Having declared the init script classpath, you can use the classes in your init script as you would any other classes on the classpath. The following example adds to the previous example, and uses classes from the init script classpath.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -1,3 +1,4 @@
+[[performance_gradle]]
 = Improving the Performance of Gradle Builds
 
 TIP: Want faster Gradle Builds? https://gradle.com/training/build-cache-deep-dive/?bid=guides-performance[Register here] for our Build Cache training session to learn how Gradle Enterprise can speed up builds by up to 90%.
@@ -115,7 +116,7 @@ In addition to the top-level performance summary of your build execution, you ca
 
 == Configuration
 
-As describes in <<build_lifecycle.adoc#,the build lifecycle chapter>>, a Gradle build goes through 3 phases: initialization, configuration, and execution.
+As describes in <<build_lifecycle.adoc#build_lifecycle,the build lifecycle chapter>>, a Gradle build goes through 3 phases: initialization, configuration, and execution.
 The important thing to understand here is that configuration code always executes regardless of which tasks will run.
 That means any expensive work performed during configuration will slow every invocation down, even simple ones like `gradle help` and `gradle tasks`.
 
@@ -349,7 +350,7 @@ It is also possible to use a shared build cache service, like https://gradle.com
 Shared caches can reduce the number of tasks you need to execute by reusing outputs already generated elsewhere.
 This can significantly decrease build times for both CI and developer builds.
 
-For extensive information about leveraging the build cache in your build, check out the documentation about <<build_cache_use_cases.adoc#,using the build cache>>.
+For extensive information about leveraging the build cache in your build, check out the documentation about <<build_cache_use_cases.adoc#use_cases_cache,using the build cache>>.
 It covers the different scenarios caching can improve, and detailed discussions of the different caveats you need to be aware of when enabling caching for a build.
 
 Again, build scans can help you investigate how well your tasks are caching.
@@ -376,7 +377,7 @@ The build scan above shows that `:task1` and `:task3` could be improved and made
 The Gradle daemon is a mechanism for improving the performance of Gradle.
 As of Gradle 3.0, the daemon is enabled by default, but if you are using an older version, you should definitely enable it on local developer machines.
 You will see big improvements in build speed by doing so.
-You can learn how to do that in <<gradle_daemon.adoc#,this section>>.
+You can learn how to do that in <<gradle_daemon.adoc#gradle_daemon,this section>>.
 
 On CI machines the benefit you can expect from the daemon depends on your setup.
 If you have long-lived CI agents and you build lots of small projects that all use the same Gradle version and JVM arguments, then the daemon can reduce your turnarounds.
@@ -565,7 +566,7 @@ dependencies {
 
 This can significantly reduce the "ripple" effect of a single change in large multi-project builds.
 The `implementation` Configuration is available in the `java` plugin.
-`api` dependencies can only be defined by libraries, which should use the <<java_library_plugin.adoc#,`java-library`>> plugin.
+`api` dependencies can only be defined by libraries, which should use the <<java_library_plugin.adoc#java_library_plugin,`java-library`>> plugin.
 
 === Incremental compilation
 

--- a/subprojects/docs/src/docs/userguide/troubleshooting.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting.adoc
@@ -76,7 +76,7 @@ If not, then the problem exists within the execution of one or more of the reque
 [[sec:troubleshooting_dependency_resolution]]
 == Debugging dependency resolution
 
-Common dependency resolution issues such as resolving version conflicts are covered in <<viewing_debugging_dependencies.adoc#,Troubleshooting Dependency Resolution>>.
+Common dependency resolution issues such as resolving version conflicts are covered in <<viewing_debugging_dependencies.adoc#viewing-debugging-dependencies,Troubleshooting Dependency Resolution>>.
 
 You can see a dependency tree and see which resolved dependency versions differed from what was requested by clicking the _Dependencies_ view and using the search functionality, specifying the resolution reason.
 
@@ -88,7 +88,7 @@ The link:https://scans.gradle.com/s/sample/troubleshooting-userguide/dependencie
 [[sec:troubleshooting_performance]]
 == Troubleshooting slow Gradle builds
 
-For build performance issues (including “slow sync time”), see <<performance.adoc#,improving the Performance of Gradle Builds>>.
+For build performance issues (including “slow sync time”), see <<performance.adoc#performance_gradle,improving the Performance of Gradle Builds>>.
 
 Android developers should watch a presentation by the Android SDK Tools team about link:https://youtu.be/7ll-rkLCtyk[Speeding Up Your Android Gradle Builds].
 Many tips are also covered in the Android Studio user guide link:https://developer.android.com/studio/build/optimize-your-build.html[on optimizing build speed].

--- a/subprojects/docs/src/docs/userguide/userguide.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide.adoc
@@ -37,9 +37,9 @@ Gradle is an open-source build automation tool focused on flexibility and perfor
 == New projects with Gradle
 
 Getting started with Gradle is easy!
-First, follow our guide to <<installation.adoc#, download and install Gradle>>, then check out link:../samples/index.html[our samples] to create your first build.
+First, follow our guide to <<installation.adoc#installation, download and install Gradle>>, then check out link:../samples/index.html[our samples] to create your first build.
 
-If you're currently using Maven, see a visual link:{website}/maven-vs-gradle/[Gradle vs Maven comparison] and follow the guide for <<migrating_from_maven.adoc#,migrating from Maven to Gradle>>.
+If you're currently using Maven, see a visual link:{website}/maven-vs-gradle/[Gradle vs Maven comparison] and follow the guide for <<migrating_from_maven.adoc#migrating_from_maven,migrating from Maven to Gradle>>.
 
 == Using existing Gradle builds
 

--- a/subprojects/docs/src/docs/userguide/what_is_gradle.adoc
+++ b/subprojects/docs/src/docs/userguide/what_is_gradle.adoc
@@ -108,7 +108,7 @@ It would be great if you could build your project using only the build logic bun
 
 Gradle provides several mechanisms that allow you to extend it, such as:
 
- * <<custom_tasks#,Custom task types>>.
+ * <<custom_tasks#custom_tasks,Custom task types>>.
 +
 When you want the build to do some work that an existing task can't do, you can simply write your own task type. It's typically best to put the source file for a custom task type in the <<organizing_gradle_projects#sec:build_sources,_buildSrc_>> directory or in a packaged plugin. Then you can use the custom task type just like any of the Gradle-provided ones.
 


### PR DESCRIPTION
These are broken in the single page rendering as they redirect to the
top of the page instead of the right section matching the page
inclusion.