### PR TITLE
Fix plugin import spec not used for files

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlCatalogFileParser.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/std/TomlCatalogFileParser.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class TomlDependenciesFileParser {
+public class TomlCatalogFileParser {
     private static final Splitter SPLITTER = Splitter.on(":").trimResults();
     private static final String DEPENDENCIES_KEY = "dependencies";
     private static final String BUNDLES_KEY = "bundles";
@@ -73,7 +73,7 @@ public class TomlDependenciesFileParser {
         }
         List<String> keys = dependenciesTable.keySet()
             .stream()
-            .peek(TomlDependenciesFileParser::validateAlias)
+            .peek(TomlCatalogFileParser::validateAlias)
             .sorted(Comparator.comparing(String::length))
             .collect(Collectors.toList());
         for (String alias : keys) {
@@ -89,7 +89,7 @@ public class TomlDependenciesFileParser {
         }
         List<String> keys = versionsTable.keySet()
             .stream()
-            .peek(TomlDependenciesFileParser::validateAlias)
+            .peek(TomlCatalogFileParser::validateAlias)
             .sorted(Comparator.comparing(String::length))
             .collect(Collectors.toList());
         for (String alias : keys) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/std/TomlDependenciesFileParserTest.groovy
@@ -292,7 +292,7 @@ class TomlDependenciesFileParserTest extends Specification {
     }
 
     private void parse(String name) {
-        TomlDependenciesFileParser.parse(toml(name), builder, pluginsSpec, importConf)
+        TomlCatalogFileParser.parse(toml(name), builder, pluginsSpec, importConf)
         model = builder.build()
         assert model != null: "Expected model to be generated but it wasn't"
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/CatalogPluginsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/central/CatalogPluginsIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.central
+
+import org.gradle.integtests.resolve.PluginDslSupport
+import org.gradle.test.fixtures.plugin.PluginBuilder
+import org.gradle.test.fixtures.server.http.MavenHttpPluginRepository
+import org.junit.Rule
+import spock.lang.Issue
+
+class CatalogPluginsIntegrationTest extends AbstractCentralDependenciesIntegrationTest implements PluginDslSupport {
+    @Rule
+    final MavenHttpPluginRepository pluginPortal = MavenHttpPluginRepository.asGradlePluginPortal(executer, mavenRepo)
+
+    def setup() {
+        usePluginRepoMirror = false // otherwise the plugin portal fixture doesn't work!
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/16079")
+    def "should use excludes for catalogs imported from files"() {
+        String taskName = 'greet'
+        String message = 'Hello from plugin!'
+        String pluginId = 'com.acme.greeter'
+        String pluginVersion = '1.5'
+        def plugin = new PluginBuilder(file("greeter"))
+            .addPluginWithPrintlnTask(taskName, message, pluginId)
+            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
+
+        file("dependencies1.toml") << """
+[plugins]
+com.acme.greeter = "1.7"
+        """
+        file("dependencies2.toml") << """
+[plugins]
+com.acme.greeter = "1.5"
+        """
+
+        file("settings.gradle") << """
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("dependencies1.toml")) {
+                excludePlugin("com.acme.greeter")
+            }
+        }
+        create("libs2") {
+            from(files("dependencies2.toml"))
+        }
+    }
+}"""
+        withPlugin pluginId
+
+        when:
+        plugin.allowAll()
+        succeeds taskName
+
+        then:
+        outputContains message
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -144,7 +144,7 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
                 }
             }
         """
-        file("gradle/dependency-locks/settings-incomingPlatformsForLibs.lockfile") << """
+        file("gradle/dependency-locks/settings-incomingCatalogForLibs0.lockfile") << """
 org.gradle.test:my-platform:1.0
 """
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/catalog/internal/TomlWriterTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/catalog/internal/TomlWriterTest.groovy
@@ -21,7 +21,7 @@ import groovy.transform.Canonical
 import org.gradle.api.internal.std.DefaultVersionCatalog
 import org.gradle.api.internal.std.DefaultVersionCatalogBuilder
 import org.gradle.api.internal.std.ImportConfiguration
-import org.gradle.api.internal.std.TomlDependenciesFileParser
+import org.gradle.api.internal.std.TomlCatalogFileParser
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
 import org.gradle.util.TestUtil
@@ -96,7 +96,7 @@ class TomlWriterTest extends Specification {
             pluginsSpec,
             Stub(Supplier))
         ins.withCloseable {
-            TomlDependenciesFileParser.parse(it, builder, pluginsSpec, new ImportConfiguration(acceptAll(), acceptAll(), acceptAll(), acceptAll()))
+            TomlCatalogFileParser.parse(it, builder, pluginsSpec, new ImportConfiguration(acceptAll(), acceptAll(), acceptAll(), acceptAll()))
         }
         return new Model(builder.build(), plugins)
     }


### PR DESCRIPTION
If a catalog was imported from a file, the logic to associate a node
in the resolved dependency graph to the actual dependency was broken.
The consequence is that we wouldn't associate the import spec, which
defines plugin excludes, to the actual catalog being imported, and
as such the import spec was ignored.

This commit fixes the problem by removing the optimization logic,
which was broken, and instead relies on creating one configuration
per catalog being imported.

Fixes #16079
