### PR TITLE
Allow custom identity for credential provider in artifact repositories

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
@@ -16,6 +16,7 @@
 package org.gradle.api.artifacts.repositories;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.credentials.Credentials;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -121,6 +122,33 @@ public interface AuthenticationSupported {
      * @since 6.6
      */
     void credentials(Class<? extends Credentials> credentialsType);
+
+    /**
+     * Configures the credentials for this repository that will be provided by the build with a custom identity.
+     * <p>
+     * Credentials will be provided from Gradle properties based on the given identity.
+     * If credentials for this repository can not be resolved and the repository will be used in the current build, then the build will fail to start and point to the missing configuration.
+     * <pre class='autoTested'>
+     * repositories {
+     *     maven {
+     *         url "${url}"
+     *         credentials(PasswordCredentials, 'myRepoIdentity')
+     *     }
+     * }
+     * </pre>
+     * <p>
+     * The following credential types are currently supported for the {@code credentialsType} argument:
+     * <ul>
+     * <li>{@link org.gradle.api.credentials.PasswordCredentials}</li>
+     * <li>{@link org.gradle.api.credentials.AwsCredentials}</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException if {@code credentialsType} is not of a supported type
+     *
+     * @since 7.1
+     */
+    @Incubating
+    void credentials(Class<? extends Credentials> credentialsType, String identity);
 
     /**
      * <p>Configures the authentication schemes for this repository.

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/CredentialsDslIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/CredentialsDslIntegrationTest.groovy
@@ -36,4 +36,19 @@ class CredentialsDslIntegrationTest extends AbstractIntegrationSpec {
         'ivyWithPassword' | ivyPasswordCredentials()
         'passwordTyped'   | passwordCredentialsTyped()
     }
+
+    @Unroll
+    def "can configure repositories with [#scenario] DSL using credential properties"() {
+        given:
+        executer.withArguments("-PmyRepoIdentityUsername=myUsername", "-PmyRepoIdentityPassword=myPassword")
+
+        expect:
+        buildFile << dsl
+        succeeds 'help'
+
+        where:
+        scenario       | dsl
+        'fromIdentity' | identityCredentials()
+        'fromName'     | repoNameCredentials()
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/support/RepositoryDslSupport.groovy
@@ -73,4 +73,30 @@ repositories {
 }
 """
     }
+
+    def identityCredentials() {
+        """
+        repositories {
+            maven {
+                url "${url}"
+                name = 'My Awesome Repository (Release)'
+                credentials(PasswordCredentials, 'myRepoIdentity')
+                getCredentials(PasswordCredentials)
+            }
+        }
+        """
+    }
+
+    def repoNameCredentials() {
+        """
+        repositories {
+            maven {
+                url "${url}"
+                name = 'myRepoIdentity'
+                credentials(PasswordCredentials)
+                getCredentials(PasswordCredentials)
+            }
+        }
+        """
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
@@ -86,6 +86,12 @@ public abstract class AbstractAuthenticationSupportedRepository extends Abstract
     }
 
     @Override
+    public void credentials(Class<? extends Credentials> credentialsType, String identity) {
+        invalidateDescriptor();
+        delegate.credentials(credentialsType, identity);
+    }
+
+    @Override
     public void authentication(Action<? super AuthenticationContainer> action) {
         invalidateDescriptor();
         delegate.authentication(action);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AuthenticationSupporter.java
@@ -89,6 +89,11 @@ public class AuthenticationSupporter {
         this.credentials.set(providerFactory.credentials(credentialsType, identity));
     }
 
+    public void credentials(Class<? extends Credentials> credentialsType, String identity) {
+        this.usesCredentials = true;
+        this.credentials.set(providerFactory.credentials(credentialsType, identity));
+    }
+
     public void setConfiguredCredentials(Credentials credentials) {
         this.usesCredentials = true;
         this.credentials.set(credentials);

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_repositories.adoc
@@ -773,7 +773,7 @@ Gradle provides link:{javadocPath}/org/gradle/api/artifacts/repositories/Authent
 that allows you to declare only the type of required credentials. Credential values are looked up from the <<build_environment.adoc#sec:gradle_configuration_properties,Gradle Properties>>
 during the build that requires them.
 
-For example, given repository configuration:
+For example, given repository configurations:
 
 .Externalized repository credentials
 ====
@@ -781,9 +781,11 @@ include::sample[dir="samples/credentials-handling/publishing-credentials/groovy"
 include::sample[dir="samples/credentials-handling/publishing-credentials/kotlin",files="build.gradle.kts[tags=repositories]"]
 ====
 
-The username and password will be looked up from `mySecureRepositoryUsername` and `mySecureRepositoryPassword` properties.
+For both repositories the username and password will be looked up from `mySecureRepositoryUsername` and `mySecureRepositoryPassword` properties.
 
-Note that the configuration property prefix - the identity - is determined from the repository name.
+For the first repository the configuration property prefix - the identity - is determined from the repository name.
+For the second repository the identity is explicitly specified by the user. This is particularly useful when more than one repository uses the same credentials. Note that the identity (provided by either approach) must only have letters or digits in its name.
+
 Credentials can then be provided in any of supported ways for Gradle Properties -
 `gradle.properties` file, command line arguments, environment variables or a combination of those options.
 

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/build.gradle
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/groovy/build.gradle
@@ -18,9 +18,16 @@ publishing {
     }
 // tag::repositories[]
     repositories {
+        // using the repository name to resolve credentials
         maven {
             name = 'mySecureRepository'
             credentials(PasswordCredentials)
+            // url = uri(<<some repository url>>)
+        }
+        // using an explicit identity to resolve credentials
+        maven {
+            name = 'myAwesomeReleaseRepository'
+            credentials(PasswordCredentials, 'mySecureRepository')
             // url = uri(<<some repository url>>)
         }
     }

--- a/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/credentials-handling/publishing-credentials/kotlin/build.gradle.kts
@@ -18,9 +18,16 @@ publishing {
     }
 // tag::repositories[]
     repositories {
+        // using the repository name to resolve credentials
         maven {
             name = "mySecureRepository"
             credentials(PasswordCredentials::class)
+            // url = uri(<<some repository url>>)
+        }
+        // using an explicit identity to resolve credentials
+        maven {
+            name = "myAwesomeReleaseRepository"
+            credentials(PasswordCredentials, "mySecureRepository")
             // url = uri(<<some repository url>>)
         }
     }


### PR DESCRIPTION
Fixes #16431
Fixes #16432

### Context
A common pattern in my Gradle projects is to define a bunch of repositories for resolving dependencies and publishing. Some of them use the same credentials. The credentials feature introduced in 6.6 would be useful for such a case, but the fact that the identity relies on the repository name makes it impossible to reuse for multiple repositories.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
