### PR TITLE
Let `DefaultCachedClasspathTransformer` schedule all operations at once

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/UncheckedException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/UncheckedException.java
@@ -68,7 +68,7 @@ public final class UncheckedException extends RuntimeException {
         }
     }
 
-    public static <T> T callUnchecked(Callable<T> callable) {
+    public static <T> T unchecked(Callable<T> callable) {
         try {
             return callable.call();
         } catch (Exception e) {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -163,10 +163,8 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     private Optional<Either<HashCode, URL>> cachedURL(URL original, ClasspathFileTransformer transformer, ConcurrentTransformContext seen) {
         if (original.getProtocol().equals("file")) {
-            return unchecked(() ->
-                cachedFile(new File(original.toURI()), transformer, seen).map(
-                    result -> result.map(Convert::fileToURL)
-                )
+            return cachedFile(new File(unchecked(original::toURI)), transformer, seen).map(
+                result -> result.map(Convert::fileToURL)
             );
         }
         return Optional.of(right(original));
@@ -292,7 +290,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
 
     private static class Convert {
         public static URL fileToURL(File file) {
-            return unchecked(() -> file.toURI().toURL());
+            return unchecked(file.toURI()::toURL);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Either.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Either.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath;
+
+import java.util.function.Function;
+
+import static org.gradle.internal.Cast.uncheckedCast;
+
+/**
+ * Represents values with two possibilities.
+ *
+ * @param <L> the left type.
+ * @param <R> the right type.
+ */
+public abstract class Either<L, R> {
+
+    public static <L, R> Either<L, R> left(L value) {
+        return new Left<>(value);
+    }
+
+    public static <L, R> Either<L, R> right(R value) {
+        return new Right<>(value);
+    }
+
+    public abstract <U> U fold(Function<L, U> l, Function<R, U> r);
+
+    public abstract <U> Either<L, U> map(Function<R, U> r);
+
+    private static class Left<L, R> extends Either<L, R> {
+        private final L value;
+
+        public Left(L value) {
+            this.value = value;
+        }
+
+        @Override
+        public <U> U fold(Function<L, U> l, Function<R, U> r) {
+            return l.apply(value);
+        }
+
+        @Override
+        public <U> Either<L, U> map(Function<R, U> r) {
+            return uncheckedCast(this);
+        }
+    }
+
+    private static class Right<L, R> extends Either<L, R> {
+        private final R value;
+
+        public Right(R value) {
+            this.value = value;
+        }
+
+        @Override
+        public <U> U fold(Function<L, U> l, Function<R, U> r) {
+            return r.apply(value);
+        }
+
+        @Override
+        public <U> Either<L, U> map(Function<R, U> r) {
+            return new Right<>(r.apply(value));
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.TestInMemoryCacheFactory
 import org.junit.Rule
+import spock.lang.Ignore
 import spock.lang.Subject
 
 import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic
@@ -312,6 +313,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         0 * fileAccessTimeJournal._
     }
 
+    @Ignore("wip")
     def "removes entries with duplicate content when usage is none"() {
         given:
         def dir = testDir.file("thing.dir")
@@ -340,6 +342,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         0 * fileAccessTimeJournal._
     }
 
+    @Ignore("wip")
     def "removes entries with duplicate content when usage is build logic"() {
         given:
         def dir = testDir.file("thing.dir")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -34,7 +34,6 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.testfixtures.internal.TestInMemoryCacheFactory
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Subject
 
 import static org.gradle.internal.classpath.CachedClasspathTransformer.StandardTransform.BuildLogic
@@ -313,7 +312,6 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         0 * fileAccessTimeJournal._
     }
 
-    @Ignore("wip")
     def "removes entries with duplicate content when usage is none"() {
         given:
         def dir = testDir.file("thing.dir")
@@ -342,7 +340,6 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         0 * fileAccessTimeJournal._
     }
 
-    @Ignore("wip")
     def "removes entries with duplicate content when usage is build logic"() {
         given:
         def dir = testDir.file("thing.dir")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -73,6 +73,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static org.gradle.internal.UncheckedException.unchecked;
 import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.NON_INCREMENTAL;
 import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.PRIMARY;
 import static org.gradle.internal.file.TreeType.DIRECTORY;
@@ -368,7 +369,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
                 }
                 throw new IllegalStateException("Invalid result path: " + absolutePath);
             });
-            UncheckedException.callUnchecked(() -> Files.write(getResultsFile(workspace).toPath(), (Iterable<String>) relativePaths::iterator));
+            unchecked(() -> Files.write(getResultsFile(workspace).toPath(), (Iterable<String>) relativePaths::iterator));
         }
 
         private ImmutableList<File> readResultsFile(File workspace) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Try;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.execution.DeferredExecutionHandler;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.UnitOfWork;


### PR DESCRIPTION
So scheduling, synchronization and cancellation are all handled by the executor service.