### PR TITLE
Use JDK16 compatible version of test-kit for cross-version tests

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -177,6 +177,12 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
     }
 
     static String determineMinimumVersionThatRunsOnCurrentJavaVersion(String desiredGradleVersion) {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            def compatibleVersion = GradleVersion.version("7.0-20210224105427+0000")
+            if (GradleVersion.version(desiredGradleVersion) < compatibleVersion) {
+                return compatibleVersion.version
+            }
+        }
         if (JavaVersion.current().isJava11Compatible()) {
             def compatibleVersion = GradleVersion.version("4.8.1") // see https://github.com/gradle/gradle/issues/4860
             if (GradleVersion.version(desiredGradleVersion) < compatibleVersion) {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerArgumentsIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testkit.runner
 
-import groovy.transform.NotYetImplemented
+import groovy.test.NotYetImplemented
 import spock.lang.Issue
 
 class GradleRunnerArgumentsIntegrationTest extends BaseGradleRunnerIntegrationTest {


### PR DESCRIPTION
The downside here is that we will lose coverage once we move the JDK15 pipeline to JDK16 - we will only be testing this on Java8 and Java16.