### PR TITLE
Improve JCenter shut down message

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -121,7 +121,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * @param action a configuration action
      * @return the added repository
-     * @deprecated JCenter will soon be <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter">shut down</a>. Use {@link #mavenCentral()} instead.
+     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">shutdown</a> in February 2021. Use {@link #mavenCentral()} instead.
      */
     @Deprecated
     MavenArtifactRepository jcenter(Action<? super MavenArtifactRepository> action);
@@ -141,7 +141,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * @return the added resolver
      * @see #jcenter(Action)
-     * @deprecated JCenter will soon be <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter">shut down</a>. Use {@link #mavenCentral()} instead.
+     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">shutdown</a> in February 2021. Use {@link #mavenCentral()} instead.
      */
     @Deprecated
     MavenArtifactRepository jcenter();

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
         'flat-dir'             | flatDirRepoBlock()            | expectedFlatDirRepo()            | null
         'local maven'          | mavenLocalRepoBlock()         | expectedMavenLocalRepo()         | null
         'maven central'        | mavenCentralRepoBlock()       | expectedMavenCentralRepo()       | null
-        'jcenter'              | jcenterRepoBlock()            | expectedJcenterRepo()            | "The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JCenter will soon be shut down. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
+        'jcenter'              | jcenterRepoBlock()            | expectedJcenterRepo()            | "The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
         'google'               | googleRepoBlock()             | expectedGoogleRepo()             | null
         'gradle plugin portal' | gradlePluginPortalRepoBlock() | expectedGradlePluginPortalRepo() | null
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedRepositoryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedRepositoryIntegrationTest.groovy
@@ -30,7 +30,7 @@ class DeprecatedRepositoryIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning "The RepositoryHandler.jcenter() method has been deprecated." +
-            " This is scheduled to be removed in Gradle 8.0. JCenter will soon be shut down. Use mavenCentral() instead." +
+            " This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead." +
             " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
 
         then:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -124,7 +124,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
     private void deprecateJCenter(String method, String replacement) {
         DeprecationLogger.deprecateMethod(RepositoryHandler.class, method)
-            .withAdvice("JCenter will soon be shut down. Use " + replacement + " instead.")
+            .withAdvice("JFrog announced JCenter's shutdown in February 2021. Use " + replacement + " instead.")
             .willBeRemovedInGradle8()
             .withUpgradeGuideSection(6, "jcenter_deprecation")
             .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -62,7 +62,8 @@ Users can still opt in to have this unique identifier part of the produced metad
 [[jcenter_deprecation]]
 === The `jcenter()` convenience method is now deprecated
 
-JFrog recently link:https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter[announced] the decommission of JCenter.
+JFrog link:https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter[announced] the decommission of JCenter.
+This has the potential to https://blog.gradle.org/jcenter-shutdown[impact many Gradle builds].
 Gradle emits a deprecation warning when `jcenter()` is used in the repository configuration.
 Consider <<declaring_repositories.adoc#declaring-repositories,using>> `mavenCentral()`, `google()` or a private `maven` repository instead.
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -287,7 +287,7 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning "The RepositoryHandler.jcenter() method has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. JCenter will soon be shut down. Use mavenCentral() instead. " +
+            "This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
         succeeds "help"
     }


### PR DESCRIPTION
Because these migration notes or deprecation message could be read years
from now, the form is changed to have meaning today and later.