### PR TITLE
Rename JavaIncrementalExecution{Integration -> Performance}Test

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -400,7 +400,7 @@
     "linux" : 459000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for abi change",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for abi change",
   "durations" : [ {
     "testProject" : "largeGroovyMultiProject",
     "linux" : 662000
@@ -417,7 +417,7 @@
     "linux" : 929000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for abi change with configuration caching",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for abi change with configuration caching",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 329000,
@@ -425,7 +425,7 @@
     "macOs" : 659000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for non-abi change",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change",
   "durations" : [ {
     "testProject" : "largeGroovyMultiProject",
     "linux" : 564000
@@ -442,7 +442,7 @@
     "linux" : 934000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for non-abi change with configuration caching",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change with configuration caching",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 305000,
@@ -450,7 +450,7 @@
     "macOs" : 589000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.test for non-abi change",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 401000
@@ -462,7 +462,7 @@
     "linux" : 284000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble (parallel false)",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel false)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 508000
@@ -471,14 +471,14 @@
     "linux" : 154000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble (parallel true)",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel true)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 385000,
     "windows" : 484000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble with local build cache enabled (parallel false)",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 538000
@@ -487,7 +487,7 @@
     "linux" : 167000
   } ]
 }, {
-  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble with local build cache enabled (parallel true)",
+  "scenario" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
   "durations" : [ {
     "testProject" : "largeJavaMultiProject",
     "linux" : 405000

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -715,7 +715,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for abi change",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for abi change",
     "groups" : [ {
       "testProject" : "largeGroovyMultiProject",
       "coverage" : {
@@ -738,7 +738,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for abi change with configuration caching",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for abi change with configuration caching",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -746,7 +746,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for non-abi change",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change",
     "groups" : [ {
       "testProject" : "largeGroovyMultiProject",
       "coverage" : {
@@ -769,7 +769,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.assemble for non-abi change with configuration caching",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.assemble for non-abi change with configuration caching",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -777,7 +777,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.test for non-abi change",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.test for non-abi change",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -795,7 +795,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble (parallel false)",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel false)",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -808,7 +808,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble (parallel true)",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel true)",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -816,7 +816,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble with local build cache enabled (parallel false)",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {
@@ -829,7 +829,7 @@
       }
     } ]
   }, {
-    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionIntegrationTest.up-to-date assemble with local build cache enabled (parallel true)",
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",
       "coverage" : {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -36,7 +36,7 @@ import static org.gradle.performance.results.OperatingSystem.MAC_OS
 import static org.gradle.performance.results.OperatingSystem.WINDOWS
 
 @LeaksFileHandles("The TAPI keeps handles to the distribution it starts open in the test JVM")
-class JavaIncrementalExecutionIntegrationTest extends AbstractIncrementalExecutionPerformanceTest {
+class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecutionPerformanceTest {
     JavaTestProject testProject
     boolean isGroovyProject
 


### PR DESCRIPTION
I called the test `IntegrationTest` instead of `PerformanceTest` when I introduced it 🤦 