### PR TITLE
Create less garbage for hierarchical data structures

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.plan;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.RelativePath;
@@ -40,7 +39,7 @@ public class ExecutionNodeAccessHierarchy {
     private final Stat stat;
 
     public ExecutionNodeAccessHierarchy(CaseSensitivity caseSensitivity, Stat stat) {
-        this.root = new ValuedVfsHierarchy<>(ImmutableList.of(), EmptyChildMap.getInstance(), caseSensitivity);
+        this.root = new ValuedVfsHierarchy<>(PersistentList.of(), EmptyChildMap.getInstance(), caseSensitivity);
         this.stat = stat;
     }
 
@@ -52,7 +51,7 @@ public class ExecutionNodeAccessHierarchy {
     public ImmutableSet<Node> getNodesAccessing(String location) {
         return visitValues(location, new AbstractNodeAccessVisitor() {
             @Override
-            public void visitChildren(Iterable<NodeAccess> values, Supplier<String> relativePathSupplier) {
+            public void visitChildren(PersistentList<NodeAccess> values, Supplier<String> relativePathSupplier) {
                 values.forEach(this::addNode);
             }
         });
@@ -67,7 +66,7 @@ public class ExecutionNodeAccessHierarchy {
     public ImmutableSet<Node> getNodesAccessing(String location, Spec<FileTreeElement> filter) {
         return visitValues(location, new AbstractNodeAccessVisitor() {
             @Override
-            public void visitChildren(Iterable<NodeAccess> values, Supplier<String> relativePathSupplier) {
+            public void visitChildren(PersistentList<NodeAccess> values, Supplier<String> relativePathSupplier) {
                 String relativePathFromLocation = relativePathSupplier.get();
                 if (relativePathMatchesSpec(filter, new File(location, relativePathFromLocation), relativePathFromLocation)) {
                     values.forEach(this::addNode);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/PersistentList.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/PersistentList.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.internal.Cast;
+
+import javax.annotation.CheckReturnValue;
+import java.util.function.Consumer;
+
+public interface PersistentList<T> {
+    static <T> PersistentList<T> of() {
+        return Cast.uncheckedCast(Nil.NIL);
+    }
+
+    static <T> PersistentList<T> of(T first) {
+        return PersistentList.<T>of().add(first);
+    }
+
+    void forEach(Consumer<? super T> consumer);
+
+    @CheckReturnValue
+    PersistentList<T> add(T element);
+}
+
+class Nil<T> implements PersistentList<T> {
+    public static final Nil<Object> NIL = new Nil<>();
+
+    @Override
+    public void forEach(Consumer<? super T> consumer) {
+    }
+
+    @Override
+    public PersistentList<T> add(T element) {
+        return new Cons<>(element, this);
+    }
+}
+
+class Cons<T> implements PersistentList<T> {
+    private final T head;
+    private final PersistentList<T> tail;
+
+    public Cons(T head, PersistentList<T> tail) {
+        this.head = head;
+        this.tail = tail;
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> consumer) {
+        consumer.accept(head);
+        tail.forEach(consumer);
+    }
+
+    @Override
+    public PersistentList<T> add(T element) {
+        return new Cons<>(element, this);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
@@ -24,6 +24,8 @@ import org.gradle.internal.snapshot.EmptyChildMap;
 import org.gradle.internal.snapshot.VfsRelativePath;
 
 import javax.annotation.CheckReturnValue;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
@@ -33,12 +35,12 @@ import java.util.function.Supplier;
  * This is an immutable data structure.
  */
 public final class ValuedVfsHierarchy<T> {
-    private final ImmutableList<T> values;
+    private final List<T> values;
 
     private final ChildMap<ValuedVfsHierarchy<T>> children;
     private final CaseSensitivity caseSensitivity;
 
-    public ValuedVfsHierarchy(ImmutableList<T> values, ChildMap<ValuedVfsHierarchy<T>> children, CaseSensitivity caseSensitivity) {
+    public ValuedVfsHierarchy(List<T> values, ChildMap<ValuedVfsHierarchy<T>> children, CaseSensitivity caseSensitivity) {
         this.values = values;
         this.children = children;
         this.caseSensitivity = caseSensitivity;
@@ -123,13 +125,10 @@ public final class ValuedVfsHierarchy<T> {
     @CheckReturnValue
     public ValuedVfsHierarchy<T> recordValue(VfsRelativePath location, T value) {
         if (location.length() == 0) {
-            return new ValuedVfsHierarchy<>(
-                ImmutableList.<T>builderWithExpectedSize(values.size() + 1)
-                    .addAll(values)
-                    .add(value)
-                    .build(), children,
-                caseSensitivity
-            );
+            List<T> newValues = new ArrayList<>(values.size() + 1);
+            newValues.addAll(values);
+            newValues.add(value);
+            return new ValuedVfsHierarchy<>(newValues, children, caseSensitivity);
         }
         ChildMap<ValuedVfsHierarchy<T>> newChildren = children.store(location, caseSensitivity, new ChildMap.StoreHandler<ValuedVfsHierarchy<T>>() {
             @Override
@@ -145,7 +144,10 @@ public final class ValuedVfsHierarchy<T> {
 
             @Override
             public ValuedVfsHierarchy<T> mergeWithExisting(ValuedVfsHierarchy<T> child) {
-                return new ValuedVfsHierarchy<>(ImmutableList.<T>builderWithExpectedSize(child.getValues().size() + 1).addAll(child.getValues()).add(value).build(), child.getChildren(), caseSensitivity);
+                List<T> newValues = new ArrayList<>(child.getValues().size() + 1);
+                newValues.addAll(child.getValues());
+                newValues.add(value);
+                return new ValuedVfsHierarchy<>(newValues, child.getChildren(), caseSensitivity);
             }
 
             @Override
@@ -161,7 +163,7 @@ public final class ValuedVfsHierarchy<T> {
         return new ValuedVfsHierarchy<>(values, newChildren, caseSensitivity);
     }
 
-    private ImmutableList<T> getValues() {
+    private List<T> getValues() {
         return values;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ValuedVfsHierarchy.java
@@ -16,11 +16,10 @@
 
 package org.gradle.execution.plan;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.internal.snapshot.CaseSensitivity;
 import org.gradle.internal.snapshot.ChildMap;
-import org.gradle.internal.snapshot.ChildMapFactory;
 import org.gradle.internal.snapshot.EmptyChildMap;
+import org.gradle.internal.snapshot.SingletonChildMap;
 import org.gradle.internal.snapshot.VfsRelativePath;
 
 import javax.annotation.CheckReturnValue;
@@ -133,7 +132,7 @@ public final class ValuedVfsHierarchy<T> {
 
             @Override
             public ValuedVfsHierarchy<T> handleAsAncestorOfChild(String childPath, ValuedVfsHierarchy<T> child) {
-                ChildMap<ValuedVfsHierarchy<T>> singletonChild = ChildMapFactory.childMapFromSorted(ImmutableList.of(new ChildMap.Entry<>(VfsRelativePath.of(childPath).suffixStartingFrom(location.length() + 1).getAsString(), child)));
+                ChildMap<ValuedVfsHierarchy<T>> singletonChild = new SingletonChildMap<>(new ChildMap.Entry<>(VfsRelativePath.of(childPath).suffixStartingFrom(location.length() + 1).getAsString(), child));
                 return new ValuedVfsHierarchy<>(PersistentList.of(value), singletonChild, caseSensitivity);
             }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNode.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNode.java
@@ -152,7 +152,7 @@ public abstract class AbstractIncompleteFileSystemNode implements FileSystemNode
     }
 
     private static boolean anyChildMatches(ChildMap<FileSystemNode> children, Predicate<FileSystemNode> predicate) {
-        return children.entries().stream()
+        return children.entries()
             .map(ChildMap.Entry::getValue)
             .anyMatch(predicate);
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMap.java
@@ -19,6 +19,7 @@ package org.gradle.internal.snapshot;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 public interface ChildMap<T> {
 
@@ -26,7 +27,7 @@ public interface ChildMap<T> {
 
     List<T> values();
 
-    List<Entry<T>> entries();
+    Stream<Entry<T>> entries();
 
     void visitChildren(BiConsumer<String, ? super T> visitor);
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMapFactory.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMapFactory.java
@@ -46,6 +46,22 @@ public class ChildMapFactory {
             case 1:
                 return new SingletonChildMap<>(sortedEntries.get(0));
             default:
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                ChildMap.Entry<T>[] childArray = sortedEntries.toArray(new ChildMap.Entry[]{});
+                return (size < MINIMUM_CHILD_COUNT_FOR_BINARY_SEARCH)
+                    ? new MediumChildMap<>(childArray)
+                    : new LargeChildMap<>(childArray);
+        }
+    }
+
+    public static <T> ChildMap<T> childMapFromSorted(ChildMap.Entry<T>[] sortedEntries) {
+        int size = sortedEntries.length;
+        switch (size) {
+            case 0:
+                return EmptyChildMap.getInstance();
+            case 1:
+                return new SingletonChildMap<>(sortedEntries[0]);
+            default:
                 return (size < MINIMUM_CHILD_COUNT_FOR_BINARY_SEARCH)
                     ? new MediumChildMap<>(sortedEntries)
                     : new LargeChildMap<>(sortedEntries);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMapFactory.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/ChildMapFactory.java
@@ -16,12 +16,9 @@
 
 package org.gradle.internal.snapshot;
 
-import com.google.common.collect.ImmutableList;
-
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 
 public class ChildMapFactory {
     /**
@@ -33,25 +30,11 @@ public class ChildMapFactory {
     private static final int MINIMUM_CHILD_COUNT_FOR_BINARY_SEARCH = 10;
 
     public static <T> ChildMap<T> childMap(CaseSensitivity caseSensitivity, Collection<ChildMap.Entry<T>> entries) {
-        List<ChildMap.Entry<T>> sortedEntries = new ArrayList<>(entries);
-        sortedEntries.sort(Comparator.comparing(ChildMap.Entry::getPath, PathUtil.getPathComparator(caseSensitivity)));
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        ChildMap.Entry<T>[] entryArray = new ChildMap.Entry[entries.size()];
+        ChildMap.Entry<T>[] sortedEntries = entries.toArray(entryArray);
+        Arrays.sort(sortedEntries, Comparator.comparing(ChildMap.Entry::getPath, PathUtil.getPathComparator(caseSensitivity)));
         return childMapFromSorted(sortedEntries);
-    }
-
-    public static <T> ChildMap<T> childMapFromSorted(List<ChildMap.Entry<T>> sortedEntries) {
-        int size = sortedEntries.size();
-        switch (size) {
-            case 0:
-                return EmptyChildMap.getInstance();
-            case 1:
-                return new SingletonChildMap<>(sortedEntries.get(0));
-            default:
-                @SuppressWarnings({"unchecked", "rawtypes"})
-                ChildMap.Entry<T>[] childArray = sortedEntries.toArray(new ChildMap.Entry[]{});
-                return (size < MINIMUM_CHILD_COUNT_FOR_BINARY_SEARCH)
-                    ? new MediumChildMap<>(childArray)
-                    : new LargeChildMap<>(childArray);
-        }
     }
 
     public static <T> ChildMap<T> childMapFromSorted(ChildMap.Entry<T>[] sortedEntries) {
@@ -70,9 +53,10 @@ public class ChildMapFactory {
 
     static <T> ChildMap<T> childMap(CaseSensitivity caseSensitivity, ChildMap.Entry<T> entry1, ChildMap.Entry<T> entry2) {
         int compared = PathUtil.getPathComparator(caseSensitivity).compare(entry1.getPath(), entry2.getPath());
-        List<ChildMap.Entry<T>> sortedEntries = compared < 0
-            ? ImmutableList.of(entry1, entry2)
-            : ImmutableList.of(entry2, entry1);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        ChildMap.Entry<T>[] sortedEntries = compared < 0
+            ? new ChildMap.Entry[] { entry1, entry2 }
+            : new ChildMap.Entry[] { entry2, entry1 };
         return childMapFromSorted(sortedEntries);
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshot.java
@@ -23,7 +23,6 @@ import org.gradle.internal.hash.HashCode;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static org.gradle.internal.snapshot.ChildMapFactory.childMapFromSorted;
 import static org.gradle.internal.snapshot.SnapshotVisitResult.CONTINUE;
@@ -38,9 +37,17 @@ public class DirectorySnapshot extends AbstractFileSystemLocationSnapshot {
     private final HashCode contentHash;
 
     public DirectorySnapshot(String absolutePath, String name, AccessType accessType, HashCode contentHash, List<FileSystemLocationSnapshot> children) {
-        this(absolutePath, name, accessType, contentHash, childMapFromSorted(children.stream()
-            .map(it -> new ChildMap.Entry<>(it.getName(), it))
-            .collect(Collectors.toList())));
+        this(absolutePath, name, accessType, contentHash, childMapFromSorted(entriesFromChildren(children)));
+    }
+
+    private static ChildMap.Entry<FileSystemLocationSnapshot>[] entriesFromChildren(List<FileSystemLocationSnapshot> children) {
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        ChildMap.Entry<FileSystemLocationSnapshot>[] entries = new ChildMap.Entry[children.size()];
+        for (int i = 0; i < children.size(); i++) {
+            FileSystemLocationSnapshot child = children.get(i);
+            entries[i] = new ChildMap.Entry<>(child.getName(), child);
+        }
+        return entries;
     }
 
     public DirectorySnapshot(String absolutePath, String name, AccessType accessType, HashCode contentHash, ChildMap<FileSystemLocationSnapshot> children) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/EmptyChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/EmptyChildMap.java
@@ -19,6 +19,7 @@ package org.gradle.internal.snapshot;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 public class EmptyChildMap<T> implements ChildMap<T> {
     private static final EmptyChildMap<Object> INSTANCE = new EmptyChildMap<>();
@@ -62,8 +63,8 @@ public class EmptyChildMap<T> implements ChildMap<T> {
     }
 
     @Override
-    public List<Entry<T>> entries() {
-        return Collections.emptyList();
+    public Stream<Entry<T>> entries() {
+        return Stream.empty();
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/LargeChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/LargeChildMap.java
@@ -16,11 +16,9 @@
 
 package org.gradle.internal.snapshot;
 
-import java.util.List;
-
 public class LargeChildMap<T> extends AbstractListChildMap<T> {
 
-    public LargeChildMap(List<Entry<T>> children) {
+    public LargeChildMap(Entry<T>[] children) {
         super(children);
     }
 
@@ -28,7 +26,7 @@ public class LargeChildMap<T> extends AbstractListChildMap<T> {
     public <R> R withNode(VfsRelativePath targetPath, CaseSensitivity caseSensitivity, NodeHandler<T, R> handler) {
         int childIndexWithCommonPrefix = findChildIndexWithCommonPrefix(targetPath, caseSensitivity);
         if (childIndexWithCommonPrefix >= 0) {
-            Entry<T> entry = entries.get(childIndexWithCommonPrefix);
+            Entry<T> entry = entries[childIndexWithCommonPrefix];
             return entry.withNode(targetPath, caseSensitivity, handler);
         }
         return handler.handleUnrelatedToAnyChild();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MediumChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MediumChildMap.java
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.snapshot;
 
-import java.util.List;
 import java.util.Optional;
 
 public class MediumChildMap<T> extends AbstractListChildMap<T> {
-    protected MediumChildMap(List<Entry<T>> children) {
+    protected MediumChildMap(Entry<T>[] children) {
         super(children);
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SearchUtil.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SearchUtil.java
@@ -69,4 +69,38 @@ public abstract class SearchUtil {
                 return -(low + 1);  // key not found
         }
     }
+
+    public static <T> int binarySearch(T[] sortedElements, Comparable<T> key) {
+        int size = sortedElements.length;
+        switch (size) {
+            case 0:
+                return -1;
+            case 1:
+                T onlyElement = sortedElements[0];
+                int comparedToSearch = key.compareTo(onlyElement);
+                return comparedToSearch == 0
+                    ? 0
+                    : comparedToSearch < 0
+                        ? -1
+                        : -2;
+            default:
+                int low = 0;
+                int high = size - 1;
+
+                while (low <= high) {
+                    int mid = (low + high) >>> 1;
+                    T midVal = sortedElements[mid];
+                    int cmp = key.compareTo(midVal);
+
+                    if (cmp > 0) {
+                        low = mid + 1;
+                    } else if (cmp < 0) {
+                        high = mid - 1;
+                    } else {
+                        return mid; // key found
+                    }
+                }
+                return -(low + 1);  // key not found
+        }
+    }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SearchUtil.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SearchUtil.java
@@ -36,40 +36,6 @@ public abstract class SearchUtil {
      *         that this guarantees that the return value will be &gt;= 0 if
      *         and only if the key is found.
      */
-    public static <T> int binarySearch(List<T> sortedElements, Comparable<T> key) {
-        int size = sortedElements.size();
-        switch (size) {
-            case 0:
-                return -1;
-            case 1:
-                T onlyElement = sortedElements.get(0);
-                int comparedToSearch = key.compareTo(onlyElement);
-                return comparedToSearch == 0
-                    ? 0
-                    : comparedToSearch < 0
-                        ? -1
-                        : -2;
-            default:
-                int low = 0;
-                int high = size - 1;
-
-                while (low <= high) {
-                    int mid = (low + high) >>> 1;
-                    T midVal = sortedElements.get(mid);
-                    int cmp = key.compareTo(midVal);
-
-                    if (cmp > 0) {
-                        low = mid + 1;
-                    } else if (cmp < 0) {
-                        high = mid - 1;
-                    } else {
-                        return mid; // key found
-                    }
-                }
-                return -(low + 1);  // key not found
-        }
-    }
-
     public static <T> int binarySearch(T[] sortedElements, Comparable<T> key) {
         int size = sortedElements.length;
         switch (size) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SingletonChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SingletonChildMap.java
@@ -19,6 +19,7 @@ package org.gradle.internal.snapshot;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import static org.gradle.internal.snapshot.ChildMapFactory.childMap;
 
@@ -44,8 +45,8 @@ public class SingletonChildMap<T> implements ChildMap<T> {
     }
 
     @Override
-    public List<Entry<T>> entries() {
-        return Collections.singletonList(entry);
+    public Stream<Entry<T>> entries() {
+        return Stream.of(entry);
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractCaseVfsRelativePathTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractCaseVfsRelativePathTest.groovy
@@ -156,7 +156,7 @@ abstract class AbstractCaseVfsRelativePathTest extends Specification {
 
     def "path #spec.searchedPrefix has common prefix with #spec.expectedIndex in #spec.children"() {
         expect:
-        SearchUtil.binarySearch(spec.children) { child ->
+        SearchUtil.binarySearch(spec.children.toArray()) { child ->
             VfsRelativePath.of(spec.searchedPrefix).compareToFirstSegment(child, caseSensitivity)
         } == spec.expectedIndex
         spec.children.each { child ->

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
@@ -69,10 +69,10 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
     }
 
     ChildMap<CHILD> createChildren(List<String> pathsToParent) {
-        return ChildMapFactory.childMapFromSorted(pathsToParent.stream()
+        return ChildMapFactory.childMapFromSorted(convertToArray(pathsToParent.stream()
             .sorted(PathUtil.getPathComparator(CASE_SENSITIVE))
             .map { childPath -> new ChildMap.Entry(childPath, mockChild()) }
-            .collect(Collectors.toList()))
+            .collect(Collectors.toList())))
     }
 
     ChildMap<FileSystemNode> childrenWithSelectedChildReplacedBy(FileSystemNode replacement) {
@@ -82,7 +82,11 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
     ChildMap<FileSystemNode> childrenWithSelectedChildReplacedBy(String replacementPath, FileSystemNode replacement) {
         def newChildren = new ArrayList<ChildMap.Entry<FileSystemNode>>(entriesFor(children))
         newChildren.set(indexOfSelectedChild, new ChildMap.Entry<FileSystemNode>(replacementPath, replacement))
-        return ChildMapFactory.childMapFromSorted(newChildren)
+        return ChildMapFactory.childMapFromSorted(convertToArray(newChildren))
+    }
+
+    protected static <T> ChildMap.Entry<T>[] convertToArray(List<ChildMap.Entry<T>> entries) {
+        return entries.toArray(new ChildMap.Entry<T>[0])
     }
 
     int getIndexOfSelectedChild() {
@@ -96,13 +100,13 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
             targetPath.compareToFirstSegment(candidate.path, CASE_SENSITIVE)
         }
         newEntries.add(insertPosition, new ChildMap.Entry<FileSystemNode>(path, newChild))
-        return ChildMapFactory.childMapFromSorted(newEntries)
+        return ChildMapFactory.childMapFromSorted(convertToArray(newEntries))
     }
 
     ChildMap<CHILD> childrenWithSelectedChildRemoved() {
         def newEntries = new ArrayList<ChildMap.Entry<CHILD>>(entriesFor(children))
         newEntries.remove(indexOfSelectedChild)
-        return ChildMapFactory.childMapFromSorted(newEntries)
+        return ChildMapFactory.childMapFromSorted(convertToArray(newEntries))
     }
 
     CHILD getNodeWithIndexOfSelectedChild(ChildMap<CHILD> newChildren) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
@@ -60,8 +60,12 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
         this.selectedChildPath = spec.selectedChildPath
         if (selectedChildPath != null) {
             def selectedChildIndex = indexOfSelectedChild
-            this.selectedChild = selectedChildIndex == -1 ? null : children.entries().get(selectedChildIndex).value
+            this.selectedChild = selectedChildIndex == -1 ? null : entriesFor(children).get(selectedChildIndex).value
         }
+    }
+
+    private static <T> List<ChildMap.Entry<T>> entriesFor(ChildMap<T> children) {
+        children.entries().collect(Collectors.toList())
     }
 
     ChildMap<CHILD> createChildren(List<String> pathsToParent) {
@@ -76,18 +80,18 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
     }
 
     ChildMap<FileSystemNode> childrenWithSelectedChildReplacedBy(String replacementPath, FileSystemNode replacement) {
-        def newChildren = new ArrayList<ChildMap.Entry<FileSystemNode>>(children.entries())
+        def newChildren = new ArrayList<ChildMap.Entry<FileSystemNode>>(entriesFor(children))
         newChildren.set(indexOfSelectedChild, new ChildMap.Entry<FileSystemNode>(replacementPath, replacement))
         return ChildMapFactory.childMapFromSorted(newChildren)
     }
 
     int getIndexOfSelectedChild() {
-        return children.entries()*.path.indexOf(selectedChildPath)
+        return entriesFor(children)*.path.indexOf(selectedChildPath)
     }
 
     ChildMap<FileSystemNode> childrenWithAdditionalChild(String path, FileSystemNode newChild) {
         def targetPath = VfsRelativePath.of(path)
-        def newEntries = new ArrayList<ChildMap.Entry<FileSystemNode>>(children.entries())
+        def newEntries = new ArrayList<ChildMap.Entry<FileSystemNode>>(entriesFor(children))
         int insertPosition = -1 - SearchUtil.<ChildMap.Entry<FileSystemNode>>binarySearch(newEntries) { candidate ->
             targetPath.compareToFirstSegment(candidate.path, CASE_SENSITIVE)
         }
@@ -96,14 +100,14 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
     }
 
     ChildMap<CHILD> childrenWithSelectedChildRemoved() {
-        def newEntries = new ArrayList<ChildMap.Entry<CHILD>>(children.entries())
+        def newEntries = new ArrayList<ChildMap.Entry<CHILD>>(entriesFor(children))
         newEntries.remove(indexOfSelectedChild)
         return ChildMapFactory.childMapFromSorted(newEntries)
     }
 
     CHILD getNodeWithIndexOfSelectedChild(ChildMap<CHILD> newChildren) {
         int index = indexOfSelectedChild
-        return newChildren.entries().get(index).value
+        return entriesFor(newChildren).get(index).value
     }
 
     String getCommonPrefix() {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractFileSystemNodeWithChildrenTest.groovy
@@ -96,7 +96,7 @@ abstract class AbstractFileSystemNodeWithChildrenTest<NODE extends FileSystemNod
     ChildMap<FileSystemNode> childrenWithAdditionalChild(String path, FileSystemNode newChild) {
         def targetPath = VfsRelativePath.of(path)
         def newEntries = new ArrayList<ChildMap.Entry<FileSystemNode>>(entriesFor(children))
-        int insertPosition = -1 - SearchUtil.<ChildMap.Entry<FileSystemNode>>binarySearch(newEntries) { candidate ->
+        int insertPosition = -1 - SearchUtil.<ChildMap.Entry<FileSystemNode>>binarySearch(newEntries.toArray()) { candidate ->
             targetPath.compareToFirstSegment(candidate.path, CASE_SENSITIVE)
         }
         newEntries.add(insertPosition, new ChildMap.Entry<FileSystemNode>(path, newChild))

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
@@ -388,7 +388,7 @@ abstract class AbstractIncompleteFileSystemNodeTest<T extends FileSystemNode> ex
         def compared = PathUtil.getPathComparator(CASE_SENSITIVE).compare(path1, path2)
         def entry1 = new ChildMap.Entry<FileSystemNode>(path1, child1)
         def entry2 = new ChildMap.Entry<FileSystemNode>(path2, child2)
-        return compared < 0 ? ChildMapFactory.childMapFromSorted([entry1, entry2]) : ChildMapFactory.childMapFromSorted([entry2, entry1])
+        return compared < 0 ? ChildMapFactory.childMapFromSorted(convertToArray([entry1, entry2])) : ChildMapFactory.childMapFromSorted(convertToArray([entry2, entry1]))
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/CaseSensitiveVfsRelativePathTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/CaseSensitiveVfsRelativePathTest.groovy
@@ -30,7 +30,7 @@ class CaseSensitiveVfsRelativePathTest extends AbstractCaseVfsRelativePathTest {
         expect:
         for (int i = 0; i < children.size(); i++) {
             def searchedChild = children[i]
-            int foundIndex = SearchUtil.binarySearch(children) { child ->
+            int foundIndex = SearchUtil.binarySearch(children.toArray()) { child ->
                 VfsRelativePath.of(searchedChild).compareToFirstSegment(child, CASE_SENSITIVE)
             }
             assert foundIndex == i
@@ -43,7 +43,7 @@ class CaseSensitiveVfsRelativePathTest extends AbstractCaseVfsRelativePathTest {
         expect:
         for (int i = 0; i < children.size(); i++) {
             def searchedChild = children[i].substring(0, 3)
-            int foundIndex = SearchUtil.binarySearch(children) { child ->
+            int foundIndex = SearchUtil.binarySearch(children.toArray()) { child ->
                 VfsRelativePath.of(searchedChild).compareToFirstSegment(child, CASE_SENSITIVE)
             }
             assert foundIndex == i

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/SearchUtilTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/SearchUtilTest.groovy
@@ -24,7 +24,7 @@ class SearchUtilTest extends Specification {
 
     def "search for #searchedChild in #sortedChildren is #expectedResult"() {
         expect:
-        SearchUtil.binarySearch(children, searchedChild) == expectedResult
+        SearchUtil.binarySearch(children.toArray(), searchedChild) == expectedResult
 
         where:
         children | searchedChild


### PR DESCRIPTION
When looking at allocation flame graphs for a fully up-to-date `assembleDebug` build on https://github.com/bingranl/android-benchmark-project, it seems like we create a lot of allocations for copying arrays for our hierarchical data structures. This PR reduces this amount by half by
- Using a persistent Cons/Nil list for storing the nodes in ValuedVfsHierarchy.
- By using arrays and not `ArrayList`s in `ChildMap`.

These changes don't seem to change the actual wall-clock time for running `assembleDebug`, though they also don't complicate the code much, so maybe we should merge them anyway.

Related to #16581.

