### PR TITLE
Fix PMD custom ruleset test

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -28,8 +28,10 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
 
     def setup() {
         buildFile << """
-            apply plugin: "java"
-            apply plugin: "pmd"
+            plugins {
+                id("java")
+                id("pmd")
+            }
 
             ${mavenCentralRepository()}
 
@@ -317,6 +319,8 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
             pathToRuleset = "rulesets/braces.xml"
         } else if (versionNumber < VersionNumber.version(6)) {
             pathToRuleset = "rulesets/java/braces.xml"
+        } else if (versionNumber < VersionNumber.version(6, 13)) {
+            pathToRuleset = "category/java/codestyle.xml/IfStmtsMustUseBraces"
         }
         """
             <ruleset name="custom"

--- a/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java
+++ b/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java
@@ -125,7 +125,11 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     public static VersionNumber version(int major) {
-        return new VersionNumber(major, 0, 0, 0, null, DEFAULT_SCHEME);
+        return version(major, 0);
+    }
+
+    public static VersionNumber version(int major, int minor) {
+        return new VersionNumber(major, minor, 0, 0, null, DEFAULT_SCHEME);
     }
 
     /**


### PR DESCRIPTION
IfStmtsMustUseBraces ruleset is deprecated and replaced with
ControlStatementBraces in the current PMD version, but we
also test version 6.0.0 where it was not yet deprecated.
This change adjusts the test to use the old rule where the
new one is not yet available.
