### PR TITLE
Update test-distribution plugin to version 2.0-rc-7

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.5.2")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-5")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0-rc-7")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.13.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0-rc-5")
+    id("com.gradle.enterprise.test-distribution").version("2.0-rc-7")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
Compared to 2.0-rc-5 and 2.0-rc-6 it adds the following:
* fixes sporadic NPE when TD processes a message from a disconnected agent
* single test execution (eg from the IDE) is optimized
* no longer sending back empty output files
* session information is reported
* debug port logging is visible again

Manual tests on local machine:
* `./gradlew depMan:embeddedIntegTest -DenableTestDistribution=true -Pgradle.internal.testdistribution.writeTraceFile=true` ✅ (https://ge.gradle.org/s/f4hp2o4dein4e)
* `./gradlew clean dependency-management:configCacheTest -DenableTestDistribution=true -Pgradle.internal.testdistribution.writeTraceFile=true` ✅ (https://ge.gradle.org/s/rgrktexu7a7em)
