### PR TITLE
Don't let exception during receipt file creation go unnoticed

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -66,11 +66,17 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
             .withDisplayName(CACHE_NAME)
             .withCrossVersionCache(CacheBuilder.LockTarget.DefaultTarget)
             .withLockOptions(mode(FileLockManager.LockMode.OnDemand))
-            .withCleanup(CompositeCleanupAction.builder()
-                .add(UnusedVersionsCacheCleanup.create(CACHE_NAME, CACHE_VERSION_MAPPING, usedGradleVersions))
-                .add(new LeastRecentlyUsedCacheCleanup(new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP), fileAccessTimeJournal, DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES))
-                .build())
-            .open();
+            .withCleanup(
+                CompositeCleanupAction.builder()
+                    .add(UnusedVersionsCacheCleanup.create(CACHE_NAME, CACHE_VERSION_MAPPING, usedGradleVersions))
+                    .add(
+                        new LeastRecentlyUsedCacheCleanup(
+                            new SingleDepthFilesFinder(FILE_TREE_DEPTH_TO_TRACK_AND_CLEANUP),
+                            fileAccessTimeJournal,
+                            DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES
+                        )
+                    ).build()
+            ).open();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 
+import static java.lang.String.format;
 import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 
 class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer {
@@ -96,7 +97,10 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
             try {
                 receipt.createNewFile();
             } catch (IOException e) {
-                LOGGER.debug("Failed to create receipt for instrumented classpath file '{}/{}'.", destDirName, destFileName, e);
+                throw new UncheckedIOException(
+                    format("Failed to create receipt for instrumented classpath file '%s/%s'.", destDirName, destFileName),
+                    e
+                );
             }
             return transformed;
         } finally {


### PR DESCRIPTION
As that could lead to a situation where the jar file held open by the original daemon in which the exception happened would cause every subsequent daemon to fail with `The process cannot access the file because it is being used by another process.` as they try to replace it due to the missing receipt file.