### PR TITLE
Fix tests using ModuleJarFixture for JDK16

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/jpms/ModuleJarFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/jpms/ModuleJarFixture.groovy
@@ -131,7 +131,7 @@ class ModuleJarFixture {
         }
 
         @Override
-        String getName() { return uri.getRawSchemeSpecificPart() }
+        String getName() { return super.uri.getRawSchemeSpecificPart() }
 
         @Override
         OutputStream openOutputStream() throws IOException {


### PR DESCRIPTION
For some reason, Groovy does not see the protected `uri` property of SimpleJavaFile object from
ModuleJarFixture subclass when executing on JDK16. The property is there on JDK16. Explicitly
referencing it via `super.uri` works around this problem.
