### PR TITLE
Upgraded smoke tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,3 +1,3 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=4.1.2,4.2.0-beta05,7.0.0-alpha07
+latests=4.1.2,4.2.0-beta06,7.0.0-alpha09
 nightly=


### PR DESCRIPTION
from 4.2.0-beta05 to 4.2.0-beta06
from 7.0-alpha07 to 7.0-alpha09
