### PR TITLE
Update Scala snippet and documentation to use toolchains for cross-compilation

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -516,7 +516,6 @@ tasks.named("docsTest") { task ->
         }
 
         // TODO investigate ignored snippets
-        excludeTestsMatching 'org.gradle.docs.samples.*.snippet-scala-cross-compilation_groovy_sanityCheck.sample' // There is no java executable in /Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin. Expression: executable.exists()
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-groovy-cross-compilation_*.sample'  // compilation error
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-java-cross-compilation_*.sample' // fails to find javadoc
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-kotlin-dsl-android-build_*.sample' // plugin [id: 'com.android.application', version: '3.2.0', apply: false] was not found: Gradle Central Plugin Repository

--- a/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/groovy_plugin.adoc
@@ -314,7 +314,7 @@ Also see <<java_plugin.adoc#sec:incremental_compilation_known_issues,Known issue
 == Compiling and testing for Java 6 or Java 7
 
 With <<toolchains.adoc#toolchains,toolchain support>> added to `GroovyCompile`, it is possible to compile Groovy code using a different Java version than the one running Gradle.
-If you also have Java source files, this will also configure `JavaCompile` to use the right Java compiler is used, as can be seen in the <<building_java_projects.adoc#sec:java_cross_compilation,Java plugin>> documentation.
+If you also have Java source files, this will also configure `JavaCompile` to use the right Java compiler, as can be seen in the <<building_java_projects.adoc#sec:java_cross_compilation,Java plugin>> documentation.
 
 === Example: Configure Java 7 build for Groovy
 

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -257,16 +257,14 @@ Note that Zinc's Nailgun based daemon mode is not supported. Instead, we plan to
 [[sec:scala_cross_compilation]]
 == Compiling and testing for Java 6 or Java 7
 
-The Scala compiler ignores Gradle's `targetCompatibility` and `sourceCompatibility` settings. In Scala 2.11, the Scala compiler always compiles to Java 6 compatible bytecode. In Scala 2.12, the Scala compiler always compiles to Java 8 compatible bytecode. If you also have Java source, you can follow the same steps as for the <<building_java_projects.adoc#sec:java_cross_compilation,Java plugin>> to ensure the correct Java compiler is used.
+With <<toolchains.adoc#toolchains,toolchain support>> added to `ScalaCompile`, it is possible to compile Scala code using a different Java version than the one running Gradle.
+If you also have Java source files, this will also configure `JavaCompile` to use the right Java compiler, as can be seen in the <<building_java_projects.adoc#sec:java_cross_compilation,Java plugin>> documentation.
+
+The Scala compiler ignores Gradle's `targetCompatibility` and `sourceCompatibility` settings.
+In Scala 2.11, the Scala compiler always compiles to Java 6 compatible bytecode.
+In Scala 2.12, the Scala compiler always compiles to Java 8 compatible bytecode.
 
 .Configure Java 6 build for Scala
-
-[source,properties]
-.gradle.properties
-----
-include::{snippetsPath}/scala/crossCompilation/groovy/gradle.properties[]
-----
-
 ====
 include::sample[dir="snippets/scala/crossCompilation/groovy",files="build.gradle[tags=scala-cross-compilation]"]
 include::sample[dir="snippets/scala/crossCompilation/kotlin",files="build.gradle.kts[tags=scala-cross-compilation]"]

--- a/subprojects/docs/src/snippets/scala/crossCompilation/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/scala/crossCompilation/groovy/build.gradle
@@ -15,30 +15,8 @@ dependencies {
 
 // tag::scala-cross-compilation[]
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
-}
-
-assert hasProperty('java6Home') : "Set the property 'java6Home' in your your gradle.properties pointing to a Java 6 installation"
-def javaExecutablesPath = new File(java6Home, 'bin')
-def javaExecutables = [:].withDefault { execName ->
-    def executable = new File(javaExecutablesPath, execName)
-    assert executable.exists() : "There is no ${execName} executable in ${javaExecutablesPath}"
-    executable
-}
-
-tasks.withType(AbstractCompile) {
-    options.with {
-        fork = true
-        forkOptions.javaHome = file(java6Home)
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(6)
     }
-}
-tasks.withType(Test) {
-    executable = javaExecutables.java
-}
-tasks.withType(JavaExec) {
-    executable = javaExecutables.java
-}
-tasks.withType(Javadoc) {
-    executable = javaExecutables.javadoc
 }
 // end::scala-cross-compilation[]

--- a/subprojects/docs/src/snippets/scala/crossCompilation/groovy/gradle.properties
+++ b/subprojects/docs/src/snippets/scala/crossCompilation/groovy/gradle.properties
@@ -1,2 +1,0 @@
-# in $HOME/.gradle/gradle.properties
-java6Home=/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home

--- a/subprojects/docs/src/snippets/scala/crossCompilation/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/scala/crossCompilation/kotlin/build.gradle.kts
@@ -15,31 +15,8 @@ dependencies {
 
 // tag::scala-cross-compilation[]
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_6
-}
-
-require(hasProperty("java6Home")) { "Set the property 'java6Home' in your your gradle.properties pointing to a Java 6 installation" }
-val java6Home: String by project
-val javaExecutablesPath = File(java6Home, "bin")
-fun javaExecutable(execName: String): String {
-    val executable = File(javaExecutablesPath, execName)
-    require(executable.exists()) { "There is no ${execName} executable in ${javaExecutablesPath}" }
-    return executable.toString()
-}
-
-tasks.withType<ScalaCompile>().configureEach {
-    options.apply {
-        isFork = true
-        forkOptions.javaHome = file(java6Home)
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(6))
     }
-}
-tasks.withType<Test>().configureEach {
-    executable = javaExecutable("java")
-}
-tasks.withType<JavaExec>().configureEach {
-    executable = javaExecutable("java")
-}
-tasks.withType<Javadoc>().configureEach {
-    executable = javaExecutable("javadoc")
 }
 // end::scala-cross-compilation[]

--- a/subprojects/docs/src/snippets/scala/crossCompilation/kotlin/gradle.properties
+++ b/subprojects/docs/src/snippets/scala/crossCompilation/kotlin/gradle.properties
@@ -1,2 +1,0 @@
-# in $HOME/.gradle/gradle.properties
-java6Home=/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home


### PR DESCRIPTION
This also re-enables an otherwise ignored test that relied on hardcoded filesystem location to find JDK6.

https://github.com/gradle/gradle/issues/16238