### PR TITLE
Upgrade tested version of nebula plugin plugin

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -63,7 +63,7 @@ abstract class AbstractSmokeTest extends Specification {
         static nebulaDependencyRecommender = "9.1.1"
 
         // https://plugins.gradle.org/plugin/nebula.plugin-plugin
-        static nebulaPluginPlugin = "14.5.0"
+        static nebulaPluginPlugin = "15.3.0"
 
         // https://plugins.gradle.org/plugin/nebula.lint
         static nebulaLint = "16.15.9"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NebulaPluginsSmokeTest.groovy
@@ -248,10 +248,4 @@ testImplementation('junit:junit:4.7')""")
             'nebula.resolution-rules': Versions.of(TestedVersions.nebulaResolutionRules)
         ]
     }
-
-    @Override
-    Map<String, String> getExtraPluginsRequiredForValidation(String testedPluginId, String version) {
-        // TODO: Use newer version of nebula.plugin-plugin which applies the newer coveralls plugin
-        return testedPluginId == 'nebula.plugin-plugin' ? ['com.github.kt3k.coveralls': '2.11.0'] : [:]
-    }
 }


### PR DESCRIPTION
This plugin uses a newer version of the coveralls plugin which fixes some validation warnings.

Fixes gradle/gradle-private#3298