### PR TITLE
Adjust TAPI JDK compatibility test to run on JDK16

### DIFF
--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -26,6 +26,12 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
     def setup() {
         System.out.println("TAPI client is using Java " + clientJdkVersion)
 
+        def jvmArgs = """
+            if (${clientJdkVersion.isCompatibleWith(JavaVersion.VERSION_16)} && ['2.6', '2.14.1'].contains(project.findProperty("gradleVersion"))) {
+                jvmArgs = ["--add-opens", "java.base/java.lang=ALL-UNNAMED"]
+            }
+        """
+
         def compilerJdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_6)
         String compilerJavaHomePath = TextUtil.normaliseFileSeparators(compilerJdk.javaHome.absolutePath)
         executer.beforeExecute {
@@ -48,6 +54,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
                     languageVersion = JavaLanguageVersion.of(Integer.valueOf(project.findProperty("clientJdk")))
                 }
                 enableAssertions = true
+                $jvmArgs
 
                 args = [ "help", file("test-project"), project.findProperty("gradleVersion"), project.findProperty("targetJdk"), gradle.gradleUserHomeDir ]
             }
@@ -59,6 +66,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
                     languageVersion = JavaLanguageVersion.of(Integer.valueOf(project.findProperty("clientJdk")))
                 }
                 enableAssertions = true
+                $jvmArgs
 
                 args = [ "action", file("test-project"), project.findProperty("gradleVersion"), project.findProperty("targetJdk"), gradle.gradleUserHomeDir ]
             }
@@ -79,120 +87,119 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
         file("test-project/build.gradle") << "println 'Hello from ' + gradle.gradleVersion"
         file("test-project/settings.gradle") << "rootProject.name = 'target-project'"
         file("src/main/java/ToolingApiCompatibilityClient.java") << """
-import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ProjectConnection;
+            import org.gradle.tooling.GradleConnector;
+            import org.gradle.tooling.ProjectConnection;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
+            import java.io.ByteArrayOutputStream;
+            import java.io.File;
 
-public class ToolingApiCompatibilityClient {
-    public static void main(String[] args) throws Exception {
-        // parameters
-        // 1. action
-        // 2. project directory
-        // 3. target gradle version (or home)
-        // 4. target JDK
-        // 5. gradle user home
-        if (args.length == 5) {
-            String action = args[0];
-            File projectDir = new File(args[1]);
-            String gradleVersion = args[2];
-            File javaHome = new File(args[3]);
-            File gradleUserHome = new File(args[4]);
-            System.out.println("action = " + action);
-            System.out.println("projectDir = " + projectDir);
-            System.out.println("gradleVersion = " + gradleVersion);
-            System.out.println("javaHome = " + javaHome);
-            System.out.println("gradleUserHome = " + gradleUserHome);
-            if (action.equals("help")) {
-                int result = runHelp(projectDir, gradleVersion, javaHome, gradleUserHome);
-                System.exit(result);
-            } else if (action.equals("action")) {
-                int result = buildAction(projectDir, gradleVersion, javaHome, gradleUserHome);
-                System.exit(result);
+            public class ToolingApiCompatibilityClient {
+                public static void main(String[] args) throws Exception {
+                    // parameters
+                    // 1. action
+                    // 2. project directory
+                    // 3. target gradle version (or home)
+                    // 4. target JDK
+                    // 5. gradle user home
+                    if (args.length == 5) {
+                        String action = args[0];
+                        File projectDir = new File(args[1]);
+                        String gradleVersion = args[2];
+                        File javaHome = new File(args[3]);
+                        File gradleUserHome = new File(args[4]);
+                        System.out.println("action = " + action);
+                        System.out.println("projectDir = " + projectDir);
+                        System.out.println("gradleVersion = " + gradleVersion);
+                        System.out.println("javaHome = " + javaHome);
+                        System.out.println("gradleUserHome = " + gradleUserHome);
+                        if (action.equals("help")) {
+                            int result = runHelp(projectDir, gradleVersion, javaHome, gradleUserHome);
+                            System.exit(result);
+                        } else if (action.equals("action")) {
+                            int result = buildAction(projectDir, gradleVersion, javaHome, gradleUserHome);
+                            System.exit(result);
+                        }
+                    }
+                }
+
+                private static int runHelp(File projectLocation, String gradleVersion, File javaHome, File gradleUserHome) {
+                    GradleConnector connector = GradleConnector.newConnector();
+                    connector.useGradleVersion(gradleVersion);
+
+                    ProjectConnection connection = null;
+
+                    try {
+                        connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(gradleUserHome).connect();
+
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+                        connection.newBuild()
+                            .forTasks("help")
+                            .setStandardOutput(out)
+                            .setStandardError(err)
+                            .setJavaHome(javaHome)
+                            .run();
+
+                        assert out.toString().contains("Hello from");
+                        System.err.println(err.toString());
+                        return 0;
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return 1;
+                    } finally {
+                        if (connection != null) {
+                            connection.close();
+                        }
+                    }
+                }
+
+               private static int buildAction(File projectLocation, String gradleVersion, File javaHome, File gradleUserHome) {
+                    GradleConnector connector = GradleConnector.newConnector();
+                    connector.useGradleVersion(gradleVersion);
+
+                    ProjectConnection connection = null;
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    ByteArrayOutputStream err = new ByteArrayOutputStream();
+                    try {
+                        connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(gradleUserHome).connect();
+                        String result = connection.action(new ToolingApiCompatibilityBuildAction())
+                            .setStandardOutput(out)
+                            .setStandardError(err)
+                            .setJavaHome(javaHome)
+                            .run();
+                        assert result.contains("Build action result");
+                        return 0;
+                    } catch(Exception e) {
+                        e.printStackTrace();
+                        return 1;
+                    } finally {
+                        System.out.println(out.toString());
+                        System.err.println(err.toString());
+                        if (connection != null) {
+                            connection.close();
+                        }
+                    }
+               }
             }
-        }
-    }
-
-    private static int runHelp(File projectLocation, String gradleVersion, File javaHome, File gradleUserHome) {
-        GradleConnector connector = GradleConnector.newConnector();
-        connector.useGradleVersion(gradleVersion);
-
-        ProjectConnection connection = null;
-
-        try {
-            connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(gradleUserHome).connect();
-
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            ByteArrayOutputStream err = new ByteArrayOutputStream();
-
-            connection.newBuild()
-                .forTasks("help")
-                .setStandardOutput(out)
-                .setStandardError(err)
-                .setJavaHome(javaHome)
-                .run();
-
-            assert out.toString().contains("Hello from");
-            System.err.println(err.toString());
-            return 0;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return 1;
-        } finally {
-            if (connection != null) {
-                connection.close();
-            }
-        }
-    }
-
-   private static int buildAction(File projectLocation, String gradleVersion, File javaHome, File gradleUserHome) {
-        GradleConnector connector = GradleConnector.newConnector();
-        connector.useGradleVersion(gradleVersion);
-
-        ProjectConnection connection = null;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        try {
-            connection = connector.forProjectDirectory(projectLocation).useGradleUserHomeDir(gradleUserHome).connect();
-            String result = connection.action(new ToolingApiCompatibilityBuildAction())
-                .setStandardOutput(out)
-                .setStandardError(err)
-                .setJavaHome(javaHome)
-                .run();
-            assert result.contains("Build action result");
-            return 0;
-        } catch(Exception e) {
-            e.printStackTrace();
-            return 1;
-        } finally {
-            System.out.println(out.toString());
-            System.err.println(err.toString());
-            if (connection != null) {
-                connection.close();
-            }
-        }
-   }
-}
-"""
+        """
         file("src/main/java/ToolingApiCompatibilityBuildAction.java") << """
