### PR TITLE
Fix for #11036 – Provide messages for null pointer exceptions when map property literals contain `null`

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -4,6 +4,7 @@ This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community members for their contributions to this release of Gradle:
  [Peter Runge](https://github.com/causalnet)
+ [kiwi-oss](https://github.com/kiwi-oss)
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -632,7 +632,7 @@ task thing {
         where:
         key         | value         || message
         '(null)'    | "'someValue'" || 'Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a null key.'
-        "'someKey'" | 'null'        || 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value.'
+        "'someKey'" | 'null'        || 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value for key "someKey".'
         '(null)'    | 'null'        || 'Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a null key.'
     }
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
@@ -613,6 +614,26 @@ task thing {
 
         expect:
         succeeds('verify')
+    }
+
+    @Issue('gradle/gradle#11036')
+    def "fails with precise error message when property is a map literal with null values"() {
+        given:
+        buildFile << """
+            verify {
+                prop = [${key}: ${value}]
+            }
+        """
+
+        expect:
+        fails('verify')
+        failureCauseContains(message)
+
+        where:
+        key         | value         || message
+        '(null)'    | "'someValue'" || 'Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a null key.'
+        "'someKey'" | 'null'        || 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value.'
+        '(null)'    | 'null'        || 'Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a null key.'
     }
 
     def "fails when property with no value is queried"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -616,7 +616,7 @@ task thing {
         succeeds('verify')
     }
 
-    @Issue('gradle/gradle#11036')
+    @Issue('https://github.com/gradle/gradle/issues/11036')
     def "fails with precise error message when property is a map literal with null values"() {
         given:
         buildFile << """

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
@@ -42,8 +42,8 @@ class ValidatingMapEntryCollector<K, V> implements MapEntryCollector<K, V> {
             Map.class.getName(), keyType.getName());
         Preconditions.checkNotNull(
             value,
-            "Cannot get the value of a property of type %s with value type %s as the source contains a null value.",
-            Map.class.getName(), valueType.getName());
+            "Cannot get the value of a property of type %s with value type %s as the source contains a null value for key \"%s\".",
+            Map.class.getName(), valueType.getName(), key);
 
         K sanitizedKey = keySanitizer.sanitize(key);
         if (!keyType.isInstance(sanitizedKey)) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValidatingMapEntryCollector.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.provider;
 
+import com.google.common.base.Preconditions;
+
 import java.util.Map;
 
 class ValidatingMapEntryCollector<K, V> implements MapEntryCollector<K, V> {
@@ -34,15 +36,26 @@ class ValidatingMapEntryCollector<K, V> implements MapEntryCollector<K, V> {
 
     @Override
     public void add(K key, V value, Map<K, V> dest) {
+        Preconditions.checkNotNull(
+            key,
+            "Cannot get the value of a property of type %s with key type %s as the source contains a null key.",
+            Map.class.getName(), keyType.getName());
+        Preconditions.checkNotNull(
+            value,
+            "Cannot get the value of a property of type %s with value type %s as the source contains a null value.",
+            Map.class.getName(), valueType.getName());
+
         K sanitizedKey = keySanitizer.sanitize(key);
         if (!keyType.isInstance(sanitizedKey)) {
-            throw new IllegalArgumentException(String.format("Cannot get the value of a property of type %s with key type %s as the source contains a key of type %s.",
+            throw new IllegalArgumentException(String.format(
+                "Cannot get the value of a property of type %s with key type %s as the source contains a key of type %s.",
                 Map.class.getName(), keyType.getName(), key.getClass().getName()));
         }
 
         V sanitizedValue = valueSanitizer.sanitize(value);
         if (!valueType.isInstance(sanitizedValue)) {
-            throw new IllegalArgumentException(String.format("Cannot get the value of a property of type %s with value type %s as the source contains a value of type %s.",
+            throw new IllegalArgumentException(String.format(
+                "Cannot get the value of a property of type %s with value type %s as the source contains a value of type %s.",
                 Map.class.getName(), valueType.getName(), value.getClass().getName()));
         }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -483,7 +483,7 @@ The value of this property is derived from: <source>""")
 
         then:
         def e = thrown NullPointerException
-        e.message == 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value.'
+        e.message == 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value for key "k".'
     }
 
     def "throws NullPointerException when adding an entry with a null key to the property"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.state.ManagedFactory
 import org.gradle.util.TestUtil
 import org.gradle.util.internal.TextUtil
 import org.spockframework.util.Assert
+import spock.lang.Issue
 import spock.lang.Unroll
 
 class MapPropertySpec extends PropertySpec<Map<String, String>> {
@@ -459,6 +460,7 @@ The value of this property is derived from: <source>""")
         assertValueIs([:])
     }
 
+    @Issue('gradle/gradle#11036')
     def "throws NullPointerException when provider returns map with null key to property"() {
         given:
         property.putAll(Providers.of(Collections.singletonMap(null, 'value')))
@@ -467,9 +469,11 @@ The value of this property is derived from: <source>""")
         property.get()
 
         then:
-        thrown NullPointerException
+        def e = thrown NullPointerException
+        e.message == 'Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a null key.'
     }
 
+    @Issue('gradle/gradle#11036')
     def "throws NullPointerException when provider returns map with null value to property"() {
         given:
         property.putAll(Providers.of(['k': null]))
@@ -478,7 +482,8 @@ The value of this property is derived from: <source>""")
         property.get()
 
         then:
-        thrown NullPointerException
+        def e = thrown NullPointerException
+        e.message == 'Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a null value.'
     }
 
     def "throws NullPointerException when adding an entry with a null key to the property"() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #11036

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
This solves the issue that `null` values in map properties provided as literals result in null pointer exceptions without error message, making it difficult to identify the issue without debugging Gradle.

`Null` values and keys were already checked and even resulted in useful error messages, but only if they are added to a map property via `put`.

I didn't update any documentation because I don't think the changes require it. The null pointer exceptions were thrown already, they just didn't contain a message.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
