### PR TITLE
Apply Kotlin compiler workaround for JDK16 in build-init

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -103,7 +103,7 @@ class KotlinApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
 
         class SampleMain {
         }
-"""
+        """
         subprojectDir.file("src/test/kotlin/org/acme/SampleMainTest.kt") << """
                 package org.acme
 

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -91,13 +91,13 @@ class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
 
             class SampleMain {
             }
-    """
+        """
         subprojectDir.file("src/test/kotlin/org/acme/SampleMainTest.kt") << """
-                    package org.acme
+            package org.acme
 
-                    class SampleMainTest {
-                    }
-            """
+            class SampleMainTest {
+            }
+        """
         when:
         run('init', '--type', 'kotlin-library', '--dsl', scriptDsl.id)
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmApplicationProjectInitDescriptor.java
@@ -46,6 +46,7 @@ public class JvmApplicationProjectInitDescriptor extends JvmProjectInitDescripto
     @Override
     public void generateProjectBuildScript(String projectName, InitSettings settings, BuildScriptBuilder buildScriptBuilder) {
         super.generateProjectBuildScript(projectName, settings, buildScriptBuilder);
+        applyKotlinCompilerWorkaroundIfJdk16(settings);
 
         if ("app".equals(projectName)) {
             buildScriptBuilder.block(null, "application", b -> {

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmLibraryProjectInitDescriptor.java
@@ -39,6 +39,7 @@ public class JvmLibraryProjectInitDescriptor extends JvmProjectInitDescriptor {
     @Override
     public void generateProjectBuildScript(String projectName, InitSettings settings, BuildScriptBuilder buildScriptBuilder) {
         super.generateProjectBuildScript(projectName, settings, buildScriptBuilder);
+        applyKotlinCompilerWorkaroundIfJdk16(settings);
 
         applyLibraryPlugin(buildScriptBuilder);
         buildScriptBuilder.dependency(


### PR DESCRIPTION
Build init for Kotlin projects will generate a gradle.properties with a workaround
property that allows Kotlin JVM plugin to compile Kotlin on JDK16.
