### PR TITLE
Update test-distribution plugin to version 2.0-rc-6

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-5")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-6")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.13.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0-rc-5")
+    id("com.gradle.enterprise.test-distribution").version("2.0-rc-6")
 }
 
 includeBuild("build-logic-commons")

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
@@ -54,8 +54,6 @@ import static org.gradle.integtests.fixtures.compatibility.AbstractContextualMul
 public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutionContext> {
 
     private final TestEngine delegateEngine = new SpockEngine();
-    private final List<TestVariant> variants = new ArrayList<TestVariant>();
-
     @Override
     public String getId() {
         return "cross-version-test-engine";
@@ -68,8 +66,8 @@ public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutio
             return new EngineDescriptor(uniqueId, "skip");
         }
 
-        buildTestVariants(uniqueId, discoveryRequest);
-        return discoverTests(uniqueId);
+        List<TestVariant> testVariants = buildTestVariants(uniqueId, discoveryRequest);
+        return discoverTests(uniqueId, testVariants);
     }
 
     @Override
@@ -77,13 +75,16 @@ public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutio
         return new SpockExecutionContext(request.getEngineExecutionListener());
     }
 
-    private void buildTestVariants(UniqueId rootId, EngineDiscoveryRequest discoveryRequest) {
+    private List<TestVariant> buildTestVariants(UniqueId rootId, EngineDiscoveryRequest discoveryRequest) {
+        List<TestVariant> variants = new ArrayList<TestVariant>();
         variants.add(TestVariant.tapiCurrent(rootId, discoveryRequest));
         variants.add(TestVariant.selected(rootId, discoveryRequest));
         variants.add(TestVariant.tapiTargetLoaded(rootId, discoveryRequest));
+
+        return variants;
     }
 
-    private TestDescriptor discoverTests(UniqueId uniqueId) {
+    private TestDescriptor discoverTests(UniqueId uniqueId, List<TestVariant> variants) {
         EngineDescriptor rootDescriptor = new SpockEngineDescriptor(uniqueId, RunContext.get());
         for (TestVariant testVariant : variants) {
             for (TestDescriptor test : testVariant.discover(delegateEngine).getChildren()) {


### PR DESCRIPTION
Compared to 2.0-rc-5, this version offers:
* remote executors support session concept
* JVM for discovering tests is reused for one local executor actually executing tests

This means that the additional overhead we introduced when creating many more partitions than before (in order to be flexible with distributing work) is reduced now. The test JVM on the remote side keeps running and now executes multiple small partitions in a single session.

I've successfully ran it for `depMan:embeddedIntegTest` (see https://github.com/gradle/dotcom/issues/8078#issuecomment-790639227)
