### PR TITLE
Fix flakiness in experimental compiler warning silencer

### DIFF
--- a/.teamcity/subprojects.json
+++ b/.teamcity/subprojects.json
@@ -422,7 +422,7 @@
   {
     "dirName": "kotlin-dsl-plugins",
     "name": "kotlin-dsl-plugins",
-    "unitTests": false,
+    "unitTests": true,
     "functionalTests": true,
     "crossVersionTests": false
   },

--- a/subprojects/kotlin-dsl-plugins/build.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation(libs.futureKotlin("gradle-plugin"))
     implementation(libs.futureKotlin("sam-with-receiver"))
 
+    testImplementation(project(":logging"))
+
     integTestImplementation(project(":base-services"))
     integTestImplementation(project(":logging"))
     integTestImplementation(project(":core-api"))

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/ExperimentalCompilerWarningSilencer.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/ExperimentalCompilerWarningSilencer.kt
@@ -20,11 +20,10 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 
 
-internal
 class ExperimentalCompilerWarningSilencer(private val warningsToSilence: List<String>) : ContextAwareTaskLogger.MessageRewriter {
 
     private
-    val unsafeCompilerArgumentsWarningHeader = "This build uses unsafe internal compiler arguments:"
+    val unsafeCompilerArgumentsWarningFooter = "This mode is not recommended for production use,"
 
     override fun rewrite(logLevel: LogLevel, message: String): String? {
         return if (containsWarningsToBeSilenced(logLevel, message)) {
@@ -51,7 +50,7 @@ class ExperimentalCompilerWarningSilencer(private val warningsToSilence: List<St
         if (logLevel != LogLevel.WARN && logLevel != LogLevel.ERROR) {
             return false
         }
-        if (!message.contains(unsafeCompilerArgumentsWarningHeader)) {
+        if (!message.contains(unsafeCompilerArgumentsWarningFooter)) {
             return false
         }
         return true

--- a/subprojects/kotlin-dsl-plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/ExperimentalCompilerWarningSilencerTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/test/kotlin/org/gradle/kotlin/dsl/plugins/dsl/ExperimentalCompilerWarningSilencerTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.plugins.dsl
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.logging.LogLevel
+import org.junit.Test
+
+
+class ExperimentalCompilerWarningSilencerTest {
+
+    private
+    val warningToSilence = "-XXLanguage:+DisableCompatibilityModeForNewInference"
+
+    private
+    val silencer = ExperimentalCompilerWarningSilencer(listOf(warningToSilence))
+
+    @Test
+    fun `returns log message as-is when it does not contain warning to silence`() {
+        val rewrittenMessage = silencer.rewrite(LogLevel.WARN, "foo")
+
+        assertThat(rewrittenMessage).isEqualTo("foo")
+    }
+
+    @Test
+    fun `silences experimental compiler warning`() {
+        val rewrittenMessage = silencer.rewrite(
+            LogLevel.WARN,
+            """
+            This build uses unsafe internal compiler arguments:
+
+            $warningToSilence
+
+            This mode is not recommended for production use,
+            as no stability/compatibility guarantees are given on
+            compiler or generated code. Use it at your own risk!
+            """.trimIndent()
+        )
+
+        assertThat(rewrittenMessage).isNull()
+    }
+
+    @Test
+    fun `silences requested experimental compiler warning and preserves the rest of warnings`() {
+        val rewrittenMessage = silencer.rewrite(
+            LogLevel.WARN,
+            """
+            This build uses unsafe internal compiler arguments:
+
+            $warningToSilence
+            -XXLanguage:+FunctionReferenceWithDefaultValueAsOtherType
+
+            This mode is not recommended for production use,
+            as no stability/compatibility guarantees are given on
+            compiler or generated code. Use it at your own risk!
+            """.trimIndent()
+        )
+
+        assertThat(rewrittenMessage).isEqualTo(
+            """
+            This build uses unsafe internal compiler arguments:
+
+            -XXLanguage:+FunctionReferenceWithDefaultValueAsOtherType
+
+            This mode is not recommended for production use,
+            as no stability/compatibility guarantees are given on
+            compiler or generated code. Use it at your own risk!
+            """.trimIndent()
+        )
+    }
+
+    // this happens sometimes when for some reason incremental compilation fails with warning:
+    // Could not perform incremental compilation: Could not connect to Kotlin compile daemon
+    // Could not connect to kotlin daemon. Using fallback strategy.
+    @Test
+    fun `silences experimental compiler warning when warning header is missing`() {
+        val rewrittenMessage = silencer.rewrite(
+            LogLevel.WARN,
+            """
+
+            $warningToSilence
+
+            This mode is not recommended for production use,
+            as no stability/compatibility guarantees are given on
+            compiler or generated code. Use it at your own risk!
+            """.trimIndent()
+        )
+
+        assertThat(rewrittenMessage).isNull()
+    }
+}


### PR DESCRIPTION
Sometimes it happens that the experimental compiler
warning we want to silence is output without the header that
is used to identify the log message: https://ge.gradle.org/s/jbhpumzyqkdea/tests/:kotlin-dsl-plugins:embeddedIntegTest/org.gradle.kotlin.dsl.plugins.dsl.KotlinCompilerWarningsTest/experimental%20compiler%20warnings%20are%20not%20shown%20for%20known%20experimental%20features#1

This change uses the warning footer for identifying such messages instead.