### PR TITLE
Improve the validation error message layout

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -38,13 +38,13 @@ import static org.hamcrest.CoreMatchers.startsWith
 
 @TargetCoverage({ CheckstyleCoverage.getSupportedVersionsByJdk() })
 class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec implements ValidationMessageChecker {
-
     @Rule
     public final Resources resources = new Resources()
 
     def setup() {
         writeBuildFile()
         writeConfigFile()
+        expectReindentedValidationMessage()
     }
 
     def "analyze good code"() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -26,6 +26,10 @@ import static org.junit.Assume.assumeFalse
 
 class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ValidationMessageChecker {
 
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/13333")
     @Unroll
     def "absent #operator orElse #orElseKind used as task input"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -35,6 +35,9 @@ import static org.gradle.work.ChangeType.MODIFIED
 @Unroll
 @Requires(TestPrecondition.SYMLINKS)
 class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+    def setup() {
+        expectReindentedValidationMessage()
+    }
 
     def "#desc can handle symlinks"() {
         def buildScript = file("build.gradle")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
@@ -114,7 +114,7 @@ class BuildResultLoggerIntegrationTest extends AbstractIntegrationSpec implement
             tasks.register("invalid", InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidTask': property 'dummy' test problem. this is a test.")
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem())
 
         when:
         run "invalid"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -919,7 +919,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         """
 
         executer.beforeExecute {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidTask': property 'input' test problem. this is a test.")
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'input'))
         }
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DirectorySensitivityErrorHandlingIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DirectorySensitivityErrorHandlingIntegrationSpec.groovy
@@ -25,6 +25,10 @@ import spock.lang.Unroll
 
 class DirectorySensitivityErrorHandlingIntegrationSpec extends AbstractIntegrationSpec implements ValidationMessageChecker {
 
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
     @ValidationTestFor(
         ValidationProblemId.INCOMPATIBLE_ANNOTATIONS
     )

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1429,7 +1429,7 @@ task generate(type: TransformerTask) {
             ignoredAnnotatedPropertyMessage {
                 type('CustomTask').property('classpath')
                 ignoring('Internal')
-                .alsoAnnotatedWith('InputFiles', 'Classpath')
+                alsoAnnotatedWith('InputFiles', 'Classpath')
             }
         )
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -18,12 +18,17 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.reflect.problems.ValidationProblemId
+import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.ToBeImplemented
 import spock.lang.Issue
 
-class IncrementalBuildIntegrationTest extends AbstractIntegrationSpec {
+class IncrementalBuildIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+
+    def setup() {
+        expectReindentedValidationMessage()
+    }
 
     private TestFile writeDirTransformerTask() {
         buildFile << '''
@@ -1324,7 +1329,9 @@ task generate(type: TransformerTask) {
         fails 'myTask'
 
         then:
-        failure.assertThatDescription(containsNormalizedString("Type 'MyTask': property 'myPrivateInput' is private and annotated with @Input. Annotations on private getters are ignored."))
+        failureDescriptionContains(
+            privateGetterAnnotatedMessage { type('MyTask').property('myPrivateInput').annotation('Input')}
+        )
     }
 
     @ToBeImplemented("Private getters should be ignored")
@@ -1381,7 +1388,7 @@ task generate(type: TransformerTask) {
     }
 
     @ValidationTestFor(
-        ValidationProblemId.CONFLICTING_ANNOTATIONS
+        ValidationProblemId.IGNORED_PROPERTY_MUST_NOT_BE_ANNOTATED
     )
     @Issue("https://github.com/gradle/gradle/issues/11805")
     def "Groovy property annotated as @Internal with differently annotated getter is not allowed"() {
@@ -1418,8 +1425,12 @@ task generate(type: TransformerTask) {
         fails "custom"
 
         then:
-        failure.assertThatDescription(containsNormalizedString(
-            "Type 'CustomTask': property 'classpath' annotated with @Internal should not be also annotated with @InputFiles, @Classpath. A property is ignored but also has input annotations. Possible solutions: Remove the input annotations or remove the @Internal annotation."
-        ))
+        failureDescriptionContains(
+            ignoredAnnotatedPropertyMessage {
+                type('CustomTask').property('classpath')
+                ignoring('Internal')
+                .alsoAnnotatedWith('InputFiles', 'Classpath')
+            }
+        )
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -29,6 +29,7 @@ import java.nio.file.StandardCopyOption
 @Requires(TestPrecondition.SYMLINKS)
 class IncrementalBuildSymlinkHandlingIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
     def setup() {
+        expectReindentedValidationMessage()
         buildFile << """
 // This is a workaround to bust the JVM's file canonicalization cache
 def f = file("delete-me")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -33,6 +33,10 @@ import spock.lang.Unroll
 
 class NestedInputIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, ValidationMessageChecker {
 
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
     @Unroll
     def "nested #type.simpleName input adds a task dependency"() {
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -29,6 +29,9 @@ import spock.lang.Issue
 import spock.lang.Unroll
 
 class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+    def setup() {
+        expectReindentedValidationMessage()
+    }
 
     @Unroll
     def "allows optional @#annotation.simpleName to have null value"() {
@@ -91,7 +94,8 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
                 .candidates(
                     "a String or CharSequence path, for example 'src/main/java' or '/usr/include'",
                     "a String or CharSequence URI, for example 'file:/usr/include'",
-                    "a File instance or use a Path instance",
+                    "a File instance",
+                    "a Path instance",
                     "a Directory instance",
                     "a RegularFile instance",
                     "a URI or URL instance",
@@ -141,7 +145,8 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
                 .candidates(
                     "a String or CharSequence path, for example 'src/main/java' or '/usr/include'",
                     "a String or CharSequence URI, for example 'file:/usr/include'",
-                    "a File instance or use a Path instance",
+                    "a File instance",
+                    "a Path instance",
                     "a Directory instance",
                     "a RegularFile instance",
                     "a URI or URL instance",

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -394,7 +394,7 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidTask': property 'inputFile' test problem. this is a test.")
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
 
         when:
         run "invalid", "--info"
@@ -420,13 +420,13 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidTask': property 'inputFile' test problem. this is a test.")
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
 
         when:
         run "invalid"
         then:
         executedAndNotSkipped(":invalid")
-        output.count("- Type 'InvalidTask': property 'inputFile' test problem. this is a test.") == 1
+        output.count("- Type 'InvalidTask' property 'inputFile' test problem. Reason: This is a test.") == 1
     }
 
     @Requires({ GradleContextualExecuter.embedded })
@@ -446,7 +446,7 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidTask': property 'inputFile' test problem. this is a test.")
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
 
         when:
         run "invalid"
@@ -560,6 +560,7 @@ task someTask(type: SomeTask) {
         ValidationProblemId.VALUE_NOT_SET
     )
     def "null input properties registered via TaskInputs.property are not allowed"() {
+        expectReindentedValidationMessage()
         buildFile << """
             task test {
                 inputs.property("input", { null })
@@ -588,6 +589,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "null input files registered via TaskInputs.#method are not allowed"() {
+        expectReindentedValidationMessage()
         buildFile << """
             task test {
                 inputs.${method}({ null }) withPropertyName "input"
@@ -623,6 +625,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "null output files registered via TaskOutputs.#method are not allowed"() {
+        expectReindentedValidationMessage()
         buildFile << """
             task test {
                 outputs.${method}({ null }) withPropertyName "output"
@@ -658,6 +661,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "missing input files registered via TaskInputs.#method are not allowed"() {
+        expectReindentedValidationMessage()
         buildFile << """
             task test {
                 inputs.${method}({ "missing" }) withPropertyName "input"
@@ -688,6 +692,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "wrong input file type registered via TaskInputs.#method is not allowed"() {
+        expectReindentedValidationMessage()
         file("input-file.txt").touch()
         file("input-dir").createDir()
         buildFile << """
@@ -719,6 +724,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "wrong output file type registered via TaskOutputs.#method is not allowed (files)"() {
+        expectReindentedValidationMessage()
         def outputDir = file("output-dir")
         outputDir.createDir()
         buildFile << """
@@ -748,6 +754,7 @@ task someTask(type: SomeTask) {
     )
     @Unroll
     def "wrong output file type registered via TaskOutputs.#method is not allowed (directories)"() {
+        expectReindentedValidationMessage()
         def outputFile = file("output-file.txt")
         outputFile.touch()
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -484,7 +484,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
 
         expect:
         2.times {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidPing': property 'invalidInput' test problem. this is a test.")
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'))
 
             blockingServer.expect(":aInvalidPing")
             blockingServer.expectConcurrent(":bPing", ":cPing")
@@ -510,7 +510,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
 
         expect:
         2.times {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, "Type 'InvalidPing': property 'invalidInput' test problem. this is a test.")
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'))
 
             blockingServer.expectConcurrent(":aPing", ":bPing")
             blockingServer.expect(":cInvalidPing")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -671,7 +671,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
         def e = thrown WorkValidationException
         validateException(task, false, e,
             missingValueMessage { type('AnnotationProcessingTasks.TaskWithNestedBeanWithPrivateClass').property('bean.inputFile').includeLink() },
-            "Type 'AnnotationProcessingTasks.Bean2': field 'inputFile2' without corresponding getter has been annotated with @InputFile. Annotations on fields are only used if there's a corresponding getter for the field. Possible solutions: Add a getter for field 'inputFile2' or remove the annotations on 'inputFile2'. ${learnAt('validation_problems', 'ignored_annotations_on_field')}.")
+            ignoredAnnotationOnField {type('AnnotationProcessingTasks.Bean2').property('inputFile2').annotatedWith('InputFile').includeLink() })
     }
 
     @ValidationTestFor(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -151,7 +151,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         propertiesMetadata.size() == 1
         def propertyMetadata = propertiesMetadata.first()
         propertyMetadata.propertyName == 'searchPath'
-        collectProblems(typeMetadata) == ["Property 'searchPath' is broken. Test."]
+        collectProblems(typeMetadata) == [dummyValidationProblem(null, 'searchPath', 'is broken', 'Test').trim()]
     }
 
     def "custom annotation that is not relevant can have validation problems"() {
@@ -176,7 +176,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
 
         then:
         propertiesMetadata.empty
-        collectProblems(typeMetadata) == ["Property 'searchPath' is broken. Test."]
+        collectProblems(typeMetadata) == [dummyValidationProblem(null, 'searchPath', 'is broken', 'Test').trim()]
     }
 
     def "custom type annotation handler can inspect for static type problems"() {
@@ -203,7 +203,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def typeMetadata = metadataStore.getTypeMetadata(TypeWithCustomAnnotation)
 
         then:
-        collectProblems(typeMetadata) == ["Type 'DefaultTypeMetadataStoreTest.TypeWithCustomAnnotation': type is broken. Test." as String]
+        collectProblems(typeMetadata) == [dummyValidationProblem('DefaultTypeMetadataStoreTest.TypeWithCustomAnnotation', null, 'type is broken', 'Test').trim()]
     }
 
     @Unroll

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -67,6 +67,7 @@ import java.lang.annotation.Annotation
 
 import static ModifierAnnotationCategory.NORMALIZATION
 import static org.gradle.internal.reflect.validation.Severity.WARNING
+import static org.gradle.util.TextUtil.normaliseLineSeparators
 
 class DefaultTypeMetadataStoreTest extends Specification implements ValidationMessageChecker {
     static final DocumentationRegistry DOCUMENTATION_REGISTRY = new DocumentationRegistry()
@@ -423,7 +424,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
     private static List<String> collectProblems(TypeMetadata metadata) {
         def validationContext = DefaultTypeValidationContext.withoutRootType(DOCUMENTATION_REGISTRY, false)
         metadata.visitValidationFailures(null, validationContext)
-        return validationContext.problems.keySet().toList()
+        return validationContext.problems.keySet().collect { normaliseLineSeparators(it) }
     }
 
     private static boolean isOfType(PropertyMetadata metadata, Class<? extends Annotation> type) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -47,6 +47,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
     BlockingHttpServer blockingHttpServer = new BlockingHttpServer()
 
     def setup() {
+        expectReindentedValidationMessage()
         settingsFile << """
             rootProject.name = 'root'
             include 'lib'

--- a/subprojects/execution/build.gradle.kts
+++ b/subprojects/execution/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation(testFixtures(project(":messaging")))
     testImplementation(testFixtures(project(":snapshots")))
     testImplementation(testFixtures(project(":core")))
+    testImplementation(testFixtures(project(":model-core")))
 
     testFixturesImplementation(libs.guava)
     testFixturesImplementation(project(":base-services"))

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -61,6 +61,7 @@ import org.gradle.internal.hash.HashCode
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.reflect.problems.ValidationProblemId
+import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
 import org.gradle.internal.snapshot.SnapshotVisitorUtil
 import org.gradle.internal.snapshot.ValueSnapshot
@@ -83,7 +84,7 @@ import static org.gradle.internal.execution.UnitOfWork.InputPropertyType.NON_INC
 import static org.gradle.internal.reflect.validation.Severity.ERROR
 import static org.gradle.internal.reflect.validation.Severity.WARNING
 
-class IncrementalExecutionIntegrationTest extends Specification {
+class IncrementalExecutionIntegrationTest extends Specification implements ValidationMessageChecker {
     private final DocumentationRegistry documentationRegistry = new DocumentationRegistry()
 
     @Rule
@@ -606,7 +607,7 @@ class IncrementalExecutionIntegrationTest extends Specification {
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            hasProblem "Type '$Object.simpleName': Validation error. Test."
+            hasProblem dummyValidationProblem('Object', null, 'Validation error', 'Test').trim()
         }
     }
 

--- a/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
+++ b/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
@@ -40,7 +40,7 @@ class WorkValidationExceptionChecker {
         verified = [] as Set
         problems = error.problems.collect {
             // assertions do not verify the type name
-            ignoreType ? it.substring(it.indexOf(': ') + 2).capitalize() : it.capitalize()
+            ignoreType ? it.substring(it.indexOf("' ") + 2).capitalize() : it.capitalize()
         } as Set
     }
 

--- a/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
+++ b/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/WorkValidationExceptionChecker.groovy
@@ -40,7 +40,7 @@ class WorkValidationExceptionChecker {
         verified = [] as Set
         problems = error.problems.collect {
             // assertions do not verify the type name
-            ignoreType ? it.substring(it.indexOf("' ") + 2).capitalize() : it.capitalize()
+            normaliseLineSeparators(ignoreType ? it.substring(it.indexOf("' ") + 2).capitalize() : it.capitalize())
         } as Set
     }
 

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FilePropertyIntegrationTest.groovy
@@ -24,6 +24,10 @@ import org.gradle.internal.reflect.validation.ValidationTestFor
 import spock.lang.Unroll
 
 class FilePropertyIntegrationTest extends AbstractIntegrationSpec implements TasksWithInputsAndOutputs, ValidationMessageChecker {
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
     def "can attach a calculated directory to task property"() {
         buildFile """
             class SomeTask extends DefaultTask {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskErrorExecutionIntegrationTest.groovy
@@ -22,6 +22,10 @@ import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.TestFile
 
 class TaskErrorExecutionIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
     def reportsTaskActionExecutionFailsWithError() {
         buildFile << """
             task('do-stuff').doFirst {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -175,7 +175,11 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     def "warns about annotation on field without getter"() {
         expect:
         assertProperties TypeWithFieldOnlyAnnotation, [:], [
-            strict("Type 'DefaultTypeAnnotationMetadataStoreTest.TypeWithFieldOnlyAnnotation': field 'property' without corresponding getter has been annotated with @Large. Annotations on fields are only used if there's a corresponding getter for the field. Possible solutions: Add a getter for field 'property' or remove the annotations on 'property'. ${learnAt('validation_problems', 'ignored_annotations_on_field')}.")
+            strict(ignoredAnnotationOnField {
+                type('DefaultTypeAnnotationMetadataStoreTest.TypeWithFieldOnlyAnnotation').property('property')
+                    .annotatedWith('Large')
+                    .includeLink()
+            })
         ]
     }
 
@@ -210,7 +214,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         assertProperties TypeWithIsAndGetProperty, [
             bool: [(TYPE): Small],
         ], [
-            strict("Property 'bool' has redundant getters: 'getBool()' and 'isBool()'. Boolean property 'bool' has both an `is` and a `get` getter. Possible solutions: Remove one of the getters or annotate one of the getters with @Internal. ${learnAt("validation_problems", "redundant_getters")}.")
+            strict(redundantGetters {
+                property('bool')
+                    .includeLink()
+            })
         ]
         store.getTypeAnnotationMetadata(TypeWithIsAndGetProperty).propertiesAnnotationMetadata[0].method.name == "getBool"
     }
@@ -612,8 +619,8 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
             mutableSubTypeWithSetter: [(TYPE): Small],
             mutableTypeWithSetter: [(TYPE): Small]
         ], [
-            mutableSetterErrorMessage('mutableSubTypeWithSetter', MutableSubType.name),
-            mutableSetterErrorMessage('mutableTypeWithSetter', MutableType.name),
+            strict(mutableSetter { property('mutableSubTypeWithSetter').propertyType(MutableSubType.name).includeLink() }),
+            strict(mutableSetter { property('mutableTypeWithSetter').propertyType(MutableType.name).includeLink() })
         ]
     }
 
@@ -812,9 +819,6 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         "$message [STRICT]"
     }
 
-    private String mutableSetterErrorMessage(String property, String propertyType) {
-        strict("Property '$property' of mutable type '$propertyType' is writable. Properties of type '$propertyType' are already mutable. Possible solution: Remove the 'set${property.capitalize()}' method. ${learnAt("validation_problems", "mutable_type_with_setter")}.")
-    }
 }
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -41,6 +41,7 @@ import java.lang.reflect.Method
 
 import static org.gradle.internal.reflect.AnnotationCategory.TYPE
 import static org.gradle.internal.reflect.validation.Severity.ERROR
+import static org.gradle.util.TextUtil.normaliseLineSeparators
 
 class DefaultTypeAnnotationMetadataStoreTest extends Specification implements ValidationMessageChecker {
     private static final COLOR = { "color" } as AnnotationCategory
@@ -809,7 +810,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         def validationContext = DefaultTypeValidationContext.withoutRootType(documentationRegistry, false)
         metadata.visitValidationFailures(validationContext)
         List<String> actualErrors = validationContext.problems
-            .collect({ message, severity -> ("$message" + (severity == ERROR ? " [STRICT]" : "") as String) })
+            .collect({ message, severity -> (normaliseLineSeparators(message) + (severity == ERROR ? " [STRICT]" : "") as String) })
         actualErrors.sort()
         expectedErrors.sort()
         assert actualErrors == expectedErrors

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/integtests/fixtures/MissingTaskDependenciesFixture.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/integtests/fixtures/MissingTaskDependenciesFixture.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.reflect.validation.ValidationMessageChecker
 trait MissingTaskDependenciesFixture extends ValidationMessageChecker {
     void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
         expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer,
-            implicitDependency { at(producedConsumedLocation).consumer(consumer).producer(producer).includeLink() }
+            implicitDependency({ at(producedConsumedLocation).consumer(consumer).producer(producer).includeLink() }, false)
         )
     }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -16,9 +16,14 @@
 
 package org.gradle.internal.reflect.validation
 
+import org.gradle.util.TextUtil
+
 class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayConfiguration<T>> {
     private final ValidationMessageChecker checker
     boolean hasIntro = true
+    private String description
+    private String reason
+    private List<String> solutions = []
 
     ValidationMessageDisplayConfiguration(ValidationMessageChecker checker) {
         this.checker = checker
@@ -28,6 +33,21 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     String property
     String section
     boolean includeLink = false
+
+    T description(String description) {
+        this.description = description
+        this
+    }
+
+    T reason(String reason) {
+        this.reason = reason
+        this
+    }
+
+    T solution(String solution) {
+        this.solutions << solution
+        this
+    }
 
     T property(String name) {
         property = name
@@ -49,23 +69,54 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         this
     }
 
+    String getPropertyIntro() {
+        "property"
+    }
+
     private String getIntro() {
         if (hasIntro) {
-            typeName ? "Type '$typeName': ${property ? "property '${property}' " : ''}" : (property ? "Property '${property}' " : "")
+            typeName ? "Type '$typeName' ${property ? "${propertyIntro} '${property}' " : ''}" : (property ? "${propertyIntro.capitalize()} '${property}' " : "")
         } else {
             ''
         }
     }
 
     private String getOutro() {
-        includeLink ? " ${checker.learnAt("validation_problems", section)}." : ""
+        includeLink ? "${checker.learnAt("validation_problems", section)}." : ""
     }
 
-    String render(String mainBody) {
-        if (!(mainBody.endsWith('.'))) {
-            mainBody = "${mainBody}."
+    static String formatEntry(String entry) {
+        if (entry.endsWith(".")) {
+            entry.capitalize()
+        } else {
+            "${entry.capitalize()}."
         }
-        String rendered = "${intro}${mainBody}${outro}"
-        rendered
+    }
+
+    String render(boolean renderSolutions = true) {
+        def newLine = TextUtil.getPlatformLineSeparator() + checker.messageIndent
+        StringBuilder sb = new StringBuilder(intro)
+        sb.append(description)
+            .append(description.endsWith(".") ? '' : '.')
+            .append(newLine)
+            .append(newLine)
+        if (reason) {
+            sb.append("Reason: ${formatEntry(reason)}${newLine}${newLine}")
+        }
+        if (renderSolutions && !solutions.empty) {
+            if (solutions.size() > 1) {
+                sb.append("Possible solutions:$newLine")
+                solutions.eachWithIndex { String solution, int i ->
+                    sb.append("  ").append(i + 1).append(". ${formatEntry(solution)}$newLine")
+                }
+            } else {
+                sb.append("Possible solution: ${formatEntry(solutions[0])}$newLine")
+            }
+        }
+        if (outro) {
+            sb.append(newLine)
+            sb.append(outro)
+        }
+        sb.toString()
     }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.reflect.validation
 
-import org.gradle.util.TextUtil
-
 class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayConfiguration<T>> {
     private final ValidationMessageChecker checker
     boolean hasIntro = true
@@ -94,7 +92,7 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     }
 
     String render(boolean renderSolutions = true) {
-        def newLine = TextUtil.getPlatformLineSeparator() + checker.messageIndent
+        def newLine = "\n${checker.messageIndent}"
         StringBuilder sb = new StringBuilder(intro)
         sb.append(description)
             .append(description.endsWith(".") ? '' : '.')

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.util.GUtil
 import static org.gradle.plugin.devel.tasks.PluginUnderTestMetadata.IMPLEMENTATION_CLASSPATH_PROP_KEY
 import static org.gradle.plugin.devel.tasks.PluginUnderTestMetadata.METADATA_FILE_NAME
 
-class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker{
+class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
 
     private static final String TASK_NAME = 'pluginClasspathManifest'
 
@@ -33,6 +33,7 @@ class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec imp
         buildFile << """
             apply plugin: 'java'
         """
+        expectReindentedValidationMessage()
     }
 
     @ValidationTestFor(
@@ -48,7 +49,7 @@ class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec imp
         fails TASK_NAME
 
         then:
-        failureDescriptionContains(missingValueMessage { type(PluginUnderTestMetadata.simpleName).property('outputDirectory') })
+        failureDescriptionContains(missingValueMessage { type(PluginUnderTestMetadata.simpleName).property('outputDirectory').includeLink() })
     }
 
     def "implementation-classpath entry in metadata is empty if there is no classpath"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/RuntimePluginValidationIntegrationTest.groovy
@@ -27,6 +27,7 @@ class RuntimePluginValidationIntegrationTest extends AbstractPluginValidationInt
 
     @Override
     def setup() {
+        expectReindentedValidationMessage()
         buildFile << """
             tasks.register("run", MyTask)
         """

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
@@ -57,14 +57,15 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
         report.verify(messages.collectEntries {
             def fullMessage = it.message
             if (!it.defaultDocLink) {
-                fullMessage = "${fullMessage} ${learnAt(it.id, it.section)}."
+                fullMessage = "${fullMessage}\n${learnAt(it.id, it.section)}."
             }
             [(fullMessage): it.severity]
         })
 
         failure.assertHasCause "Plugin validation failed with ${messages.size()} problem${messages.size() > 1 ? 's' : ''}"
         messages.forEach { problem ->
-            failure.assertThatCause(containsString("$problem.severity: $problem.message"))
+            String indentedMessage = problem.message.replaceAll('\n', '\n    ').trim()
+            failure.assertThatCause(containsString("$problem.severity: $indentedMessage"))
         }
     }
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -53,6 +53,7 @@ import static org.gradle.internal.reflect.validation.Severity.ERROR;
 
 public abstract class ValidateAction implements WorkAction<ValidateAction.Params> {
     private final static Logger LOGGER = Logging.getLogger(ValidateAction.class);
+    public static final String PROBLEM_SEPARATOR = "--------";
 
     public interface Params extends WorkParameters {
         ConfigurableFileCollection getClasses();
@@ -125,7 +126,7 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
             try {
                 //noinspection ResultOfMethodCallIgnored
                 output.createNewFile();
-                Files.asCharSink(output, Charsets.UTF_8).write(Joiner.on('\n').join(problemMessages));
+                Files.asCharSink(output, Charsets.UTF_8).write(Joiner.on("\n" + PROBLEM_SEPARATOR + "\n").join(problemMessages));
             } catch (IOException ex) {
                 throw new java.io.UncheckedIOException(ex);
             }

--- a/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
+++ b/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
@@ -32,7 +32,7 @@ class TaskValidationReportFixture {
             .collect { message, severity ->
                 "$severity: $message"
             }
-            .join("\n")
+            .join("\n--------\n")
         assert reportFile.text == expectedReportContents
     }
 }

--- a/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
+++ b/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
@@ -33,6 +33,7 @@ class TaskValidationReportFixture {
                 "$severity: $message"
             }
             .join("\n--------\n")
-        assert reportFile.text == expectedReportContents
+        def reportText = reportFile.text.replaceAll("\r\n", "\n")
+        assert reportText == expectedReportContents
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -30,6 +30,9 @@ import java.util.jar.Manifest
 
 @TestReproducibleArchives
 class JarIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+    def setup() {
+        expectReindentedValidationMessage()
+    }
 
     def canCreateAnEmptyJar() {
         given:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -384,6 +384,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     )
     def "failsBecauseOfMissingConfigFile"() {
         Assume.assumeFalse(versionLowerThan("2.1"))
+        expectReindentedValidationMessage()
 
         expect:
         def configFile = file('groovycompilerconfig.groovy')

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -39,7 +39,7 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
                 onPlugin('com.moowork.node') {
                     failsWith([
                         (missingAnnotationMessage { type('NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
-                        "Type 'NpmSetupTask': setter 'setArgs()' should not be annotated with: @Internal. Input/Output annotations are ignored if they are placed on something else than a getter. Possible solutions: Remove the annotations or rename the method. ${learnAt("validation_problems", "ignored_annotations_on_method")}.": ERROR,
+                        (methodShouldNotBeAnnotatedMessage {type('NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
                         (missingAnnotationMessage { type('YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
                     ])
                 }


### PR DESCRIPTION
Now that we have better error messages, we can improve their layout. In particular,
with the new system, we can give more context but for compatibility reasons, they
were displayed as a "block of text".

This commit changes the rendering so that we have richer output. For example, you'd
read:

```
> Task :myTask FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':myTask' (type 'TaskWithAbsentNestedInput').
  - Type 'TaskWithAbsentNestedInput' property 'nested' doesn't have a configured value.

    Reason: This property isn't marked as optional and no value has been configured.

    Possible solutions:
      1. Assign a value to 'nested'.
      2. Mark property 'nested' as optional.

    Please refer to https://docs.gradle.org/7.0-20210310230000+0000/userguide/validation_problems.html#value_not_set for more details about this problem.
```

or:

```
A problem was found with the configuration of task ':test' (type 'DefaultTask').
  - Type 'DefaultTask' property 'input' has unsupported value 'task ':dependencyTask''.

    Reason: Type 'DefaultTask' cannot be converted to a directory.

    Possible solutions:
      1. Use a String or CharSequence path, for example 'src/main/java' or '/usr/include'.
      2. Use a String or CharSequence URI, for example 'file:/usr/include'.
      3. Use a File instance.
      4. Use a Path instance.
      5. Use a Directory instance.
      6. Use a RegularFile instance.
      7. Use a URI or URL instance.
      8. Use a TextResource instance.

    Please refer to https://docs.gradle.org/7.0-20210310230000+0000/userguide/validation_problems.html#unsupported_notation for more details about this problem.
```

The good:

- error messages are now much easier to read
- error messages are more actionable
- the new test fixtures made it really easy to change the error message
- some tests which weren't using the new fixture were fixed

The bad:

- deprecation warnings are very hard to deal with in tests, because we don't detect multiline messages
properly (this is due to 2 problems: we perform validation at the end of the build AND we don't have markers
for those messages, we do plain string parsing)
- indentation changes in some messages because of nested exceptions, so a convenience was added to take this
into account. Again, because the fixtures we use are very picky on the layout and don't tolerate mismatches
in spacing.

The goal of this PR is NOT to improve the old fixtures. They should probably be changed to tolerate whatever
format wrt whitespaces. Testing the actual error message should belong to unit testing, if we ever want to
do this.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
