### PR TITLE
Check existence of virtual disk before subst

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -74,7 +74,7 @@ fun BuildSteps.substDirOnWindows(os: Os) {
         script {
             name = "SETUP_VIRTUAL_DISK_FOR_PERF_TEST"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = """subst p: "%teamcity.build.checkoutDir%" """
+            scriptContent = """dir p: || subst p: "%teamcity.build.checkoutDir%" """
         }
         cleanBuildLogicBuild("P:/build-logic-commons", os)
         cleanBuildLogicBuild("P:/build-logic", os)
@@ -86,7 +86,7 @@ fun BuildSteps.removeSubstDirOnWindows(os: Os) {
         script {
             name = "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = """subst p: /d"""
+            scriptContent = """dir p: && subst p: /d"""
         }
         cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic-commons", os)
         cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic", os)


### PR DESCRIPTION
If the build was cancelled or something unexpected happens, the virtual
disk might not be unmounted successfully, failing all subsequent builds.
Let's check the existence of virtual disk before subst.

Example: https://builds.gradle.org/viewLog.html?buildId=41886577&buildTypeId=Gradle_Master_Check_PerformanceTest6bucket3&tab=buildLog&_focus=406#_state=406