### PR TITLE
Improve performance of dependency resolution on worker constrained hosts

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationConstraint.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationConstraint.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+/**
+ * Constraint to apply to the execution of a {@link BuildOperation}.
+ */
+public enum BuildOperationConstraint {
+    /**
+     * Constrain execution by the configured maximum number of workers.
+     */
+    MAX_WORKERS,
+
+    /**
+     * Unconstrained execution allowing as many threads as required to a maximum of 10 times the configured workers.
+     */
+    UNCONSTRAINED
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationExecutor.java
@@ -80,12 +80,26 @@ public interface BuildOperationExecutor extends BuildOperationRunner {
     <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> schedulingAction);
 
     /**
+     * Overload allowing {@link BuildOperationConstraint} to be specified.
+     *
+     * @see BuildOperationExecutor#runAllWithAccessToProjectState(Action)
+     */
+    <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint);
+
+    /**
      * Same as {@link #runAll(Action)}. However, the actions are allowed to access mutable project state. In general, this is more likely to
      * result in deadlocks and other flaky behaviours.
      *
      * <p>See {@link org.gradle.internal.resources.ProjectLeaseRegistry#whileDisallowingProjectLockChanges(Factory)} for more details.
      */
     <O extends RunnableBuildOperation> void runAllWithAccessToProjectState(Action<BuildOperationQueue<O>> schedulingAction);
+
+    /**
+     * Overload allowing {@link BuildOperationConstraint} to be specified.
+     *
+     * @see BuildOperationExecutor#runAllWithAccessToProjectState(Action)
+     */
+    <O extends RunnableBuildOperation> void runAllWithAccessToProjectState(Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint);
 
     /**
      * Submits an arbitrary number of operations, created synchronously by the scheduling action, to be executed by the supplied
@@ -95,4 +109,11 @@ public interface BuildOperationExecutor extends BuildOperationRunner {
      * <p>Actions are not permitted to access any mutable project state. Generally, this is preferred.</p>
      */
     <O extends BuildOperation> void runAll(BuildOperationWorker<O> worker, Action<BuildOperationQueue<O>> schedulingAction);
+
+    /**
+     * Overload allowing {@link BuildOperationConstraint} to be specified.
+     *
+     * @see BuildOperationExecutor#runAll(BuildOperationWorker, Action)
+     */
+    <O extends BuildOperation> void runAll(BuildOperationWorker<O> worker, Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint);
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -78,20 +78,34 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
     }
 
     @Override
-    public <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> generator) {
-        generator.execute(new TestBuildOperationQueue<O>(log));
+    public <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> schedulingAction) {
+        runAll(schedulingAction, BuildOperationConstraint.MAX_WORKERS);
+    }
+
+    @Override
+    public <O extends RunnableBuildOperation> void runAll(Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint) {
+        schedulingAction.execute(new TestBuildOperationQueue<O>(log));
     }
 
     @Override
     public <O extends RunnableBuildOperation> void runAllWithAccessToProjectState(Action<BuildOperationQueue<O>> schedulingAction) {
+        runAllWithAccessToProjectState(schedulingAction, BuildOperationConstraint.MAX_WORKERS);
+    }
+
+    @Override
+    public <O extends RunnableBuildOperation> void runAllWithAccessToProjectState(Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint) {
         runAll(schedulingAction);
     }
 
     @Override
     public <O extends BuildOperation> void runAll(BuildOperationWorker<O> worker, Action<BuildOperationQueue<O>> schedulingAction) {
-        throw new UnsupportedOperationException();
+        runAll(worker, schedulingAction, BuildOperationConstraint.MAX_WORKERS);
     }
 
+    @Override
+    public <O extends BuildOperation> void runAll(BuildOperationWorker<O> worker, Action<BuildOperationQueue<O>> schedulingAction, BuildOperationConstraint buildOperationConstraint) {
+        throw new UnsupportedOperationException();
+    }
 
     private static class TestBuildOperationContext implements BuildOperationContext {
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ParallelResolveArtifactSet.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.Action;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
+import org.gradle.internal.operations.BuildOperationConstraint;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -62,7 +63,7 @@ public abstract class ParallelResolveArtifactSet {
         public void visit(ArtifactVisitor visitor) {
             // Start preparing the result
             StartVisitAction visitAction = new StartVisitAction(visitor);
-            buildOperationProcessor.runAll(visitAction);
+            buildOperationProcessor.runAll(visitAction, BuildOperationConstraint.UNCONSTRAINED);
 
             // Now visit the result in order
             visitAction.visitResults();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -57,6 +57,7 @@ import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
+import org.gradle.internal.operations.BuildOperationConstraint;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
@@ -353,7 +354,7 @@ public class DependencyGraphBuilder {
                 for (final ComponentState componentState : toDownloadInParallel) {
                     buildOperationQueue.add(new DownloadMetadataOperation(componentState));
                 }
-            });
+            }, BuildOperationConstraint.UNCONSTRAINED);
         }
     }
 


### PR DESCRIPTION
Unconstrain dependency metadata and artifact resolution instead let the limits of the underlying HttpClient pool impose limits on per-client concurrency.

<!--- The issue this PR addresses -->
Fixes #5328

### Context
On environments with limited CPU cores dependency metadata and artifact resolution is unnecessarily constrained the the maximum number of workers. The work is network and disk IO bound and the underlying HttpClient imposes appropriate request concurrency limits per route.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
