### PR TITLE
WIP: Normalize line endings in known source file types

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingNormalizationIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingNormalizationIntegrationSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+abstract class AbstractLineEndingNormalizationIntegrationSpec extends AbstractIntegrationSpec {
+    abstract String getStatusForReusedOutput()
+
+    abstract void execute(String... tasks)
+
+    abstract void cleanWorkspace()
+
+    @Unroll
+    def "tasks are not sensitive to line endings in known source files by default (#fileType files, #sensitivity.name() path sensitivity)"() {
+        createTaskWithNormalization(sensitivity)
+
+        buildFile << """
+            taskWithInputs {
+                sources.from(project.files("foo"))
+                outputFile = project.file("\${buildDir}/output.txt")
+            }
+        """
+        file("foo/Changing.${fileType}") << "\nhere's a line\nhere's another line\n\n"
+        file('foo/Changing.other') << "\nhere's a line\nhere's another line\n\n"
+
+        when:
+        execute("taskWithInputs")
+
+        then:
+        executedAndNotSkipped(":taskWithInputs")
+
+        when:
+        file("foo/Changing.${fileType}").text = file("foo/Changing.${fileType}").text.replaceAll('\\n', '\r\n')
+        cleanWorkspace()
+        execute("taskWithInputs")
+
+        then:
+        reused(":taskWithInputs")
+
+        when:
+        file('foo/Changing.other').text = file('foo/Changing.other').text.replaceAll('\\n', '\r\n')
+        cleanWorkspace()
+        execute("taskWithInputs")
+
+        then:
+        executedAndNotSkipped(":taskWithInputs")
+
+        where:
+        [fileType, sensitivity] << [['java', 'groovy', 'kotlin'], PathSensitivity.values()].combinations()
+    }
+
+    def reused(String taskPath) {
+        assert result.groupedOutput.task(taskPath).outcome == statusForReusedOutput
+        return true
+    }
+
+    def createTaskWithNormalization(PathSensitivity pathSensitivity) {
+        buildFile << """
+            task taskWithInputs(type: TaskWithInputs)
+
+            @CacheableTask
+            class TaskWithInputs extends DefaultTask {
+                @InputFiles
+                @PathSensitive(PathSensitivity.${pathSensitivity.name()})
+                FileCollection sources
+
+                @OutputFile
+                File outputFile
+
+                public TaskWithInputs() {
+                    sources = project.files()
+                }
+
+                @TaskAction
+                void doSomething() {
+                    outputFile.withWriter { writer ->
+                        sources.each { writer.println it }
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingNormalizationIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractLineEndingNormalizationIntegrationSpec.groovy
@@ -62,7 +62,7 @@ abstract class AbstractLineEndingNormalizationIntegrationSpec extends AbstractIn
         executedAndNotSkipped(":taskWithInputs")
 
         where:
-        [fileType, sensitivity] << [['java', 'groovy', 'kotlin'], PathSensitivity.values()].combinations()
+        [fileType, sensitivity] << [['java', 'groovy', 'kt'], PathSensitivity.values()].combinations()
     }
 
     def reused(String taskPath) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedLineEndingNormalizationIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedLineEndingNormalizationIntegrationSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.util.TextUtil
+
+
+class CachedLineEndingNormalizationIntegrationSpec extends AbstractLineEndingNormalizationIntegrationSpec {
+    def buildCachePath = TextUtil.normaliseFileSeparators(testDirectory.file("build-cache").absolutePath)
+
+    def setup() {
+        buildFile << """
+            plugins { id 'base' }
+        """
+        settingsFile << """
+            buildCache {
+                local {
+                    directory = file('${buildCachePath}')
+                }
+            }
+        """
+    }
+
+    @Override
+    void execute(String... tasks) {
+        withBuildCache().run tasks
+    }
+
+    @Override
+    void cleanWorkspace() {
+        run "clean"
+    }
+
+    @Override
+    String getStatusForReusedOutput() {
+        return "FROM-CACHE"
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UpToDateLineEndingNormalizationIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UpToDateLineEndingNormalizationIntegrationSpec.groovy
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.api.tasks
 
-import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotHasher;
-import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.snapshot.RegularFileSnapshot;
 
-import javax.annotation.Nullable;
+class UpToDateLineEndingNormalizationIntegrationSpec extends AbstractLineEndingNormalizationIntegrationSpec {
+    @Override
+    String getStatusForReusedOutput() {
+        return "UP-TO-DATE"
+    }
 
-public interface ResourceSnapshotterCacheService {
-    @Nullable
-    HashCode hashFile(RegularFileSnapshotContext fileSnapshotContext, RegularFileContextHasher hasher, HashCode configurationHash);
+    @Override
+    void execute(String... tasks) {
+        succeeds tasks
+    }
 
-    @Nullable
-    HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileSnapshotHasher hasher, HashCode configurationHash);
+    @Override
+    void cleanWorkspace() {
+        // do nothing
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitResourceSnapshotterCacheService.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/SplitResourceSnapshotterCacheService.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.cache.GlobalCacheLocations;
+import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 
 /**
  * A {@link ResourceSnapshotterCacheService} that delegates to the global service for immutable files
@@ -35,11 +37,20 @@ public class SplitResourceSnapshotterCacheService implements ResourceSnapshotter
     }
 
     @Override
-    public HashCode hashFile(RegularFileSnapshotContext fileSnapshotContext, RegularFileHasher hasher, HashCode configurationHash) {
+    public HashCode hashFile(RegularFileSnapshotContext fileSnapshotContext, RegularFileContextHasher hasher, HashCode configurationHash) {
         if (globalCacheLocations.isInsideGlobalCache(fileSnapshotContext.getSnapshot().getAbsolutePath())) {
             return globalCache.hashFile(fileSnapshotContext, hasher, configurationHash);
         } else {
             return localCache.hashFile(fileSnapshotContext, hasher, configurationHash);
+        }
+    }
+
+    @Override
+    public HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileSnapshotHasher hasher, HashCode configurationHash) {
+        if (globalCacheLocations.isInsideGlobalCache(fileSnapshot.getAbsolutePath())) {
+            return globalCache.hashFile(fileSnapshot, hasher, configurationHash);
+        } else {
+            return localCache.hashFile(fileSnapshot, hasher, configurationHash);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -64,6 +64,7 @@ import org.gradle.internal.file.ReservedFileSystemLocation;
 import org.gradle.internal.file.ReservedFileSystemLocationRegistry;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
 import org.gradle.internal.fingerprint.classpath.impl.DefaultClasspathFingerprinter;
+import org.gradle.internal.fingerprint.impl.FileCollectionFingerprinterRegistrations;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -72,9 +73,10 @@ import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ProjectExecutionServices extends DefaultServiceRegistry {
-
     public ProjectExecutionServices(ProjectInternal project) {
         super("Configured project services for '" + project.getPath() + "'", project.getServices());
     }
@@ -184,8 +186,13 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         );
     }
 
-    FileCollectionFingerprinterRegistry createFileCollectionFingerprinterRegistry(List<FileCollectionFingerprinter> fingerprinters) {
-        return new DefaultFileCollectionFingerprinterRegistry(fingerprinters);
+    FileCollectionFingerprinterRegistry createFileCollectionFingerprinterRegistry(List<FileCollectionFingerprinter> fingerprinters, FileCollectionFingerprinterRegistrations fileCollectionFingerprinterRegistrations) {
+        return new DefaultFileCollectionFingerprinterRegistry(
+            Stream.concat(
+                fileCollectionFingerprinterRegistrations.getRegistrants().stream(),
+                fingerprinters.stream()
+            ).collect(Collectors.toList())
+        );
     }
 
     InputFingerprinter createInputFingerprinter(

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
@@ -20,19 +20,15 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
-import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scopes.BuildSession.class)
 public class AbsolutePathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public AbsolutePathFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter) {
-        super(fingerprintingStrategyFor(directorySensitivity), fileCollectionSnapshotter);
-    }
-
-    static FingerprintingStrategy fingerprintingStrategyFor(DirectorySensitivity directorySensitivity) {
-        return directorySensitivity == DirectorySensitivity.IGNORE_DIRECTORIES ? AbsolutePathFingerprintingStrategy.IGNORE_DIRECTORIES : AbsolutePathFingerprintingStrategy.DEFAULT;
+    public AbsolutePathFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileContentHasher fileContentHasher) {
+        super(new AbsolutePathFingerprintingStrategy(directorySensitivity, fileContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.fingerprint.impl;
+
+import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter;
+import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
+import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FileCollectionFingerprinterRegistrations {
+    private final List<FileCollectionFingerprinter> registrants;
+
+    public FileCollectionFingerprinterRegistrations(StringInterner stringInterner, FileCollectionSnapshotter fileCollectionSnapshotter, FileContentHasher fileContentHasher) {
+        this.registrants = Arrays.stream(DirectorySensitivity.values())
+            .flatMap(directorySensitivity ->
+                Stream.of(
+                    new AbsolutePathFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, fileContentHasher),
+                    new RelativePathFileCollectionFingerprinter(stringInterner, directorySensitivity, fileCollectionSnapshotter, fileContentHasher),
+                    new NameOnlyFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, fileContentHasher)
+                )
+            ).collect(Collectors.toList());
+        this.registrants.add(new IgnoredPathFileCollectionFingerprinter(fileCollectionSnapshotter, fileContentHasher));
+    }
+
+    public FileCollectionFingerprinterRegistrations(StringInterner stringInterner, FileCollectionSnapshotter fileCollectionSnapshotter) {
+        this(stringInterner, fileCollectionSnapshotter, FileContentHasher.NONE);
+    }
+
+    public List<? extends FileCollectionFingerprinter> getRegistrants() {
+        return registrants;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileCollectionFingerprinter.java
@@ -19,11 +19,12 @@ package org.gradle.internal.fingerprint.impl;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 
 public class IgnoredPathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public IgnoredPathFileCollectionFingerprinter(FileCollectionSnapshotter fileCollectionSnapshotter) {
-        super(IgnoredPathFingerprintingStrategy.INSTANCE, fileCollectionSnapshotter);
+    public IgnoredPathFileCollectionFingerprinter(FileCollectionSnapshotter fileCollectionSnapshotter, FileContentHasher fileContentHasher) {
+        super(new IgnoredPathFingerprintingStrategy(fileContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFileCollectionFingerprinter.java
@@ -20,18 +20,12 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.NameOnlyInputNormalizer;
-
-import static org.gradle.internal.fingerprint.impl.NameOnlyFingerprintingStrategy.DEFAULT;
-import static org.gradle.internal.fingerprint.impl.NameOnlyFingerprintingStrategy.IGNORE_DIRECTORIES;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 
 public class NameOnlyFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public NameOnlyFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter) {
-        super(fingerPrintingStrategyFor(directorySensitivity), fileCollectionSnapshotter);
-    }
-
-    private static NameOnlyFingerprintingStrategy fingerPrintingStrategyFor(DirectorySensitivity directorySensitivity) {
-        return directorySensitivity == DirectorySensitivity.IGNORE_DIRECTORIES ? IGNORE_DIRECTORIES : DEFAULT;
+    public NameOnlyFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileContentHasher fileContentHasher) {
+        super(new NameOnlyFingerprintingStrategy(directorySensitivity, fileContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFileCollectionFingerprinter.java
@@ -21,11 +21,12 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 
 public class RelativePathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public RelativePathFileCollectionFingerprinter(StringInterner stringInterner, DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter) {
-        super(new RelativePathFingerprintingStrategy(stringInterner, directorySensitivity), fileCollectionSnapshotter);
+    public RelativePathFileCollectionFingerprinter(StringInterner stringInterner, DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileContentHasher fileContentHasher) {
+        super(new RelativePathFingerprintingStrategy(stringInterner, directorySensitivity, fileContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -37,7 +37,6 @@ import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
-import org.gradle.api.internal.changedetection.state.SourceFileFilter;
 import org.gradle.api.internal.changedetection.state.SplitFileHasher;
 import org.gradle.api.internal.changedetection.state.SplitResourceSnapshotterCacheService;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -398,9 +397,8 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             FileCollectionSnapshotter fileCollectionSnapshotter,
             ResourceSnapshotterCacheService resourceSnapshotterCacheService
         ) {
-            SourceFileFilter sourceFileFilter = new DefaultSourceFileFilter(fileSystem);
             FileHasher lineEndingNormalizingHasher = new LineEndingNormalizationFileHasher(streamHasher);
-            FileContentHasher lineEndingAwareRegularFileHasher = new LineEndingAwareFileContentHasher(lineEndingNormalizingHasher, resourceSnapshotterCacheService, sourceFileFilter);
+            FileContentHasher lineEndingAwareRegularFileHasher = new LineEndingAwareFileContentHasher(lineEndingNormalizingHasher, resourceSnapshotterCacheService, new DefaultSourceFileFilter());
             return new FileCollectionFingerprinterRegistrations(stringInterner, fileCollectionSnapshotter, lineEndingAwareRegularFileHasher);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.normalization.internal;
+
+import org.gradle.api.internal.changedetection.state.SourceFileFilter;
+import org.gradle.api.internal.file.DefaultFileTreeElement;
+import org.gradle.api.tasks.util.PatternSet;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+
+import java.io.File;
+
+public class DefaultSourceFileFilter extends PatternSet implements SourceFileFilter {
+    // TODO Perhaps instead of having a list of known file extensions, we should use a simple
+    // heuristic to determine if the file is text or binary.  Something like what Git uses:
+    // https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.30.0#n187
+    public static final String[] KNOWN_SOURCE_FILES = new String[] {
+        "**/*.java",
+        "**/*.groovy",
+        "**/*.kotlin"
+    };
+
+    private final FileSystem fileSystem;
+
+    public DefaultSourceFileFilter(FileSystem fileSystem) {
+        super();
+        this.fileSystem = fileSystem;
+        include(KNOWN_SOURCE_FILES);
+    }
+
+    @Override
+    public void appendConfigurationToHasher(Hasher hasher) {
+        getIncludes().forEach(include -> hasher.putString("include:" + include));
+        getExcludes().forEach(exclude -> hasher.putString("exclude:" + exclude));
+    }
+
+    @Override
+    public boolean isSourceFile(File file) {
+        return getAsSpec().isSatisfiedBy(DefaultFileTreeElement.of(file, fileSystem));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
@@ -25,29 +25,31 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Set;
 
+import static org.apache.commons.io.FilenameUtils.getExtension;
+
 public class DefaultSourceFileFilter implements SourceFileFilter {
     // TODO Perhaps instead of having a list of known file extensions, we should use a simple
     // heuristic to determine if the file is text or binary.  Something like what Git uses:
     // https://git.kernel.org/pub/scm/git/git.git/tree/xdiff-interface.c?h=v2.30.0#n187
     public static final Set<String> KNOWN_SOURCE_FILE_EXTS = ImmutableSet.of(
-        ".java",
-        ".groovy",
-        ".kotlin"
+        "java",
+        "groovy",
+        "kt"
     );
-    private final Set<String> includes;
+    private final Set<String> sourceFileExtensions;
 
     public DefaultSourceFileFilter() {
         super();
-        this.includes = Sets.newHashSet(KNOWN_SOURCE_FILE_EXTS);
+        this.sourceFileExtensions = Sets.newHashSet(KNOWN_SOURCE_FILE_EXTS);
     }
 
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
-        includes.forEach(hasher::putString);
+        sourceFileExtensions.forEach(hasher::putString);
     }
 
     @Override
     public boolean isSourceFile(@Nonnull File file) {
-        return includes.stream().anyMatch(extension -> file.getName().endsWith(extension));
+        return sourceFileExtensions.contains(getExtension(file.getName()));
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultSourceFileFilter.java
@@ -21,8 +21,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.internal.changedetection.state.SourceFileFilter;
 import org.gradle.internal.hash.Hasher;
 
-import javax.annotation.Nonnull;
-import java.io.File;
+import javax.annotation.Nullable;
 import java.util.Set;
 
 import static org.apache.commons.io.FilenameUtils.getExtension;
@@ -49,7 +48,7 @@ public class DefaultSourceFileFilter implements SourceFileFilter {
     }
 
     @Override
-    public boolean isSourceFile(@Nonnull File file) {
-        return sourceFileExtensions.contains(getExtension(file.getName()));
+    public boolean isSourceFile(@Nullable String path) {
+        return sourceFileExtensions.contains(getExtension(path));
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -68,6 +68,7 @@ import org.gradle.internal.execution.steps.SkipUpToDateStep
 import org.gradle.internal.execution.steps.ValidateStep
 import org.gradle.internal.file.ReservedFileSystemLocationRegistry
 import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -122,7 +123,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def fileCollectionSnapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
     def outputSnapshotter = new DefaultOutputSnapshotter(fileCollectionSnapshotter)
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileContentHasher.NONE)
     def fingerprinterRegistry = Stub(FileCollectionFingerprinterRegistry) {
         getFingerprinter(_) >> fingerprinter
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.execution.history.changes.ChangeTypeInternal
 import org.gradle.internal.execution.history.changes.DefaultFileChange
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.ChangeListener
@@ -32,7 +33,7 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def fileCollectionSnapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileContentHasher.NONE)
     def listener = Mock(ChangeListener)
 
     @Rule

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -52,6 +52,7 @@ import org.gradle.internal.execution.history.impl.DefaultOverlappingOutputDetect
 import org.gradle.internal.execution.timeout.TimeoutHandler
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
 import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -91,7 +92,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     def fileCollectionFactory = TestFiles.fileCollectionFactory()
     def artifactTransformListener = Mock(ArtifactTransformListener)
 
-    def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter)
+    def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileContentHasher.NONE)
     def fileCollectionFingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([dependencyFingerprinter])
     def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionFingerprinterRegistry, valueSnapshotter)
 

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -59,6 +59,7 @@ import org.gradle.internal.file.TreeType
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
@@ -97,7 +98,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def snapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, snapshotter)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, snapshotter, FileContentHasher.NONE)
     def executionHistoryStore = new TestExecutionHistoryStore()
     def outputChangeListener = new OutputChangeListener() {
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
+import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
 import org.gradle.internal.hash.HashCode
@@ -34,7 +36,7 @@ class NonIncrementalInputChangesTest extends Specification {
     def "can iterate changes more than once"() {
         def fingerprint = DefaultCurrentFileCollectionFingerprint.from(
             new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
-            AbsolutePathFingerprintingStrategy.DEFAULT
+            new AbsolutePathFingerprintingStrategy(DirectorySensitivity.DEFAULT, FileContentHasher.NONE)
         )
 
         Provider<FileSystemLocation> value = Mock()

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/AbstractFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/AbstractFileHasher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+public abstract class AbstractFileHasher implements FileHasher {
+
+    protected final StreamHasher streamHasher;
+
+    public AbstractFileHasher(StreamHasher streamHasher) {
+        this.streamHasher = streamHasher;
+    }
+
+    protected InputStream getInputStream(File file) {
+        try {
+            return new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s' as it does not exist.", file), e);
+        }
+    }
+
+    protected HashCode hash(InputStream inputStream) {
+        try {
+            return streamHasher.hash(inputStream);
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException ignored) {
+                // Ignored
+            }
+        }
+    }
+
+    @Override
+    public HashCode hash(File file, long length, long lastModified) {
+        return hash(file);
+    }
+}

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -29,11 +29,15 @@ public class DefaultFileHasher implements FileHasher {
         this.streamHasher = streamHasher;
     }
 
+    protected InputStream getInputStream(File file) throws FileNotFoundException {
+        return new FileInputStream(file);
+    }
+
     @Override
     public HashCode hash(File file) {
         InputStream inputStream;
         try {
-            inputStream = new FileInputStream(file);
+            inputStream = getInputStream(file);
         } catch (FileNotFoundException e) {
             throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s' as it does not exist.", file), e);
         }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -16,44 +16,15 @@
 package org.gradle.internal.hash;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
 
-public class DefaultFileHasher implements FileHasher {
-    private final StreamHasher streamHasher;
+public class DefaultFileHasher extends AbstractFileHasher {
 
     public DefaultFileHasher(StreamHasher streamHasher) {
-        this.streamHasher = streamHasher;
-    }
-
-    protected InputStream getInputStream(File file) throws FileNotFoundException {
-        return new FileInputStream(file);
+        super(streamHasher);
     }
 
     @Override
     public HashCode hash(File file) {
-        InputStream inputStream;
-        try {
-            inputStream = getInputStream(file);
-        } catch (FileNotFoundException e) {
-            throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s' as it does not exist.", file), e);
-        }
-        try {
-            return streamHasher.hash(inputStream);
-        } finally {
-            try {
-                inputStream.close();
-            } catch (IOException ignored) {
-                // Ignored
-            }
-        }
-    }
-
-    @Override
-    public HashCode hash(File file, long length, long lastModified) {
-        return hash(file);
+        return hash(getInputStream(file));
     }
 }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
@@ -17,19 +17,17 @@
 package org.gradle.internal.hash;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
 
 /**
  * A {@link FileHasher} that normalizes line endings.
  */
-public class LineEndingNormalizationFileHasher extends DefaultFileHasher {
+public class LineEndingNormalizationFileHasher extends AbstractFileHasher {
     public LineEndingNormalizationFileHasher(StreamHasher streamHasher) {
         super(streamHasher);
     }
 
     @Override
-    protected InputStream getInputStream(File file) throws FileNotFoundException {
-        return new LineEndingNormalizingInputStream(super.getInputStream(file));
+    public HashCode hash(File file) {
+        return hash(new LineEndingNormalizingInputStream(getInputStream(file)));
     }
 }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.internal.hash;
 
-import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotHasher;
-import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.snapshot.RegularFileSnapshot;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 
-import javax.annotation.Nullable;
+/**
+ * A {@link FileHasher} that normalizes line endings.
+ */
+public class LineEndingNormalizationFileHasher extends DefaultFileHasher {
+    public LineEndingNormalizationFileHasher(StreamHasher streamHasher) {
+        super(streamHasher);
+    }
 
-public interface ResourceSnapshotterCacheService {
-    @Nullable
-    HashCode hashFile(RegularFileSnapshotContext fileSnapshotContext, RegularFileContextHasher hasher, HashCode configurationHash);
-
-    @Nullable
-    HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileSnapshotHasher hasher, HashCode configurationHash);
+    @Override
+    protected InputStream getInputStream(File file) throws FileNotFoundException {
+        return new LineEndingNormalizingInputStream(super.getInputStream(file));
+    }
 }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizationFileHasher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.hash;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 
 /**
@@ -28,6 +29,6 @@ public class LineEndingNormalizationFileHasher extends AbstractFileHasher {
 
     @Override
     public HashCode hash(File file) {
-        return hash(new LineEndingNormalizingInputStream(getInputStream(file)));
+        return hash(new LineEndingNormalizingInputStream(new BufferedInputStream(getInputStream(file))));
     }
 }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizingInputStream.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/LineEndingNormalizingInputStream.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An input stream that normalizes line endings from '\r' and '\r\n' to '\n' while reading
+ * the stream.
+ */
+public class LineEndingNormalizingInputStream extends InputStream {
+    int peekAhead = -1;
+    private final InputStream delegate;
+
+    public LineEndingNormalizingInputStream(InputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    public int read() throws IOException {
+        // Get our next byte from the peek ahead buffer if it contains anything
+        int next = peekAhead;
+
+        // If there was something in the peek ahead buffer, use it, otherwise read the next byte
+        if (next != -1) {
+            peekAhead = -1;
+        } else {
+            next = delegate.read();
+        }
+
+        // If the next bytes are '\r' or '\r\n', replace it with '\n'
+        if (next == '\r') {
+            peekAhead = delegate.read();
+            if (peekAhead == '\n') {
+                peekAhead = -1;
+            }
+            next = '\n';
+        }
+
+        return next;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        delegate.close();
+    }
+}

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/LineEndingNormalizingInputStreamTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/LineEndingNormalizingInputStreamTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+class LineEndingNormalizingInputStreamTest extends Specification {
+    @Rule
+    TemporaryFolder tempDir = new TemporaryFolder()
+
+    @Unroll
+    def "can normalize line endings in input streams (eol = '#description')"() {
+        def stream = inputStream("${eol}This is a line${eol}Another line${eol}${eol}Yet another line\nAnd one more\n\nAnd yet one more${eol}")
+
+        expect:
+        stream.bytes == '\nThis is a line\nAnother line\n\nYet another line\nAnd one more\n\nAnd yet one more\n'.bytes
+
+        where:
+        eol     | description
+        '\r'    | 'CR'
+        '\r\n'  | 'CR-LF'
+        '\n'    | 'LF'
+    }
+
+    static InputStream inputStream(String input) {
+        return new LineEndingNormalizingInputStream(new ByteArrayInputStream(input.bytes))
+    }
+}

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingAwareFileContentHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingAwareFileContentHasher.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state;
+
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
+import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+/**
+ * A {@link FileContentHasher} that detects source files and normalizes the line endings
+ * in the content.  For files that are not "known" source files, it simply returns the previously
+ * calculated snapshot hash.
+ */
+public class LineEndingAwareFileContentHasher implements FileContentHasher {
+    private final FileHasher lineEndingNormalizingHasher;
+    private final ResourceSnapshotterCacheService cacheService;
+    private final SourceFileFilter sourceFileFilter;
+    private final HashCode configurationHashCode;
+
+    public LineEndingAwareFileContentHasher(FileHasher lineEndingNormalizingHasher, ResourceSnapshotterCacheService cacheService, SourceFileFilter sourceFileFilter) {
+        this.lineEndingNormalizingHasher = lineEndingNormalizingHasher;
+        this.cacheService = cacheService;
+        this.sourceFileFilter = sourceFileFilter;
+        this.configurationHashCode = getConfigurationHashCode();
+    }
+
+    private HashCode getConfigurationHashCode() {
+        Hasher hasher = Hashing.newHasher();
+        appendConfigurationToHasher(hasher);
+        return hasher.hash();
+    }
+
+    @Override
+    public void appendConfigurationToHasher(Hasher hasher) {
+        hasher.putString(getClass().getName());
+        sourceFileFilter.appendConfigurationToHasher(hasher);
+    }
+
+    @Nullable
+    @Override
+    public HashCode hash(RegularFileSnapshot snapshot) {
+        File file = new File(snapshot.getAbsolutePath());
+        return sourceFileFilter.isSourceFile(file)
+            ? cacheService.hashFile(snapshot, s -> lineEndingNormalizingHasher.hash(file), configurationHashCode)
+            : snapshot.getHash();
+    }
+}

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingAwareFileContentHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingAwareFileContentHasher.java
@@ -59,9 +59,8 @@ public class LineEndingAwareFileContentHasher implements FileContentHasher {
     @Nullable
     @Override
     public HashCode hash(RegularFileSnapshot snapshot) {
-        File file = new File(snapshot.getAbsolutePath());
-        return sourceFileFilter.isSourceFile(file)
-            ? cacheService.hashFile(snapshot, s -> lineEndingNormalizingHasher.hash(file), configurationHashCode)
+        return sourceFileFilter.isSourceFile(snapshot.getAbsolutePath())
+            ? cacheService.hashFile(snapshot, s -> lineEndingNormalizingHasher.hash(new File(snapshot.getAbsolutePath())), configurationHashCode)
             : snapshot.getHash();
     }
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RegularFileContextHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RegularFileContextHasher.java
@@ -16,16 +16,15 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.snapshot.RegularFileSnapshot;
 
 import javax.annotation.Nullable;
 
-public interface ResourceSnapshotterCacheService {
-    @Nullable
-    HashCode hashFile(RegularFileSnapshotContext fileSnapshotContext, RegularFileContextHasher hasher, HashCode configurationHash);
+public interface RegularFileContextHasher {
 
+    /**
+     * Returns {@code null} if the file should be ignored.
+     */
     @Nullable
-    HashCode hashFile(RegularFileSnapshot fileSnapshot, RegularFileSnapshotHasher hasher, HashCode configurationHash);
+    HashCode hash(RegularFileSnapshotContext snapshotContext);
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RegularFileSnapshotContext.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/RegularFileSnapshotContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot;
 import java.util.function.Supplier;
 
 public interface RegularFileSnapshotContext {
-    public Supplier<String[]> getRelativePathSegments();
+    Supplier<String[]> getRelativePathSegments();
 
-    public RegularFileSnapshot getSnapshot();
+    RegularFileSnapshot getSnapshot();
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ResourceFilter.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ResourceFilter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.hash.Hasher;
 
 import java.util.function.Supplier;

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ResourceHasher.java
@@ -16,8 +16,10 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
+
 /**
  * Hashes resources (e.g., a class file in a jar or a class file in a directory)
  */
-public interface ResourceHasher extends ConfigurableNormalizer, RegularFileHasher, ZipEntryHasher {
+public interface ResourceHasher extends ConfigurableNormalizer, RegularFileContextHasher, ZipEntryContextHasher {
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/SourceFileFilter.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/SourceFileFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,15 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.hash.Hasher;
 
+import java.io.File;
+
 /**
- * A resource entry filter supporting exact matches of values.
+ * Represents a filter which can determine if a given file should be considered a
+ * source file or not.
  */
-public interface ResourceEntryFilter extends ConfigurableNormalizer {
-    ResourceEntryFilter FILTER_NOTHING = new ResourceEntryFilter() {
-        @Override
-        public boolean shouldBeIgnored(String entry) {
-            return false;
-        }
-
-        @Override
-        public void appendConfigurationToHasher(Hasher hasher) {
-            hasher.putString(getClass().getName());
-        }
-    };
-
-    boolean shouldBeIgnored(String entry);
+public interface SourceFileFilter {
+    boolean isSourceFile(File file);
+    void appendConfigurationToHasher(Hasher hasher);
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/SourceFileFilter.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/SourceFileFilter.java
@@ -18,13 +18,11 @@ package org.gradle.api.internal.changedetection.state;
 
 import org.gradle.internal.hash.Hasher;
 
-import java.io.File;
-
 /**
  * Represents a filter which can determine if a given file should be considered a
  * source file or not.
  */
 public interface SourceFileFilter {
-    boolean isSourceFile(File file);
+    boolean isSourceFile(String path);
     void appendConfigurationToHasher(Hasher hasher);
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipEntryContextHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipEntryContextHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,18 @@
 
 package org.gradle.api.internal.changedetection.state;
 
-import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.hash.HashCode;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
 
 /**
- * A resource normalizer which is configurable.
- *
- * Allows tracking changes to its configuration.
+ * Hashes a zip entry (e.g. a class file in a jar, a manifest file, a properties file)
  */
-public interface ConfigurableNormalizer {
-    void appendConfigurationToHasher(Hasher hasher);
+public interface ZipEntryContextHasher {
+    /**
+     * Returns {@code null} if the zip entry should be ignored.
+     */
+    @Nullable
+    HashCode hash(ZipEntryContext zipEntryContext) throws IOException;
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.archive.impl.StreamZipInput;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
+import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
@@ -41,7 +42,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-public class ZipHasher implements RegularFileHasher, ConfigurableNormalizer {
+public class ZipHasher implements RegularFileContextHasher, ConfigurableNormalizer {
 
     private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar");
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipHasher.class);

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.changedetection.state.DefaultRegularFileSnapshotC
 import org.gradle.api.internal.changedetection.state.IgnoringResourceHasher;
 import org.gradle.api.internal.changedetection.state.MetaInfAwareClasspathResourceHasher;
 import org.gradle.api.internal.changedetection.state.PropertiesFileAwareClasspathResourceHasher;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
 import org.gradle.api.internal.changedetection.state.RegularFileSnapshotContext;
 import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
@@ -83,7 +84,7 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
                                            ZipHasher zipHasher,
                                            ResourceSnapshotterCacheService cacheService,
                                            Interner<String> stringInterner) {
-        super(identifier);
+        super(identifier, FileContentHasher.NONE);
         this.nonZipFingerprintingStrategy = nonZipFingerprintingStrategy;
         this.classpathResourceHasher = classpathResourceHasher;
         this.cacheService = cacheService;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/ConfigurableNormalizer.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/ConfigurableNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.internal.fingerprint.hashing;
 
-import org.gradle.internal.hash.HashCode;
-
-import javax.annotation.Nullable;
-import java.io.IOException;
+import org.gradle.internal.hash.Hasher;
 
 /**
- * Hashes a zip entry (e.g. a class file in a jar, a manifest file, a properties file)
+ * A resource normalizer which is configurable.
+ *
+ * Allows tracking changes to its configuration.
  */
-public interface ZipEntryHasher {
-    /**
-     * Returns {@code null} if the zip entry should be ignored.
-     */
-    @Nullable
-    HashCode hash(ZipEntryContext zipEntryContext) throws IOException;
+public interface ConfigurableNormalizer {
+    void appendConfigurationToHasher(Hasher hasher);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/FileContentHasher.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/FileContentHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.internal.fingerprint.hashing;
 
-import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 
-/**
- * A resource entry filter supporting exact matches of values.
- */
-public interface ResourceEntryFilter extends ConfigurableNormalizer {
-    ResourceEntryFilter FILTER_NOTHING = new ResourceEntryFilter() {
-        @Override
-        public boolean shouldBeIgnored(String entry) {
-            return false;
-        }
-
+public interface FileContentHasher extends RegularFileSnapshotHasher, ConfigurableNormalizer {
+    FileContentHasher NONE = new FileContentHasher() {
         @Override
         public void appendConfigurationToHasher(Hasher hasher) {
             hasher.putString(getClass().getName());
         }
-    };
 
-    boolean shouldBeIgnored(String entry);
+        @Override
+        public HashCode hash(RegularFileSnapshot snapshot) {
+            return snapshot.getHash();
+        }
+    };
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/RegularFileSnapshotHasher.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/RegularFileSnapshotHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.changedetection.state;
+package org.gradle.internal.fingerprint.hashing;
 
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
 
 import javax.annotation.Nullable;
 
-public interface RegularFileHasher {
-
+public interface RegularFileSnapshotHasher {
     /**
      * Returns {@code null} if the file should be ignored.
      */
     @Nullable
-    HashCode hash(RegularFileSnapshotContext snapshotContext);
+    HashCode hash(RegularFileSnapshot snapshot);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
@@ -16,16 +16,25 @@
 
 package org.gradle.internal.fingerprint.impl;
 
+import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
+import org.gradle.internal.snapshot.RegularFileSnapshot;
+
+import javax.annotation.Nullable;
 
 public abstract class AbstractFingerprintingStrategy implements FingerprintingStrategy {
     private final String identifier;
     private final CurrentFileCollectionFingerprint emptyFingerprint;
+    private final FileContentHasher fileContentHasher;
 
-    public AbstractFingerprintingStrategy(String identifier) {
+    public AbstractFingerprintingStrategy(String identifier, FileContentHasher fileContentHasher) {
         this.identifier = identifier;
         this.emptyFingerprint = new EmptyCurrentFileCollectionFingerprint(identifier);
+        this.fileContentHasher = fileContentHasher;
     }
 
     @Override
@@ -36,5 +45,10 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
     @Override
     public CurrentFileCollectionFingerprint getEmptyFingerprint() {
         return emptyFingerprint;
+    }
+
+    @Nullable
+    protected HashCode hashSnapshotContent(FileSystemLocationSnapshot snapshot) {
+        return snapshot.getType() == FileType.RegularFile ? fileContentHasher.hash((RegularFileSnapshot)snapshot) : snapshot.getHash();
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -21,6 +21,8 @@ import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
@@ -35,14 +37,11 @@ import java.util.Map;
  * File names for root directories are ignored.
  */
 public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrategy {
-
-    public static final NameOnlyFingerprintingStrategy DEFAULT = new NameOnlyFingerprintingStrategy(DirectorySensitivity.DEFAULT);
-    public static final NameOnlyFingerprintingStrategy IGNORE_DIRECTORIES = new NameOnlyFingerprintingStrategy(DirectorySensitivity.IGNORE_DIRECTORIES);
     public static final String IDENTIFIER = "NAME_ONLY";
     private final DirectorySensitivity directorySensitivity;
 
-    private NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity) {
-        super(IDENTIFIER);
+    public NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity, FileContentHasher fileContentHasher) {
+        super(IDENTIFIER, fileContentHasher);
         this.directorySensitivity = directorySensitivity;
     }
 
@@ -60,10 +59,14 @@ public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrate
             public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
                 String absolutePath = snapshot.getAbsolutePath();
                 if (processedEntries.add(absolutePath) && directorySensitivity.shouldFingerprint(snapshot)) {
-                    FileSystemLocationFingerprint fingerprint = isRoot && snapshot.getType() == FileType.Directory
-                        ? IgnoredPathFileSystemLocationFingerprint.DIRECTORY
-                        : new DefaultFileSystemLocationFingerprint(snapshot.getName(), snapshot);
-                    builder.put(absolutePath, fingerprint);
+                    if (isRoot && snapshot.getType() == FileType.Directory) {
+                        builder.put(absolutePath, IgnoredPathFileSystemLocationFingerprint.DIRECTORY);
+                    } else {
+                        HashCode normalizedContentHash = hashSnapshotContent(snapshot);
+                        if (normalizedContentHash != null) {
+                            builder.put(absolutePath, new DefaultFileSystemLocationFingerprint(snapshot.getName(), snapshot.getType(), normalizedContentHash));
+                        }
+                    }
                 }
                 return SnapshotVisitResult.CONTINUE;
             }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -70,7 +70,7 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
         roots.accept(new RelativePathTracker(), (snapshot, relativePath) -> {
             String absolutePath = snapshot.getAbsolutePath();
             if (processedEntries.add(absolutePath) && directorySensitivity.shouldFingerprint(snapshot)) {
-                FileSystemLocationFingerprint fingerprint = null;
+                FileSystemLocationFingerprint fingerprint;
                 if (relativePath.isRoot()) {
                     if (snapshot.getType() == FileType.Directory) {
                         fingerprint = IgnoredPathFileSystemLocationFingerprint.DIRECTORY;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -22,11 +22,14 @@ import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
+import org.gradle.internal.fingerprint.hashing.FileContentHasher;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.RelativePathTracker;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -41,10 +44,14 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
 
     private final Interner<String> stringInterner;
 
-    public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity) {
-        super(IDENTIFIER);
+    public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity, FileContentHasher fileContentHasher) {
+        super(IDENTIFIER, fileContentHasher);
         this.stringInterner = stringInterner;
         this.directorySensitivity = directorySensitivity;
+    }
+
+    public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity) {
+        this(stringInterner, directorySensitivity, FileContentHasher.NONE);
     }
 
     @Override
@@ -63,21 +70,30 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
         roots.accept(new RelativePathTracker(), (snapshot, relativePath) -> {
             String absolutePath = snapshot.getAbsolutePath();
             if (processedEntries.add(absolutePath) && directorySensitivity.shouldFingerprint(snapshot)) {
-                FileSystemLocationFingerprint fingerprint;
+                FileSystemLocationFingerprint fingerprint = null;
                 if (relativePath.isRoot()) {
                     if (snapshot.getType() == FileType.Directory) {
                         fingerprint = IgnoredPathFileSystemLocationFingerprint.DIRECTORY;
                     } else {
-                        fingerprint = new DefaultFileSystemLocationFingerprint(snapshot.getName(), snapshot);
+                        fingerprint = fingerprint(snapshot.getName(), snapshot.getType(), snapshot);
                     }
                 } else {
-                    fingerprint = new DefaultFileSystemLocationFingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot);
+                    fingerprint = fingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot.getType(), snapshot);
                 }
-                builder.put(absolutePath, fingerprint);
+
+                if (fingerprint != null) {
+                    builder.put(absolutePath, fingerprint);
+                }
             }
             return SnapshotVisitResult.CONTINUE;
         });
         return builder.build();
+    }
+
+    @Nullable
+    FileSystemLocationFingerprint fingerprint(String name, FileType type, FileSystemLocationSnapshot snapshot) {
+        HashCode normalizedContentHash = hashSnapshotContent(snapshot);
+        return normalizedContentHash == null ? null : new DefaultFileSystemLocationFingerprint(name, type, normalizedContentHash);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -59,7 +59,7 @@ public class RegularFileSnapshot extends AbstractFileSystemLocationSnapshot impl
 
     @Override
     public boolean isContentUpToDate(FileSystemLocationSnapshot other) {
-        if (!(other instanceof RegularFileSnapshot)) {
+        if (!(other.getType() == FileType.RegularFile)) {
             return false;
         }
         return contentHash.equals(((RegularFileSnapshot) other).contentHash);

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.MutableReference
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FingerprintingStrategy
+import org.gradle.internal.fingerprint.hashing.FileContentHasher
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
@@ -82,7 +83,7 @@ class PathNormalizationStrategyTest extends Specification {
     }
 
     def "sensitivity NONE"() {
-        def fingerprints = collectFingerprints(IgnoredPathFingerprintingStrategy.INSTANCE)
+        def fingerprints = collectFingerprints(new IgnoredPathFingerprintingStrategy(FileContentHasher.NONE))
         expect:
         allFilesToFingerprint.each { file ->
             if (file.isFile() || !file.exists()) {
@@ -105,8 +106,8 @@ class PathNormalizationStrategyTest extends Specification {
 
         where:
         strategy << [
-            NameOnlyFingerprintingStrategy.DEFAULT,
-            NameOnlyFingerprintingStrategy.IGNORE_DIRECTORIES
+            new NameOnlyFingerprintingStrategy(DirectorySensitivity.DEFAULT, FileContentHasher.NONE),
+            new NameOnlyFingerprintingStrategy(DirectorySensitivity.IGNORE_DIRECTORIES, FileContentHasher.NONE)
         ]
     }
 
@@ -144,8 +145,8 @@ class PathNormalizationStrategyTest extends Specification {
 
         where:
         strategy << [
-            AbsolutePathFingerprintingStrategy.DEFAULT,
-            AbsolutePathFingerprintingStrategy.IGNORE_DIRECTORIES
+            new AbsolutePathFingerprintingStrategy(DirectorySensitivity.DEFAULT, FileContentHasher.NONE),
+            new AbsolutePathFingerprintingStrategy(DirectorySensitivity.IGNORE_DIRECTORIES, FileContentHasher.NONE)
         ]
     }
 


### PR DESCRIPTION
See #9072.

This adds basic line ending normalization when fingerprinting known source file types.  This intentionally does not include any mechanisms for configuration of the source file types.  

A future improvement might be to expand this to all text file types by inferring whether a file is text or binary using a heuristic.