-import org.gradle.tooling.BuildAction;
-import org.gradle.tooling.BuildController;
+            import org.gradle.tooling.BuildAction;
+            import org.gradle.tooling.BuildController;
 
-public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
+            public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
 
-    @Override
-    public String execute(BuildController controller) {
-        return "Build action result: " + controller.toString();
-    }
-}
-"""
+                @Override
+                public String execute(BuildController controller) {
+                    return "Build action result: " + controller.toString();
+                }
+            }
+        """
     }
 
     abstract JavaVersion getClientJdkVersion()
 
-    @Unroll
-    def "tapi client can launch task with Gradle #gradleVersion on Java #gradleDaemonJdkVersion.majorVersion"(JavaVersion gradleDaemonJdkVersion, String gradleVersion) {
+    def "tapi client can launch task with Gradle and Java combination"(JavaVersion gradleDaemonJdkVersion, String gradleVersion) {
         setup:
         def tapiClientCompilerJdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_6)
         def gradleDaemonJdk = AvailableJavaHomes.getJdk(gradleDaemonJdkVersion)
@@ -226,7 +233,7 @@ public class ToolingApiCompatibilityBuildAction implements BuildAction<String> {
     }
 
     @Unroll
-    def "tapi client can run build action with Gradle #gradleVersion on Java #gradleDaemonJdkVersion.majorVersion"(JavaVersion gradleDaemonJdkVersion, String gradleVersion) {
+    def "tapi client can run build action with Gradle and Java combination"(JavaVersion gradleDaemonJdkVersion, String gradleVersion) {
         setup:
         def tapiClientCompilerJdk = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_6)
         def gradleDaemonJdk = AvailableJavaHomes.getJdk(gradleDaemonJdkVersion)


### PR DESCRIPTION
Older TAPI versions, specifically 2.6 and 2.14.1 perform illegal reflective accesses
that throw on JDK16. Adjust the test to add required opens when running those old
versions on JDK16.
