### PR TITLE
Configure plugin validation outside of the expect block

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractPluginValidatingSmokeTest.groovy
@@ -64,9 +64,10 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
 
             $buildScriptConfigurationForValidation
         """
+        configureValidation(id, version)
 
         expect:
-        performValidation(id, version)
+        performValidation()
 
         where:
         iterations << iterations()
@@ -77,8 +78,7 @@ abstract class AbstractPluginValidatingSmokeTest extends AbstractSmokeTest imple
         allPlugins.alwaysPasses = true
     }
 
-    void performValidation(String pluginId, String version) {
-        configureValidation(pluginId, version)
+    void performValidation() {
         allPlugins.performValidation()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -378,13 +378,8 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
     }
 
     @Override
-    Map<String, String> getExtraPluginsRequiredForValidation(String testedPluginId, String version) {
-        AGP_VERSIONS.assumeCurrentJavaVersionIsSupportedBy(version)
-        return super.getExtraPluginsRequiredForValidation(testedPluginId, version)
-    }
-
-    @Override
     void configureValidation(String testedPluginId, String version) {
+        AGP_VERSIONS.assumeCurrentJavaVersionIsSupportedBy(version)
         buildFile << """
             android {
                 compileSdkVersion 24


### PR DESCRIPTION
That allows the `configureValidation()` method to throw assumption failed exceptions actually skipping the test and not failing it.