### PR TITLE
Remove non-dynamic constraint on plugin versions.

### DIFF
--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -130,7 +130,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         useCustomRepository("""
             resolutionStrategy.eachPlugin {
                 if(requested.id.name == 'plugin') {
-                    useVersion("+")
+                    useVersion("x")
                 }
             }
         """)
@@ -139,7 +139,35 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("pluginTask")
 
         then:
-        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '+'] was not found")
+        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: 'x'] was not found")
+    }
+
+    def 'when version range is specified, resolution succeeds'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1.2'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useVersion("1.+")
+                }
+            }
+        """)
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
     }
 
     def 'when invalid artifact version is specified, resolution fails'() {
@@ -158,7 +186,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         useCustomRepository("""
             resolutionStrategy.eachPlugin {
                 if(requested.id.name == 'plugin') {
-                    useModule("org.example.plugin:plugin:+")
+                    useModule("org.example.plugin:plugin:x")
                 }
             }
         """)
@@ -167,7 +195,35 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("pluginTask")
 
         then:
-        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '1.2', artifact: 'org.example.plugin:plugin:+'] was not found")
+        failure.assertHasDescription("Plugin [id: 'org.example.plugin', version: '1.2', artifact: 'org.example.plugin:plugin:x'] was not found")
+    }
+
+    def 'when artifact version range is specified, resolution succeeds'() {
+        given:
+        publishTestPlugin()
+        buildScript """
+          plugins {
+              id "org.example.plugin" version '1.2'
+          }
+          plugins.withType(org.gradle.test.TestPlugin) {
+            println "I'm here"
+          }
+        """
+
+        and:
+        useCustomRepository("""
+            resolutionStrategy.eachPlugin {
+                if(requested.id.name == 'plugin') {
+                    useModule("org.example.plugin:plugin:1.+")
+                }
+            }
+        """)
+
+        when:
+        succeeds("pluginTask")
+
+        then:
+        output.contains("I'm here")
     }
 
     def 'can specify an artifact to use'() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -71,11 +71,6 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
             return;
         }
 
-        if (versionSelectorScheme.parseSelector(markerVersion).isDynamic()) {
-            result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported");
-            return;
-        }
-
         if (exists(markerDependency)) {
             handleFound(result, pluginRequest, markerDependency);
         } else {

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -85,11 +85,11 @@ class ArtifactRepositoriesPluginResolverTest extends Specification {
         1 * result.found(SOURCE_NAME, _)
     }
 
-    def "fail pluginRequests with dynamic versions"() {
+    def "accept pluginRequests with dynamic versions"() {
         when:
         resolver.resolve(request("plugin", "latest.revision"), result)
 
         then:
-        1 * result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported")
+        1 * result.found(SOURCE_NAME, _)
     }
 }


### PR DESCRIPTION
Fixes #14704

This is already merged in master from request #16046. However, we would also like this included in the next 6.x release if at all possible. There was also a related update to release notes for 7.0 here: https://github.com/gradle/gradle/commit/748a816d779965621313a6b705b9b534a3ed59a0

Signed-off-by: Ståle Undheim <staale@staale.org>

### Context
This updates so that we can use version ranges in the plugin block. We have several internal plugins that we use, which we also make patch changes to that will benefit all our projects, without them having to do anything but rebuild. We have over 40 projects that depend on our core plugins, and it would be a rather large task to have to update all of them to use the new version of the plugins on each path change.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
