### PR TITLE
Enable incremental compilation with Java records 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
@@ -19,5 +19,5 @@ package org.gradle.internal.classanalysis;
 import org.objectweb.asm.Opcodes;
 
 public class AsmConstants {
-    public static final int ASM_LEVEL = Opcodes.ASM7;
+    public static final int ASM_LEVEL = Opcodes.ASM9;
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classanalysis/AsmConstants.java
@@ -19,5 +19,5 @@ package org.gradle.internal.classanalysis;
 import org.objectweb.asm.Opcodes;
 
 public class AsmConstants {
-    public static final int ASM_LEVEL = Opcodes.ASM9;
+    public static final int ASM_LEVEL = Opcodes.ASM8;
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -133,6 +133,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK15_OR_LATER({
         JavaVersion.current() >= JavaVersion.VERSION_15
     }),
+    JDK16_OR_LATER({
+        JavaVersion.current() >= JavaVersion.VERSION_16
+    }),
     JDK_ORACLE({
         System.getProperty('java.vm.vendor') == 'Oracle Corporation'
     }),


### PR DESCRIPTION
Update the ASM opcodes version used internally so that it supports Java records.

Fixes https://github.com/gradle/gradle/issues/14744
