### PR TITLE
Remove DeprecationMessageBuilder.willBeRemovedInGradle7()

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -25,7 +25,6 @@ import java.util.List;
 @CheckReturnValue
 public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
 
-    private static final GradleVersion GRADLE7 = GradleVersion.version("7.0");
     private static final GradleVersion GRADLE8 = GradleVersion.version("8.0");
 
     private String summary;
@@ -51,26 +50,10 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
     }
 
     /**
-     * Output: This is scheduled to be removed in Gradle 7.0.
-     */
-    public WithDeprecationTimeline willBeRemovedInGradle7() {
-        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE7);
-        return new WithDeprecationTimeline(this);
-    }
-
-    /**
      * Output: This is scheduled to be removed in Gradle 8.0.
      */
     public WithDeprecationTimeline willBeRemovedInGradle8() {
         this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE8);
-        return new WithDeprecationTimeline(this);
-    }
-
-    /**
-     * Output: This will fail with an error in Gradle 7.0.
-     */
-    public WithDeprecationTimeline willBecomeAnErrorInGradle7() {
-        this.deprecationTimeline = DeprecationTimeline.willBecomeAnErrorInVersion(GRADLE7);
         return new WithDeprecationTimeline(this);
     }
 
@@ -243,15 +226,6 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             this.property = property;
         }
 
-        /**
-         * Output: This is scheduled to be removed in Gradle 7.
-         */
-        @Override
-        public WithDeprecationTimeline willBeRemovedInGradle7() {
-            setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE7));
-            return new WithDeprecationTimeline(this);
-        }
-
         @Override
         public WithDeprecationTimeline willBeRemovedInGradle8() {
             setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE8));
@@ -299,15 +273,6 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             this.systemProperty = systemProperty;
             // This never happens in user code
             setIndirectUsage();
-        }
-
-        /**
-         * Output: This is scheduled to be removed in Gradle 7.
-         */
-        @Override
-        public WithDeprecationTimeline willBeRemovedInGradle7() {
-            setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE7));
-            return new WithDeprecationTimeline(this);
         }
 
         @Override
@@ -487,13 +452,6 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
             this.behaviour = behaviour;
         }
 
-        /**
-         * Output: This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
-         */
-        public WithDeprecationTimeline willBeRemovedInGradle7() {
-            setDeprecationTimeline(DeprecationTimeline.behaviourWillBeRemovedInVersion(GRADLE7));
-            return new WithDeprecationTimeline(this);
-        }
         /**
          * Output: This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
          */


### PR DESCRIPTION
Everything has been removed which should have been removed for Gradle 7.0.

Fixes #16203.