### PR TITLE
Add resource lock to promotion jobs

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -43,6 +43,9 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
             param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
             param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
             param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
+            // https://www.jetbrains.com/help/teamcity/shared-resources.html#Viewing+Shared+Resources+Usage
+            // we only allow 1 promotion job running at the same time to avoid website xml conflicts
+            param("teamcity.locks.writeLock.promotionJobLock", "PromotionJobLock")
         }
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -45,7 +45,7 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
             param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
             // https://www.jetbrains.com/help/teamcity/shared-resources.html#Viewing+Shared+Resources+Usage
             // we only allow 1 promotion job running at the same time to avoid website xml conflicts
-            param("teamcity.locks.writeLock.promotionJobLock", "PromotionJobLock")
+            param("teamcity.locks.writeLock.WebsiteReleasesXmlWriteLock", "WebsiteReleasesXmlWriteLock")
         }
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -45,7 +45,7 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
             param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
             // https://www.jetbrains.com/help/teamcity/shared-resources.html#Viewing+Shared+Resources+Usage
             // we only allow 1 promotion job running at the same time to avoid website xml conflicts
-            param("teamcity.locks.writeLock.WebsiteReleasesXmlWriteLock", "WebsiteReleasesXmlWriteLock")
+            param("teamcity.locks.writeLock.WebsiteReleasesXml", "WebsiteReleasesXml")
         }
     }
 }


### PR DESCRIPTION
Our promotion jobs depends on some exclusive-access-only resources,
so we want to run them exclusively. This PR adds a lock to promotion
jobs so that only one job can be running at a time.
