### PR TITLE
Add configuration cache smoke tests for gradle/gradle local dev workflows

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -93,7 +93,6 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheDebugLogIntegrationTest"
     }
 
-    @NotYetImplemented
     def "can run Gradle cross-version tests with configuration cache enabled"() {
 
         given:
@@ -109,7 +108,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":configuration-cache:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -119,7 +118,6 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.task(":configuration-cache:embeddedCrossVersionTest").outcome == TaskOutcome.SUCCESS
     }
 
-    @NotYetImplemented
     def "can run Gradle smoke tests with configuration cache enabled"() {
 
         given:
@@ -135,7 +133,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":smoke-test:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -145,13 +143,12 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.task(":smoke-test:smokeTest").outcome == TaskOutcome.SUCCESS
     }
 
-    @NotYetImplemented
     def "can run Gradle soak tests with configuration cache enabled"() {
 
         given:
         def tasks = [
             ':soak:forkingIntegTest',
-            '--tests=org.gradle.vfs.FileSystemWatchingSoakTest'
+            '--tests=org.gradle.connectivity.MavenCentralDependencyResolveIntegrationTest'
         ]
 
         when:
@@ -161,7 +158,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":soak:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -184,7 +181,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":configuration-cache:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -212,7 +209,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":architecture-test:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -222,7 +219,6 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.task(":architecture-test:checkBinaryCompatibility").outcome == TaskOutcome.SUCCESS
     }
 
-    @NotYetImplemented
     def "can build and install Gradle binary distribution with configuration cache enabled"() {
 
         given:
@@ -238,7 +234,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":distributions-full:clean"])
 
         then:
         configurationCacheRun(tasks, 1)
@@ -266,7 +262,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateStored()
 
         when:
