### PR TITLE
Fix potential `NoClassDefFoundError`

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStore.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
-import groovy.transform.Generated;
 import org.gradle.api.Action;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -374,7 +373,7 @@ public class DefaultTypeAnnotationMetadataStore implements TypeAnnotationMetadat
      * @return true if we suspect this method to be a safely ignorable generated method
      */
     private boolean isIgnoredGeneratedGroovyMethod(Method method) {
-        return method.getAnnotation(Generated.class) != null && method.getName().contains("$");
+        return generatedMethodDetector.test(method) && method.getName().contains("$");
     }
 
     private void processMethodAnnotations(Method method, Map<String, PropertyAnnotationMetadataBuilder> methodBuilders, TypeValidationContext validationContext) {


### PR DESCRIPTION
This commit workarounds a classloading issue reported by a user
by reusing the supplied `generatedMethodDetector`, which is
actually already verifying that the method is annotated with
Groovy's `@Generated` method.

## Context

Fixes (?) this exception reported by a user. I'm actually not sure _why_ this change would make this error go away but working on a fix I realized that the injected `generatedMethodDetector` is actually already testing for Groovy's `@Generated` annotation. However for some reason because it's injected it doesn't seem to trigger a bug. Or maybe it's because it's not called?

```
java.lang.NoClassDefFoundError: groovy/transform/Generated
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.isIgnoredGeneratedGroovyMethod(DefaultTypeAnnotationMetadataStore.java:377)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.shouldIgnore(DefaultTypeAnnotationMetadataStore.java:361)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.processMethodAnnotations(DefaultTypeAnnotationMetadataStore.java:381)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.extractPropertiesFrom(DefaultTypeAnnotationMetadataStore.java:245)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.createTypeAnnotationMetadata(DefaultTypeAnnotationMetadataStore.java:215)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.lambda$getTypeAnnotationMetadata$1(DefaultTypeAnnotationMetadataStore.java:185)
	at org.gradle.cache.Cache.lambda$get$0(Cache.java:31)
	at org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory$AbstractCrossBuildInMemoryCache.get(DefaultCrossBuildInMemoryCacheFactory.java:134)
	at org.gradle.cache.Cache.get(Cache.java:31)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.getTypeAnnotationMetadata(DefaultTypeAnnotationMetadataStore.java:185)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.lambda$visitSuperTypes$22(DefaultTypeAnnotationMetadataStore.java:464)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.visitSuperTypes(DefaultTypeAnnotationMetadataStore.java:464)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.inheritMethods(DefaultTypeAnnotationMetadataStore.java:228)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.createTypeAnnotationMetadata(DefaultTypeAnnotationMetadataStore.java:211)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.lambda$getTypeAnnotationMetadata$1(DefaultTypeAnnotationMetadataStore.java:185)
	at org.gradle.cache.Cache.lambda$get$0(Cache.java:31)
	at org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory$AbstractCrossBuildInMemoryCache.get(DefaultCrossBuildInMemoryCacheFactory.java:134)
	at org.gradle.cache.Cache.get(Cache.java:31)
	at org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore.getTypeAnnotationMetadata(DefaultTypeAnnotationMetadataStore.java:185)
	at org.gradle.api.internal.tasks.properties.DefaultTypeMetadataStore.createTypeMetadata(DefaultTypeMetadataStore.java:95)
	at org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory$AbstractCrossBuildInMemoryCache.get(DefaultCrossBuildInMemoryCacheFactory.java:134)
	at org.gradle.api.internal.tasks.properties.DefaultTypeMetadataStore.getTypeMetadata(DefaultTypeMetadataStore.java:89)
	at org.gradle.api.internal.tasks.properties.bean.RuntimeBeanNodeFactory.createRoot(RuntimeBeanNodeFactory.java:33)
	at org.gradle.api.internal.tasks.properties.DefaultPropertyWalker.visitProperties(DefaultPropertyWalker.java:38)
	at org.gradle.api.internal.tasks.TaskPropertyUtils.visitProperties(TaskPropertyUtils.java:44)
	at org.gradle.api.internal.tasks.TaskPropertyUtils.visitProperties(TaskPropertyUtils.java:34)
	at org.gradle.api.internal.tasks.DefaultTaskOutputs.getFileProperties(DefaultTaskOutputs.java:143)
	at org.gradle.api.internal.tasks.DefaultTaskOutputs$TaskOutputUnionFileCollection.visitChildren(DefaultTaskOutputs.java:234)
	at org.gradle.api.internal.file.CompositeFileCollection.visitContents(CompositeFileCollection.java:119)
	at org.gradle.api.internal.file.AbstractFileCollection.getFiles(AbstractFileCollection.java:130)
	at org.gradle.api.internal.file.AbstractFileCollection.iterator(AbstractFileCollection.java:176)
	at com.android.build.gradle.internal.tasks.NonIncrementalTaskKt.cleanUpTaskOutputs(NonIncrementalTask.kt:81)
	at com.android.build.gradle.internal.tasks.NonIncrementalGlobalTask$taskAction$$inlined$recordTaskAction$1.invoke(BaseTask.kt:62)
	at com.android.build.gradle.internal.tasks.Blocks.recordSpan(Blocks.java:51)
	at com.android.build.gradle.internal.tasks.NonIncrementalGlobalTask.taskAction(NonIncrementalTask.kt:94)
	at com.android.build.api.variant.impl.TaskBasedOperationsImplTest.asynchronousTest(TaskBasedOperationsImplTest.kt:325)
```