### PR TITLE
Unmount virtual disk before mounting it

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -41,7 +41,7 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
 }
 
 fun performanceTestCommandLine(task: String, baselines: String, extraParameters: String = "", os: Os = Os.LINUX) = listOf(
-    "$task${if (extraParameters.isEmpty()) "" else " $extraParameters" }",
+    "$task${if (extraParameters.isEmpty()) "" else " $extraParameters"}",
     "-PperformanceBaselines=$baselines",
     "-PtestJavaVersion=${os.perfTestJavaVersion.major}",
     "-PtestJavaVendor=${os.perfTestJavaVendor}",
@@ -74,7 +74,10 @@ fun BuildSteps.substDirOnWindows(os: Os) {
         script {
             name = "SETUP_VIRTUAL_DISK_FOR_PERF_TEST"
             executionMode = BuildStep.ExecutionMode.ALWAYS
-            scriptContent = """dir p: || subst p: "%teamcity.build.checkoutDir%" """
+            scriptContent = """
+                subst p: /d
+                subst p: "%teamcity.build.checkoutDir%"
+                """.trimIndent()
         }
         cleanBuildLogicBuild("P:/build-logic-commons", os)
         cleanBuildLogicBuild("P:/build-logic", os)


### PR DESCRIPTION
To avoid the situation that previous build was not completed, leaving
the virtual disk mounted.
