### PR TITLE
Allow HttpBuildCache to optionally follow redirects

### DIFF
--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -175,7 +175,7 @@ public class HttpBuildCache extends AbstractBuildCache {
     /**
      * Specifies whether it is acceptable to follow a redirect from the build cache server.
      *
-     * @see #isAllowInsecureProtocol()
+     * @see #isFollowRedirects()
      * @since 7.0
      */
     @Incubating

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -41,6 +41,7 @@ public class HttpBuildCache extends AbstractBuildCache {
     private URI url;
     private boolean allowUntrustedServer;
     private boolean allowInsecureProtocol;
+    private boolean followRedirects;
 
     public HttpBuildCache() {
         this.credentials = new HttpBuildCacheCredentials();
@@ -157,4 +158,28 @@ public class HttpBuildCache extends AbstractBuildCache {
     public void setAllowInsecureProtocol(boolean allowInsecureProtocol) {
         this.allowInsecureProtocol = allowInsecureProtocol;
     }
+
+    /**
+     * Specifies whether it is acceptable to follow a redirect from the build cache server.
+     * <p>
+     * This intentionally requires a user to opt-in to follow a redirect on a case by case basis.
+     *
+     * @since 7.0
+     */
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    /**
+     * Specifies whether it is acceptable to follow a redirect from the build cache server.
+     *
+     * @see #isAllowInsecureProtocol()
+     * @since 7.0
+     */
+    public void setFollowRedirects(boolean followRedirects) {
+        this.followRedirects = followRedirects;
+    }
+
+
+
 }

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -17,6 +17,7 @@
 package org.gradle.caching.http;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.caching.configuration.AbstractBuildCache;
 
 import javax.annotation.Nullable;
@@ -166,6 +167,7 @@ public class HttpBuildCache extends AbstractBuildCache {
      *
      * @since 7.0
      */
+    @Incubating
     public boolean isFollowRedirects() {
         return followRedirects;
     }
@@ -176,6 +178,7 @@ public class HttpBuildCache extends AbstractBuildCache {
      * @see #isAllowInsecureProtocol()
      * @since 7.0
      */
+    @Incubating
     public void setFollowRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
     }

--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/internal/DefaultHttpBuildCacheServiceFactory.java
@@ -78,13 +78,14 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
         boolean authenticated = !authentications.isEmpty();
         boolean allowUntrustedServer = configuration.isAllowUntrustedServer();
         boolean allowInsecureProtocol = configuration.isAllowInsecureProtocol();
+        boolean followRedirects = configuration.isFollowRedirects();
 
         HttpRedirectVerifier redirectVerifier =
             createRedirectVerifier(noUserInfoUrl, allowInsecureProtocol);
 
         DefaultHttpSettings.Builder builder = DefaultHttpSettings.builder()
             .withAuthenticationSettings(authentications)
-            .followRedirects(false)
+            .followRedirects(followRedirects)
             .withRedirectVerifier(redirectVerifier);
         if (allowUntrustedServer) {
             builder.allowUntrustedConnections();
@@ -96,6 +97,7 @@ public class DefaultHttpBuildCacheServiceFactory implements BuildCacheServiceFac
         describer.type("HTTP")
             .config("url", noUserInfoUrl.toASCIIString())
             .config("authenticated", Boolean.toString(authenticated))
+            .config("followRedirects", Boolean.toString(followRedirects))
             .config("allowUntrustedServer", Boolean.toString(allowUntrustedServer))
             .config("allowInsecureProtocol", Boolean.toString(allowInsecureProtocol));
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.caching.http.HttpBuildCache.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.caching.http.HttpBuildCache.xml
@@ -32,6 +32,9 @@
             <tr>
                 <td>allowInsecureProtocol</td>
             </tr>
+            <tr>
+                <td>followRedirects</td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
@@ -314,6 +314,18 @@ include::sample[dir="snippets/buildCache/http-build-cache/groovy",files="setting
 include::sample[dir="snippets/buildCache/http-build-cache/kotlin",files="settings.gradle.kts[tags=allow-untrusted-server]"]
 ====
 
+[NOTE]
+====
+The HTTP build cache does not support following HTTP redirects by default. You may encounter problems using a build cache backend that requires HTTP clients that support HTTP redirects.
+In that case, set link:{groovyDslPath}/org.gradle.caching.http.HttpBuildCache.html#org.gradle.caching.http.HttpBuildCache:followRedirects[HttpBuildCache.isFollowRedirects()] to `true`.
+====
+
+.Follow Redirects
+====
+include::sample[dir="snippets/buildCache/http-build-cache/groovy",files="settings.gradle[tags=follow-redirects]"]
+include::sample[dir="snippets/buildCache/http-build-cache/kotlin",files="settings.gradle.kts[tags=follow-redirects]"]
+====
+
 [[sec:build_cache_configure_use_cases]]
 === Configuration use cases
 

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/groovy/settings.gradle
@@ -16,3 +16,12 @@ buildCache {
     }
 }
 // end::allow-untrusted-server[]
+
+// tag::follow-redirects[]
+buildCache {
+    remote(HttpBuildCache) {
+        url = 'https://example.com:8123/cache/'
+        followRedirects = true
+    }
+}
+// end::follow-redirects[]

--- a/subprojects/docs/src/snippets/buildCache/http-build-cache/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/http-build-cache/kotlin/settings.gradle.kts
@@ -15,3 +15,12 @@ buildCache {
     }
 }
 // end::allow-untrusted-server[]
+
+// tag::follow-redirects[]
+buildCache {
+    remote<HttpBuildCache> {
+        url = uri("https://example.com:8123/cache/")
+        isFollowRedirects = true
+    }
+}
+// end::follow-redirects[]


### PR DESCRIPTION
Fixes #14433

### Context
Some build-cache server implementations require support for HTTP 302 redirects. Jfrog's Artifactory is one of these build-cache implementations. This PR introduces a new option to configure the HttpBuildCache to support HTTP 302 redirects.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
