### PR TITLE
Make invokeMethod() work in withGroovybuilder block

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GroovyInteroperabilityIntegrationTest.kt
@@ -31,6 +31,10 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
             """
             class MyExtension {
                 String server = 'default'
+
+                def configureServerName(serverName) {
+                    this.server = serverName
+                }
             }
 
             class MyPlugin implements Plugin<Project> {
@@ -51,6 +55,7 @@ class GroovyInteroperabilityIntegrationTest : AbstractKotlinIntegrationTest() {
                 getProperty("server")
                 setProperty("server", "newValue")
                 setMetaClass(getMetaClass())
+                invokeMethod("configureServerName", "myservername")
             }
             """
         )

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/GroovyInteroperability.kt
@@ -277,6 +277,9 @@ class GroovyBuilderScopeForGroovyObject(override val delegate: GroovyObject) : G
     override fun setMetaClass(metaClass: MetaClass?) {
         delegate.metaClass = metaClass
     }
+
+    override fun invokeMethod(name: String, args: Any?): Any? =
+        delegate.invokeMethod(name, args)
 }
 
 


### PR DESCRIPTION
Fixes #16461

The `withGroovyBuilder` block was broken after the Groovy3 upgrade as the methods on `GroovyObject` got default implementation, which has an [unexpected behavior in Kotlin](https://youtrack.jetbrains.com/issue/KT-18324).

We worked around the issue by removing the Kotlin delegation from `GroovyBuilderScopeForGroovyObject` and used the plain old Java delegate pattern.

We forgot to add `invokeMethod` to `GroovyBuilderScopeForGroovyObject` which is the root cause for https://github.com/gradle/gradle/issues/16461.