### PR TITLE
Make IDEA convention mapping behave more intuitively

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -266,10 +266,11 @@ public class IdeaPlugin extends IdePlugin {
         module.setName(defaultModuleName);
 
         ConventionMapping conventionMapping = ((IConventionAware) module).getConventionMapping();
+        Set<File> sourceDirs = Sets.newLinkedHashSet();
         conventionMapping.map("sourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
-                return Sets.newLinkedHashSet();
+                return sourceDirs;
             }
         });
         conventionMapping.map("contentRoot", new Callable<File>() {
@@ -278,31 +279,35 @@ public class IdeaPlugin extends IdePlugin {
                 return project.getProjectDir();
             }
         });
+        Set<File> testSourceDirs = Sets.newLinkedHashSet();
         conventionMapping.map("testSourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
-                return Sets.newLinkedHashSet();
+                return testSourceDirs;
             }
         });
+        Set<File> resourceDirs = Sets.newLinkedHashSet();
         conventionMapping.map("resourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() throws Exception {
-                return Sets.newLinkedHashSet();
+                return resourceDirs;
             }
         });
+        Set<File> testResourceDirs = Sets.newLinkedHashSet();
         conventionMapping.map("testResourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() throws Exception {
-                return Sets.newLinkedHashSet();
+                return testResourceDirs;
             }
         });
+
+        Set<File> excludeDirs = Sets.newLinkedHashSet();
         conventionMapping.map("excludeDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
-                Set<File> defaultExcludes = Sets.newLinkedHashSet();
-                defaultExcludes.add(project.file(".gradle"));
-                defaultExcludes.add(project.getBuildDir());
-                return defaultExcludes;
+                excludeDirs.add(project.file(".gradle"));
+                excludeDirs.add(project.getBuildDir());
+                return excludeDirs;
             }
         });
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/idea/IdeaPluginTest.groovy
@@ -213,6 +213,21 @@ class IdeaPluginTest extends AbstractProjectBuilderSpec {
         publicTypeOfExtension("idea") == typeOf(IdeaModel)
     }
 
+    def "can add to file set properties"() {
+        given:
+        applyPluginToProjects()
+        def source = new File("foo")
+
+        when:
+        property(project.idea.module).add(source)
+
+        then:
+        property(project.idea.module).contains(source)
+
+        where:
+        property << [{ it.sourceDirs }, { it.testSourceDirs }, { it.resourceDirs }, { it.testResourceDirs }, { it.excludeDirs }]
+    }
+
     private TypeOf<?> publicTypeOfExtension(String named) {
         project.extensions.extensionsSchema.find { it.name == named }.publicType
     }


### PR DESCRIPTION
By always returning the same Set from the convention mapping,
so that add() calls are never lost.

Fixes #8749

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
