### PR TITLE
Fix compilation avoidance test

### DIFF
--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -892,7 +892,10 @@ class BuildOperationsAssertions(buildOperationsFixture: BuildOperationsFixture, 
     val bodyCompileOperations = buildOperationsFixture.all(Pattern.compile("Compile script build.gradle.kts \\(BODY\\)"))
 
     private
-    val compileAvoidanceWarnings = output.lines().filter { it.startsWith("Cannot use Kotlin build script compile avoidance with") }
+    val compileAvoidanceWarnings = output.lines()
+        .filter { it.startsWith("Cannot use Kotlin build script compile avoidance with") }
+        // filter out avoidance warnings for versioned jars - those come from Kotlin/libraries that don't change when code under test changes
+        .filterNot { it.contains(Regex("\\d.jar: ")) }
 
     init {
         if (!expectWarnings) {


### PR DESCRIPTION
This test became dependent on the order that the test methods are executed because some of the tests
care about the compile avoidance warnings while others don't. The tests that do care about
compile avoidance warnings only care about the warnings originating from user code (build scripts).
However, there are also compile avoidance warnings originating from library jars and those are
only output during the first test executed (as the libraries don't change between executions).
Given the first test executed does not care about the warnings, the subsequent tests executed
will only see the ones from user code and all is green. If a test that cares about warnings
is executed in isolation (or first in order), it will see all the warnings and it will fail
because of too many warnings.

This change filters out the uninteresting warnings so that the order of execution does not play a role.

Should fix the flakiness: https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe/Vilnius&tests.container=org.gradle.kotlin.dsl.integration.BuildScriptCompileAvoidanceIntegrationTest&tests.sortField=FAILED&tests.unstableOnly=true