### PR TITLE
Fix filtering for duplicate imports

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GroovyImportsIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can handle duplicate imports in init scripts"() {
+        def initScript = file('init.gradle')
+        initScript << """
+initscript {
+    repositories { ${mavenCentralRepository()} }
+    dependencies {
+        classpath 'org.apache.commons:commons-math3:3.6.1'
+    }
+}
+
+import org.apache.commons.math3.util.FastMath
+import org.apache.commons.math3.util.FastMath
+"""
+
+        expect:
+        args("--init-script", initScript.toString())
+        succeeds("help")
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/SubsetScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/SubsetScriptTransformer.java
@@ -59,11 +59,10 @@ public class SubsetScriptTransformer extends AbstractScriptTransformer {
             ImportNode importedClass = iter.next();
             if (!AstUtils.isVisible(source, importedClass.getClassName())) {
                 try {
-                    final ImportNode importNode = source.getAST().getImport(importedClass.getAlias());
                     Field field = ModuleNode.class.getDeclaredField("imports");
                     field.setAccessible(true);
-                    List<?> value = (List<?>) field.get(source.getAST());
-                    value.remove(importNode);
+                    @SuppressWarnings("unchecked") List<ImportNode> value = (List<ImportNode>) field.get(source.getAST());
+                    value.removeIf(i -> i.getAlias().equals(importedClass.getAlias()));
                 } catch (Exception e) {
                     throw UncheckedException.throwAsUncheckedException(e);
                 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/SubsetScriptTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/SubsetScriptTransformer.java
@@ -88,17 +88,11 @@ public class SubsetScriptTransformer extends AbstractScriptTransformer {
         ClassNode scriptClass = AstUtils.getScriptClass(source);
 
         // Remove all the classes other than the main class
-        Iterator<ClassNode> classes = source.getAST().getClasses().iterator();
-        while (classes.hasNext()) {
-            ClassNode classNode = classes.next();
-            if (classNode != scriptClass) {
-                classes.remove();
-            }
-        }
+        source.getAST().getClasses().removeIf(classNode -> classNode != scriptClass);
 
         // Remove all the methods from the main class
         if (scriptClass != null) {
-            for (MethodNode methodNode : new ArrayList<MethodNode>(scriptClass.getMethods())) {
+            for (MethodNode methodNode : new ArrayList<>(scriptClass.getMethods())) {
                 if (!methodNode.getName().equals("run")) {
                     AstUtils.removeMethod(scriptClass, methodNode);
                 }


### PR DESCRIPTION
If a script contained multiple imports for the same
class (e.g. IntelliJ init scripts), our filter didn't
work as it relied on the instance
equality but looking up the import always yields the first
import node. This then fails as we try to compile the script
before resolving those dependencies.