### PR TITLE
Bump deprecation warnings from 7.0 to 8.0

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsScriptExecutionIntegrationTest.groovy
@@ -36,7 +36,7 @@ class SettingsScriptExecutionIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("enableFeaturePreview('$feature') has been deprecated. This is scheduled to be removed in Gradle 7.0. " +
+        executer.expectDocumentedDeprecationWarning("enableFeaturePreview('$feature') has been deprecated. This is scheduled to be removed in Gradle 8.0. " +
             "The feature flag is no longer relevant, please remove it from your settings file. " +
             "See https://docs.gradle.org/current/userguide/feature_lifecycle.html#feature_preview for more details.")
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetFactoryTest.groovy
@@ -56,7 +56,7 @@ class DefaultSourceDirectorySetFactoryTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDocumentedDeprecationWarning('Internal API SourceDirectorySetFactory has been deprecated. This is scheduled to be removed in Gradle 7.0. ' +
+        executer.expectDocumentedDeprecationWarning('Internal API SourceDirectorySetFactory has been deprecated. This is scheduled to be removed in Gradle 8.0. ' +
             'Please use ObjectFactory.sourceDirectorySet(String, String) instead. ' +
             'See https://docs.gradle.org/current/userguide/lazy_configuration.html#property_files_api_reference for more details.')
         run 'deprecation'

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySetFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySetFactory.java
@@ -42,7 +42,7 @@ public class DefaultSourceDirectorySetFactory implements SourceDirectorySetFacto
     private static void deprecate() {
         DeprecationLogger.deprecateInternalApi("SourceDirectorySetFactory")
             .replaceWith("ObjectFactory.sourceDirectorySet(String, String)")
-            .willBeRemovedInGradle7()
+            .willBeRemovedInGradle8()
             .withUserManual("lazy_configuration", "property_files_api_reference")
             .nagUser();
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -369,7 +369,7 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
             DeprecationLogger
                 .deprecate("enableFeaturePreview('" + feature.name() + "')")
                 .withAdvice("The feature flag is no longer relevant, please remove it from your settings file.")
-                .willBeRemovedInGradle7()
+                .willBeRemovedInGradle8()
                 .withUserManual("feature_lifecycle", "feature_preview")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -283,7 +283,7 @@ project(':tool') {
 
         expect:
         executer.expectDocumentedDeprecationWarning("Using force on a dependency has been deprecated. " +
-            "This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). " +
+            "This is scheduled to be removed in Gradle 8.0. Consider using strict version constraints instead (version { strictly ... } }). " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#forced_dependencies")
         run("tool:dependencies")
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -100,7 +100,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
         if (force) {
             DeprecationLogger.deprecate("Using force on a dependency")
                 .withAdvice("Consider using strict version constraints instead (version { strictly ... } }).")
-                .willBeRemovedInGradle7()
+                .willBeRemovedInGradle8()
                 .withUpgradeGuideSection(5, "forced_dependencies")
                 .nagUser();
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -144,7 +144,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         Mock(TimeoutHandler),
         { String behavior ->
             DeprecationLogger.deprecateBehaviour(behavior)
-                .willBeRemovedInGradle7()
+                .willBeRemovedInGradle8()
                 .undocumented()
                 .nagUser()
         },

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecatedUsageBuildOperationProgressIntegrationTest.groovy
@@ -29,26 +29,26 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         file('settings.gradle') << "rootProject.name = 'root'"
 
         file('init.gradle') << """
-            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Init script').willBeRemovedInGradle7().undocumented().nagUser();
-            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Init script').willBeRemovedInGradle7().undocumented().nagUser();
+            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Init script').willBeRemovedInGradle8().undocumented().nagUser();
+            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Init script').willBeRemovedInGradle8().undocumented().nagUser();
         """
 
         file('script.gradle') << """
-            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Plugin script').willBeRemovedInGradle7().undocumented().nagUser();
+            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Plugin script').willBeRemovedInGradle8().undocumented().nagUser();
         """
 
         buildScript """
             apply from: 'script.gradle'
             apply plugin: SomePlugin
 
-            org.gradle.internal.deprecation.DeprecationLogger.deprecateBuildInvocationFeature('Some invocation feature').withAdvice("Don't do custom invocation.").willBeRemovedInGradle7().undocumented().nagUser()
-            org.gradle.internal.deprecation.DeprecationLogger.deprecateIndirectUsage('Some indirect deprecation').withAdvice('Some advice.').willBeRemovedInGradle7().undocumented().nagUser()
+            org.gradle.internal.deprecation.DeprecationLogger.deprecateBuildInvocationFeature('Some invocation feature').withAdvice("Don't do custom invocation.").willBeRemovedInGradle8().undocumented().nagUser()
+            org.gradle.internal.deprecation.DeprecationLogger.deprecateIndirectUsage('Some indirect deprecation').withAdvice('Some advice.').willBeRemovedInGradle8().undocumented().nagUser()
 
             task t(type:SomeTask) {
                 doLast {
                     org.gradle.internal.deprecation.DeprecationLogger.deprecate('Custom Task action')
                             .withAdvice('Use task type X instead.').withContext("Task ':t' should not have custom actions attached.")
-                            .willBeRemovedInGradle7()
+                            .willBeRemovedInGradle8()
                             .undocumented()
                             .nagUser()
                 }
@@ -58,14 +58,14 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
             class SomePlugin implements Plugin<Project> {
                 void apply(Project p){
-                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Plugin').willBeRemovedInGradle7().undocumented().nagUser();
+                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Plugin').willBeRemovedInGradle8().undocumented().nagUser();
                 }
             }
 
             class SomeTask extends DefaultTask {
                 @TaskAction
                 void someAction(){
-                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Typed task').willBeRemovedInGradle7().undocumented().nagUser();
+                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Typed task').willBeRemovedInGradle8().undocumented().nagUser();
                 }
             }
 
@@ -77,7 +77,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         then:
         def initDeprecation = operations.only("Apply initialization script 'init.gradle' to build").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         initDeprecation.details.summary == 'Init script has been deprecated.'
-        initDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        initDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         initDeprecation.details.advice == null
         initDeprecation.details.contextualAdvice == null
         initDeprecation.details.stackTrace.size > 0
@@ -86,7 +86,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def pluginDeprecation = operations.only("Apply plugin SomePlugin to root project 'root'").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         pluginDeprecation.details.summary == 'Plugin has been deprecated.'
-        pluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        pluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         pluginDeprecation.details.advice == null
         pluginDeprecation.details.contextualAdvice == null
         pluginDeprecation.details.type == 'USER_CODE_DIRECT'
@@ -96,7 +96,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def invocationDeprecation = operations.only("Apply build file 'build.gradle' to root project 'root'").progress.findAll { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }[0]
         invocationDeprecation.details.summary == 'Some invocation feature has been deprecated.'
-        invocationDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        invocationDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         invocationDeprecation.details.advice == "Don't do custom invocation."
         invocationDeprecation.details.type == "BUILD_INVOCATION"
         invocationDeprecation.details.stackTrace.size > 0
@@ -105,7 +105,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def userIndirectCodeDeprecation = operations.only("Apply build file 'build.gradle' to root project 'root'").progress.findAll { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }[1]
         userIndirectCodeDeprecation.details.summary == 'Some indirect deprecation has been deprecated.'
-        userIndirectCodeDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        userIndirectCodeDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         userIndirectCodeDeprecation.details.advice == "Some advice."
         userIndirectCodeDeprecation.details.type == 'USER_CODE_INDIRECT'
         userIndirectCodeDeprecation.details.stackTrace.size > 0
@@ -114,7 +114,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def scriptPluginDeprecation = operations.only("Apply script 'script.gradle' to root project 'root'").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         scriptPluginDeprecation.details.summary == 'Plugin script has been deprecated.'
-        scriptPluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        scriptPluginDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         scriptPluginDeprecation.details.advice == null
         scriptPluginDeprecation.details.type == 'USER_CODE_DIRECT'
         scriptPluginDeprecation.details.stackTrace.size > 0
@@ -123,7 +123,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def taskDoLastDeprecation = operations.only("Execute doLast {} action for :t").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         taskDoLastDeprecation.details.summary == 'Custom Task action has been deprecated.'
-        taskDoLastDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        taskDoLastDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         taskDoLastDeprecation.details.advice == 'Use task type X instead.'
         taskDoLastDeprecation.details.contextualAdvice == "Task ':t' should not have custom actions attached."
         taskDoLastDeprecation.details.type == 'USER_CODE_DIRECT'
@@ -133,7 +133,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def typedTaskDeprecation = operations.only("Execute someAction for :t").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         typedTaskDeprecation.details.summary == 'Typed task has been deprecated.'
-        typedTaskDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        typedTaskDeprecation.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         typedTaskDeprecation.details.advice == null
         typedTaskDeprecation.details.contextualAdvice == null
         typedTaskDeprecation.details.type == 'USER_CODE_DIRECT'
@@ -144,7 +144,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def typedTaskDeprecation2 = operations.only("Execute someAction for :t2").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         typedTaskDeprecation2.details.summary == 'Typed task has been deprecated.'
-        typedTaskDeprecation2.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        typedTaskDeprecation2.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         typedTaskDeprecation2.details.advice == null
         typedTaskDeprecation2.details.contextualAdvice == null
         typedTaskDeprecation2.details.type == 'USER_CODE_DIRECT'
@@ -157,7 +157,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
     def "emits deprecation warnings as build operation progress events for buildSrc builds"() {
         when:
         file('buildSrc/build.gradle') << """
-            org.gradle.internal.deprecation.DeprecationLogger.deprecate('BuildSrc script').willBeRemovedInGradle7().undocumented().nagUser();
+            org.gradle.internal.deprecation.DeprecationLogger.deprecate('BuildSrc script').willBeRemovedInGradle8().undocumented().nagUser();
         """
 
         and:
@@ -167,7 +167,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         then:
         def buildSrcDeprecations = operations.only("Apply build file 'buildSrc${File.separator}build.gradle' to project ':buildSrc'").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         buildSrcDeprecations.details.summary.contains('BuildSrc script has been deprecated.')
-        buildSrcDeprecations.details.removalDetails.contains('This is scheduled to be removed in Gradle 7.0.')
+        buildSrcDeprecations.details.removalDetails.contains('This is scheduled to be removed in Gradle 8.0.')
         buildSrcDeprecations.details.advice == null
         buildSrcDeprecations.details.contextualAdvice == null
         buildSrcDeprecations.details.type == 'USER_CODE_DIRECT'
@@ -179,11 +179,11 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
     def "emits deprecation warnings as build operation progress events for composite builds"() {
         file('included/settings.gradle') << "rootProject.name = 'included'"
         file('included/build.gradle') << """
-            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Included build script').willBeRemovedInGradle7().undocumented().nagUser();
+            org.gradle.internal.deprecation.DeprecationLogger.deprecate('Included build script').willBeRemovedInGradle8().undocumented().nagUser();
 
             task t {
                 doLast {
-                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Included build task').willBeRemovedInGradle7().undocumented().nagUser();
+                    org.gradle.internal.deprecation.DeprecationLogger.deprecate('Included build task').willBeRemovedInGradle8().undocumented().nagUser();
                 }
             }
         """
@@ -204,7 +204,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
         then:
         def includedBuildScriptDeprecations = operations.only("Apply build file 'included${File.separator}build.gradle' to project ':included'").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         includedBuildScriptDeprecations.details.summary == 'Included build script has been deprecated.'
-        includedBuildScriptDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        includedBuildScriptDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         includedBuildScriptDeprecations.details.advice == null
         includedBuildScriptDeprecations.details.contextualAdvice == null
         includedBuildScriptDeprecations.details.type == 'USER_CODE_DIRECT'
@@ -214,7 +214,7 @@ class DeprecatedUsageBuildOperationProgressIntegrationTest extends AbstractInteg
 
         def includedBuildTaskDeprecations = operations.only("Execute doLast {} action for :included:t").progress.find { it.hasDetailsOfType(DeprecatedUsageProgressDetails) }
         includedBuildTaskDeprecations.details.summary == 'Included build task has been deprecated.'
-        includedBuildTaskDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 7.0.'
+        includedBuildTaskDeprecations.details.removalDetails == 'This is scheduled to be removed in Gradle 8.0.'
         includedBuildTaskDeprecations.details.advice == null
         includedBuildTaskDeprecations.details.contextualAdvice == null
         includedBuildTaskDeprecations.details.type == 'USER_CODE_DIRECT'

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -35,8 +35,8 @@ import javax.annotation.concurrent.ThreadSafe;
  * Context can be added in free text using {@link DeprecationMessageBuilder#withContext(String)}.
  * Advice is constructed contextually using {@link DeprecationMessageBuilder.WithReplacement#replaceWith(Object)} methods based on the thing being deprecated. Alternatively, it can be populated using {@link DeprecationMessageBuilder#withAdvice(String)}.
  * DeprecationTimeline is mandatory and is added using one of:
- * - ${@link DeprecationMessageBuilder#willBeRemovedInGradle7()}
- * - ${@link DeprecationMessageBuilder#willBecomeAnErrorInGradle7()}
+ * - ${@link DeprecationMessageBuilder#willBeRemovedInGradle8()}
+ * - ${@link DeprecationMessageBuilder#willBecomeAnErrorInGradle8()}
  * After DeprecationTimeline is set, Documentation reference must be added using one of:
  * - {@link DeprecationMessageBuilder.WithDeprecationTimeline#withUpgradeGuideSection(int, String)}
  * - {@link DeprecationMessageBuilder.WithDeprecationTimeline#withDslReference(Class, String)}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
@@ -43,8 +43,8 @@ class DeprecationLoggerTest extends ConcurrentSpec {
 
     def "logs deprecation warning once until reset"() {
         when:
-        DeprecationLogger.deprecate("nag").willBeRemovedInGradle7().undocumented().nagUser()
-        DeprecationLogger.deprecate("nag").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecate("nag").willBeRemovedInGradle8().undocumented().nagUser()
+        DeprecationLogger.deprecate("nag").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         def events = outputEventListener.events
@@ -53,7 +53,7 @@ class DeprecationLoggerTest extends ConcurrentSpec {
 
         when:
         DeprecationLogger.reset()
-        DeprecationLogger.deprecate("nag").willBeRemovedInGradle7().undocumented().nagUser()
+        DeprecationLogger.deprecate("nag").willBeRemovedInGradle8().undocumented().nagUser()
 
         then:
         events.size() == 2
@@ -73,7 +73,7 @@ class DeprecationLoggerTest extends ConcurrentSpec {
 
         and:
         1 * factory.create() >> {
-            DeprecationLogger.deprecate("nag").willBeRemovedInGradle7().undocumented().nagUser()
+            DeprecationLogger.deprecate("nag").willBeRemovedInGradle8().undocumented().nagUser()
             return "result"
         }
         0 * _
@@ -102,13 +102,13 @@ class DeprecationLoggerTest extends ConcurrentSpec {
         async {
             start {
                 thread.blockUntil.disabled
-                DeprecationLogger.deprecate("nag").willBeRemovedInGradle7().undocumented().nagUser()
+                DeprecationLogger.deprecate("nag").willBeRemovedInGradle8().undocumented().nagUser()
                 instant.logged
             }
             start {
                 DeprecationLogger.whileDisabled {
                     instant.disabled
-                    DeprecationLogger.deprecate("ignored").willBeRemovedInGradle7().undocumented().nagUser()
+                    DeprecationLogger.deprecate("ignored").willBeRemovedInGradle8().undocumented().nagUser()
                     thread.blockUntil.logged
                 }
             }

--- a/subprojects/performance/src/templates/generateLotsOfDeprecationWarnings/build.gradle
+++ b/subprojects/performance/src/templates/generateLotsOfDeprecationWarnings/build.gradle
@@ -28,7 +28,7 @@ void createDeprecations(int iterations) {
 
 @groovy.transform.CompileStatic
 void nagUserOfDeprecated(String thing) {
-    org.gradle.internal.deprecation.DeprecationLogger.deprecate(thing).willBecomeAnErrorInGradle7().undocumented().nagUser();
+    org.gradle.internal.deprecation.DeprecationLogger.deprecate(thing).willBecomeAnErrorInGradle8().undocumented().nagUser();
 
 }
 


### PR DESCRIPTION
The updated places are:
- tests where the warnings act as test data.
- Deprecation of 'force' was extended
- Deprecation of 'SourceDirectorySetFactory' was extended (#15844)
