### PR TITLE
Recover gracefully from crashes during build logic classpath transform 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/IOQuery.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/IOQuery.java
@@ -15,8 +15,10 @@
  */
 package org.gradle.internal.io;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 public interface IOQuery<T> {
+    @Nullable
     T run() throws IOException, InterruptedException;
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -30,7 +30,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
@@ -50,25 +49,14 @@ public class ClasspathBuilder {
      * Creates a Jar file using the given action to add entries to the file. If the file already exists it will be replaced.
      */
     public void jar(File jarFile, Action action) {
-        tryToBuildJar(jarFile, action, StandardCopyOption.REPLACE_EXISTING);
-    }
-
-    /**
-     * Creates a Jar file using the given action to add entries to the file. Fails if the file already exists.
-     */
-    public void nonReplacingJar(File jarFile, Action action) {
-        tryToBuildJar(jarFile, action);
-    }
-
-    private void tryToBuildJar(File jarFile, Action action, CopyOption... moveOptions) {
         try {
-            buildJar(jarFile, action, moveOptions);
+            buildJar(jarFile, action);
         } catch (Exception e) {
             throw new GradleException(String.format("Failed to create Jar file %s.", jarFile), e);
         }
     }
 
-    private void buildJar(File jarFile, Action action, CopyOption... moveOptions) throws IOException {
+    private void buildJar(File jarFile, Action action) throws IOException {
         File parentDir = jarFile.getParentFile();
         File tmpFile = temporaryFileProvider.createTemporaryFile(jarFile.getName(), ".tmp");
         try {
@@ -77,7 +65,7 @@ public class ClasspathBuilder {
                 outputStream.setLevel(0);
                 action.execute(new ZipEntryBuilder(outputStream));
             }
-            Files.move(tmpFile.toPath(), jarFile.toPath(), moveOptions);
+            Files.move(tmpFile.toPath(), jarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         } finally {
             Files.deleteIfExists(tmpFile.toPath());
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -107,7 +107,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
         return fileLockManager.lock(
             file,
             mode(FileLockManager.LockMode.Exclusive),
-            "instrumented classpath file"
+            "instrumented jar cache"
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -21,14 +21,15 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.archive.ZipEntry;
 import org.gradle.api.internal.file.archive.ZipInput;
 import org.gradle.api.internal.file.archive.impl.FileZipInput;
+import org.gradle.cache.FileLock;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.internal.filelock.LockOptionsBuilder;
 import org.gradle.internal.Pair;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.FileException;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
-import org.gradle.internal.io.ExponentialBackoff;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.util.GFileUtils;
 import org.objectweb.asm.ClassReader;
@@ -39,21 +40,24 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.format;
 
 class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentingClasspathFileTransformer.class);
     private static final int CACHE_FORMAT = 2;
 
+    private final FileLockManager fileLockManager;
     private final ClasspathWalker classpathWalker;
     private final ClasspathBuilder classpathBuilder;
     private final CachedClasspathTransformer.Transform transform;
     private final HashCode configHash;
 
-    public InstrumentingClasspathFileTransformer(ClasspathWalker classpathWalker, ClasspathBuilder classpathBuilder, CachedClasspathTransformer.Transform transform) {
+    public InstrumentingClasspathFileTransformer(
+        FileLockManager fileLockManager,
+        ClasspathWalker classpathWalker,
+        ClasspathBuilder classpathBuilder,
+        CachedClasspathTransformer.Transform transform
+    ) {
+        this.fileLockManager = fileLockManager;
         this.classpathWalker = classpathWalker;
         this.classpathBuilder = classpathBuilder;
         this.transform = transform;
@@ -69,72 +73,44 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
 
     @Override
     public File transform(File source, FileSystemLocationSnapshot sourceSnapshot, File cacheDir) {
-        String name = sourceSnapshot.getType() == FileType.Directory
-            ? source.getName() + ".jar"
-            : source.getName();
-        String destFileName = hashOf(sourceSnapshot).toString() + '/' + name;
-        return transformIfNeeded(source, cacheDir, destFileName);
-    }
+        File destDir = new File(cacheDir, hashOf(sourceSnapshot));
+        String destFileName = sourceSnapshot.getType() == FileType.Directory ? source.getName() + ".jar" : source.getName();
+        File receipt = new File(destDir, ".receipt");
+        File transformed = new File(destDir, destFileName);
 
-    private File transformIfNeeded(File source, File cacheDir, String destFileName) {
-        File receipt = new File(cacheDir, destFileName + ".receipt");
-        File transformed = new File(cacheDir, destFileName);
+        // Avoid file locking overhead by checking for the receipt first.
         if (receipt.isFile()) {
             return transformed;
         }
+
+        final FileLock fileLock = fileLockManager.lock(transformed, exclusiveCrossVersionLock(), "instrumented classpath file");
         try {
-            transform(source, transformed);
-        } catch (RuntimeException e) {
-            if (e.getCause() instanceof FileAlreadyExistsException) {
-                // A concurrent writer has already started writing to the file.
-                // We run identical transforms concurrently and we can sometimes finish two transforms at the same
-                // time in a way that Files.move (see [ClasspathBuilder.nonReplacingJar]) will see [transformed] created before
-                // the move is done.
-                // Just wait until the transformed file is ready for consumption.
-                LOGGER.debug("Instrumented classpath file '{}' already exists.", destFileName, e);
-                waitForReceiptOf(destFileName, receipt);
+            if (receipt.isFile()) {
+                // Lock was acquired after a concurrent writer has already finished.
                 return transformed;
-            } else {
-                throw e;
             }
-        }
-        try {
-            receipt.createNewFile();
-        } catch (IOException e) {
-            LOGGER.debug("Failed to create receipt for instrumented classpath file '{}'.", destFileName, e);
-        }
-        return transformed;
-    }
-
-    private void waitForReceiptOf(String destFileName, File receipt) {
-        if (!waitFor(receipt)) {
-            throw new IllegalStateException(
-                format("Timeout waiting for instrumented classpath file: '%s'.", destFileName)
-            );
+            transform(source, transformed);
+            try {
+                receipt.createNewFile();
+            } catch (IOException e) {
+                LOGGER.debug("Failed to create receipt for instrumented classpath file '{}'.", destFileName, e);
+            }
+            return transformed;
+        } finally {
+            fileLock.close();
         }
     }
 
-    /**
-     * Waits up to 60 seconds for the given file to appear.
-     *
-     * @return true when the file appears before the timeout, false otherwise.
-     */
-    private boolean waitFor(File file) {
-        try {
-            return ExponentialBackoff
-                .of(60, TimeUnit.SECONDS)
-                .retryUntil(() -> file.isFile() ? file : null) != null;
-        } catch (InterruptedException | IOException e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        }
+    private LockOptionsBuilder exclusiveCrossVersionLock() {
+        return LockOptionsBuilder.mode(FileLockManager.LockMode.Exclusive).useCrossVersionImplementation();
     }
 
-    private HashCode hashOf(FileSystemLocationSnapshot sourceSnapshot) {
+    private String hashOf(FileSystemLocationSnapshot sourceSnapshot) {
         Hasher hasher = Hashing.defaultFunction().newHasher();
         hasher.putHash(configHash);
         // TODO - apply runtime classpath normalization?
         hasher.putHash(sourceSnapshot.getHash());
-        return hasher.hash();
+        return hasher.hash().toString();
     }
 
     private void transform(File source, File dest) {
@@ -147,7 +123,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     }
 
     private void instrument(File source, File dest) {
-        classpathBuilder.nonReplacingJar(dest, builder -> {
+        classpathBuilder.jar(dest, builder -> {
             try {
                 visitEntries(source, builder);
             } catch (FileException e) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -43,7 +43,7 @@ import java.io.IOException;
 
 class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentingClasspathFileTransformer.class);
-    private static final int CACHE_FORMAT = 2;
+    private static final int CACHE_FORMAT = 3;
 
     private final FileLockManager fileLockManager;
     private final ClasspathWalker classpathWalker;

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -75,7 +75,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     public File transform(File source, FileSystemLocationSnapshot sourceSnapshot, File cacheDir) {
         File destDir = new File(cacheDir, hashOf(sourceSnapshot));
         String destFileName = sourceSnapshot.getType() == FileType.Directory ? source.getName() + ".jar" : source.getName();
-        File receipt = new File(destDir, ".receipt");
+        File receipt = new File(destDir, destFileName + ".receipt");
         File transformed = new File(destDir, destFileName);
 
         // Avoid file locking overhead by checking for the receipt first.

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.initialization.loadercache.DefaultClassLoaderCache;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.cache.CacheRepository;
+import org.gradle.cache.FileLockManager;
 import org.gradle.cache.GlobalCache;
 import org.gradle.cache.GlobalCacheLocations;
 import org.gradle.cache.internal.CacheRepositoryServices;
@@ -164,7 +165,8 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
         ClasspathWalker classpathWalker,
         ClasspathBuilder classpathBuilder,
         ExecutorFactory executorFactory,
-        GlobalCacheLocations globalCacheLocations
+        GlobalCacheLocations globalCacheLocations,
+        FileLockManager fileLockManager
     ) {
         return new DefaultCachedClasspathTransformer(
             cacheRepository,
@@ -174,7 +176,9 @@ public class GradleUserHomeScopeServices extends WorkerSharedUserHomeScopeServic
             classpathBuilder,
             fileSystemAccess,
             executorFactory,
-            globalCacheLocations);
+            globalCacheLocations,
+            fileLockManager
+        );
     }
 
     ExecFactory createExecFactory(ExecFactory parent, FileResolver fileResolver, FileCollectionFactory fileCollectionFactory, Instantiator instantiator, ObjectFactory objectFactory, JavaModuleDetector javaModuleDetector) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -239,7 +239,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/302304bc931e51b58cca7d2afbcf5dff/thing.jar")
+        def cachedFile = testDir.file("cached/0c4609ccad144ecd67de0f5055612706/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -267,7 +267,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/8b0593fec1c27c3dbbda663412a6bdb6/thing.dir.jar")
+        def cachedFile = testDir.file("cached/0182f189bcceffcfbcb1d6944c1fb9f1/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -297,8 +297,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/8b0593fec1c27c3dbbda663412a6bdb6/thing.dir.jar")
-        def cachedFile = testDir.file("cached/302304bc931e51b58cca7d2afbcf5dff/thing.jar")
+        def cachedDir = testDir.file("cached/0182f189bcceffcfbcb1d6944c1fb9f1/thing.dir.jar")
+        def cachedFile = testDir.file("cached/0c4609ccad144ecd67de0f5055612706/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -355,8 +355,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/8b0593fec1c27c3dbbda663412a6bdb6/thing.dir.jar")
-        def cachedFile = testDir.file("cached/302304bc931e51b58cca7d2afbcf5dff/thing.jar")
+        def cachedDir = testDir.file("cached/0182f189bcceffcfbcb1d6944c1fb9f1/thing.dir.jar")
+        def cachedFile = testDir.file("cached/0c4609ccad144ecd67de0f5055612706/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -376,7 +376,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/8deeef5e07b15e2002404e3a37932030/thing.jar")
+        def cachedFile = testDir.file("cached/79e71a4b2456ff233f0822bf605c8f7c/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.CacheBuilder
 import org.gradle.cache.CacheRepository
+import org.gradle.cache.FileLockManager
 import org.gradle.cache.GlobalCacheLocations
 import org.gradle.cache.internal.CacheScopeMapping
 import org.gradle.cache.internal.UsedGradleVersions
@@ -66,6 +67,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
     def classpathBuilder = new ClasspathBuilder(TestFiles.tmpDirTemporaryFileProvider(testDirectoryProvider.root))
     def fileSystemAccess = TestFiles.fileSystemAccess()
     def globalCacheLocations = Stub(GlobalCacheLocations)
+    def fileLockManager = Stub(FileLockManager)
     URLClassLoader testClassLoader = null
 
     @Subject
@@ -77,7 +79,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         classpathBuilder,
         fileSystemAccess,
         executorFactory,
-        globalCacheLocations
+        globalCacheLocations,
+        fileLockManager
     )
 
     def cleanup() {
@@ -126,7 +129,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         0 * fileAccessTimeJournal._
     }
 
-    def "discards missing file when tranform is build logic"() {
+    def "discards missing file when transform is build logic"() {
         given:
         def classpath = DefaultClassPath.of(testDir.file("missing"))
 


### PR DESCRIPTION
By rewriting the transformed file when the receipt file cannot be found.

The transformer acquires an exclusive file lock on the resulting file to prevent race conditions involving concurrent writers.