### PR TITLE
Update wrapper to latest nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-milestone-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.0-20210316151045+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
For the fixes required to run Gradle tests with the configuration cache enabled.

Signed-off-by: Rodrigo B. de Oliveira <rodrigo@gradle.com>