### PR TITLE
Disable testing TLSv1 and TLSv1.1 on JDK16

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/DeprecatedTLSVersionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/DeprecatedTLSVersionDependencyResolutionIntegrationTest.groovy
@@ -62,42 +62,11 @@ class DeprecatedTLSVersionDependencyResolutionIntegrationTest extends AbstractHt
         )
     }
 
-    def "unable to resolve dependencies when server does not support requested TLS version"() {
-        given:
-        keyStore.enableSslWithServerCert(mavenHttpRepo.server) {
-            it.addExcludeProtocols("TLSv1.2")
-            it.setExcludeCipherSuites()
-        }
-        keyStore.configureServerCert(executer)
-        def module = mavenHttpRepo.module('group', 'projectA', '1.2').publish()
-        and:
-        writeBuildFile()
-        when:
-        module.allowAll()
-        executer.withArgument("-Dhttps.protocols=TLSv1.2")
-        then:
-        executer.withStackTraceChecksDisabled()
-        fails('listJars')
-        and:
-        failure.assertHasDescription("Execution failed for task ':listJars'")
-        failure.assertHasCause("Could not GET '$server.uri")
-        failure.assertThatCause(
-            allOf(
-                anyOf(
-                    startsWith("The server does not support the client's requested TLS protocol versions:"),
-                    startsWith("The server may not support the client's requested TLS protocol versions:") // Windows
-                ),
-                containsString("You may need to configure the client to allow other protocols to be used."),
-                containsString("See: https://docs.gradle.org/")
-            )
-        )
-    }
-
     def "able to resolve dependencies when the user manually specifies the supported TLS versions using `https.protocols`"() {
         given:
         keyStore.enableSslWithServerCert(mavenHttpRepo.server) {
-            it.addExcludeProtocols("TLSv1.3")
-            it.setIncludeProtocols("TLSv1.2")
+            it.addExcludeProtocols("TLSv1.2", "TLSv1.3")
+            it.setIncludeProtocols("TLSv1", "TLSv1.1")
             it.setExcludeCipherSuites()
         }
         keyStore.configureServerCert(executer)
@@ -107,27 +76,27 @@ class DeprecatedTLSVersionDependencyResolutionIntegrationTest extends AbstractHt
         when:
         module.allowAll()
         and:
-        executer.withArgument("-Dhttps.protocols=TLSv1.2")
+        executer.withArgument("-Dhttps.protocols=TLSv1,TLSv1.1")
         then:
         succeeds('listJars')
     }
 
     def writeBuildFile() {
         buildFile << """
-            repositories {
-                maven {
-                    url "${mavenHttpRepo.uri}"
-                }
-            }
-            configurations { compile }
-            dependencies {
-                compile 'group:projectA:1.2'
-            }
-            task listJars {
-                doLast {
-                    assert configurations.compile.collect { it.name } == ['projectA-1.2.jar']
-                }
-            }
-        """
+repositories {
+    maven {
+        url "${mavenHttpRepo.uri}"
+    }
+}
+configurations { compile }
+dependencies {
+    compile 'group:projectA:1.2'
+}
+task listJars {
+    doLast {
+        assert configurations.compile.collect { it.name } == ['projectA-1.2.jar']
+    }
+}
+"""
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/DeprecatedTLSVersionDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/DeprecatedTLSVersionDependencyResolutionIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.integtests.resolve.http
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.test.fixtures.keystore.TestKeyStore
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 import static org.hamcrest.CoreMatchers.allOf
@@ -62,6 +64,8 @@ class DeprecatedTLSVersionDependencyResolutionIntegrationTest extends AbstractHt
         )
     }
 
+    // TLSv1 and TLSv1.1 are disabled by default on JDK16: https://bugs.openjdk.java.net/browse/JDK-8202343
+    @Requires(TestPrecondition.JDK15_OR_EARLIER)
     def "able to resolve dependencies when the user manually specifies the supported TLS versions using `https.protocols`"() {
         given:
         keyStore.enableSslWithServerCert(mavenHttpRepo.server) {
@@ -83,20 +87,20 @@ class DeprecatedTLSVersionDependencyResolutionIntegrationTest extends AbstractHt
 
     def writeBuildFile() {
         buildFile << """
-repositories {
-    maven {
-        url "${mavenHttpRepo.uri}"
-    }
-}
-configurations { compile }
-dependencies {
-    compile 'group:projectA:1.2'
-}
-task listJars {
-    doLast {
-        assert configurations.compile.collect { it.name } == ['projectA-1.2.jar']
-    }
-}
-"""
+            repositories {
+                maven {
+                    url "${mavenHttpRepo.uri}"
+                }
+            }
+            configurations { compile }
+            dependencies {
+                compile 'group:projectA:1.2'
+            }
+            task listJars {
+                doLast {
+                    assert configurations.compile.collect { it.name } == ['projectA-1.2.jar']
+                }
+            }
+        """
     }
 }


### PR DESCRIPTION
TLSv1 and TLSv1.1 have been deprecated and they are disabled by default in JDK16: https://bugs.openjdk.java.net/browse/JDK-8202343
