### PR TITLE
Use the output hierarchy to check for overlapping outputs in execution plan

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -77,8 +77,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     private final TaskNodeFactory taskNodeFactory;
     private final TaskDependencyResolver dependencyResolver;
     private final NodeValidator nodeValidator;
-    private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy inputHierarchy;
+    private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
     private Spec<? super Task> filter = Specs.satisfyAll();
 
@@ -99,16 +99,16 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         TaskNodeFactory taskNodeFactory,
         TaskDependencyResolver dependencyResolver,
         NodeValidator nodeValidator,
-        ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy inputHierarchy,
+        ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy
     ) {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
         this.dependencyResolver = dependencyResolver;
         this.nodeValidator = nodeValidator;
-        this.outputHierarchy = outputHierarchy;
         this.inputHierarchy = inputHierarchy;
+        this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
     }
 
@@ -505,8 +505,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         reachableCache.clear();
         dependenciesWhichRequireMonitoring.clear();
         runningNodes.clear();
-        outputHierarchy.clear();
         inputHierarchy.clear();
+        outputHierarchy.clear();
         destroyableHierarchy.clear();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
@@ -20,22 +20,22 @@ import org.gradle.internal.file.Stat;
 import org.gradle.internal.snapshot.CaseSensitivity;
 
 public class ExecutionNodeAccessHierarchies {
-    private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy inputHierarchy;
+    private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
 
     public ExecutionNodeAccessHierarchies(CaseSensitivity caseSensitivity, Stat stat) {
-        outputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
         inputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
+        outputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
         destroyableHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
-    }
-
-    public ExecutionNodeAccessHierarchy getOutputHierarchy() {
-        return outputHierarchy;
     }
 
     public ExecutionNodeAccessHierarchy getInputHierarchy() {
         return inputHierarchy;
+    }
+
+    public ExecutionNodeAccessHierarchy getOutputHierarchy() {
+        return outputHierarchy;
     }
 
     public ExecutionNodeAccessHierarchy getDestroyableHierarchy() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
@@ -22,10 +22,12 @@ import org.gradle.internal.snapshot.CaseSensitivity;
 public class ExecutionNodeAccessHierarchies {
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy inputHierarchy;
+    private final ExecutionNodeAccessHierarchy destroyableHierarchy;
 
     public ExecutionNodeAccessHierarchies(CaseSensitivity caseSensitivity, Stat stat) {
         outputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
         inputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
+        destroyableHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
     }
 
     public ExecutionNodeAccessHierarchy getOutputHierarchy() {
@@ -34,5 +36,9 @@ public class ExecutionNodeAccessHierarchies {
 
     public ExecutionNodeAccessHierarchy getInputHierarchy() {
         return inputHierarchy;
+    }
+
+    public ExecutionNodeAccessHierarchy getDestroyableHierarchy() {
+        return destroyableHierarchy;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -203,6 +203,8 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
 
     private static void addHardSuccessorTasksToQueue(Node node, Set<Node> seenNodes, Queue<Node> queue) {
         node.getHardSuccessors().forEach(successor -> {
+            // We are searching for dependencies between tasks, so we can skip everything which is not a task when searching.
+            // For example we can skip all the transform nodes between two task nodes.
             if (successor instanceof LocalTaskNode) {
                 if (seenNodes.add(successor)) {
                     queue.add(successor);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -44,12 +44,12 @@ import java.util.Set;
 
 public class LocalTaskNodeExecutor implements NodeExecutor {
 
-    private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy inputHierarchy;
+    private final ExecutionNodeAccessHierarchy outputHierarchy;
 
-    public LocalTaskNodeExecutor(ExecutionNodeAccessHierarchy outputHierarchy, ExecutionNodeAccessHierarchy inputHierarchy) {
-        this.outputHierarchy = outputHierarchy;
+    public LocalTaskNodeExecutor(ExecutionNodeAccessHierarchy inputHierarchy, ExecutionNodeAccessHierarchy outputHierarchy) {
         this.inputHierarchy = inputHierarchy;
+        this.outputHierarchy = outputHierarchy;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -54,7 +54,6 @@ import org.gradle.execution.CompositeAwareTaskSelector;
 import org.gradle.execution.DefaultBuildConfigurationActionExecuter;
 import org.gradle.execution.DefaultBuildWorkExecutor;
 import org.gradle.execution.DefaultTasksBuildExecutionAction;
-import org.gradle.execution.UndefinedBuildWorkExecutor;
 import org.gradle.execution.DryRunBuildExecutionAction;
 import org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction;
 import org.gradle.execution.IncludedBuildLifecycleBuildWorkExecutor;
@@ -63,6 +62,7 @@ import org.gradle.execution.SelectedTaskExecutionAction;
 import org.gradle.execution.TaskNameResolver;
 import org.gradle.execution.TaskNameResolvingBuildConfigurationAction;
 import org.gradle.execution.TaskSelector;
+import org.gradle.execution.UndefinedBuildWorkExecutor;
 import org.gradle.execution.commandline.CommandLineTaskConfigurer;
 import org.gradle.execution.commandline.CommandLineTaskParser;
 import org.gradle.execution.plan.DefaultExecutionPlan;
@@ -246,7 +246,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             dependencyResolver,
             new DefaultNodeValidator(),
             executionNodeAccessHierarchies.getOutputHierarchy(),
-            executionNodeAccessHierarchies.getInputHierarchy()
+            executionNodeAccessHierarchies.getInputHierarchy(),
+            executionNodeAccessHierarchies.getDestroyableHierarchy()
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -205,8 +205,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
 
     LocalTaskNodeExecutor createLocalTaskNodeExecutor(ExecutionNodeAccessHierarchies executionNodeAccessHierarchies) {
         return new LocalTaskNodeExecutor(
-            executionNodeAccessHierarchies.getOutputHierarchy(),
-            executionNodeAccessHierarchies.getInputHierarchy()
+            executionNodeAccessHierarchies.getInputHierarchy(),
+            executionNodeAccessHierarchies.getOutputHierarchy()
         );
     }
 
@@ -245,8 +245,8 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             taskNodeFactory,
             dependencyResolver,
             new DefaultNodeValidator(),
-            executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getInputHierarchy(),
+            executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getDestroyableHierarchy()
         );
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -55,7 +55,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         _ * lease.tryLock() >> true
         def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(IncludedBuildTaskGraph))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs))
     }
 
     TaskInternal task(Map<String, ?> options = [:], String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -43,7 +43,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     def setup() {
         def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(IncludedBuildTaskGraph))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
         _ * workerLease.tryLock() >> true
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -82,7 +82,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(IncludedBuildTaskGraph))
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
     def projectStateRegistry = Stub(ProjectStateRegistry)
-    def executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+    def executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
     def taskGraph = new DefaultTaskExecutionGraph(
         new DefaultPlanExecutor(parallelismConfiguration, executorFactory, workerLeases, cancellationToken, coordinationService),
         [nodeExecutor],


### PR DESCRIPTION
This addresses some more of the performance regression here: https://github.com/gradle/gradle/issues/16048

We now use the output hierarchy information to check whether a task can be scheduled with the currently running nodes. That makes things a little bit faster again (another 2-3%). So together with https://github.com/gradle/gradle/pull/16178 we should be back to the performance of 6.8.2.