### PR TITLE
Add JDK16 workaround in embedded Kotlin test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/util/VersionNumberIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/util/VersionNumberIntegrationTest.groovy
@@ -16,14 +16,22 @@
 
 package org.gradle.util
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.dsl.GradleDsl
 
 
 class VersionNumberIntegrationTest extends AbstractIntegrationSpec {
 
-    def "nullability with Kotlin jsr-305 strict"() {
+    def setup() {
+        // Workaround until external kotlin-dsl plugins support JDK16 properly
+        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            System.setProperty("kotlin.daemon.jvm.options", "--illegal-access=permit")
+        }
+    }
 
+    def "nullability with Kotlin jsr-305 strict"() {
         given:
         file("src/main/kotlin/Test.kt") << """
             import org.gradle.util.VersionNumber

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -24,15 +24,26 @@ import org.gradle.api.logging.Logger
 
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 import org.hamcrest.CoreMatchers.containsString
 
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
 import org.junit.Test
 
 
 class EmbeddedKotlinPluginTest : AbstractPluginTest() {
+
+    @Before
+    fun `apply Kotlin JDK16 workaround`() {
+        // Workaround until external kotlin-dsl plugins support JDK16 properly
+        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            System.setProperty("kotlin.daemon.jvm.options", "--illegal-access=permit")
+        }
+    }
 
     @Test
     fun `applies the kotlin plugin`() {

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -45,6 +45,8 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
             kotlinDslPluginOptions {
                 tasks.withType<KotlinCompile>().configureEach {
                     it.doFirst {
+                        // Workaround until external kotlin-dsl plugins support JDK16 properly
+                        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
                         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
                             System.setProperty("kotlin.daemon.jvm.options", "--illegal-access=permit")
                         }


### PR DESCRIPTION
Apply JDK16 workaround for embedded Kotlin JVM plugins used in our tests so that we do not lose coverage on JDK16 until the root cause is fixed in external Kotlin DSL plugins (which should happen with 1.5.x line). https://youtrack.jetbrains.com/issue/KT-43704#focus=Comments-27-4625141.0-0