### PR TITLE
Enable Gretty plugin smoke test

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -107,7 +107,7 @@ abstract class AbstractSmokeTest extends Specification {
         })
 
         // https://plugins.gradle.org/plugin/org.gretty
-        static gretty = "3.0.3"
+        static gretty = "3.0.4"
 
         // https://plugins.gradle.org/plugin/org.ajoberstar.grgit
         static grgit = "4.1.0"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -16,13 +16,19 @@
 
 package org.gradle.smoketests
 
-import spock.lang.Ignore
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-@Ignore("Ignored until https://github.com/gretty-gradle-plugin/gretty/issues/80 is resolved.")
+@UnsupportedWithConfigurationCache(
+    because = "The Gretty plugin does not support configuration caching"
+)
 class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
 
+    // Jetty 9 only works with Java 8
+    @Requires(TestPrecondition.JDK8)
     def 'run with jetty'() {
         given:
         useSample('gretty-example')
@@ -32,7 +38,7 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
                 id "org.gretty" version "${TestedVersions.gretty}"
             }
 
-            ${mavenCentralRepository()}
+            ${jcenterRepository()}
 
             dependencies {
                 implementation group: 'log4j', name: 'log4j', version: '1.2.15', ext: 'jar'
@@ -64,6 +70,7 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
 
         then:
         result.task(':checkContainerUp').outcome == SUCCESS
+        expectNoDeprecationWarnings(result)
     }
 
     @Override


### PR DESCRIPTION
Now that Gretty 3.0.4 is out which works with Gradle 7.

Fixes https://github.com/gradle/gradle-private/issues/3299.