### PR TITLE
Update test-distribution plugin to version 2.0.2-rc-1

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.6")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.1")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.2-rc-1")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.13.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0.1")
+    id("com.gradle.enterprise.test-distribution").version("2.0.2-rc-1")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
To enable JDK 16 support