### PR TITLE
Decouple severity from the cacheability state

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.reflect.MessageFormattingTypeValidationContext;
-import org.gradle.internal.reflect.validation.Severity;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblem;
 
@@ -45,8 +44,8 @@ public class DefaultWorkValidationContext implements WorkValidationContext {
         return new MessageFormattingTypeValidationContext(documentationRegistry, null) {
             @Override
             protected void recordProblem(TypeValidationProblem problem) {
-                Severity severity = problem.getSeverity();
-                if (severity == Severity.CACHEABILITY_WARNING && !cacheable) {
+                boolean cacheableProblemOnly = problem.getPayload().map(TypeValidationProblem.Payload::isCacheabilityProblemOnly).orElse(false);
+                if (cacheableProblemOnly && !cacheable) {
                     return;
                 }
                 problems.add(problem);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -43,11 +43,11 @@ public class DefaultTypeValidationContext extends MessageFormattingTypeValidatio
 
     @Override
     protected void recordProblem(TypeValidationProblem problem) {
-        Severity severity = problem.getSeverity();
-        if (severity == Severity.CACHEABILITY_WARNING && !cacheable) {
+        boolean cacheableProblemOnly = problem.getPayload().map(TypeValidationProblem.Payload::isCacheabilityProblemOnly).orElse(false);
+        if (cacheableProblemOnly && !cacheable) {
             return;
         }
-        problems.put(TypeValidationProblemRenderer.renderMinimalInformationAbout(problem), severity.toReportableSeverity());
+        problems.put(TypeValidationProblemRenderer.renderMinimalInformationAbout(problem), problem.getSeverity());
     }
 
     public ImmutableMap<String, Severity> getProblems() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
@@ -63,8 +63,7 @@ abstract public class MessageFormattingTypeValidationContext implements TypeVali
 
     @Override
     public void visitPropertyProblem(Severity kind, @Nullable String parentProperty, @Nullable String property, String message) {
-        visitPropertyProblem(problem ->
-        {
+        visitPropertyProblem(problem -> {
             PropertyProblemBuilder problemBuilder = problem.reportAs(kind.toReportableSeverity());
             // this code should go away once all messages go through the builder instead
             if (kind == Severity.CACHEABILITY_WARNING) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
@@ -63,8 +63,14 @@ abstract public class MessageFormattingTypeValidationContext implements TypeVali
 
     @Override
     public void visitPropertyProblem(Severity kind, @Nullable String parentProperty, @Nullable String property, String message) {
-        visitPropertyProblem(problem -> problem.reportAs(kind)
-            .forProperty(parentProperty, property)
+        visitPropertyProblem(problem ->
+        {
+            PropertyProblemBuilder problemBuilder = problem.reportAs(kind.toReportableSeverity());
+            // this code should go away once all messages go through the builder instead
+            if (kind == Severity.CACHEABILITY_WARNING) {
+                problemBuilder.isCachabilityProblemOnly();
+            }
+            problemBuilder.forProperty(parentProperty, property)
             .withDescription(() -> {
                 StringBuilder builder = new StringBuilder();
                 if (rootType != null) {
@@ -88,7 +94,8 @@ abstract public class MessageFormattingTypeValidationContext implements TypeVali
                 builder.append(message);
                 builder.append('.');
                 return builder.toString();
-            }));
+            });
+        });
     }
 
     abstract protected void recordProblem(TypeValidationProblem problem);

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/MessageFormattingTypeValidationContext.java
@@ -68,7 +68,7 @@ abstract public class MessageFormattingTypeValidationContext implements TypeVali
             PropertyProblemBuilder problemBuilder = problem.reportAs(kind.toReportableSeverity());
             // this code should go away once all messages go through the builder instead
             if (kind == Severity.CACHEABILITY_WARNING) {
-                problemBuilder.isCachabilityProblemOnly();
+                problemBuilder.onlyAffectsCacheableWork();
             }
             problemBuilder.forProperty(parentProperty, property)
             .withDescription(() -> {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
@@ -34,6 +34,7 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
     protected Supplier<String> reason = () -> null;
     protected UserManualReference userManualReference;
     protected final List<Supplier<Solution>> possibleSolutions = Lists.newArrayListWithExpectedSize(1);
+    protected boolean cacheabilityProblemOnly = false;
 
     public AbstractValidationProblemBuilder(DocumentationRegistry documentationRegistry) {
         this.documentationRegistry = documentationRegistry;
@@ -83,6 +84,12 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
         DefaultSolutionBuilder builder = new DefaultSolutionBuilder(documentationRegistry, solution);
         solutionSpec.execute(builder);
         possibleSolutions.add(builder.build());
+        return Cast.uncheckedCast(this);
+    }
+
+    @Override
+    public T isCachabilityProblemOnly() {
+        this.cacheabilityProblemOnly = true;
         return Cast.uncheckedCast(this);
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
@@ -88,7 +88,7 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
     }
 
     @Override
-    public T isCachabilityProblemOnly() {
+    public T onlyAffectsCacheableWork() {
         this.cacheabilityProblemOnly = true;
         return Cast.uncheckedCast(this);
     }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
@@ -43,6 +43,7 @@ public class DefaultPropertyValidationProblemBuilder extends AbstractValidationP
             shortProblemDescription,
             longDescription,
             reason,
+            TypeValidationProblem.Payload.of(cacheabilityProblemOnly),
             userManualReference,
             possibleSolutions
         );

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
@@ -44,6 +44,7 @@ public class DefaultTypeValidationProblemBuilder extends AbstractValidationProbl
             shortProblemDescription,
             longDescription,
             reason,
+            TypeValidationProblem.Payload.of(cacheabilityProblemOnly),
             userManualReference,
             possibleSolutions
         );

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/Severity.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/Severity.java
@@ -39,6 +39,8 @@ public enum Severity {
 
     /**
      * Reduce options to {@link #WARNING} and {@link #ERROR}.
+     * This method should go away, as well as the cacheability enum value,
+     * once all validation warnings are migrated to the new builder system
      */
     public Severity toReportableSeverity() {
         return this == CACHEABILITY_WARNING

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
@@ -15,16 +15,16 @@
  */
 package org.gradle.internal.reflect.validation;
 
+import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.problems.BaseProblem;
 import org.gradle.problems.Solution;
-import org.gradle.internal.reflect.problems.ValidationProblemId;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Severity, TypeValidationProblemLocation, Void> {
+public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Severity, TypeValidationProblemLocation, TypeValidationProblem.Payload> {
     @Nullable
     private final UserManualReference userManualReference;
 
@@ -34,12 +34,13 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
                                  Supplier<String> shortDescription,
                                  Supplier<String> longDescription,
                                  Supplier<String> reason,
+                                 TypeValidationProblem.Payload payload,
                                  @Nullable UserManualReference userManualReference,
                                  List<Supplier<Solution>> solutions) {
         super(id,
             severity,
             where,
-            null,
+            payload,
             shortDescription,
             longDescription,
             reason,
@@ -50,5 +51,28 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
 
     public Optional<UserManualReference> getUserManualReference() {
         return Optional.ofNullable(userManualReference);
+    }
+
+    public static class Payload {
+
+        private static Payload CACHEABILITY_PROBLEM_ONLY = new Payload(true);
+        private static Payload STANDARD_PROBLEM = new Payload(false);
+
+        public static Payload of(boolean cacheableProblemOnly) {
+            if (cacheableProblemOnly) {
+                return CACHEABILITY_PROBLEM_ONLY;
+            }
+            return STANDARD_PROBLEM;
+        }
+
+        private final boolean isCacheabilityProblemOnly;
+
+        public Payload(boolean isCacheabilityProblemOnly) {
+            this.isCacheabilityProblemOnly = isCacheabilityProblemOnly;
+        }
+
+        public boolean isCacheabilityProblemOnly() {
+            return isCacheabilityProblemOnly;
+        }
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
@@ -55,8 +55,8 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
 
     public static class Payload {
 
-        private static Payload CACHEABILITY_PROBLEM_ONLY = new Payload(true);
-        private static Payload STANDARD_PROBLEM = new Payload(false);
+        private static final Payload CACHEABILITY_PROBLEM_ONLY = new Payload(true);
+        private static final Payload STANDARD_PROBLEM = new Payload(false);
 
         public static Payload of(boolean cacheableProblemOnly) {
             if (cacheableProblemOnly) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
@@ -57,4 +57,5 @@ public interface ValidationProblemBuilder<T extends ValidationProblemBuilder<T>>
         return addPossibleSolution(() -> solution);
     }
 
+    T isCachabilityProblemOnly();
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/ValidationProblemBuilder.java
@@ -57,5 +57,5 @@ public interface ValidationProblemBuilder<T extends ValidationProblemBuilder<T>>
         return addPossibleSolution(() -> solution);
     }
 
-    T isCachabilityProblemOnly();
+    T onlyAffectsCacheableWork();
 }


### PR DESCRIPTION
The existing validation code conflates the severity of a problem with
the cacheability state. This commit decouples things by making the
severity only talk about severity, and having the cacheability state
carried as part of the problem payload.

The enum value is still used for all problems which do not use the
new builder mechanism. The plan is to finally get rid of this enum
value.
