### PR TITLE
Fix deprecation message of Kotlin DSL eager extensions for Configuration accessors

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ConfigurationDeprecatedExtensions.kt
@@ -499,4 +499,4 @@ fun <T : Configuration> NamedDomainObjectProvider<T>.addToAntBuilder(builder: An
 
 
 private
-const val deprecationMessage = "Scheduled to be removed in Gradle 6.0"
+const val deprecationMessage = "Scheduled to be removed in Gradle 8.0"


### PR DESCRIPTION
What the title says