### PR TITLE
Make precompiled kotlin-dsl scripts adapters comply with ktlint conventions 0.7.0

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -29,7 +29,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
             """
             plugins {
                 `kotlin-dsl`
-                id("org.gradle.kotlin-dsl.ktlint-convention") version "0.6.0"
+                id("org.gradle.kotlin-dsl.ktlint-convention") version "0.7.0"
             }
 
             $repositoriesBlock

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateScriptPluginAdapters.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GenerateScriptPluginAdapters.kt
@@ -75,6 +75,7 @@ fun PrecompiledScriptPlugin.writeScriptPluginAdapterTo(outputDir: File) {
 
         $packageDeclaration
 
+
         /**
          * Precompiled [$scriptFileName][$compiledScriptTypeName] script plugin.
          *


### PR DESCRIPTION
As a prerequisite for https://github.com/gradle/gradle/pull/16376