-        run(["clean"])
+        run([":docs:clean"])
 
         then:
         configurationCacheRun(tasks, 1)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Ignore
 
 /**
  * Smoke test building gradle/gradle with configuration cache enabled.
@@ -241,6 +242,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.task(":distributions-full:binInstallation").outcome == TaskOutcome.SUCCESS
     }
 
+    @Ignore("Broken by at least the Asciidoctor plugin, and takes 40mins on CI")
     @NotYetImplemented
     def "can build and test Gradle documentation with configuration cache enabled"() {
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -74,7 +74,8 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
 
         given: "tasks whose configuration can only be loaded in the original daemon"
         def supportedTasks = [
-            ":configuration-cache:embeddedIntegTest", "--tests=org.gradle.configurationcache.ConfigurationCacheIntegrationTest"
+            ":configuration-cache:embeddedIntegTest",
+            "--tests=org.gradle.configurationcache.ConfigurationCacheDebugLogIntegrationTest"
         ]
 
         when:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -42,7 +42,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         given: "tasks whose configuration can be safely cached across daemons"
         def supportedTasks = [
             ":tooling-api:publishLocalPublicationToLocalRepository",
-            ":base-services:test",
+            ":base-services:test", "--tests=org.gradle.api.JavaVersionSpec"
         ]
 
         when:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -37,9 +37,9 @@ import org.gradle.util.TestPrecondition
 })
 class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeTest {
 
-    def "can run Gradle unit tests with configuration cache enabled across daemons"() {
+    def "can run Gradle unit tests with configuration cache enabled"() {
 
-        given: "tasks whose configuration can be safely cached across daemons"
+        given:
         def supportedTasks = [
             ":tooling-api:publishLocalPublicationToLocalRepository",
             ":base-services:test", "--tests=org.gradle.api.JavaVersionSpec"
@@ -51,17 +51,10 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         then:
         assertConfigurationCacheStateStored()
 
-        when: "reusing the configuration cache in the same daemon"
-        configurationCacheRun supportedTasks, 0
-
-        then:
-        assertConfigurationCacheStateLoaded()
-        result.task(":tooling-api:publishLocalPublicationToLocalRepository").outcome == TaskOutcome.SUCCESS
-
         when:
-        run(["clean"])
+        run([":tooling-api:clean", ":base-services:clean"])
 
-        and: "reusing the configuration cache in a different daemon"
+        and:
         configurationCacheRun supportedTasks + ["--info"], 1
 
         then:
@@ -70,7 +63,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.task(":tooling-api:publishLocalPublicationToLocalRepository").outcome == TaskOutcome.SUCCESS
     }
 
-    def "can run Gradle integ tests with configuration cache enabled (original daemon only)"() {
+    def "can run Gradle integ tests with configuration cache enabled"() {
 
         given: "tasks whose configuration can only be loaded in the original daemon"
         def supportedTasks = [
@@ -84,8 +77,11 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         then:
         assertConfigurationCacheStateStored()
 
-        when: "reusing the configuration cache in the same daemon"
-        configurationCacheRun supportedTasks, 0
+        when:
+        run([":configuration-cache:clean"])
+
+        then:
+        configurationCacheRun supportedTasks, 1
 
         then:
         assertConfigurationCacheStateLoaded()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -90,7 +90,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         then:
         assertConfigurationCacheStateLoaded()
         result.task(":configuration-cache:embeddedIntegTest").outcome == TaskOutcome.SUCCESS
-        assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheIntegrationTest"
+        assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheDebugLogIntegrationTest"
     }
 
     @NotYetImplemented

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.smoketests
 
+import groovy.test.NotYetImplemented
+import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheMaxProblemsOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheOption
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
@@ -88,6 +90,190 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         result.output.count("Reusing configuration cache") == 1
         result.task(":configuration-cache:embeddedIntegTest").outcome == TaskOutcome.SUCCESS
         assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheIntegrationTest"
+    }
+
+    @NotYetImplemented
+    def "can run Gradle cross-version tests with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':configuration-cache:embeddedCrossVersionTest',
+            '--tests=org.gradle.configurationcache.ConfigurationCacheCrossVersionTest'
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":configuration-cache:embeddedCrossVersionTest").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can run Gradle smoke tests with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':smoke-test:smokeTest',
+            '--tests=org.gradle.smoketests.ErrorPronePluginSmokeTest'
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":smoke-test:smokeTest").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can run Gradle soak tests with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':soak:forkingIntegTest',
+            '--tests=org.gradle.vfs.FileSystemWatchingSoakTest'
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":soak:forkingIntegTest").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can run Gradle codeQuality with configuration cache enabled"() {
+
+        given:
+        def tasks = [':configuration-cache:codeQuality']
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":configuration-cache:runKtlintCheckOverMainSourceSet").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:validatePlugins").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:codenarcIntegTest").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:checkstyleIntegTestGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:classycleIntegTest").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:codeQuality").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can run Gradle checkBinaryCompatibility with configuration cache enabled"() {
+
+        given:
+        def tasks = [':architecture-test:checkBinaryCompatibility']
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":architecture-test:checkBinaryCompatibility").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can build and install Gradle binary distribution with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':distributions-full:binDistributionZip',
+            ':distributions-full:binInstallation'
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":distributions-full:binDistributionZip").outcome == TaskOutcome.SUCCESS
+        result.task(":distributions-full:binInstallation").outcome == TaskOutcome.SUCCESS
+    }
+
+    @NotYetImplemented
+    def "can build and test Gradle documentation with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':docs:docs',
+            ':docs:docsTest',
+            "-D${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}=8192".toString(), // TODO remove
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run(["clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":docs:docs").outcome == TaskOutcome.SUCCESS
+        result.task("':docs:docsTest'").outcome == TaskOutcome.SUCCESS
     }
 
     private TestExecutionResult assertTestClassExecutedIn(String subProjectDir, String testClass) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -49,13 +49,13 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         configurationCacheRun supportedTasks, 0
 
         then:
-        result.output.count("Calculating task graph as no configuration cache is available") == 1
+        assertConfigurationCacheStateStored()
 
         when: "reusing the configuration cache in the same daemon"
         configurationCacheRun supportedTasks, 0
 
         then:
-        result.output.count("Reusing configuration cache") == 1
+        assertConfigurationCacheStateLoaded()
         result.task(":tooling-api:publishLocalPublicationToLocalRepository").outcome == TaskOutcome.SUCCESS
 
         when:
@@ -65,7 +65,7 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         configurationCacheRun supportedTasks + ["--info"], 1
 
         then:
-        result.output.count("Reusing configuration cache") == 1
+        assertConfigurationCacheStateLoaded()
         result.output.contains("Starting build in new daemon")
         result.task(":tooling-api:publishLocalPublicationToLocalRepository").outcome == TaskOutcome.SUCCESS
     }
@@ -82,13 +82,13 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         configurationCacheRun supportedTasks, 0
 
         then:
-        result.output.count("Calculating task graph as no configuration cache is available") == 1
+        assertConfigurationCacheStateStored()
 
         when: "reusing the configuration cache in the same daemon"
         configurationCacheRun supportedTasks, 0
 
         then:
-        result.output.count("Reusing configuration cache") == 1
+        assertConfigurationCacheStateLoaded()
         result.task(":configuration-cache:embeddedIntegTest").outcome == TaskOutcome.SUCCESS
         assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheIntegrationTest"
     }
@@ -275,6 +275,16 @@ class GradleBuildConfigurationCacheSmokeTest extends AbstractGradleceptionSmokeT
         assertConfigurationCacheStateLoaded()
         result.task(":docs:docs").outcome == TaskOutcome.SUCCESS
         result.task("':docs:docsTest'").outcome == TaskOutcome.SUCCESS
+    }
+
+    @Override
+    protected void assertConfigurationCacheStateStored() {
+        assert result.output.count("Calculating task graph as no configuration cache is available") == 1
+    }
+
+    @Override
+    protected void assertConfigurationCacheStateLoaded() {
+        assert result.output.count("Reusing configuration cache") == 1
     }
 
     private TestExecutionResult assertTestClassExecutedIn(String subProjectDir, String testClass) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildConfigurationCacheSmokeTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.util.TestPrecondition
 /**
  * Smoke test building gradle/gradle with configuration cache enabled.
  *
- * gradle/gradle requires Java >=9 and <=11 to build, see {@link GradleBuildJvmSpec}.
+ * gradle/gradle requires Java >=9 and <=11 to build, see {@link AbstractGradleceptionSmokeTest.GradleBuildJvmSpec}.
  */
 @Requires(value = TestPrecondition.JDK9_OR_LATER, adhoc = {
     GradleContextualExecuter.isNotConfigCache() && GradleBuildJvmSpec.isAvailable()


### PR DESCRIPTION
This PR adds coverage for local development workflows with the configuration cache enabled on the `gradle/gradle` build.
Subsequent PRs will try to fix the introduced tests.
This will allow us to make sure we don't introduce regressions for these workflows.

Still turning problems into warnings.
None of the added tests pass at this point and are annotated with `@NotYetImplemented`.
One can have a look at the reported problems and failures in the test reports on CI.

The test for building the Gradle documentation is `@Ignore`d for now as it takes 40 minutes to build and is known to be broken by at least the Asciidoctor plugin. It can be used for local investigations and ready to be enabled when it work.

We should get rid of those tests once our CI enables the configuration cache by default as all this will then be covered.