### PR TITLE
Improve documentation on publishing distributions

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/distribution_plugin.adoc
@@ -105,7 +105,7 @@ A distribution can be published using the <<publishing_ivy.adoc#publishing_ivy, 
 [[sec:publishing_distributions_publish_plugins]]
 === Using the Ivy/Maven Publish Plugins
 
-To publish a distribution to an Ivy repository with the <<publishing_ivy.adoc#publishing_ivy, Ivy Publish Plugin>>, simply add one or both of its archive tasks to an link:{groovyDslPath}/org.gradle.api.publish.ivy.IvyPublication.html[IvyPublication]. The following sample demonstrates how to add the ZIP archive of the `main` distribution and the TAR archive of the `custom` distribution to the `myDistribution` publication:
+To publish a distribution to an Ivy repository with the <<publishing_ivy.adoc#publishing_ivy, Ivy Publish Plugin>>, add one or both of its archive tasks to an link:{groovyDslPath}/org.gradle.api.publish.ivy.IvyPublication.html[IvyPublication]. The following sample demonstrates how to add the ZIP archive of the `main` distribution and the TAR archive of the `custom` distribution to the `myDistribution` publication:
 
 .Adding distribution archives to an Ivy publication
 ====

--- a/subprojects/docs/src/snippets/ivy-publish/distribution/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ivy-publish/distribution/kotlin/build.gradle.kts
@@ -28,7 +28,7 @@ distributions {
 publishing {
     publications {
         create<IvyPublication>("myDistribution") {
-            artifact(tasks.distZip.get())
+            artifact(tasks.distZip)
             artifact(tasks["customDistTar"])
         }
     }

--- a/subprojects/docs/src/snippets/ivy-publish/distribution/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ivy-publish/distribution/kotlin/build.gradle.kts
@@ -28,7 +28,7 @@ distributions {
 publishing {
     publications {
         create<IvyPublication>("myDistribution") {
-            artifact(tasks.distZip)
+            artifact(tasks.distZip.get())
             artifact(tasks["customDistTar"])
         }
     }

--- a/subprojects/docs/src/snippets/maven-publish/distribution/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/maven-publish/distribution/kotlin/build.gradle.kts
@@ -28,7 +28,7 @@ distributions {
 publishing {
     publications {
         create<MavenPublication>("myDistribution") {
-            artifact(tasks.distZip.get())
+            artifact(tasks.distZip)
             artifact(tasks["customDistTar"])
         }
     }


### PR DESCRIPTION
- Remove 'simply' as it's only simple for the author but not necessarily
  for the reader.
- Adapt Kotlin snippet to artifact method being able to process
  TaskProviders now.
