### PR TITLE
Update Cucumber framework tests

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest.groovy
@@ -35,9 +35,7 @@ class CucumberJVMReportIntegrationTest extends AbstractSampleIntegrationTest {
         executedAndNotSkipped(":test")
         and:
         DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
-        result.assertTestClassesExecuted("RunCukesTest", "Scenario: Say hello /two/three")
-        result.testClass("Scenario: Say hello /two/three").assertTestPassed("Given I have a hello app with Howdy and /four")
-        result.testClass("Scenario: Say hello /two/three").assertTestPassed("Then it should answer with Howdy World")
-        result.testClass("Scenario: Say hello /two/three").assertTestPassed("When I ask it to say hi and /five/six/seven")
+        result.assertTestClassesExecuted("RunCukesTest", "Hello World /one")
+        result.testClass("Hello World /one").assertTestPassed("Say hello /two/three")
     }
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/build.gradle
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-apply plugin: 'java'
+plugins {
+    id("java")
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    testImplementation "junit:junit:4.13"
-    testImplementation "info.cukes:cucumber-java:1.1.2"
-    testImplementation "info.cukes:cucumber-junit:1.1.2"
+    testImplementation "io.cucumber:cucumber-java:6.8.1"
+    testImplementation "io.cucumber:cucumber-junit:6.8.1"
 }
 
 test {

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/src/test/java/HelloStepdefs.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/src/test/java/HelloStepdefs.java
@@ -1,6 +1,6 @@
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class HelloStepdefs {
     @Given("^I have a hello app with Howdy and /four")

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/src/test/java/RunCukesTest.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/cucumberjvm/CucumberJVMReportIntegrationTest/testReportingSupportsCucumberStepsWithSlashes/src/test/java/RunCukesTest.java
@@ -1,4 +1,4 @@
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)


### PR DESCRIPTION
Use a current version of Cucumber framework in tests so that it is compatible with JDK16.
