### PR TITLE
Fix incremental task samples tests

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -511,9 +511,6 @@ tasks.named("docsTest") { task ->
 
         // TODO investigate ignored snippets
         excludeTestsMatching 'org.gradle.docs.samples.*.snippet-scala-cross-compilation_groovy_sanityCheck.sample' // There is no java executable in /Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home/bin. Expression: executable.exists()
-        if (org.gradle.internal.os.OperatingSystem.current().macOsX) {
-            excludeTestsMatching 'org.gradle.docs.samples.*.snippet-tasks-incremental-task_*_incrementalTask*.sample' // Some 'incrementalTask' tests seem to be flaky on OS X only
-        }
     }
 }
 

--- a/subprojects/docs/src/snippets/tasks/incrementalTask/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/incrementalTask/groovy/build.gradle
@@ -1,4 +1,5 @@
 task originalInputs() {
+    outputs.dir('inputs')
     doLast {
         file('inputs').mkdir()
         file('inputs/1.txt').text = 'Content for file 1.'
@@ -9,6 +10,7 @@ task originalInputs() {
 
 // tag::updated-inputs[]
 task updateInputs() {
+    outputs.dir('inputs')
     doLast {
         file('inputs/1.txt').text = 'Changed content for existing file 1.'
         file('inputs/4.txt').text = 'Content for new file 4.'
@@ -18,6 +20,7 @@ task updateInputs() {
 
 // tag::removed-input[]
 task removeInput() {
+    outputs.dir('inputs')
     doLast {
         file('inputs/3.txt').delete()
     }
@@ -26,6 +29,7 @@ task removeInput() {
 
 // tag::removed-output[]
 task removeOutput() {
+    outputs.dir("$buildDir/outputs")
     doLast {
         file("$buildDir/outputs/1.txt").delete()
     }
@@ -39,6 +43,8 @@ task incrementalReverse(type: IncrementalReverseTask) {
     inputProperty = project.properties['taskInputProperty'] ?: 'original'
 }
 // end::reverse[]
+
+incrementalReverse.mustRunAfter(originalInputs, updateInputs, removeInput, removeOutput)
 
 // tag::incremental-task[]
 abstract class IncrementalReverseTask extends DefaultTask {

--- a/subprojects/docs/src/snippets/tasks/incrementalTask/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/incrementalTask/kotlin/build.gradle.kts
@@ -1,4 +1,5 @@
 tasks.register("originalInputs") {
+    outputs.dir("inputs")
     doLast {
         file("inputs").mkdir()
         file("inputs/1.txt").writeText("Content for file 1.")
@@ -9,6 +10,7 @@ tasks.register("originalInputs") {
 
 // tag::updated-inputs[]
 tasks.register("updateInputs") {
+    outputs.dir("inputs")
     doLast {
         file("inputs/1.txt").writeText("Changed content for existing file 1.")
         file("inputs/4.txt").writeText("Content for new file 4.")
@@ -18,6 +20,7 @@ tasks.register("updateInputs") {
 
 // tag::removed-input[]
 tasks.register("removeInput") {
+    outputs.dir("inputs")
     doLast {
         file("inputs/3.txt").delete()
     }
@@ -26,6 +29,7 @@ tasks.register("removeInput") {
 
 // tag::removed-output[]
 tasks.register("removeOutput") {
+    outputs.dir("$buildDir/outputs")
     doLast {
         file("$buildDir/outputs/1.txt").delete()
     }
@@ -39,6 +43,8 @@ tasks.register<IncrementalReverseTask>("incrementalReverse") {
     inputProperty.set(project.properties["taskInputProperty"] as String? ?: "original")
 }
 // end::reverse[]
+
+tasks.named("incrementalReverse") { mustRunAfter("originalInputs", "updateInputs", "removeInput", "removeOutput") }
 
 // tag::incremental-task[]
 abstract class IncrementalReverseTask : DefaultTask() {


### PR DESCRIPTION
the problem was that the tasks changing
the inputs of the incremental task did
not declare the inputs as outputs, so
Gradle did not pick up the changes.

Fixes gradle/gradle-private#3264.