### PR TITLE
Do not allow use of configuration cache with GradleBuild task

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheStartParameter.kt
@@ -21,13 +21,16 @@ import org.gradle.api.internal.StartParameterInternal
 import org.gradle.configurationcache.extensions.unsafeLazy
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.initialization.layout.BuildLayout
+import org.gradle.internal.buildtree.BuildTreeBuildPath
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
+import org.gradle.util.Path
 import java.io.File
 
 
 @ServiceScope(Scopes.BuildTree::class)
 class ConfigurationCacheStartParameter(
+    private val buildTreeBuildPath: BuildTreeBuildPath,
     private val buildLayout: BuildLayout,
     startParameter: StartParameter
 ) {
@@ -36,7 +39,8 @@ class ConfigurationCacheStartParameter(
     val startParameter = startParameter as StartParameterInternal
 
     val isEnabled: Boolean
-        get() = startParameter.isConfigurationCache
+        get() = buildTreeBuildPath.path == Path.ROOT // Do not attempt to use configuration caching for GradleBuild task
+            && startParameter.isConfigurationCache
 
     val isQuiet: Boolean
         get() = startParameter.isConfigurationCacheQuiet

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.initialization.layout.BuildLayout
+import org.gradle.internal.buildtree.BuildTreeBuildPath
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
@@ -91,6 +92,7 @@ class ConfigurationCacheKeyTest {
     fun cacheKeyStringFromStartParameter(configure: StartParameterInternal.() -> Unit): String =
         ConfigurationCacheKey(
             ConfigurationCacheStartParameter(
+                BuildTreeBuildPath.ROOT,
                 BuildLayout(
                     file("root"),
                     file("settings"),

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -34,6 +34,7 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.NestedBuildState;
 import org.gradle.internal.build.NestedRootBuild;
 import org.gradle.internal.build.RootBuildState;
+import org.gradle.internal.buildtree.BuildTreeBuildPath;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.Stoppable;
@@ -242,7 +243,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             StartParameter startParameter = buildDefinition.getStartParameter();
             BuildRequestMetaData buildRequestMetaData = new DefaultBuildRequestMetaData(Time.currentTimeMillis());
             BuildSessionState buildSessionState = new BuildSessionState(userHomeDirServiceRegistry, crossBuildSessionState, startParameter, buildRequestMetaData, ClassPath.EMPTY, buildCancellationToken, buildRequestMetaData.getClient(), new NoOpBuildEventConsumer());
-            BuildTreeState nestedBuildTree = new BuildTreeState(buildSessionState.getServices(), BuildType.TASKS);
+            BuildTreeState nestedBuildTree = new BuildTreeState(buildSessionState.getServices(), BuildType.TASKS, new BuildTreeBuildPath(build.getIdentityPath()));
             return doNewInstance(buildDefinition, build, parent, nestedBuildTree, ImmutableList.of(nestedBuildTree, buildSessionState));
         }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeBuildPath.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeBuildPath.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import org.gradle.util.Path;
+
+/**
+ * The path of the root of the build tree.
+ *
+ * This is only ever non root for the build tree's created by the GradleBuild task.
+ */
+public class BuildTreeBuildPath {
+
+    public final Path path;
+
+    public BuildTreeBuildPath(Path path) {
+        this.path = path;
+    }
+
+    public static final BuildTreeBuildPath ROOT = new BuildTreeBuildPath(Path.ROOT);
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeScopeServices.java
@@ -39,10 +39,12 @@ import java.util.List;
 public class BuildTreeScopeServices {
     private final BuildTreeState buildTree;
     private final BuildType buildType;
+    private final BuildTreeBuildPath buildTreeBuildPath;
 
-    public BuildTreeScopeServices(BuildTreeState buildTree, BuildType buildType) {
+    public BuildTreeScopeServices(BuildTreeState buildTree, BuildType buildType, BuildTreeBuildPath buildTreeBuildPath) {
         this.buildTree = buildTree;
         this.buildType = buildType;
+        this.buildTreeBuildPath = buildTreeBuildPath;
     }
 
     protected void configure(ServiceRegistration registration, List<PluginServiceRegistry> pluginServiceRegistries) {
@@ -51,6 +53,7 @@ public class BuildTreeScopeServices {
         }
         registration.add(BuildTreeState.class, buildTree);
         registration.add(BuildType.class, buildType);
+        registration.add(BuildTreeBuildPath.class, buildTreeBuildPath);
         registration.add(GradleEnterprisePluginManager.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeState.java
@@ -31,11 +31,11 @@ import java.util.function.Function;
 public class BuildTreeState implements Closeable {
     private final ServiceRegistry services;
 
-    public BuildTreeState(ServiceRegistry parent, BuildType buildType) {
+    public BuildTreeState(ServiceRegistry parent, BuildType buildType, BuildTreeBuildPath buildTreeBuildPath) {
         services = ServiceRegistryBuilder.builder()
             .displayName("build tree services")
             .parent(parent)
-            .provider(new BuildTreeScopeServices(this, buildType))
+            .provider(new BuildTreeScopeServices(this, buildType, buildTreeBuildPath))
             .build();
 
         // This initialization construct should be generalized for all types of service registries.

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -47,6 +47,7 @@ import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.RootBuildState;
+import org.gradle.internal.buildtree.BuildTreeBuildPath;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -108,7 +109,7 @@ public class ProjectBuilderImpl {
         CrossBuildSessionState crossBuildSessionState = new CrossBuildSessionState(globalServices, startParameter);
         GradleUserHomeScopeServiceRegistry userHomeServices = userHomeServicesOf(globalServices);
         BuildSessionState buildSessionState = new BuildSessionState(userHomeServices, crossBuildSessionState, startParameter, buildRequestMetaData, ClassPath.EMPTY, new DefaultBuildCancellationToken(), buildRequestMetaData.getClient(), new NoOpBuildEventConsumer());
-        BuildTreeState buildTreeState = new BuildTreeState(buildSessionState.getServices(), BuildType.TASKS);
+        BuildTreeState buildTreeState = new BuildTreeState(buildSessionState.getServices(), BuildType.TASKS, BuildTreeBuildPath.ROOT);
         TestBuildScopeServices buildServices = new TestBuildScopeServices(buildTreeState.getServices(), homeDir);
         TestRootBuild build = new TestRootBuild(projectDir);
         buildServices.add(BuildState.class, build);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeScopeLifecycleBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeScopeLifecycleBuildActionExecuter.java
@@ -17,6 +17,7 @@
 package org.gradle.launcher.exec;
 
 import org.gradle.api.internal.BuildType;
+import org.gradle.internal.buildtree.BuildTreeBuildPath;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.session.BuildSessionContext;
@@ -28,7 +29,7 @@ public class BuildTreeScopeLifecycleBuildActionExecuter implements BuildActionEx
     @Override
     public BuildActionResult execute(BuildAction action, BuildActionParameters actionParameters, BuildSessionContext buildSession) {
         BuildType buildType = action.isRunTasks() ? BuildType.TASKS : BuildType.MODEL;
-        try (BuildTreeState buildTree = new BuildTreeState(buildSession.getServices(), buildType)) {
+        try (BuildTreeState buildTree = new BuildTreeState(buildSession.getServices(), buildType, BuildTreeBuildPath.ROOT)) {
             return buildTree.run(context ->
                 context.getBuildTreeServices().get(BuildTreeBuildActionExecutor.class).execute(action, actionParameters, context));
         }


### PR DESCRIPTION
At least, the mechanism used to observe the classloader structure for serialization is not compatible with this usage.