### PR TITLE
Improvements to dependency locking

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/build/ConfigurationCacheIncludedBuildState.kt
@@ -30,7 +30,7 @@ import org.gradle.initialization.ConfigurationCache
 import org.gradle.initialization.DefaultGradleLauncher
 import org.gradle.initialization.DefaultGradleLauncherFactory
 import org.gradle.initialization.GradleLauncher
-import org.gradle.initialization.InternalBuildFinishedListener
+import org.gradle.initialization.internal.InternalBuildFinishedListener
 import org.gradle.initialization.SettingsPreparer
 import org.gradle.initialization.TaskExecutionPreparer
 import org.gradle.initialization.exception.ExceptionAnalyser

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -193,7 +193,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
         includedBuildControllers.finishBuild(failures);
         try {
             buildListener.buildFinished(buildResult);
-            buildFinishedListener.buildFinished((GradleInternal) buildResult.getGradle());
+            buildFinishedListener.buildFinished((GradleInternal) buildResult.getGradle(), buildResult.getFailure() != null);
         } catch (Throwable t) {
             failures.add(t);
         }

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -25,6 +25,7 @@ import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -29,6 +29,7 @@ import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.NestedBuildState;

--- a/subprojects/core/src/main/java/org/gradle/initialization/InternalBuildFinishedListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InternalBuildFinishedListener.java
@@ -25,8 +25,9 @@ public interface InternalBuildFinishedListener {
      * Called after all user buildFinished hooks have been executed, but before
      * services are shutdown.
      * @param gradle the Gradle instance being finalized
+     * @param failed
      */
-    default void buildFinished(GradleInternal gradle) {
+    default void buildFinished(GradleInternal gradle, boolean failed) {
 
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/internal/InternalBuildFinishedListener.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/internal/InternalBuildFinishedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.initialization;
+package org.gradle.initialization.internal;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.service.scopes.EventScope;

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.execution.BuildWorkExecutor
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.initialization.exception.ExceptionAnalyser
+import org.gradle.initialization.internal.InternalBuildFinishedListener
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.service.scopes.BuildScopeServices
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -429,8 +429,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             if (startParameter.isWriteDependencyLocks()) {
                 listenerManager.addListener(new InternalBuildFinishedListener() {
                     @Override
-                    public void buildFinished(GradleInternal gradle) {
-                        dependencyLockingProvider.buildFinished();
+                    public void buildFinished(GradleInternal gradle, boolean failed) {
+                        if (!failed) {
+                            dependencyLockingProvider.buildFinished();
+                        }
                     }
                 });
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -110,7 +110,7 @@ import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
-import org.gradle.initialization.InternalBuildFinishedListener;
+import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildState;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -686,7 +686,7 @@ class DependencyManagementBuildScopeServices {
         if (cacheDecoratorFactory instanceof CleaningInMemoryCacheDecoratorFactory) {
             listenerManager.addListener(new InternalBuildFinishedListener() {
                 @Override
-                public void buildFinished(GradleInternal build) {
+                public void buildFinished(GradleInternal build, boolean failed) {
                     ((CleaningInMemoryCacheDecoratorFactory) cacheDecoratorFactory).clearCaches(ComponentMetadataRuleExecutor::isMetadataRuleExecutorCache);
                 }
             });
@@ -719,7 +719,7 @@ class DependencyManagementBuildScopeServices {
     private void registerBuildFinishedHooks(ListenerManager listenerManager, DependencyVerificationOverride dependencyVerificationOverride) {
         listenerManager.addListener(new InternalBuildFinishedListener() {
             @Override
-            public void buildFinished(GradleInternal build) {
+            public void buildFinished(GradleInternal build, boolean failed) {
                 dependencyVerificationOverride.buildFinished(build);
             }
         });

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -140,7 +140,7 @@ import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.DependenciesAccessors;
-import org.gradle.initialization.InternalBuildFinishedListener;
+import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.initialization.layout.ProjectCacheDir;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ResolutionStrategyInternal.java
@@ -91,6 +91,14 @@ public interface ResolutionStrategyInternal extends ResolutionStrategy {
      */
     boolean isDependencyLockingEnabled();
 
+    /**
+     * Confirms that an unlocked configuration has been resolved.
+     * This allows the lock state for said configuration to be dropped if it existed before.
+     *
+     * @param configurationName the unlocked configuration
+     */
+    void confirmUnlockedConfigurationResolved(String configurationName);
+
     CapabilitiesResolutionInternal getCapabilitiesResolutionRules();
 
     boolean isFailingOnDynamicVersions();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyLockingProvider.java
@@ -24,17 +24,60 @@ import org.gradle.api.provider.Property;
 
 import java.util.Set;
 
+/**
+ * Provides dependency locking support for dependency configuration resolution.
+ */
 public interface DependencyLockingProvider {
 
+    /**
+     * Loads the lock state associated to the given configuration.
+     *
+     * @param configurationName the configuration to load lock state for
+     *
+     * @return the lock state of the configuration
+     * @throws org.gradle.internal.locking.MissingLockStateException If the {@code LockMode} is {@link LockMode#STRICT} but no lock state can be found.
+     */
     DependencyLockingState loadLockState(String configurationName);
 
+    /**
+     * Records the resolution result for a locked configuration.
+     *
+     * @param configurationName the configuration that was resolved
+     * @param resolutionResult the resolution result information necessary for locking
+     * @param changingResolvedModules any modules that are resolved and marked as changing which defeats locking purpose
+     */
     void persistResolvedDependencies(String configurationName, Set<ModuleComponentIdentifier> resolutionResult, Set<ModuleComponentIdentifier> changingResolvedModules);
 
+    /**
+     * The current locking mode, exposed in the {@link org.gradle.api.artifacts.dsl.DependencyLockingHandler}.
+     *
+     * @return the locking mode
+     */
     Property<LockMode> getLockMode();
 
+    /**
+     * Build finished hook for persisting per project lockfile
+     */
     void buildFinished();
 
+    /**
+     * The file to be used as the per project lock file, exposed in the {@link DefaultDependencyHandler}.
+     *
+     * @return the lock file
+     */
     RegularFileProperty getLockFile();
 
+    /**
+     * A list of module identifiers that are to be ignored in the lock state, exposed in the {@link org.gradle.api.artifacts.dsl.DependencyLockingHandler}.
+     * @return
+     */
     ListProperty<String> getIgnoredDependencies();
+
+    /**
+     * Confirms that a configuration is not locked.
+     * This allows the lock state for said configuration to be dropped if it existed before.
+     *
+     * @param configurationName the unlocked configuration
+     */
+    void confirmConfigurationNotLocked(String configurationName);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -171,6 +171,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         if (resolutionStrategy.isDependencyLockingEnabled()) {
             lockingVisitor = new DependencyLockingArtifactVisitor(configuration.getName(), resolutionStrategy.getDependencyLockingProvider());
             visitors.add(lockingVisitor);
+        } else {
+            resolutionStrategy.confirmUnlockedConfigurationResolved(configuration.getName());
         }
         ImmutableList<DependencyArtifactsVisitor> allVisitors = visitors.build();
         CompositeDependencyArtifactsVisitor artifactsVisitor = new CompositeDependencyArtifactsVisitor(allVisitors);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -339,6 +339,11 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
+    public void confirmUnlockedConfigurationResolved(String configurationName) {
+        dependencyLockingProvider.confirmConfigurationNotLocked(configurationName);
+    }
+
+    @Override
     public CapabilitiesResolutionInternal getCapabilitiesResolutionRules() {
         return capabilitiesResolution;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -237,6 +237,14 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
         return ignoredDependencies;
     }
 
+    @Override
+    public void confirmConfigurationNotLocked(String configurationName) {
+        if (writeLocks) {
+            loadLockState();
+            allLockState.remove(configurationName);
+        }
+    }
+
     private static class LockingDependencySubstitution implements DependencySubstitutionInternal {
 
         private final ComponentSelector selector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.resource.local.FileResourceListener;
+import org.gradle.util.GFileUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -204,6 +206,15 @@ public class LockFileReaderWriter {
         mapLockStateFromDependencyToConfiguration(lockState, dependencyToConfigurations, emptyConfigurations);
 
         writeUniqueLockfile(lockfilePath, dependencyToConfigurations, emptyConfigurations);
+
+        cleanupLegacyLockFiles(lockState.keySet());
+    }
+
+    private void cleanupLegacyLockFiles(Set<String> lockedConfigurations) {
+        lockedConfigurations.stream()
+            .map(f -> lockFilesRoot.resolve(decorate(f) + FILE_SUFFIX))
+            .map(Path::toFile)
+            .forEach(GFileUtils::deleteQuietly);
     }
 
     private void writeUniqueLockfile(Path lockfilePath, Map<String, List<String>> dependencyToConfigurations, List<String> emptyConfigurations) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/NoOpDependencyLockingProvider.java
@@ -67,4 +67,9 @@ public class NoOpDependencyLockingProvider implements DependencyLockingProvider 
     public ListProperty<String> getIgnoredDependencies() {
         throw new IllegalStateException("Should not be invoked on the no-op instance");
     }
+
+    @Override
+    public void confirmConfigurationNotLocked(String configurationName) {
+        // No-op
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1032,7 +1032,7 @@ class DependencyGraphBuilderTest extends Specification {
     }
 
     def rootProject(String name, String revision = '1.0', List<String> extraConfigs = []) {
-        def metaData = new RootLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema, NoOpDependencyLockingProvider.getInstance())
+        def metaData = new RootLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema, NoOpDependencyLockingProvider.instance)
         metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ImmutableSet.of("default"), true, true, attributes, true, null, true, ImmutableCapabilities.EMPTY, Collections.&emptyList)
         extraConfigs.each { String config ->
             metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ImmutableSet.of("default", config), true, true, attributes, true, null, true, ImmutableCapabilities.EMPTY, Collections.&emptyList)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -84,7 +84,7 @@ class DefaultDependencyLockingProviderTest extends Specification {
         provider.buildFinished()
 
         then:
-        tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME).text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+        uniqueLockFile.text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
 org:bar:1.3=conf
 org:foo:1.0=conf
 empty=
@@ -257,6 +257,25 @@ empty=
         ',org:foo'      | ''
         'org:foo:1.0'   | 'org:foo:1.0'
         '*:*'           | '*:*'
+    }
+
+    def 'can drop lock state for no longer locked configuration'() {
+        uniqueLockFile << """
+org:foo:1.0=conf,otherConf
+empty=
+"""
+        startParameter.isWriteDependencyLocks() >> true
+        provider = newProvider()
+
+        when:
+        provider.confirmConfigurationNotLocked('conf')
+        provider.buildFinished()
+
+        then:
+        uniqueLockFile.text == """${LockFileReaderWriter.LOCKFILE_HEADER_LIST.join('\n')}
+org:foo:1.0=otherConf
+empty=
+""".denormalize()
     }
 
     private DefaultDependencyLockingProvider newProvider() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -145,6 +145,11 @@ class LockfileFixture {
         }
     }
 
+    void assertLegacyLockfileMissing(String configurationName) {
+        def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, "$configurationName$LockFileReaderWriter.FILE_SUFFIX")
+        assert !lockFile.exists()
+    }
+
     private enum LockScope {
         PROJECT, BUILDSCRIPT, SETTINGS
     }


### PR DESCRIPTION
* Clean up legacy lockfiles once migrated
* Clean up lock state for configurations that are no longer locked
* Do not write lockfile on build failure