### PR TITLE
Make fully empty lock state delete the lock file

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/AbstractLockingIntegrationTest.groovy
@@ -108,7 +108,9 @@ dependencies {
         succeeds 'dependencies', '--write-locks'
 
         then:
-        lockfileFixture.expectLockStateMissing('unlockedConf')
+        lockfileFixture.expectNoSettingsLockFile()
+        lockfileFixture.expectNoBuildscripLockFile()
+        lockfileFixture.expectNoLockFile()
     }
 
     @ToBeFixedForConfigurationCache

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -200,6 +200,12 @@ public class LockFileReaderWriter {
         checkValidRoot();
         Path lockfilePath = getUniqueLockfilePath();
 
+        if (lockState.isEmpty()) {
+            // Remove the file when no lock state
+            GFileUtils.deleteQuietly(lockfilePath.toFile());
+            return;
+        }
+
         // Revert mapping
         Map<String, List<String>> dependencyToConfigurations = new TreeMap<>();
         List<String> emptyConfigurations = new ArrayList<>();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -63,6 +63,19 @@ empty=c
         !lockDir.exists()
     }
 
+    def 'deletes an unique lock file on empty lock state'() {
+        def uniqueLockfile = tmpDir.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+
+        given:
+        uniqueLockfile << 'Some file content'
+
+        when:
+        lockFileReaderWriter.writeUniqueLockfile(Collections.emptyMap());
+
+        then:
+        !uniqueLockfile.exists()
+    }
+
     def 'writes dependencies and configurations sorted in the unique lock file'() {
         when:
         lockFileReaderWriter.writeUniqueLockfile([b: ['foo', 'bar'], d: ['bar', 'foobar'],a: ['foo'], e: [], f: [], c: []])

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/locking/LockfileFixture.groovy
@@ -137,12 +137,29 @@ class LockfileFixture {
     }
 
     void expectLockStateMissing(String configurationName) {
-        def lockFile = testDirectory.file(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER, LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+        def lockFile = testDirectory.file(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
         if (lockFile.exists()) {
             assert !lockFile.text.contains(configurationName)
         } else {
             assert !lockFile.exists()
         }
+    }
+
+    void expectNoLockFile() {
+        expectMissingLockFile(LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+    }
+
+    void expectNoSettingsLockFile() {
+        expectMissingLockFile(LockFileReaderWriter.SETTINGS_SCRIPT_PREFIX + LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+    }
+
+    void expectNoBuildscripLockFile() {
+        expectMissingLockFile(LockFileReaderWriter.BUILD_SCRIPT_PREFIX + LockFileReaderWriter.UNIQUE_LOCKFILE_NAME)
+    }
+
+    private void expectMissingLockFile(String fileName) {
+        def lockFile = testDirectory.file(fileName)
+        assert !lockFile.exists()
     }
 
     void assertLegacyLockfileMissing(String configurationName) {


### PR DESCRIPTION
When writing locks and the lock state is fully empty, the lockfile
should be removed. That is there are effectively no locked configuration
- which is not the same as locked configuration without dependencies.