### PR TITLE
docs: Reword the section about executing tasks

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -54,32 +54,30 @@ The following sections describe use of the Gradle command-line interface, groupe
 [[sec:command_line_executing_tasks]]
 == Executing tasks
 
-You can run a task and all of its <<tutorial_using_tasks.adoc#sec:task_dependencies,dependencies>>.
-----
-$ gradle myTask
-----
-
 You can learn about what projects and tasks are available in the <<#sec:command_line_project_reporting, project reporting section>>.
-
 Most builds support a common set of tasks known as <<more_about_tasks#sec:lifecycle_tasks,_lifecycle tasks_>>. These include the `build`, `assemble`, and `check` tasks.
+
+In order to execute a task called "myTask" on the root project, type:
+----
+$ gradle :myTask
+----
+
+This will run the single "myTask" and also all of its <<tutorial_using_tasks.adoc#sec:task_dependencies,task dependencies>>.
 
 [[executing_tasks_in_multi_project_builds]]
 === Executing tasks in multi-project builds
-In a <<intro_multi_project_builds.adoc#intro_multi_project_builds, multi-project build>>, subproject tasks can be executed with ":" separating subproject name and task name. The following are equivalent _when run from the root project_.
-
+In a <<intro_multi_project_builds.adoc#intro_multi_project_builds, multi-project build>>, subproject tasks can be executed with ":" separating subproject name and task name. The following are equivalent _when run from the root project_:
 ----
 $ gradle :my-subproject:taskName
 $ gradle my-subproject:taskName
 ----
 
-You can also run a task for all subprojects using the task name only. For example, this will run the "test" task for all subprojects when invoked from the root project directory.
-
+You can also run a task for _all_ subprojects by again using a task _selector_ that consists of the task name only. For example, this will run the "test" task for all subprojects when invoked from the root project directory:
 ----
 $ gradle test
 ----
 
 When invoking Gradle from within a subproject, the project name should be omitted:
-
 ----
 $ cd my-subproject
 $ gradle taskName


### PR DESCRIPTION
Make more clear what the difference between the "canonical" syntax with
a leading ":" before a task name and the task selector syntax is.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

### Context
The concept of task selectors was only implicitly mentioned and should get clarification. Also see https://discuss.gradle.org/t/include-directory-project-vs-include-directory-project/20748/9.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
