### PR TITLE
Revert "Use JDK16 as max java and JDK17 as experimental java in CI"

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -18,6 +18,6 @@ package common
 
 enum class JvmCategory(val vendor: JvmVendor, val version: JvmVersion) {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.oracle, JvmVersion.java16),
-    EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java17)
+    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java15),
+    EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java16)
 }

--- a/.teamcity/src/main/kotlin/common/JvmVersion.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVersion.kt
@@ -25,6 +25,5 @@ enum class JvmVersion(val major: Int) {
     java13(13),
     java14(14),
     java15(15),
-    java16(16),
-    java17(17)
+    java16(16)
 }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -133,8 +133,8 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
-        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java9.oracle.64bit%,%linux.java10.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java12.openjdk.64bit%,%linux.java13.openjdk.64bit%,%linux.java14.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%"
-        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java9.oracle.64bit%,%windows.java10.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java12.openjdk.64bit%,%windows.java13.openjdk.64bit%,%windows.java14.openjdk.64bit%,%windows.java15.openjdk.64bit%,%windows.java16.openjdk.64bit%,%windows.java17.openjdk.64bit%"
+        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java9.oracle.64bit%,%linux.java10.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java12.openjdk.64bit%,%linux.java13.openjdk.64bit%,%linux.java14.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%"
+        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java9.oracle.64bit%,%windows.java10.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java12.openjdk.64bit%,%windows.java13.openjdk.64bit%,%windows.java14.openjdk.64bit%,%windows.java15.openjdk.64bit%,%windows.java16.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
         return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -s $daemon --continue $extraParameters -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\" \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -81,7 +81,7 @@ class PerformanceTestBuildTypeTest {
             "-PtestJavaVersion=8",
             "-PtestJavaVendor=oracle",
             "-Porg.gradle.java.installations.auto-download=false",
-            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java9.oracle.64bit%,%linux.java10.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java12.openjdk.64bit%,%linux.java13.openjdk.64bit%,%linux.java14.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%\"",
+            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java9.oracle.64bit%,%linux.java10.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java12.openjdk.64bit%,%linux.java13.openjdk.64bit%,%linux.java14.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",


### PR DESCRIPTION
Reverts gradle/gradle#16464

We are seeing NPEs with test-distribution enabled jobs.