### PR TITLE
Fix `platform` notation with type-safe project accessors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
@@ -116,6 +116,30 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         outputContains 'Type-safe project accessors is an incubating feature.'
     }
 
+    def "can use the #notation notation on type-safe accessor"() {
+        settingsFile << """
+            include 'other'
+        """
+
+        buildFile << """
+            configurations {
+                implementation
+            }
+            dependencies {
+                implementation($notation(projects.other))
+            }
+        """
+
+        when:
+        run 'help'
+
+        then:
+        outputDoesNotContain('it was probably created by a plugin using internal APIs')
+
+        where:
+        notation << [ 'platform', 'testFixtures']
+    }
+
     def "buildSrc project accessors are independent from the main build accessors"() {
         file("buildSrc/build.gradle") << """
             assert project(":one").is(projects.one.dependencyProject)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -43,12 +43,18 @@ public class DefaultProjectDependencyFactory {
 
     public ProjectDependency create(ProjectInternal project, String configuration) {
         DefaultProjectDependency projectDependency = instantiator.newInstance(DefaultProjectDependency.class, project, configuration, projectAccessListener, buildProjectDependencies);
-        projectDependency.setAttributesFactory(attributesFactory);
-        projectDependency.setCapabilityNotationParser(capabilityNotationParser);
+        prepareProject(projectDependency);
         return projectDependency;
     }
 
+    private void prepareProject(DefaultProjectDependency projectDependency) {
+        projectDependency.setAttributesFactory(attributesFactory);
+        projectDependency.setCapabilityNotationParser(capabilityNotationParser);
+    }
+
     public ProjectDependency create(Project project) {
-        return instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener, buildProjectDependencies);
+        DefaultProjectDependency projectDependency = instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener, buildProjectDependencies);
+        prepareProject(projectDependency);
+        return projectDependency;
     }
 }


### PR DESCRIPTION
### Context

Before this commit, trying to use `platform(projects.foo)` or `testFixtures(projects.foo)` triggered the following error:

> it was probably created by a plugin using internal APIs

Discovered while dogfooding :)

Didn't create a milestone for rc2 yet, just prepared in case we have one.

