### PR TITLE
Use command line argument provider for samples tests system property

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 }
 
 extensions.create<IntegrationTestExtension>("integTest").apply {
-    usesSamples.convention(false)
+    usesJavadocCodeSnippets.convention(false)
 }
 
 val sourceSet = addSourceSet(TestType.INTEGRATION)

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/extension/IntegrationTestExtension.kt
@@ -20,5 +20,5 @@ import org.gradle.api.provider.Property
 
 
 abstract class IntegrationTestExtension {
-    abstract val usesSamples: Property<Boolean>
+    abstract val usesJavadocCodeSnippets: Property<Boolean>
 }

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -40,7 +40,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.process.CommandLineArgumentProvider
-import java.io.File
 
 
 fun Project.addDependenciesAndConfigurations(prefix: String) {

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -31,7 +31,7 @@ import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.api.file.Directory
-import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceSet
@@ -131,8 +131,8 @@ fun Project.getBucketProvider() = gradle.sharedServices.registerIfAbsent("buildB
 }
 
 internal
-class SamplesBaseDirPropertyProvider(@InputFiles @PathSensitive(PathSensitivity.RELATIVE) val autoTestedSamplesPath: Directory) : CommandLineArgumentProvider {
-    override fun asArguments() = listOf("-DdeclaredSampleInputs=${autoTestedSamplesPath.asFile.absolutePath}")
+class SamplesBaseDirPropertyProvider(@InputDirectory @PathSensitive(PathSensitivity.RELATIVE) val autoTestedSamplesDir: Directory) : CommandLineArgumentProvider {
+    override fun asArguments() = listOf("-DdeclaredSampleInputs=${autoTestedSamplesDir.asFile.absolutePath}")
 }
 
 internal

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -130,10 +130,12 @@ fun Project.getBucketProvider() = gradle.sharedServices.registerIfAbsent("buildB
     parameters.repoRoot.set(repoRoot())
 }
 
+
 internal
 class SamplesBaseDirPropertyProvider(@InputDirectory @PathSensitive(PathSensitivity.RELATIVE) val autoTestedSamplesDir: Directory) : CommandLineArgumentProvider {
     override fun asArguments() = listOf("-DdeclaredSampleInputs=${autoTestedSamplesDir.asFile.absolutePath}")
 }
+
 
 internal
 fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet, testType: TestType, extraConfig: Action<IntegrationTest>): TaskProvider<IntegrationTest> =

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -148,7 +148,7 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
         testClassesDirs = sourceSet.output.classesDirs
         classpath = sourceSet.runtimeClasspath
         extraConfig.execute(this)
-        if (integTest.usesSamples.get()) {
+        if (integTest.usesJavadocCodeSnippets.get()) {
             val samplesDir = layout.projectDirectory.dir("src/main")
             jvmArgumentProviders.add(SamplesBaseDirPropertyProvider(samplesDir))
         }

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -36,5 +36,5 @@ strictCompile {
     ignoreParameterizedVarargType() // [unchecked] Possible heap pollution from parameterized vararg type: ArtifactResolutionQuery, RepositoryContentDescriptor, HasMultipleValues
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -182,5 +182,5 @@ tasks.compileTestGroovy {
     groovyOptions.fork("memoryInitialSize" to "128M", "memoryMaximumSize" to "1G")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)

--- a/subprojects/ide-native/build.gradle.kts
+++ b/subprojects/ide-native/build.gradle.kts
@@ -44,4 +44,4 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-native"))
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/ide/build.gradle.kts
+++ b/subprojects/ide/build.gradle.kts
@@ -63,5 +63,5 @@ classycle {
     excludePatterns.add("org/gradle/plugins/ide/idea/model/internal/*")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AutoTestedSamplesUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AutoTestedSamplesUtil.groovy
@@ -51,7 +51,7 @@ class AutoTestedSamplesUtil {
 
     static void assertDeclaredAsInput(String dir) {
         String inputs = System.getProperty("declaredSampleInputs")
-        assert inputs: "Must declare samples dir as inputs: 'integTest.usesSamples.set(true)'"
+        assert inputs: "Must declare source directory as input: 'integTest.testJavadocCodeSnippets.set(true)'"
         assert inputs == dir
     }
 

--- a/subprojects/ivy/build.gradle.kts
+++ b/subprojects/ivy/build.gradle.kts
@@ -59,4 +59,4 @@ dependencies {
     crossVersionTestDistributionRuntimeOnly(project(":distributions-core"))
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/language-java/build.gradle.kts
+++ b/subprojects/language-java/build.gradle.kts
@@ -84,4 +84,4 @@ classycle {
 }
 
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/language-native/build.gradle.kts
+++ b/subprojects/language-native/build.gradle.kts
@@ -68,4 +68,4 @@ classycle {
     excludePatterns.add("org/gradle/language/nativeplatform/internal/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/maven/build.gradle.kts
+++ b/subprojects/maven/build.gradle.kts
@@ -63,4 +63,4 @@ classycle {
     excludePatterns.add("org/gradle/api/artifacts/maven/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/platform-base/build.gradle.kts
+++ b/subprojects/platform-base/build.gradle.kts
@@ -40,4 +40,4 @@ classycle {
     excludePatterns.add("org/gradle/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/platform-jvm/build.gradle.kts
+++ b/subprojects/platform-jvm/build.gradle.kts
@@ -54,4 +54,4 @@ classycle {
     excludePatterns.add("org/gradle/jvm/toolchain/internal/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/platform-native/build.gradle.kts
+++ b/subprojects/platform-native/build.gradle.kts
@@ -63,4 +63,4 @@ classycle {
     excludePatterns.add("org/gradle/nativeplatform/toolchain/internal/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/plugin-development/build.gradle.kts
+++ b/subprojects/plugin-development/build.gradle.kts
@@ -53,4 +53,4 @@ dependencies {
     testFixturesImplementation(project(":model-core"))
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/plugins/build.gradle.kts
+++ b/subprojects/plugins/build.gradle.kts
@@ -78,5 +78,5 @@ classycle {
     excludePatterns.add("org/gradle/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)

--- a/subprojects/publish/build.gradle.kts
+++ b/subprojects/publish/build.gradle.kts
@@ -26,4 +26,4 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-core"))
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/samples/build.gradle.kts
+++ b/subprojects/samples/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     integTestDistributionRuntimeOnly(project(":distributions-full"))
 }
 
-integTest.usesSamples.set(true)
 testFilesCleanup.reportOnly.set(true)

--- a/subprojects/scala/build.gradle.kts
+++ b/subprojects/scala/build.gradle.kts
@@ -55,4 +55,4 @@ classycle {
     excludePatterns.add("org/gradle/language/scala/tasks/*")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/signing/build.gradle.kts
+++ b/subprojects/signing/build.gradle.kts
@@ -39,4 +39,4 @@ classycle {
     excludePatterns.add("org/gradle/plugins/signing/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/testing-base/build.gradle.kts
+++ b/subprojects/testing-base/build.gradle.kts
@@ -54,4 +54,4 @@ classycle {
     excludePatterns.add("org/gradle/api/internal/tasks/testing/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -72,4 +72,4 @@ tasks.test {
     exclude("org/gradle/api/internal/tasks/testing/testng/ATestNGFactoryClass*.*")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)

--- a/subprojects/tooling-api/build.gradle.kts
+++ b/subprojects/tooling-api/build.gradle.kts
@@ -79,7 +79,7 @@ classycle {
     excludePatterns.add("org/gradle/tooling/**")
 }
 
-integTest.usesSamples.set(true)
+integTest.usesJavadocCodeSnippets.set(true)
 testFilesCleanup.reportOnly.set(true)
 
 apply(from = "buildship.gradle")


### PR DESCRIPTION
So that the resulting build cache entries do not depend on the absolute paths that are values of this system property.
