### PR TITLE
Fix kotlin-jvm and java-gradle-plugin interactions with configuration cache enabled

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractProjectRelocationIntegrationTest.groovy
@@ -20,10 +20,7 @@ import org.gradle.test.fixtures.file.TestFile
 
 abstract class AbstractProjectRelocationIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
-    @ToBeFixedForConfigurationCache(bottomSpecs = [
-        "JavaGradlePluginRelocationTest",
-        "ScalaCompileRelocationIntegrationTest"
-    ])
+    @ToBeFixedForConfigurationCache(bottomSpecs = ["ScalaCompileRelocationIntegrationTest"])
     def "project is relocatable"() {
         def originalDir = file("original-dir")
         originalDir.file("settings.gradle") << localCacheConfiguration()

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -198,7 +198,10 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
                         return true;
                     });
                 });
-                return sourceSet.getOutput().plus(view.getFiles());
+                return pluginUnderTestMetadataTask.getProject().getObjects().fileCollection().from(
+                    sourceSet.getOutput(),
+                    view.getFiles().getElements()
+                );
             });
         });
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -99,15 +99,10 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
     def 'kotlin jvm and groovy plugins combined (kotlin=#kotlinVersion)'() {
         given:
         buildFile << """
-            buildscript {
-                ext.kotlin_version = '$kotlinVersion'
-                repositories { mavenCentral() }
-                dependencies {
-                    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-                }
+            plugins {
+                id 'groovy'
+                id 'org.jetbrains.kotlin.jvm' version '$kotlinVersion'
             }
-            apply plugin: 'kotlin'
-            apply plugin: 'groovy'
 
             repositories {
                 mavenCentral()
@@ -145,15 +140,10 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
     def 'kotlin jvm and java-gradle-plugin plugins combined (kotlin=#kotlinVersion)'() {
         given:
         buildFile << """
-            buildscript {
-                ext.kotlin_version = '$kotlinVersion'
-                repositories { mavenCentral() }
-                dependencies {
-                    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-                }
+            plugins {
+                id 'java-gradle-plugin'
+                id 'org.jetbrains.kotlin.jvm' version '$kotlinVersion'
             }
-            apply plugin: 'kotlin'
-            apply plugin: 'java-gradle-plugin'
 
             repositories {
                 mavenCentral()


### PR DESCRIPTION
By making the java-gradle-plugin's component-filtered-artifact-view based file collection used to generate the _plugin under test metadata_ resolved before storing the configuration cache,

### Context
This fixes https://github.com/gradle/gradle/issues/16183
Also see https://github.com/gradle/gradle/issues/16223

