### PR TITLE
Update test-distribution plugin to version 2.0-rc-5

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-3")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-4")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.11.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-4")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-5")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.11.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:0.7")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0-rc-3")
+    id("com.gradle.enterprise.test-distribution").version("2.0-rc-4")
 }
 
 includeBuild("build-logic-commons")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0-rc-4")
+    id("com.gradle.enterprise.test-distribution").version("2.0-rc-5")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
**IMPORTANT - Converted PR to draft mode as we're not sure whether we want to include another commit for the new RC**

Compared to 2.0-rc-3, this version offers:
* session support on the client (multiple partitions executed in same JUnit launcher session) + chrome trace integration
* local executors support session concept
* compatibility with configuration cache

I've successfully ran it for `depMan:embeddedIntegTest`
