### PR TITLE
Improve writing the performance test JSON files

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -303,7 +303,8 @@ fun Project.propertiesForPerformanceDb(): Map<String, String> {
     } else {
         selectStringProperties(
             PropertyNames.dbUrl,
-            PropertyNames.dbUsername
+            PropertyNames.dbUsername,
+            PropertyNames.dbPassword
         )
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinition.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinition.groovy
@@ -69,6 +69,7 @@ class PerformanceTestScenarioDefinition {
     void writeTo(File file) {
         sort()
         new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(file, this)
+        file.append('\n')
     }
 
     PerformanceTestScenarioDefinition sort() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestRuntimesGenerator.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +73,7 @@ public class PerformanceTestRuntimesGenerator {
 
         new ObjectMapper().writerWithDefaultPrettyPrinter()
             .writeValue(runtimesFile, json);
+        Files.write(runtimesFile.toPath(), "\n".getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
     }
 
 }


### PR DESCRIPTION
These are some small improvements for the tasks writing `performance-tests-ci.json` and `performance-test-durations.json`:
- Append a newline to the end of the JSON files as configured by our `.editorconfig`
- Allow specifying the performance DB password in the user's `gradle.properties`.