### PR TITLE
Adjust smoke tests to work with JDK16

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/PlayCoverage.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/PlayCoverage.groovy
@@ -21,7 +21,7 @@ import org.gradle.util.VersionNumber
 import static org.gradle.api.JavaVersion.current
 
 class PlayCoverage {
-    static final String DEFAULT_PLAY_VERSION = "2.6.5"
+    static final String DEFAULT_PLAY_VERSION = "2.7.9"
     static final List<VersionNumber> ALL_VERSIONS = ["2.4.11", "2.5.18", DEFAULT_PLAY_VERSION].collect { VersionNumber.parse(it) }
     static final List<VersionNumber> JDK9_COMPATIBLE_VERSIONS = [DEFAULT_PLAY_VERSION]
     static final List<String> ALL = ALL_VERSIONS.asImmutable()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/external/AbstractPlayExternalContinuousBuildIntegrationTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/external/AbstractPlayExternalContinuousBuildIntegrationTest.groovy
@@ -64,7 +64,7 @@ abstract class AbstractPlayExternalContinuousBuildIntegrationTest extends Abstra
 
     static java9AddJavaSqlModuleArgs() {
         if (JavaVersion.current().isJava9Compatible()) {
-            return "forkOptions.jvmArgs += ['--add-modules', 'java.sql']"
+            return "forkOptions.jvmArgs += ['--add-modules', 'java.sql', '--add-opens', 'java.base/sun.net.www.protocol.file=ALL-UNNAMED']"
         } else {
             return ""
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/external/AbstractPlayExternalContinuousBuildIntegrationTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/fixtures/external/AbstractPlayExternalContinuousBuildIntegrationTest.groovy
@@ -42,7 +42,7 @@ abstract class AbstractPlayExternalContinuousBuildIntegrationTest extends Abstra
         playRunBuildFile << """
             runPlay {
                 httpPort = 0
-                ${java9AddJavaSqlModuleArgs()}
+                ${jpmsForkOptions()}
             }
         """
 
@@ -62,7 +62,7 @@ abstract class AbstractPlayExternalContinuousBuildIntegrationTest extends Abstra
         return super.succeeds(tasks)
     }
 
-    static java9AddJavaSqlModuleArgs() {
+    static jpmsForkOptions() {
         if (JavaVersion.current().isJava9Compatible()) {
             return "forkOptions.jvmArgs += ['--add-modules', 'java.sql', '--add-opens', 'java.base/sun.net.www.protocol.file=ALL-UNNAMED']"
         } else {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ErrorPronePluginSmokeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.smoketests
 
-
+import org.gradle.api.JavaVersion
 import spock.lang.Issue
 
 class ErrorPronePluginSmokeTest extends AbstractPluginValidatingSmokeTest {
@@ -42,11 +42,12 @@ class ErrorPronePluginSmokeTest extends AbstractPluginValidatingSmokeTest {
             }
 
             dependencies {
-                errorprone("com.google.errorprone:error_prone_core:2.3.3")
+                errorprone("com.google.errorprone:error_prone_core:2.5.1")
             }
 
             tasks.withType(JavaCompile).configureEach {
                 options.fork = true
+                ${jpmsJvmArgs()}
                 options.errorprone {
                     check("DoubleBraceInitialization", net.ltgt.gradle.errorprone.CheckSeverity.ERROR)
                 }
@@ -76,5 +77,23 @@ class ErrorPronePluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         [
             'net.ltgt.errorprone': Versions.of(TestedVersions.errorProne)
         ]
+    }
+
+    private static String jpmsJvmArgs() {
+        if (JavaVersion.current().isJava9Compatible()) {
+            return """
+                options.forkOptions.jvmArgs += [
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED"
+                ]
+            """
+        }
+        return ""
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/play/integtest/fixtures/external/basicplayapp/build.gradle
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/play/integtest/fixtures/external/basicplayapp/build.gradle
@@ -4,6 +4,6 @@ plugins {
 
 // repositories added in PlayApp class
 dependencies {
-    implementation "com.typesafe.play:play-guice_2.12:2.6.15"
+    implementation "com.typesafe.play:play-guice_2.13:2.7.9"
     implementation "ch.qos.logback:logback-classic:1.2.3"
 }


### PR DESCRIPTION
Smoke tests test external tools, some of which access JDK internals reflectively. In order for the tests that use such tools to run on JDK16, this change explicitly configures `--add-opens` for the accessed packages in specific tests.