### PR TITLE
Add JPMS configuration for config-cache reflective accesses

### DIFF
--- a/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
+++ b/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
@@ -26,7 +26,8 @@ class BuildOperationExecutorIntegrationTest extends AbstractIntegrationSpec {
 
     def "produces sensible error when there are failures both enqueuing and running operations" () {
         if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
-            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+            // For java.util.concurrent.CountDownLatch being serialized reflectively by configuration cache
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
         }
 
         buildFile << """

--- a/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
+++ b/subprojects/base-services/src/integTest/groovy/org/gradle/internal/operations/BuildOperationExecutorIntegrationTest.groovy
@@ -16,13 +16,19 @@
 
 package org.gradle.internal.operations
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Matchers
 import spock.lang.Issue
 
 class BuildOperationExecutorIntegrationTest extends AbstractIntegrationSpec {
 
     def "produces sensible error when there are failures both enqueuing and running operations" () {
+        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+        }
+
         buildFile << """
             import org.gradle.internal.operations.BuildOperationExecutor
             import org.gradle.internal.operations.RunnableBuildOperation

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -50,7 +50,9 @@ public class JpmsConfiguration {
         List<String> configurationCacheJpmsArgs = Collections.unmodifiableList(Arrays.asList(
             "--add-opens", "java.prefs/java.util.prefs=ALL-UNNAMED", // required by JavaObjectSerializationCodec.kt
             "--add-opens", "java.base/java.nio.charset=ALL-UNNAMED", // required by BeanSchemaKt
-            "--add-opens", "java.base/java.net=ALL-UNNAMED" // required by JavaObjectSerializationCodec
+            "--add-opens", "java.base/java.net=ALL-UNNAMED", // required by JavaObjectSerializationCodec
+            "--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED", // serialized from groovy.lang.Reference
+            "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED" // serialized from org.gradle.internal.file.StatStatistics$Collector
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -51,7 +51,6 @@ public class JpmsConfiguration {
             "--add-opens", "java.prefs/java.util.prefs=ALL-UNNAMED", // required by JavaObjectSerializationCodec.kt
             "--add-opens", "java.base/java.nio.charset=ALL-UNNAMED", // required by BeanSchemaKt
             "--add-opens", "java.base/java.net=ALL-UNNAMED", // required by JavaObjectSerializationCodec
-            "--add-opens", "java.base/java.util.concurrent=ALL-UNNAMED", // serialized from groovy.lang.Reference
             "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED" // serialized from org.gradle.internal.file.StatStatistics$Collector
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ArtifactCollectionIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.integtests.resolve.api
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveInterceptor
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 
@@ -188,10 +190,15 @@ class Main {
                     assert artifacts.artifacts.size() == 3
                 }
             }
-"""
+        """
 
         when:
         succeeds "help"
+
+        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
+            // For java.util.concurrent.CopyOnWriteArrayList from DefaultMultiCauseException being serialized reflectively by configuration cache
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent=ALL-UNNAMED')
+        }
         fails "verify"
 
         then:

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
@@ -59,7 +59,8 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
     def "expires daemon immediately when garbage collector is thrashing"() {
         given:
         if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
-            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+            // For java.util.concurrent.CountDownLatch being serialized reflectively by configuration cache
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
         }
 
         configureGarbageCollectionHeapEventsFor(256, 512, 100, garbageCollector.monitoringStrategy.thrashingThreshold + 0.2)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitoringIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.fixtures.compatibility.MultiVersionTest
 import org.gradle.integtests.fixtures.compatibility.MultiVersionTestCategory
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.daemon.JavaGarbageCollector
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.launcher.daemon.server.health.DaemonMemoryStatus
 
 import static org.gradle.launcher.daemon.server.DaemonStateCoordinator.DAEMON_STOPPING_IMMEDIATELY_MESSAGE
@@ -57,6 +58,10 @@ class GarbageCollectionMonitoringIntegrationTest extends DaemonIntegrationSpec {
 
     def "expires daemon immediately when garbage collector is thrashing"() {
         given:
+        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+        }
+
         configureGarbageCollectionHeapEventsFor(256, 512, 100, garbageCollector.monitoringStrategy.thrashingThreshold + 0.2)
         waitForImmediateDaemonExpiration()
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.launcher.daemon.server.scaninfo
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
@@ -92,7 +93,14 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         """
 
         when:
-        executer.withArguments(continuous ? ['waitForExpiration', '--continuous'] : ['waitForExpiration']).run()
+        openJpmsModulesForConfigurationCache()
+        if (continuous) {
+            executer.withArgument('waitForExpiration')
+            executer.withArgument('--continuous')
+        } else {
+            executer.withArgument('waitForExpiration')
+        }
+        executer.run()
 
         then:
         file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
@@ -111,7 +119,10 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         """
 
         when:
-        executer.withArguments('waitForExpiration').run()
+        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+        }
+        executer.withArgument('waitForExpiration').run()
 
         then:
         file(EXPIRATION_EVENT).text.startsWith "onExpirationEvent fired with: expiring daemon with TestExpirationStrategy uuid:"
@@ -122,7 +133,8 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
            ${imports()}
            ${waitForExpirationTask()}
         """
-        def waitForExpirationResult = executer.withArguments('waitForExpiration').runWithFailure()
+        openJpmsModulesForConfigurationCache()
+        def waitForExpirationResult = executer.withArgument('waitForExpiration').runWithFailure()
 
         then:
         waitForExpirationResult.assertHasCause("Timed out waiting for expiration event")
@@ -142,6 +154,7 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
 
         when:
         startAForegroundDaemon()
+        openJpmsModulesForConfigurationCache()
         executer.withTasks('waitForExpiration').run()
 
         then:
@@ -262,6 +275,12 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
 
         def latch = new CountDownLatch(1)
         """
+    }
+
+    private void openJpmsModulesForConfigurationCache() {
+        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+        }
     }
 
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/server/scaninfo/DaemonScanInfoIntegrationSpec.groovy
@@ -119,9 +119,7 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
         """
 
         when:
-        if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
-            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
-        }
+        openJpmsModulesForConfigurationCache()
         executer.withArgument('waitForExpiration').run()
 
         then:
@@ -279,7 +277,8 @@ class DaemonScanInfoIntegrationSpec extends DaemonIntegrationSpec {
 
     private void openJpmsModulesForConfigurationCache() {
         if (JavaVersion.current().isJava9Compatible() && GradleContextualExecuter.isConfigCache()) {
-            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
+            // For java.util.concurrent.CountDownLatch being serialized reflectively by configuration cache
+            executer.withArgument('-Dorg.gradle.jvmargs=--add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED')
         }
     }
 


### PR DESCRIPTION
Open up JPMS modules that configuration cahce accesses reflectively
from Gradle internals. This only covers what is accessed from our integration tests.
