### PR TITLE
Remove no longer needed illegal reflective access

### DIFF
--- a/subprojects/file-collections/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
+++ b/subprojects/file-collections/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
@@ -31,7 +31,6 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicInteger
 
 @UsesNativeServices
@@ -43,10 +42,6 @@ abstract class AbstractDirectoryWalkerTest<T> extends Specification {
     SetSystemProperties setSystemPropertiesRule
 
     protected abstract List<T> getWalkers()
-
-    def cleanup() {
-        Charset.defaultCharset = null // clear cache
-    }
 
     @Unroll
     def "basic directory walking works - walker: #walkerInstance.class.simpleName"() {


### PR DESCRIPTION
It looks like the only test that relied on this reflective cleanup has been removed in 2019: https://github.com/gradle/gradle/commit/bb7122116cd344354abcb23f78b2213c509436d2

This currently breaks the tests on JDK16.

An alternative would be to set
```
tasks.test {
    // AbstractDirectoryWalkerTest reflectively accesses Charset.defaultCharset
    jvmArgs("--add-opens", "java.base/java.nio.charset=ALL-UNNAMED")
}
```
wherever AbstractDirectoryWalkerTest fixture is used.
