### PR TITLE
Improve Javadoc for ValidatePlugins

### DIFF
--- a/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/developing-plugins/implementing_gradle_plugins.adoc
@@ -76,7 +76,7 @@ include::{snippetsPath}/developingPlugins/incrementalTask/groovy/buildSrc/src/ma
 ----
 
 The first section of this guide talks about the <<plugin-development-plugin,Plugin Development plugin>>.
-As an added benefit of applying the plugin to your project, the task `validateTaskProperties` automatically checks for an existing input/output annotation for every public property defined in a custom task type implementation.
+As an added benefit of applying the plugin to your project, the task `validatePlugins` automatically checks for an existing input/output annotation for every public property defined in a custom task type implementation.
 
 [[modeling_dsl_like_apis]]
 == Modeling DSL-like APIs

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -43,10 +43,10 @@ import java.util.List;
 /**
  * Validates plugins by checking property annotations on work items like tasks and artifact transforms.
  *
- * This task should be added to a Gradle plugin project for doing static analysis on the plugin classes.
+ * This task should be used in Gradle plugin projects for doing static analysis on the plugin classes.
  *
- * The <a href="https://docs.gradle.org/current/userguide/java_gradle_plugin.html" target="_top">java-gradle-plugin</a> automatically adds
- * a {@code validatePlugins} task, so you don't have to do it yourself.
+ * The <a href="https://docs.gradle.org/current/userguide/java_gradle_plugin.html" target="_top">java-gradle-plugin</a> adds
+ * a {@code validatePlugins} task, though if you cannot use this plugin then you need to register the task yourself.
  *
  * See the user guide for more information on
  * <a href="https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks" target="_top">incremental build</a> and

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidatePlugins.java
@@ -43,6 +43,11 @@ import java.util.List;
 /**
  * Validates plugins by checking property annotations on work items like tasks and artifact transforms.
  *
+ * This task should be added to a Gradle plugin project for doing static analysis on the plugin classes.
+ *
+ * The <a href="https://docs.gradle.org/current/userguide/java_gradle_plugin.html" target="_top">java-gradle-plugin</a> automatically adds
+ * a {@code validatePlugins} task, so you don't have to do it yourself.
+ *
  * See the user guide for more information on
  * <a href="https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks" target="_top">incremental build</a> and
  * <a href="https://docs.gradle.org/current/userguide/build_cache.html#sec:task_output_caching" target="_top">caching task outputs</a>.


### PR DESCRIPTION
It was not clear from the Javadoc where to use the task. Moreover, the task name in `implementing_gradle_plugins.adoc` was wrong and pointed to the now removed task.