### PR TITLE
Promote cache cleanup deletion message from `debug` level to `info`

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AbstractCacheCleanup.java
@@ -49,7 +49,7 @@ public abstract class AbstractCacheCleanup implements CleanupAction {
                 progressMonitor.incrementSkipped();
             }
         }
-        LOGGER.debug("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);
+        LOGGER.info("{} cleanup deleted {} files/directories.", cleanableStore.getDisplayName(), filesDeleted);
     }
 
     protected int deleteEmptyParentDirectories(File baseDir, File dir) {


### PR DESCRIPTION
So it's easier to spot whether cache cleanup might be interfering with the instrumented jar cache.