### PR TITLE
Unignore jacoco samples tests on JDK15+

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -509,12 +509,6 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching 'org.gradle.docs.samples.*.snippet-java-library-module*.sample'
         }
 
-        // Do not execute JaCoCo tests on JDK >= 15 until JaCoCo we use starts supporting newer JDKs
-        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {
-            excludeTestsMatching 'org.gradle.docs.samples.*.jvm-multi-project-with-code-coverage_*_testTask.sample'
-            excludeTestsMatching 'org.gradle.docs.samples.*.snippet-testing-jacoco-application_*_jacocoApp.sample'
-        }
-
         // TODO investigate ignored snippets
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-scala-cross-compilation_groovy_sanityCheck.sample' // There is no java executable in /Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin. Expression: executable.exists()
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-groovy-cross-compilation_*.sample'  // compilation error


### PR DESCRIPTION
Jacoco has been upgraded and supports JDK15.
