### PR TITLE
Replace deprecated ctors with factory methods

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyRead.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyRead.groovy
@@ -148,7 +148,7 @@ abstract class SystemPropertyRead {
         return new SystemPropertyRead() {
             @Override
             String getJavaExpression() {
-                return "Integer.getInteger(\"$name\", new Integer($defaultValue))"
+                return "Integer.getInteger(\"$name\", Integer.valueOf($defaultValue))"
             }
 
             @Override
@@ -205,7 +205,7 @@ abstract class SystemPropertyRead {
         return new SystemPropertyRead() {
             @Override
             String getJavaExpression() {
-                return "Long.getLong(\"$name\", new Long($defaultValue))"
+                return "Long.getLong(\"$name\", Long.valueOf($defaultValue))"
             }
 
             @Override


### PR DESCRIPTION
new Integer(int)/new Long(long) have been deprecated in Java16.
Replace them with equivalent factory methods in tests.
