### PR TITLE
Set Gradle daemon JPMS arguments in client JVM when testing no-daemon mode

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -127,7 +127,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
     protected List<String> getImplicitBuildJvmArgs() {
         List<String> buildJvmOptions = super.getImplicitBuildJvmArgs();
         final Jvm current = Jvm.current();
-        if (getJavaHome().equals(current.getJavaHome()) && JavaVersion.current().isJava9Compatible()) {
+        if (getJavaHome().equals(current.getJavaHome()) && JavaVersion.current().isJava9Compatible() && !isUseDaemon()) {
             buildJvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
         }
         return buildJvmOptions;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -17,9 +17,11 @@
 package org.gradle.integtests.fixtures.executer;
 
 import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCachesProvider;
 import org.gradle.api.internal.file.TestFiles;
 import org.gradle.internal.Factory;
+import org.gradle.internal.jvm.JpmsConfiguration;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.process.internal.AbstractExecHandleBuilder;
@@ -116,10 +118,19 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
 
     @Override
     protected List<String> getAllArgs() {
-        List<String> args = new ArrayList<String>();
-        args.addAll(super.getAllArgs());
+        List<String> args = new ArrayList<>(super.getAllArgs());
         addPropagatedSystemProperties(args);
         return args;
+    }
+
+    @Override
+    protected List<String> getImplicitBuildJvmArgs() {
+        List<String> buildJvmOptions = super.getImplicitBuildJvmArgs();
+        final Jvm current = Jvm.current();
+        if (getJavaHome().equals(current.getJavaHome()) && JavaVersion.current().isJava9Compatible()) {
+            buildJvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
+        }
+        return buildJvmOptions;
     }
 
     private void addPropagatedSystemProperties(List<String> args) {

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -66,6 +66,8 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
         assumeNonEmbeddedGradleExecuter() // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
 
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
+
         withBuildScript(
             """
 
@@ -129,6 +131,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
     @Test
     fun `gradle kotlin dsl api is available in test-kit injected plugin classpath`() {
         assumeNonEmbeddedGradleExecuter() // requires a full distribution to run tests with test kit
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
 
         withBuildScript(
             """
@@ -231,7 +234,6 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
     @Test
     fun `sam-with-receiver kotlin compiler plugin is applied to production code`() {
-
         withKotlinDslPlugin()
 
         withFile(

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -860,6 +860,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
 
     private
     fun configureProjectAndExpectCompileAvoidanceWarnings(vararg tasks: String): BuildOperationsAssertions {
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
         val buildOperations = BuildOperationsFixture(executer, testDirectoryProvider)
         val output = executer.withArgument("--info").withTasks(*tasks).run().normalizedOutput
         return BuildOperationsAssertions(buildOperations, output, true)
@@ -876,6 +877,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
     // leaving this one as a workaround for test cases that have precompiled script plugins until the underlying issue is fixed
     private
     fun configureProjectWithDebugOutput(vararg tasks: String): DebugOutputFixture {
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
         return DebugOutputFixture(executer.withArgument("--debug").withTasks(*tasks).run().normalizedOutput)
     }
 }

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -241,4 +241,11 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     fun assumeNonEmbeddedGradleExecuter() {
         assumeFalse(GradleContextualExecuter.isEmbedded())
     }
+
+    protected
+    fun ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode() {
+        if (GradleContextualExecuter.isNoDaemon() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            executer.noDeprecationChecks()
+        }
+    }
 }


### PR DESCRIPTION
This is in order to ensure that JPMS arguments are set on the JVM that does the build. In no-daemon mode this JVM can be the client JVM. Normally, those arguments are only set in the daemon JVM.