### PR TITLE
Support output file trees with file roots

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1244,7 +1244,7 @@ task generate(type: TransformerTask) {
         buildScript """
             task myTask {
                 inputs.file file('input.txt')
-                outputs.files fileTree(dir: 'build/output.txt')
+                outputs.files files('build/output.txt').asFileTree
                 doLast {
                     file('build/output.txt').text = new File('input.txt').text
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DirectoryTreeOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DirectoryTreeOutputFilePropertySpec.java
@@ -27,15 +27,17 @@ import java.io.File;
  */
 public class DirectoryTreeOutputFilePropertySpec extends AbstractFilePropertySpec implements OutputFilePropertySpec {
     private final File root;
+    private final TreeType treeType;
 
-    public DirectoryTreeOutputFilePropertySpec(String propertyName, FileCollectionInternal files, File root) {
+    public DirectoryTreeOutputFilePropertySpec(String propertyName, FileCollectionInternal files, File root, TreeType treeType) {
         super(propertyName, OutputNormalizer.class, files);
         this.root = root;
+        this.treeType = treeType;
     }
 
     @Override
     public TreeType getOutputType() {
-        return TreeType.DIRECTORY;
+        return treeType;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -167,8 +167,8 @@ public class FileParameterUtils {
                     consumer.accept(new DirectoryTreeOutputFilePropertySpec(
                         propertyName + "$" + index.incrementAndGet(),
                         new PropertyFileCollection(ownerDisplayName, propertyName, "output", fileTree),
-                        root
-                    ));
+                        root,
+                        root.isFile() ? TreeType.FILE : TreeType.DIRECTORY));
                 }
             });
         }


### PR DESCRIPTION
This will work as long as the output file existed before task execution.

Fixes #15679