### PR TITLE
Fix early cyclic include issue

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/AbstractPluginBuildIntegrationTest.groovy
@@ -22,8 +22,8 @@ import org.gradle.test.fixtures.file.TestFile
 
 abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpec {
 
-    PluginBuildFixture pluginBuild(String buildName) {
-        return new PluginBuildFixture(buildName)
+    PluginBuildFixture pluginBuild(String buildName, boolean useKotlinDSL = false) {
+        return new PluginBuildFixture(buildName, useKotlinDSL)
     }
 
     PluginAndLibraryBuildFixture pluginAndLibraryBuild(String buildName) {
@@ -41,28 +41,35 @@ abstract class AbstractPluginBuildIntegrationTest extends AbstractIntegrationSpe
         final TestFile settingsPluginFile
         final TestFile projectPluginFile
 
-        PluginBuildFixture(String buildName) {
+        PluginBuildFixture(String buildName, boolean useKotlinDSL) {
+            def fileExtension = useKotlinDSL ? '.gradle.kts' : '.gradle'
+            def sourceDirectory = useKotlinDSL ? 'kotlin' : 'groovy'
+            def pluginPluginId = useKotlinDSL ? '`kotlin-dsl`' : 'id("groovy-gradle-plugin")'
+
             this.buildName = buildName
             this.settingsPluginId = "${buildName}.settings-plugin"
             this.projectPluginId = "${buildName}.project-plugin"
-            this.settingsFile = file("$buildName/settings.gradle")
-            this.buildFile = file("$buildName/build.gradle")
+            this.settingsFile = file("$buildName/settings${fileExtension}")
+            this.buildFile = file("$buildName/build${fileExtension}")
 
             settingsFile << """
                 rootProject.name = "$buildName"
             """
             buildFile << """
                 plugins {
-                    id("groovy-gradle-plugin")
+                    $pluginPluginId
+                }
+                repositories {
+                    gradlePluginPortal()
                 }
             """
-            settingsPluginFile = file("$buildName/src/main/groovy/${settingsPluginId}.settings.gradle")
+            settingsPluginFile = file("$buildName/src/main/$sourceDirectory/${settingsPluginId}.settings${fileExtension}")
             settingsPluginFile << """
-                println('$settingsPluginId applied')
+                println("$settingsPluginId applied")
             """
-            projectPluginFile = file("$buildName/src/main/groovy/${projectPluginId}.gradle")
+            projectPluginFile = file("$buildName/src/main/$sourceDirectory/${projectPluginId}${fileExtension}")
             projectPluginFile << """
-                println('$projectPluginId applied')
+                println("$projectPluginId applied")
             """
         }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
@@ -354,14 +354,15 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         build.assertProjectPluginApplied()
     }
 
-    def "Including a build as both plugin build and regular build does not lead to an error in the presence of include cycles"() {
+    @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin", iterationMatchers = [".*Kotlin.*"])
+    def "Including a build as both plugin build and regular build does not lead to an error in the presence of include cycles - #dsl DSL"() {
         given:
-        def commonsPluginBuild = pluginBuild("commons-plugin-build")
+        def commonsPluginBuild = pluginBuild("commons-plugin-build", dsl == 'Kotlin')
         def mainPluginBuild = pluginBuild("main-plugin-build")
 
         commonsPluginBuild.settingsFile.text = """
             pluginManagement {
-                includeBuild('../${mainPluginBuild.buildName}')
+                includeBuild("../${mainPluginBuild.buildName}")
             }
         """
         commonsPluginBuild.projectPluginFile.text = """
@@ -372,7 +373,7 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
 
         mainPluginBuild.settingsFile.text = """
             pluginManagement {
-                includeBuild('../${commonsPluginBuild.buildName}')
+                includeBuild("../${commonsPluginBuild.buildName}")
             }
         """
         mainPluginBuild.buildFile.text = """
@@ -383,20 +384,23 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
 
         settingsFile << """
             pluginManagement {
-                includeBuild('${mainPluginBuild.buildName}')
+                includeBuild("${mainPluginBuild.buildName}")
             }
-            includeBuild('${mainPluginBuild.buildName}')
+            includeBuild("${mainPluginBuild.buildName}")
         """
 
         when:
         buildFile << """
             plugins {
-                id('${mainPluginBuild.projectPluginId}')
+                id("${mainPluginBuild.projectPluginId}")
             }
         """
 
         then:
         succeeds("help")
+
+        where:
+        dsl << ['Groovy', 'Kotlin']
     }
 
     def "a build can be included both as a plugin build and as regular build and can contribute both settings plugins and library components"() {
@@ -574,5 +578,57 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
         succeeds("check")
         settingsPluginBuild.assertSettingsPluginApplied()
         projectPluginBuild.assertProjectPluginApplied()
+    }
+
+    @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
+    def "plugin builds can include each other without consequences - Kotlin DSL"() {
+        // This won't work in Groovy DSL due to https://github.com/gradle/gradle/issues/15416
+
+        given:
+        def settingsPluginBuild = pluginBuild("settings-plugin", true)
+        def buildLogicBuild = pluginBuild("build-logic", true)
+        def mainBuild = createDir('main')
+
+        executer.inDirectory(mainBuild)
+
+        settingsPluginBuild.settingsPluginFile.text = """
+            pluginManagement {
+                includeBuild("../${buildLogicBuild.buildName}")
+            }
+
+            println("settings plugin applied in \${rootDir.name}")
+        """
+
+        buildLogicBuild.settingsFile.text = """
+            pluginManagement {
+                includeBuild("../${settingsPluginBuild.buildName}")
+            }
+            plugins {
+                id("${settingsPluginBuild.settingsPluginId}")
+            }
+        """
+
+        // make sure both settings and project plugins are still found despite the include cycle
+        mainBuild.file('settings.gradle') << """
+            pluginManagement {
+                includeBuild("../${settingsPluginBuild.buildName}")
+            }
+            plugins {
+                id("${settingsPluginBuild.settingsPluginId}")
+            }
+        """
+        mainBuild.file('build.gradle') << """
+            plugins {
+                id("${buildLogicBuild.projectPluginId}")
+            }
+        """
+
+        when:
+        succeeds()
+
+        then:
+        outputContains("settings plugin applied in build-logic")
+        outputContains("settings plugin applied in main")
+        buildLogicBuild.assertProjectPluginApplied()
     }
 }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/plugins/PluginBuildsIntegrationTest.groovy
@@ -531,23 +531,13 @@ class PluginBuildsIntegrationTest extends AbstractPluginBuildIntegrationTest {
                 implementation("${pluginLibraryBuild.group}:${pluginLibraryBuild.buildName}")
             }
         """
-        def settingsPluginBuild = pluginBuild("settings-plugin")
-
-        // workaround to use Kotlin precompiled script plugin because Groovy version does not support pluginManagement {} in settings plugins (https://github.com/gradle/gradle/issues/15416)
-        settingsPluginBuild.buildFile.setText("""
-            plugins {
-                id("org.gradle.kotlin.kotlin-dsl") version "2.1.4"
-            }
-            repositories {
-                gradlePluginPortal()
-            }
-        """)
-        file("${settingsPluginBuild.buildName}/src/main/kotlin/${settingsPluginBuild.settingsPluginId}.settings.gradle.kts") << """
+        // use Kotlin precompiled script plugin because Groovy version does not support pluginManagement {} in settings plugins (https://github.com/gradle/gradle/issues/15416)
+        def settingsPluginBuild = pluginBuild("settings-plugin", true)
+        settingsPluginBuild.settingsPluginFile.text = """
             pluginManagement {
                 includeBuild("../${projectPluginBuild.buildName}")
             }
-            println("${settingsPluginBuild.settingsPluginId} applied")
-        """
+        """ + settingsPluginBuild.settingsPluginFile.text
 
         def projectLibrary = pluginAndLibraryBuild("project-lib")
         projectLibrary.settingsFile.setText("""

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -181,6 +181,9 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
     private void finishBuild(String action, @Nullable Throwable stageFailure) {
         if (stage == Stage.Finished) {
+            if (stageFailure != null) {
+                throw exceptionAnalyser.transform(stageFailure);
+            }
             return;
         }
 


### PR DESCRIPTION
When a build is included early (i.e. in pluginManagement {}) the the scoped visibility requires us to walk down the tree of builds which might lead to fully configuring other builds. This in turn can lead to an attempt to configure a build for which configuration has already started. In these cases, starting the configuration anew should just be skipped.

Which just means: You can't apply a pre-compiled script plugin to the build that is defining it.

The (indirect) include cycle could still make sense and thus we skip instead of giving an error.