### PR TITLE
Set common Groovy JPMS JVM args for tests 

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -180,11 +180,8 @@ fun Test.configureJvmForTest() {
         }.getOrNull()
     }
     javaLauncher.set(launcher)
-    if (jvmVersionForTest().canCompileOrRun(9)) {
-        // allow embedded executer to modify environment variables
-        jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
-        // allow embedded executer to inject legacy types into the system classloader
-        jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+    if (jvmVersionForTest().canCompileOrRun(9) && (isUnitTest() || usesEmbeddedExecuter())) {
+        jvmArgs(org.gradle.internal.jvm.GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS)
     }
 }
 
@@ -194,6 +191,10 @@ fun Test.addOsAsInputs() {
     inputs.property("operatingSystem", "${OperatingSystem.current().name} ${System.getProperty("os.arch")}")
 }
 
+fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "writeTmpPerformanceScenarioDefinitions").contains(name)
+
+fun Test.usesEmbeddedExecuter() = name.startsWith("embedded")
+
 fun configureTests() {
     normalization {
         runtimeClasspath {
@@ -201,8 +202,6 @@ fun configureTests() {
             ignore("org/gradle/build-receipt.properties")
         }
     }
-
-    fun Test.isUnitTest() = listOf("test", "writePerformanceScenarioDefinitions", "writeTmpPerformanceScenarioDefinitions").contains(name)
 
     tasks.withType<Test>().configureEach {
         filterEnvironmentVariables()

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -181,6 +181,7 @@ fun Test.configureJvmForTest() {
     }
     javaLauncher.set(launcher)
     if (jvmVersionForTest().canCompileOrRun(9) && (isUnitTest() || usesEmbeddedExecuter())) {
+        // This will break on wrapper update. Please change to org.gradle.internal.jvm.GroovyJpmsConfiguration.GROOVY_JPMS_JVM_ARGS when it does.
         jvmArgs(org.gradle.internal.jvm.GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS)
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsConfiguration.java
@@ -25,7 +25,7 @@ public class GroovyJpmsConfiguration {
      * These JVM arguments should be passed to any process that will be using Groovy on Java 9+
      * Gradle accesses those packages reflectively. On Java versions 9 to 15, the users will get
      * a warning they can do nothing about. On Java 16+, strong encapsulation of JDK internals is
-     * enforced and not having those arguments will result runtime exceptions on illegal
+     * enforced and not having those arguments will result in runtime exceptions on illegal
      * reflective accesses.
      */
     public static final List<String> GROOVY_JPMS_JVM_ARGS = Collections.unmodifiableList(Arrays.asList(

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsConfiguration.java
@@ -20,15 +20,19 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class GroovyJpmsWorkarounds {
+public class GroovyJpmsConfiguration {
     /**
      * These JVM arguments should be passed to any process that will be using Groovy on Java 9+
-     * to avoid noisy illegal access warnings that the user can't do anything about.
+     * Gradle accesses those packages reflectively. On Java versions 9 to 15, the users will get
+     * a warning they can do nothing about. On Java 16+, strong encapsulation of JDK internals is
+     * enforced and not having those arguments will result runtime exceptions on illegal
+     * reflective accesses.
      */
-    public static final List<String> SUPPRESS_COMMON_GROOVY_WARNINGS = Collections.unmodifiableList(Arrays.asList(
+    public static final List<String> GROOVY_JPMS_JVM_ARGS = Collections.unmodifiableList(Arrays.asList(
         "--add-opens", "java.base/java.lang=ALL-UNNAMED",
         "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
         "--add-opens", "java.base/java.util=ALL-UNNAMED",
+        // required by PreferenceCleaningGroovySystemLoader
         "--add-opens", "java.prefs/java.util.prefs=ALL-UNNAMED"
     ));
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsWorkarounds.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsWorkarounds.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jvm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * Replaced by GroovyJpmsConfiguration
+ * GradleBuild smoke tests still depend on this class - should be removable after a new nightly is built and the wrapper is updated
+ */
+@Deprecated
+public class GroovyJpmsWorkarounds {
+    public static final List<String> SUPPRESS_COMMON_GROOVY_WARNINGS = Collections.unmodifiableList(Arrays.asList(
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util=ALL-UNNAMED",
+        "--add-opens", "java.prefs/java.util.prefs=ALL-UNNAMED"
+    ));
+}

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -26,7 +26,7 @@ import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.DefaultClassPath;
-import org.gradle.internal.jvm.GroovyJpmsWorkarounds;
+import org.gradle.internal.jvm.GroovyJpmsConfiguration;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
@@ -97,7 +97,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         javaForkOptions.setExecutable(javaOptions.getExecutable());
         if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
-            javaForkOptions.jvmArgs(GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS);
+            javaForkOptions.jvmArgs(GroovyJpmsConfiguration.GROOVY_JPMS_JVM_ARGS);
         }
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -18,7 +18,7 @@ package org.gradle.launcher.daemon.configuration;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.internal.jvm.GroovyJpmsWorkarounds;
+import org.gradle.internal.jvm.GroovyJpmsConfiguration;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.launcher.configuration.BuildLayoutResult;
@@ -126,7 +126,7 @@ public class DaemonParameters {
     public void applyDefaultsFor(JavaVersion javaVersion) {
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
             jvmOptions.jvmArgs(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
-            jvmOptions.jvmArgs(GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS);
+            jvmOptions.jvmArgs(GroovyJpmsConfiguration.GROOVY_JPMS_JVM_ARGS);
         }
         if (hasJvmArgs) {
             return;


### PR DESCRIPTION
Illegal reflective accesses turn from warnings to errors on JDK16.
The `--add-opens` that are set in production code are also needed in unit tests and embedded integration tests when executed on JDK16.

Also, rename `GroovyJpmsWorkarounds` to `GroovyJpmsConfiguration` - those are not workarounds to suppress warnings anymore, but configuration required because of what our code relies on internally.
