### PR TITLE
Treat TaskNodes from included builds as 'task nodes'

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -211,7 +211,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         node.getHardSuccessors().forEach(successor -> {
             // We are searching for dependencies between tasks, so we can skip everything which is not a task when searching.
             // For example we can skip all the transform nodes between two task nodes.
-            if (successor instanceof LocalTaskNode) {
+            if (successor instanceof TaskNode) {
                 if (seenNodes.add(successor)) {
                     queue.add(successor);
                 }


### PR DESCRIPTION
Treat all task nodes as 'task nodes', and not only the local ones, when
distinguishing between task and non-task nodes in successor search
optimization.

Follow up to: #16178
