### PR TITLE
Upgrade test distribution plugin to 2.0-rc-3

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -14,7 +14,8 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-2")
+        // Keep version with `settings.gradle.kts` in sync
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-3")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.11.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:1.3.1")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-2")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.11.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.gradle.enterprise.gradleplugin.testdistribution.TestDistributionPlugin
+import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.tasks.ClasspathManifest
@@ -198,10 +198,6 @@ fun configureTests() {
         }
     }
 
-    if (project.testDistributionEnabled()) {
-        plugins.apply(TestDistributionPlugin::class.java)
-    }
-
     fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "writeTmpPerformanceScenarioDefinitions").contains(name)
 
     tasks.withType<Test>().configureEach {
@@ -229,6 +225,12 @@ fun configureTests() {
             println("Test distribution has been enabled for $testName")
             distribution {
                 enabled.set(true)
+
+
+                // Dogfooding TD against ge-experiment until GE 2021.1 is available on e.grdev.net and ge.gradle.org (and the new TD Gradle plugin version 2.0 is accepted)
+                this as TestDistributionExtensionInternal
+                server.set(uri("https://ge-experiment.grdev.net"))
+
                 if (BuildEnvironment.isCiServer) {
                     when {
                         OperatingSystem.current().isLinux -> requirements.set(listOf("os=linux", "gbt-dogfooding"))

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -227,8 +227,7 @@ fun configureTests() {
                 enabled.set(true)
 
                 // Dogfooding TD against ge-experiment until GE 2021.1 is available on e.grdev.net and ge.gradle.org (and the new TD Gradle plugin version 2.0 is accepted)
-                this as TestDistributionExtensionInternal
-                server.set(uri("https://ge-experiment.grdev.net"))
+                (this as TestDistributionExtensionInternal).server.set(uri("https://ge-experiment.grdev.net"))
 
                 if (BuildEnvironment.isCiServer) {
                     when {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -226,7 +226,6 @@ fun configureTests() {
             distribution {
                 enabled.set(true)
 
-
                 // Dogfooding TD against ge-experiment until GE 2021.1 is available on e.grdev.net and ge.gradle.org (and the new TD Gradle plugin version 2.0 is accepted)
                 this as TestDistributionExtensionInternal
                 server.set(uri("https://ge-experiment.grdev.net"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id("com.gradle.enterprise").version("3.5.2")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
+    id("com.gradle.enterprise.test-distribution") version "2.0-rc-2"
 }
 
 includeBuild("build-logic-commons")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,8 @@ plugins {
     id("com.gradle.enterprise").version("3.5.2")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
-    id("com.gradle.enterprise.test-distribution") version "2.0-rc-2"
+    // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
+    id("com.gradle.enterprise.test-distribution") version "2.0-rc-3"
 }
 
 includeBuild("build-logic-commons")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution") version "2.0-rc-3"
+    id("com.gradle.enterprise.test-distribution").version("2.0-rc-3")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
The TD plugin is converted to a settings plugin and we need to adjust the build script accordingly.

TODOs:
- [ ] Make sure that ge-experiment.grdev.net has enough agents
- [ ] Once merged, check if the BT builds are using TD
- [ ] Once merged, shut down agents on ge.gradle.com
- [ ] Let the BT team know how to set up the credentials to use TD locally