### PR TITLE
Fix precompiled plugin id deduction with .gradle substring in id

### DIFF
--- a/subprojects/kotlin-dsl-provider-plugins/src/test/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPluginTest.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/test/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/PrecompiledScriptPluginTest.kt
@@ -25,6 +25,15 @@ class PrecompiledScriptPluginTest : TestWithTempFiles() {
     }
 
     @Test
+    fun `plugin id can contain dot gradle dot kts substring within its id`() {
+
+        assertThat(
+            scriptPlugin("dev.gradle.ktscript.plugin.gradle.kts").id,
+            equalTo("dev.gradle.ktscript.plugin")
+        )
+    }
+
+    @Test
     fun `plugin id is prefixed by package name if present`() {
 
         assertThat(

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 
 class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -394,6 +395,22 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             plugins {
                 id 'my-plugin'
+            }
+        """
+
+        then:
+        succeeds(SAMPLE_TASK)
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/16459")
+    def "can have .gradle substring within plugin id"() {
+        when:
+        enablePrecompiledPluginsInBuildSrc()
+        pluginWithSampleTask("buildSrc/src/main/groovy/dev.gradlefoo.some-plugin.gradle")
+
+        buildFile << """
+            plugins {
+                id 'dev.gradlefoo.some-plugin'
             }
         """
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScript.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScript.java
@@ -68,7 +68,7 @@ class PrecompiledGroovyScript {
         }
 
         PluginId toPluginId(String fileName) {
-            return DefaultPluginId.of(fileName.substring(0, fileName.indexOf(fileExtension)));
+            return DefaultPluginId.of(fileName.substring(0, fileName.lastIndexOf(fileExtension)));
         }
     }
 

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/internal/precompiled/PrecompiledGroovyScriptTest.groovy
@@ -16,11 +16,9 @@
 
 package org.gradle.plugin.devel.internal.precompiled
 
-
 import org.gradle.internal.resource.TextFileResourceLoader
 import org.gradle.plugin.internal.InvalidPluginIdException
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class PrecompiledGroovyScriptTest extends Specification {
     private TextFileResourceLoader loader = Mock()
@@ -33,20 +31,20 @@ class PrecompiledGroovyScriptTest extends Specification {
         thrown InvalidPluginIdException
     }
 
-    @Unroll
-    def "creates valid java classname '#javaClass' from script filename based plugin id: #filename"() {
+    def "creates valid java classname from script filename based plugin id"() {
         expect:
         def script = new PrecompiledGroovyScript(new File("/foo/bar/$filename"), loader)
         script.pluginAdapterClassName == javaClass
 
         where:
-        filename                     | javaClass
-        "foo.gradle"                 | "FooPlugin"
-        "foo.bar.gradle"             | "FooBarPlugin"
-        "test-plugin.gradle"         | "TestPluginPlugin"
-        "foo.bar.test-plugin.gradle" | "FooBarTestPluginPlugin"
-        "foo.bar.-foo.gradle"        | "FooBarFooPlugin"
-        "foo.bar._foo.gradle"        | "FooBar_fooPlugin"
-        "123.gradle"                 | "_123Plugin"
+        filename                               | javaClass
+        "foo.gradle"                           | "FooPlugin"
+        "foo.bar.gradle"                       | "FooBarPlugin"
+        "test-plugin.gradle"                   | "TestPluginPlugin"
+        "foo.bar.test-plugin.gradle"           | "FooBarTestPluginPlugin"
+        "foo.bar.-foo.gradle"                  | "FooBarFooPlugin"
+        "foo.bar._foo.gradle"                  | "FooBar_fooPlugin"
+        "123.gradle"                           | "_123Plugin"
+        "dev.gradleplugins.some-plugin.gradle" | "DevGradlepluginsSomePluginPlugin"
     }
 }


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/16459

A precompiled Groovy plugin with file name `dev.gradlefoo.whatever.gradle` would be assigned a plugin id `dev`
and not the expected `dev.gradlefoo.whatever`.
There was a bug in how the plugin id is constructed from the filename where it took the substring before
the first occurrence of `.gradle` and used that as the plugin id. The expected behavior is to look for the
last occurrence of `.gradle` in precompiled plugin filename.

