### PR TITLE
Remove explicit Gradle property to enable file system watching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,8 @@ systemProp.gradle.publish.skip.namespace.check=true
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 
-# Enable watching the file system
-# Remove the property when file system watching is enabled by default
-org.gradle.vfs.watch=true
+# Show more VFS logging and statistics
 org.gradle.vfs.verbose=true
-# Adds more statistics
 org.gradle.vfs.debug=true
 
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")


### PR DESCRIPTION
We don't need this since FSW is enabled by default in Gradle 7.0.