### PR TITLE
Adjust Groovy multi-version tests for JDK16

### DIFF
--- a/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -29,6 +29,17 @@ class GroovyCoverage {
     static final List<String> SUPPORTS_PARAMETERS
 
     static {
+        SUPPORTED_BY_JDK = groovyVersionsSupportedByJdk(JavaVersion.current())
+        SUPPORTS_GROOVYDOC = versionsAbove(SUPPORTED_BY_JDK, "1.6.9")
+        SUPPORTS_TIMESTAMP = versionsAbove(SUPPORTED_BY_JDK, "2.4.6")
+        SUPPORTS_PARAMETERS = versionsAbove(SUPPORTED_BY_JDK, "2.5.0")
+    }
+
+    static boolean supportsJavaVersion(String groovyVersion, JavaVersion javaVersion) {
+        return groovyVersionsSupportedByJdk(javaVersion).contains(groovyVersion)
+    }
+
+    private static List<String> groovyVersionsSupportedByJdk(JavaVersion javaVersion) {
         def allVersions = [*PREVIOUS]
 
         // Only test current Groovy version if it isn't a SNAPSHOT
@@ -36,15 +47,13 @@ class GroovyCoverage {
             allVersions += GroovySystem.version
         }
 
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_14)) {
-            SUPPORTED_BY_JDK = versionsBetween(allVersions, '2.2.2', '2.5.10')
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_16)) {
+            return versionsAbove(allVersions, '3.0.0')
+        } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
+            return versionsBetween(allVersions, '2.2.2', '2.5.10')
         } else {
-            SUPPORTED_BY_JDK = allVersions
+            return allVersions
         }
-
-        SUPPORTS_GROOVYDOC = versionsAbove(SUPPORTED_BY_JDK, "1.6.9")
-        SUPPORTS_TIMESTAMP = versionsAbove(SUPPORTED_BY_JDK, "2.4.6")
-        SUPPORTS_PARAMETERS = versionsAbove(SUPPORTED_BY_JDK, "2.5.0")
     }
 
     private static List<String> versionsAbove(List<String> versionsToFilter, String threshold) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/AbstractToolchainGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/AbstractToolchainGroovyCompileIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.groovy.compile
 
 import org.gradle.internal.jvm.Jvm
+import org.gradle.testing.fixture.GroovyCoverage
 import org.junit.Assume
+
 
 abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
 
@@ -26,6 +28,8 @@ abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCo
     def setup() {
         jdk = computeJdkForTest()
         Assume.assumeNotNull(jdk)
+        Assume.assumeTrue(GroovyCoverage.supportsJavaVersion(version, jdk.javaVersion))
+
         executer.beforeExecute {
             withArgument("-Porg.gradle.java.installations.paths=${jdk.javaHome.absolutePath}")
         }
@@ -35,13 +39,13 @@ abstract class AbstractToolchainGroovyCompileIntegrationTest extends ApiGroovyCo
 
     @Override
     String compilerConfiguration() {
-"""
-    java {
-        toolchain {
-            languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
-        }
-    }
-"""
+        """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
+                }
+            }
+        """
     }
 
     @Override

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/HigherToolchainGroovyCompileIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/HigherToolchainGroovyCompileIntegrationTest.groovy
@@ -25,7 +25,7 @@ class HigherToolchainGroovyCompileIntegrationTest extends AbstractToolchainGroov
     @Override
     Jvm computeJdkForTest() {
         AvailableJavaHomes.getAvailableJdk {
-            it.languageVersion > Jvm.current().javaVersion && JavaVersion.VERSION_15.isCompatibleWith(it.languageVersion)
+            it.languageVersion > Jvm.current().javaVersion && JavaVersion.VERSION_16.isCompatibleWith(it.languageVersion)
         }
     }
 }


### PR DESCRIPTION
Test Groovy versions 3+ when running on JDK16.
