### PR TITLE
Patch Groovy interoperability in Kotlin DSL for GroovyObject method calls in withGroovyBuilder

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -263,6 +263,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      */
     File getBuildDir();
 
+
     /**
      * <p>Sets the build directory of this project. The build directory is the directory which all artifacts are
      * generated into.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -263,7 +263,6 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      */
     File getBuildDir();
 
-
     /**
      * <p>Sets the build directory of this project. The build directory is the directory which all artifacts are
      * generated into.</p>

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
@@ -25,7 +25,10 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
     @Test
     fun `can call GroovyObject methods in withGroovyBuilder`() {
         withDefaultSettings()
-        withFile("groovy.gradle", """
+
+        withFile(
+            "groovy.gradle",
+            """
             class MyExtension {
                 String server = 'default'
             }
@@ -37,8 +40,11 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
             }
 
             pluginManager.apply(MyPlugin)
-        """)
-        withBuildScript("""
+        """
+        )
+
+        withBuildScript(
+            """
             apply(from = "groovy.gradle")
 
             extensions["myextension"].withGroovyBuilder {
@@ -46,7 +52,8 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
                 setProperty("server", "newValue")
                 setMetaClass(getMetaClass())
             }
-        """)
+        """
+        )
 
         build()
     }

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.integration
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.junit.Test
+
+
+class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    fun `can call GroovyObject methods in withGroovyBuilder`() {
+        withDefaultSettings()
+        withFile("groovy.gradle", """
+            class MyExtension {
+                String server = 'default'
+            }
+
+            class MyPlugin implements Plugin<Project> {
+                void apply(project) {
+                    project.extensions.add('myextension', MyExtension)
+                }
+            }
+
+            pluginManager.apply(MyPlugin)
+        """)
+        withBuildScript("""
+            apply(from = "groovy.gradle")
+
+            extensions["myextension"].withGroovyBuilder {
+                getProperty("server")
+                setProperty("server", "newValue")
+                setMetaClass(getMetaClass())
+            }
+        """)
+
+        build()
+    }
+}

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
@@ -40,7 +40,7 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
             }
 
             pluginManager.apply(MyPlugin)
-        """
+            """
         )
 
         withBuildScript(
@@ -52,7 +52,7 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
                 setProperty("server", "newValue")
                 setMetaClass(getMetaClass())
             }
-        """
+            """
         )
 
         build()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -260,10 +260,26 @@ interface GroovyBuilderScope : GroovyObject {
 
 
 private
-class GroovyBuilderScopeForGroovyObject(override val delegate: GroovyObject) : GroovyBuilderScope, GroovyObject by delegate {
+class GroovyBuilderScopeForGroovyObject(override val delegate: GroovyObject) : GroovyBuilderScope {
 
     override fun String.invoke(vararg arguments: Any?): Any? =
         delegate.invokeMethod(this, arguments)
+
+    override fun getProperty(propertyName: String?): Any? {
+        return delegate.getProperty(propertyName)
+    }
+
+    override fun setProperty(propertyName: String?, newValue: Any?) {
+        return delegate.setProperty(propertyName, newValue)
+    }
+
+    override fun getMetaClass(): MetaClass {
+        return delegate.metaClass
+    }
+
+    override fun setMetaClass(metaClass: MetaClass?) {
+        delegate.metaClass = metaClass
+    }
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -19,11 +19,8 @@ package org.gradle.kotlin.dsl
 import groovy.lang.Closure
 import groovy.lang.GroovyObject
 import groovy.lang.MetaClass
-
-import org.gradle.kotlin.dsl.support.uncheckedCast
-
 import org.codehaus.groovy.runtime.InvokerHelper.getMetaClass
-
+import org.gradle.kotlin.dsl.support.uncheckedCast
 import org.gradle.kotlin.dsl.support.unsafeLazy
 
 


### PR DESCRIPTION
Fixes #16297

In Groovy 3, the `getProperty/setProperty/...` methods on the `GroovyObject` interface were converted to default methods. `GroovyBuilderScopeForGroovyObject` implements the `GroovyOject` interface by delegating to a `GroovyObject` instance. Because of the default methods, the delegation breaks the methods are invoked on `GroovyBuilderScopeForGroovyObject` which breaks the functionality.

The solution is to drop the delegation and invoke the `GroovyObject` methods explicitly in `GroovyBuilderScopeForGroovyObject`.