### PR TITLE
Avoid shortening git commit hash in github url

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/TestPageGenerator.java
@@ -304,7 +304,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
         }
 
         public String getUrl() {
-            return String.format("https://github.com/%s/commit/%s", repo, formatHash(hash));
+            return String.format("https://github.com/%s/commit/%s", repo, hash);
         }
 
         public String getLabel() {

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestPageGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestPageGeneratorTest.groovy
@@ -38,6 +38,15 @@ class TestPageGeneratorTest extends Specification {
         urls[1].url == 'https://github.com/gradle/dotcom/commit/abcdefg'
     }
 
+    def "shortens label for commit hash"() {
+        when:
+        def urls = new TestPageGenerator().createGitHubLinks(['d47660cb46163d058f8de40b73b2f99a11a654a7'])
+
+        then:
+        urls[0].label == 'd47660c'
+        urls[0].url == 'https://github.com/gradle/gradle/commit/d47660cb46163d058f8de40b73b2f99a11a654a7'
+    }
+
     def "accepts no vcs commit ids"() {
         expect:
         new TestPageGenerator().createGitHubLinks(inputs).isEmpty()


### PR DESCRIPTION
Given commit hashes may clash, shortening them to 7 characters might
not always work. Even though Git is able to still identify certain
commits using the abbreviation, Github may not. We keep the shorted
commit hash as label while we point the url to the full commit id.

Example:
❯ git rev-parse --short=7 d47660cb46163d058f8de40b73b2f99a11a654a7
d47660c

Not working: https://github.com/gradle/gradle/commit/d47660c
Working: https://github.com/gradle/gradle/commit/d47660cb46163d058f8de40b73b2f99a11a654a7

This fixes a problem where not all links in the "Test history" section of
performance tests are accessible.
