### PR TITLE
Fix the order in which the wrapper parses properties

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -482,6 +482,7 @@ Learn more about this in <<dependency_locking.adoc#dependency-locking,dependency
 Do not rebuild project dependencies.
 Useful for <<organizing_gradle_projects.adoc#sec:build_sources, debugging and fine-tuning `buildSrc`>>, but can lead to wrong results. Use with caution!
 
+[[sec:environment_options]]
 == Environment options
 You can customize many aspects about where build scripts, settings, caches, and so on through the options below. Learn more about customizing your <<build_environment.adoc#build_environment, build environment>>.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -32,14 +32,16 @@ Aside from configuring the build environment, you can configure a given project 
 [[sec:gradle_configuration_properties]]
 == Gradle properties
 
-Gradle provides several options that make it easy to configure the Java process that will be used to execute your build. While it's possible to configure these in your local environment via `GRADLE_OPTS` or `JAVA_OPTS`, it is useful to store certain settings like JVM memory configuration and Java home location in version control so that an entire team can work with a consistent environment.
+Gradle provides several options that make it easy to configure the Java process that will be used to execute your build. While it's possible to configure these in your local environment via `GRADLE_OPTS` or `JAVA_OPTS`, it is useful to be able to store certain settings like JVM memory configuration and Java home location in version control so that an entire team can work with a consistent environment. To do so, place these settings into a `gradle.properties` file committed to your version control system.
 
-Setting up a consistent environment for your build is as simple as placing these settings into a `gradle.properties` file. The configuration is a combination of all your `gradle.properties` files, but if an option is configured in multiple locations, the _first one wins_:
+The final configuration taken into account by Gradle is a combination of all Gradle properties set on the command line and your `gradle.properties` files. If an option is configured in multiple locations, the _first one_ found in any of these locations wins:
 
-* system properties, e.g. when `-Dgradle.user.home` is set on the command line.
+* command line, as set using the `-P` / `--project-prop` <<command_line_interface.adoc#sec:environment_options, environment options>>.
 * `gradle.properties` in `GRADLE_USER_HOME` directory.
 * `gradle.properties` in project root directory.
 * `gradle.properties` in Gradle installation directory.
+
+Note that the location of the Gradle user home may have been changed beforehand via the `-Dgradle.user.home` system property passed on the command line.
 
 The following properties can be used to configure the Gradle build environment:
 

--- a/subprojects/wrapper/build.gradle.kts
+++ b/subprojects/wrapper/build.gradle.kts
@@ -46,19 +46,3 @@ val executableJar by tasks.registering(Jar::class) {
 tasks.jar {
     from(executableJar)
 }
-
-// === TODO remove and address the following when we have a good reason to change the wrapper jar
-executableJar {
-    val cliClasspath = layout.buildDirectory.file("gradle-cli-classpath.properties") // This file was accidentally included into the gradle-wrapper.jar
-    val cliParameterNames = layout.buildDirectory.file("gradle-cli-parameter-names.properties")  // This file was accidentally included into the gradle-wrapper.jar
-    doFirst {
-        cliClasspath.get().asFile.writeText("projects=\nruntime=\n")
-        cliParameterNames.get().asFile.writeText("")
-    }
-    from(cliClasspath)
-    from(cliParameterNames)
-}
-strictCompile {
-    ignoreRawTypes() // Raw type used in 'org.gradle.wrapper.Install', fix this or add an ignore/suppress annotation there
-}
-// ===

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -72,7 +72,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then: "the checksum should be constant (unless there are code changes)"
         // TODO If you need to update this because of necessary code change in the wrapper, also address the TODO in 'wrapper.gradle.kts'
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "810cd5fb51fa916cd09c9332f5f60bdfd786871adb90e29a2b65cd74cf9730eb"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,8 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        // TODO If you need to update this because of necessary code change in the wrapper, also address the TODO in 'wrapper.gradle.kts'
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "810cd5fb51fa916cd09c9332f5f60bdfd786871adb90e29a2b65cd74cf9730eb"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "47a62eb8a42fe3739dbc2c594f1f49f45ef5de951f88aa9568c2fd45f2025447"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -67,8 +67,9 @@ public class GradleWrapperMain {
     }
 
     private static void addSystemProperties(Properties systemProperties, File gradleHome, File rootDir) {
-        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleHome, "gradle.properties")));
+        // The location with highest priority needs to come last here, as it overwrites any previous entries.
         systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(rootDir, "gradle.properties")));
+        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleHome, "gradle.properties")));
     }
 
     private static File rootDir(File wrapperJar) {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -66,10 +66,10 @@ public class GradleWrapperMain {
                 new BootstrapMainStarter());
     }
 
-    private static void addSystemProperties(Properties systemProperties, File gradleHome, File rootDir) {
+    private static void addSystemProperties(Properties systemProperties, File gradleUserHome, File rootDir) {
         // The location with highest priority needs to come last here, as it overwrites any previous entries.
         systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(rootDir, "gradle.properties")));
-        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleHome, "gradle.properties")));
+        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleUserHome, "gradle.properties")));
     }
 
     private static File rootDir(File wrapperJar) {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -55,7 +55,7 @@ public class GradleWrapperMain {
 
         File gradleUserHome = gradleUserHome(options);
 
-        addSystemProperties(gradleUserHome, rootDir);
+        addSystemProperties(systemProperties, gradleUserHome, rootDir);
 
         Logger logger = logger(options);
 
@@ -66,9 +66,9 @@ public class GradleWrapperMain {
                 new BootstrapMainStarter());
     }
 
-    private static void addSystemProperties(File gradleHome, File rootDir) {
-        System.getProperties().putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleHome, "gradle.properties")));
-        System.getProperties().putAll(SystemPropertiesHandler.getSystemProperties(new File(rootDir, "gradle.properties")));
+    private static void addSystemProperties(Properties systemProperties, File gradleHome, File rootDir) {
+        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(gradleHome, "gradle.properties")));
+        systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(rootDir, "gradle.properties")));
     }
 
     private static File rootDir(File wrapperJar) {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -235,13 +235,12 @@ public class Install {
     }
 
     private void unzip(File zip, File dest) throws IOException {
-        Enumeration entries;
         ZipFile zipFile = new ZipFile(zip);
         try {
-            entries = zipFile.entries();
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
 
             while (entries.hasMoreElements()) {
-                ZipEntry entry = (ZipEntry) entries.nextElement();
+                ZipEntry entry = entries.nextElement();
 
                 if (entry.isDirectory()) {
                     (new File(dest, entry.getName())).mkdirs();


### PR DESCRIPTION
Fixes #985 and #11864.

### Context
There were already two issues reported about this, and the fix was easy, so this should be done esp. now as the stale bot closed / is about to close the referenced issues.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
