### PR TITLE
Fix inconsistency in documentation about catalog sections

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -176,7 +176,7 @@ include::sample[dir="snippets/dependencyManagement/catalogs-toml/kotlin",files="
 [[sub::toml-dependencies-format]]
 ==== The version catalog TOML file format
 
-The https://toml.io/[TOML] file consists of 4 major sections:
+The https://toml.io/[TOML] file consists of 3 major sections:
 
 - the `[versions]` section is used to declare versions which can be referenced by dependencies
 - the `[libraries]` section is used to declare the aliases to coordinates


### PR DESCRIPTION
### Context
Fixes an oversight introduced in 560c5e9b44787b30b262be8b3954b0f134f082e1 where support for the `[plugins]` section was removed from the catalog feature.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
