### PR TITLE
Re-enable incremental task snippets tests

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -522,9 +522,6 @@ tasks.named("docsTest") { task ->
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-kotlin-dsl-android-build_*.sample' // plugin [id: 'com.android.application', version: '3.2.0', apply: false] was not found: Gradle Central Plugin Repository
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-kotlin-dsl-android-single-build_*.sample' // seems legit: java.lang.NoClassDefFoundError: Could not initialize class org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSetKt
 
-        // https://github.com/gradle/gradle-private/issues/3264
-        excludeTestsMatching '*snippet-tasks-incremental-task*'
-
         // https://github.com/gradle/gradle-private/issues/3265
         excludeTestsMatching '*jvm-multi-project-with-additional-test-types_kotlin_checkTask*'
         excludeTestsMatching '*jvm-multi-project-with-code-coverage_kotlin_testTask*'


### PR DESCRIPTION
We disabled those since they started failing.

Fixes gradle/gradle-private#3264