### PR TITLE
Fix the second link to the Gradle Kotlin DSL Primer

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_groovy_to_kotlin_dsl.adoc
@@ -39,7 +39,7 @@ Builds with slow configuration time might affect the IDE responsiveness, please 
 * The Kotlin DSL will not support `model {}` elements. This is part of the link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[discontinued Gradle Software Model].
 * Enabling the incubating link:{user-manual}multi_project_builds.html#sec:configuration_on_demand[configuration on demand] feature is not recommended as it can lead to very hard-to-diagnose problems.
 
-Read more in the link:{user-manual}kotlin_dsl.html[Gradle Kotlin DSL Primer].
+Read more in the <<kotlin_dsl.adoc#kotlin_dsl,Gradle Kotlin DSL Primer>>.
 
 If you run to trouble or a suspected bug, please take advantage of the `gradle/gradle` link:{gradle-issues}[issue tracker].
 


### PR DESCRIPTION
This PR fixes the second link to the Gradle Kotlin DSL Primer in the guide about migrating build logic from Groovy to Kotlin.

With the current version, clicking on the link at "Read more in the Gradle Kotlin DSL Primer." on [this page](https://docs.gradle.org/current/userguide/%7Buser-manual%7Dkotlin_dsl.html) leads to [here](https://docs.gradle.org/current/userguide/%7Buser-manual%7Dkotlin_dsl.html), which results in "This page does not exist.".