### PR TITLE
Update build type ids for expected cache miss

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -103,10 +103,11 @@ fun isExpectedAsciidoctorCacheMiss() =
 // 3. buildScanPerformance test, which doesn't depend on compileAll
     // 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
-        "Gradle_Check_CompileAll",
-        "Gradle_Check_BuildDistributions",
-        "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
-        "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux"
+        "Check_CompileAll",
+        "Check_BuildDistributions",
+        "Check_CompileAll",
+        "Check_BuildDistributions",
+        "Components_GradleBuildScansPlugin_Performance_PerformanceLinux"
     )
 
 fun isExpectedCompileCacheMiss() =
@@ -116,13 +117,15 @@ fun isExpectedCompileCacheMiss() =
 // 3. buildScanPerformance test, which doesn't depend on compileAll
     // 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
-        "Gradle_Check_CompileAll",
-        "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
-        "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux",
-        "Gradle_Check_Gradleception"
+        "Check_CompileAll",
+        "Check_CompileAll",
+        "Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
+        "Check_Gradleception"
     )
 
-fun isInBuild(vararg buildTypeIds: String) = System.getenv("BUILD_TYPE_ID") in buildTypeIds
+fun isInBuild(vararg buildTypeIds: String) = System.getenv("BUILD_TYPE_ID")?.let { currentBuildTypeId ->
+    buildTypeIds.any { currentBuildTypeId.endsWith(it) }
+} ?: false
 
 fun extractCheckstyleAndCodenarcData() {
     gradle.taskGraph.afterTask {

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -105,8 +105,8 @@ fun isExpectedAsciidoctorCacheMiss() =
     isInBuild(
         "Check_CompileAll",
         "Check_BuildDistributions",
-        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestMaster",
-        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestReleased"
+        "Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Component_GradlePlugin_Performance_PerformanceLatestReleased"
     )
 
 fun isExpectedCompileCacheMiss() =
@@ -117,8 +117,8 @@ fun isExpectedCompileCacheMiss() =
 // 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
         "Check_CompileAll",
-        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestMaster",
-        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestReleased"
+        "Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Component_GradlePlugin_Performance_PerformanceLatestReleased"
         "Check_Gradleception"
     )
 

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -99,13 +99,14 @@ fun isMonitoredAsciidoctorTask() = false // No asciidoctor tasks are cacheable f
 fun isExpectedAsciidoctorCacheMiss() =
 // Expected cache-miss for asciidoctor task:
 // 1. CompileAll is the seed build for docs:distDocs
-// 2. Gradle_Check_BuildDistributions is the seed build for other asciidoctor tasks
+// 2. BuildDistributions is the seed build for other asciidoctor tasks
 // 3. buildScanPerformance test, which doesn't depend on compileAll
-    // 4. buildScanPerformance test, which doesn't depend on compileAll
+// 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
         "Check_CompileAll",
         "Check_BuildDistributions",
-        "Components_GradleBuildScansPlugin_Performance_PerformanceLinux"
+        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestReleased"
     )
 
 fun isExpectedCompileCacheMiss() =
@@ -113,10 +114,11 @@ fun isExpectedCompileCacheMiss() =
 // 1. CompileAll is the seed build
 // 2. Gradleception which re-builds Gradle with a new Gradle version
 // 3. buildScanPerformance test, which doesn't depend on compileAll
-    // 4. buildScanPerformance test, which doesn't depend on compileAll
+// 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
         "Check_CompileAll",
-        "Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
+        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Enterprise_Master_Component_GradlePlugin_Performance_PerformanceLatestReleased"
         "Check_Gradleception"
     )
 

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -105,8 +105,6 @@ fun isExpectedAsciidoctorCacheMiss() =
     isInBuild(
         "Check_CompileAll",
         "Check_BuildDistributions",
-        "Check_CompileAll",
-        "Check_BuildDistributions",
         "Components_GradleBuildScansPlugin_Performance_PerformanceLinux"
     )
 
@@ -117,7 +115,6 @@ fun isExpectedCompileCacheMiss() =
 // 3. buildScanPerformance test, which doesn't depend on compileAll
     // 4. buildScanPerformance test, which doesn't depend on compileAll
     isInBuild(
-        "Check_CompileAll",
         "Check_CompileAll",
         "Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
         "Check_Gradleception"


### PR DESCRIPTION
As a followup of portable DSL change on TeamCity.