### PR TITLE
Keep a project scope input node access hierarchy

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -41,6 +41,7 @@ import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.TaskCacheabilityResolver;
 import org.gradle.caching.internal.controller.BuildCacheController;
+import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.execution.taskgraph.TaskListenerInternal;
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
@@ -99,6 +100,10 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             outputChangeListener,
             taskInputsListeners
         );
+    }
+
+    ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy createInputNodeAccessHierarchy(ExecutionNodeAccessHierarchies hierarchies) {
+        return hierarchies.createInputHierarchy();
     }
 
     TaskExecuter createTaskExecuter(

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -77,7 +77,6 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     private final TaskNodeFactory taskNodeFactory;
     private final TaskDependencyResolver dependencyResolver;
     private final NodeValidator nodeValidator;
-    private final ExecutionNodeAccessHierarchy inputHierarchy;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
     private Spec<? super Task> filter = Specs.satisfyAll();
@@ -99,7 +98,6 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         TaskNodeFactory taskNodeFactory,
         TaskDependencyResolver dependencyResolver,
         NodeValidator nodeValidator,
-        ExecutionNodeAccessHierarchy inputHierarchy,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy
     ) {
@@ -107,7 +105,6 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         this.taskNodeFactory = taskNodeFactory;
         this.dependencyResolver = dependencyResolver;
         this.nodeValidator = nodeValidator;
-        this.inputHierarchy = inputHierarchy;
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
     }
@@ -505,7 +502,6 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         reachableCache.clear();
         dependenciesWhichRequireMonitoring.clear();
         runningNodes.clear();
-        inputHierarchy.clear();
         outputHierarchy.clear();
         destroyableHierarchy.clear();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchies.java
@@ -20,18 +20,26 @@ import org.gradle.internal.file.Stat;
 import org.gradle.internal.snapshot.CaseSensitivity;
 
 public class ExecutionNodeAccessHierarchies {
-    private final ExecutionNodeAccessHierarchy inputHierarchy;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
+    private final CaseSensitivity caseSensitivity;
+    private final Stat stat;
 
     public ExecutionNodeAccessHierarchies(CaseSensitivity caseSensitivity, Stat stat) {
-        inputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
+        this.caseSensitivity = caseSensitivity;
+        this.stat = stat;
         outputHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
         destroyableHierarchy = new ExecutionNodeAccessHierarchy(caseSensitivity, stat);
     }
 
-    public ExecutionNodeAccessHierarchy getInputHierarchy() {
-        return inputHierarchy;
+    /**
+     * Create the input node access hierarchy.
+     *
+     * For performance reasons, we keep one input node access hierarchy per project,
+     * so we only have a factory method here and this is used to create the hierarchy in {@link org.gradle.execution.ProjectExecutionServices}.
+     */
+    public InputNodeAccessHierarchy createInputHierarchy() {
+        return new InputNodeAccessHierarchy(caseSensitivity, stat);
     }
 
     public ExecutionNodeAccessHierarchy getOutputHierarchy() {
@@ -40,5 +48,11 @@ public class ExecutionNodeAccessHierarchies {
 
     public ExecutionNodeAccessHierarchy getDestroyableHierarchy() {
         return destroyableHierarchy;
+    }
+
+    public static class InputNodeAccessHierarchy extends ExecutionNodeAccessHierarchy {
+        public InputNodeAccessHierarchy(CaseSensitivity caseSensitivity, Stat stat) {
+            super(caseSensitivity, stat);
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -46,11 +46,9 @@ import java.util.Set;
 
 public class LocalTaskNodeExecutor implements NodeExecutor {
 
-    private final ExecutionNodeAccessHierarchy inputHierarchy;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
 
-    public LocalTaskNodeExecutor(ExecutionNodeAccessHierarchy inputHierarchy, ExecutionNodeAccessHierarchy outputHierarchy) {
-        this.inputHierarchy = inputHierarchy;
+    public LocalTaskNodeExecutor(ExecutionNodeAccessHierarchy outputHierarchy) {
         this.outputHierarchy = outputHierarchy;
     }
 
@@ -65,11 +63,12 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
                 // This should move earlier in task scheduling, so that a worker thread does not even bother trying to run this task
                 return true;
             }
+            ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy inputHierarchy = context.getService(ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy.class);
             TaskExecutionContext ctx = new DefaultTaskExecutionContext(
                 localTaskNode,
                 localTaskNode.getTaskProperties(),
                 localTaskNode.getValidationContext(),
-                (historyMaintained, typeValidationContext) -> detectMissingDependencies(localTaskNode, historyMaintained, typeValidationContext)
+                (historyMaintained, typeValidationContext) -> detectMissingDependencies(localTaskNode, historyMaintained, inputHierarchy, typeValidationContext)
             );
             TaskExecuter taskExecuter = context.getService(TaskExecuter.class);
             taskExecuter.execute(task, state, ctx);
@@ -80,7 +79,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         }
     }
 
-    private void detectMissingDependencies(LocalTaskNode node, boolean historyMaintained, TypeValidationContext validationContext) {
+    private void detectMissingDependencies(LocalTaskNode node, boolean historyMaintained, ExecutionNodeAccessHierarchies.InputNodeAccessHierarchy inputHierarchy, TypeValidationContext validationContext) {
         for (String outputPath : node.getMutationInfo().outputPaths) {
             inputHierarchy.getNodesAccessing(outputPath).stream()
                 .filter(consumerNode -> hasNoSpecifiedOrder(node, consumerNode))

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -205,7 +205,6 @@ public class GradleScopeServices extends DefaultServiceRegistry {
 
     LocalTaskNodeExecutor createLocalTaskNodeExecutor(ExecutionNodeAccessHierarchies executionNodeAccessHierarchies) {
         return new LocalTaskNodeExecutor(
-            executionNodeAccessHierarchies.getInputHierarchy(),
             executionNodeAccessHierarchies.getOutputHierarchy()
         );
     }
@@ -245,7 +244,6 @@ public class GradleScopeServices extends DefaultServiceRegistry {
             taskNodeFactory,
             dependencyResolver,
             new DefaultNodeValidator(),
-            executionNodeAccessHierarchies.getInputHierarchy(),
             executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getDestroyableHierarchy()
         );

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -55,7 +55,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         _ * lease.tryLock() >> true
         def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(IncludedBuildTaskGraph))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs))
     }
 
     TaskInternal task(Map<String, ?> options = [:], String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -43,7 +43,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     def setup() {
         def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(IncludedBuildTaskGraph))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
         _ * workerLease.tryLock() >> true
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -82,7 +82,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(IncludedBuildTaskGraph))
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
     def projectStateRegistry = Stub(ProjectStateRegistry)
-    def executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+    def executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
     def taskGraph = new DefaultTaskExecutionGraph(
         new DefaultPlanExecutor(parallelismConfiguration, executorFactory, workerLeases, cancellationToken, coordinationService),
         [nodeExecutor],


### PR DESCRIPTION
to improve performance. This seems to mitigate a big part of #16581.

Keeping the input access hierarchy project scoped may mean that we may miss some missing dependencies of tasks writing to the input location of tasks in another project.