### PR TITLE
Add plugin validation smoke test for the Kotlin plugins

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -28,6 +28,10 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         [:]
     }
 
+    Map<String, String> getExtraPluginsRequiredForValidation(String testedPluginId, String version) {
+        extraPluginsRequiredForValidation
+    }
+
     String getBuildScriptConfigurationForValidation() {
         ""
     }
@@ -46,7 +50,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         because = "some plugins are not compatible with the configuration cache but it doesn't really matter because we get the results with the regular test suite"
     )
     def "performs static analysis of plugin #id version #version"() {
-        def extraPluginsBlock = extraPluginsRequiredForValidation.collect { pluginId, pluginVersion ->
+        def extraPluginsBlock = getExtraPluginsRequiredForValidation(id, version).collect { pluginId, pluginVersion ->
             "                id '$pluginId'" + (pluginVersion ? "version '$pluginVersion'" : "")
         }.join('\n')
 


### PR DESCRIPTION
This adds plugin validation tests for the Kotlin plugins.

It also seems like the plugin id reported for the Android plugin was different in some of the runs for AGP 1.4.30. I fixed this by making sure `PluginRegistry.findPluginForClass()` returns the same value no matter in what order the plugins have been queried.

Fixes https://github.com/gradle/gradle-private/issues/3306.