### PR TITLE
Remove ModuleIdentityExtension from unnecessary module

### DIFF
--- a/build-logic/build-update-utils/build.gradle.kts
+++ b/build-logic/build-update-utils/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 
 dependencies {
     implementation("com.google.code.gson:gson")
-    implementation(project(":module-identity"))
+    implementation(project(":basics"))
 }

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -4,10 +4,9 @@ import gradlebuild.buildutils.tasks.UpdateBranchStatus
 import gradlebuild.buildutils.tasks.UpdateReleasedVersions
 import gradlebuild.buildutils.model.ReleasedVersion
 import java.net.URL
+import gradlebuild.basics.BuildEnvironment
+import gradlebuild.basics.currentGitBranch
 
-plugins {
-    id("gradlebuild.module-identity")
-}
 
 tasks.withType<UpdateReleasedVersions>().configureEach {
     releasedVersionsFile.set(layout.projectDirectory.file("released-versions.json"))
@@ -34,7 +33,13 @@ tasks.register<UpdateReleasedVersions>("updateReleasedVersionsToLatestNightly") 
     )
 }
 
-tasks.register<UpdateBranchStatus>("updateBranchStatus")
+tasks.register<UpdateBranchStatus>("updateBranchStatus") {
+    gradleBuildBranch.set(
+        providers.environmentVariable(BuildEnvironment.BUILD_BRANCH)
+            .forUseAtConfigurationTime()
+            .orElse(currentGitBranch())
+    )
+}
 
 tasks.register<UpdateAgpVersions>("updateAgpVersions") {
     comment.set(" Generated - Update by running `./gradlew updateAgpVersions`")

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.identity.extension
 
+import gradlebuild.basics.toPreTestedCommitBaseBranch
 import gradlebuild.identity.tasks.BuildReceipt
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -49,7 +50,7 @@ abstract class ModuleIdentityExtension(val tasks: TaskContainer, val objects: Ob
      *
      * For example, for the pre-tested commit branch "pre-test/master/queue/alice/personal-branch" the logical branch is "master".
      */
-    val logicalBranch: Provider<String> = gradleBuildBranch.map(this::toPreTestedCommitBaseBranch)
+    val logicalBranch: Provider<String> = gradleBuildBranch.map(::toPreTestedCommitBaseBranch)
 
     abstract val gradleBuildCommitId: Property<String>
 
@@ -68,13 +69,5 @@ abstract class ModuleIdentityExtension(val tasks: TaskContainer, val objects: Ob
         tasks.named<Jar>("jar").configure {
             from(createBuildReceipt.map { it.receiptFolder })
         }
-    }
-
-    // pre-test/master/queue/alice/feature -> master
-    // pre-test/release/current/bob/bugfix -> release
-    private
-    fun toPreTestedCommitBaseBranch(actualBranch: String): String = when {
-        actualBranch.startsWith("pre-test/") -> actualBranch.substringAfter("/").substringBefore("/")
-        else -> actualBranch
     }
 }


### PR DESCRIPTION
### Context

As a followup of https://github.com/gradle/gradle/pull/16463 , we removed `ModuleIdentity` extension dependency in `build-update-utils`. To avoid duplicate code, some common code was extracted.