### PR TITLE
Deprecate JacocoMerge

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -37,3 +37,10 @@ Some plugins will break with this new version of Gradle, for example because the
 == Upgrading from 7.0 and earlier
 
 === Deprecations
+
+[[jacoco_merge]]
+==== JacocoMerge task type is deprecated
+
+The `JacocoMerge` task was used to provide single exec files from multiple test tasks.
+The task is being replaced by the `JacocoReport` which can also take multiple coverage reports as an input.
+Consequently, the `JacocoMerge` is now deprecated and set to be removed in Gradle 8.0.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -41,6 +41,6 @@ Some plugins will break with this new version of Gradle, for example because the
 [[jacoco_merge]]
 ==== JacocoMerge task type is deprecated
 
-The `JacocoMerge` task was used to provide single exec files from multiple test tasks.
-The task is being replaced by the `JacocoReport` which can also take multiple coverage reports as an input.
-Consequently, the `JacocoMerge` is now deprecated and set to be removed in Gradle 8.0.
+The `JacocoMerge` task was used for merging coverage reports from different subprojects into a single report.
+The same functionality is also available on the `JacocoReport` task.
+Because of the duplication, `JacocoMerge` is now deprecated and scheduled for removal in Gradle 8.0.

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -183,7 +183,7 @@ public class ThingTest {
             }
         """
         when:
-        executer.expectDocumentedDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacoco_merge")
+        executer.expectDocumentedDeprecationWarning("The task type org.gradle.testing.jacoco.tasks.JacocoMerge (used by the :jacocoMerge task) has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacoco_merge")
         succeeds 'mergedReport'
 
         then:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -183,6 +183,7 @@ public class ThingTest {
             }
         """
         when:
+        executer.expectDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge_Decorated task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead.")
         succeeds 'mergedReport'
 
         then:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -183,7 +183,7 @@ public class ThingTest {
             }
         """
         when:
-        executer.expectDocumentedDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge_Decorated task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacoco_merge")
+        executer.expectDocumentedDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacoco_merge")
         succeeds 'mergedReport'
 
         then:

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -36,7 +36,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         javaProjectUnderTest.writeSourceFiles()
     }
 
-    void generatesHtmlReportOnlyAsDefault() {
+    def "generates html report only as default"() {
         when:
         succeeds('test', 'jacocoTestReport')
 
@@ -48,7 +48,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         htmlReport().totalCoverage() == 100
     }
 
-    void canConfigureReportsInJacocoTestReport() {
+    def "can configure reports in jacoco test report"() {
         given:
         buildFile << """
             jacocoTestReport {
@@ -69,7 +69,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         file(REPORT_CSV_DEFAULT_REPORT).exists()
     }
 
-    void respectsReportingBaseDir() {
+    def "respects reporting base dir"() {
         given:
         buildFile << """
             jacocoTestReport {
@@ -89,7 +89,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         file("build/customReports/jacoco/test/jacocoTestReport.csv").exists()
     }
 
-    void canConfigureReportDirectory() {
+    def "can configure report directory"() {
         given:
         def customReportDirectory = "customJacocoReportDir"
         buildFile << """
@@ -111,14 +111,14 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         file("build/${customReportDirectory}/test/jacocoTestReport.csv").exists()
     }
 
-    void jacocoTestReportIsSkippedIfNoCoverageDataAvailable() {
+    def "jacoco test report is skipped if no coverage data available"() {
         when:
         def executionResult = succeeds('jacocoTestReport')
         then:
         executionResult.assertTaskSkipped(':jacocoTestReport')
     }
 
-    void canUseCoverageDataFromPreviousRunForCoverageReport() {
+    def "can use coverage data from previous run for coverage report"() {
         when:
         succeeds('jacocoTestReport')
 
@@ -137,7 +137,7 @@ class JacocoPluginMultiVersionIntegrationTest extends JacocoMultiVersionIntegrat
         htmlReport().totalCoverage() == 100
     }
 
-    void canMergeCoverageData() {
+    def "can merge coverage data"() {
         given:
         file("src/otherMain/java/Thing.java") << """
 public class Thing {
@@ -196,14 +196,14 @@ public class ThingTest {
 
     @Issue("GRADLE-2917")
     @ToBeFixedForConfigurationCache(because = ":dependencies")
-    void "configures default jacoco dependencies even if the configuration was resolved before"() {
+    def "configures default jacoco dependencies even if the configuration was resolved before"() {
         expect:
         //dependencies task forces resolution of the configurations
         succeeds "dependencies", "test", "jacocoTestReport"
     }
 
     @Issue("GRADLE-3498")
-    void "can use different execution data"() {
+    def "can use different execution data"() {
         setup:
         buildFile << """
         test {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginMultiVersionIntegrationTest.groovy
@@ -183,7 +183,7 @@ public class ThingTest {
             }
         """
         when:
-        executer.expectDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge_Decorated task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead.")
+        executer.expectDocumentedDeprecationWarning("The org.gradle.testing.jacoco.tasks.JacocoMerge_Decorated task type used by :jacocoMerge has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the org.gradle.testing.jacoco.tasks.JacocoReport type instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#jacoco_merge")
         succeeds 'mergedReport'
 
         then:

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -37,7 +37,6 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.testing.jacoco.tasks.JacocoBase;
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification;
-import org.gradle.testing.jacoco.tasks.JacocoMerge;
 import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import javax.inject.Inject;
@@ -136,9 +135,10 @@ public class JacocoPlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(extension::applyTo);
     }
 
+    @SuppressWarnings("deprecation")
     private void configureDefaultOutputPathForJacocoMerge() {
         Provider<File> buildDirectory = project.getLayout().getBuildDirectory().getAsFile();
-        project.getTasks().withType(JacocoMerge.class).configureEach(task ->
+        project.getTasks().withType(org.gradle.testing.jacoco.tasks.JacocoMerge.class).configureEach(task ->
             task.setDestinationFile(buildDirectory.map(buildDir -> new File(buildDir, "jacoco/" + task.getName() + ".exec")))
         );
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
@@ -91,7 +91,7 @@ public class JacocoMerge extends JacocoBase {
 
     @TaskAction
     public void merge() {
-        DeprecationLogger.deprecateTaskType(getClass(), getPath()).replaceWith(JacocoReport.class).willBeRemovedInGradle8().undocumented().nagUser();
+        DeprecationLogger.deprecateTaskType(getClass(), getPath()).replaceWith(JacocoReport.class).willBeRemovedInGradle8().withUpgradeGuideSection(7, "jacoco_merge").nagUser();
         new AntJacocoMerge(getAntBuilder()).execute(getJacocoClasspath(), getExecutionData(), getDestinationFile());
     }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
@@ -91,7 +91,7 @@ public class JacocoMerge extends JacocoBase {
 
     @TaskAction
     public void merge() {
-        DeprecationLogger.deprecateTaskType(getClass(), getPath()).replaceWith(JacocoReport.class).willBeRemovedInGradle8().withUpgradeGuideSection(7, "jacoco_merge").nagUser();
+        DeprecationLogger.deprecateTaskType(JacocoMerge.class, getPath()).replaceWith(JacocoReport.class).willBeRemovedInGradle8().withUpgradeGuideSection(7, "jacoco_merge").nagUser();
         new AntJacocoMerge(getAntBuilder()).execute(getJacocoClasspath(), getExecutionData(), getDestinationFile());
     }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoMerge.java
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskCollection;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jacoco.AntJacocoMerge;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
 
@@ -37,7 +38,11 @@ import java.io.File;
 
 /**
  * Task to merge multiple execution data files into one.
+ *
+ * @deprecated The {@link JacocoReport} task accepts multiple execution files as an input. This task type provides
+ * duplicated functionality and will be removed in Gradle 8.0.
  */
+@Deprecated
 @CacheableTask
 public class JacocoMerge extends JacocoBase {
 
@@ -86,6 +91,7 @@ public class JacocoMerge extends JacocoBase {
 
     @TaskAction
     public void merge() {
+        DeprecationLogger.deprecateTaskType(getClass(), getPath()).replaceWith(JacocoReport.class).willBeRemovedInGradle8().undocumented().nagUser();
         new AntJacocoMerge(getAntBuilder()).execute(getJacocoClasspath(), getExecutionData(), getDestinationFile());
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -203,7 +203,11 @@ public class DeprecationLogger {
      */
     @CheckReturnValue
     public static DeprecationMessageBuilder.DeprecateTaskType deprecateTaskType(Class<?> task, String path) {
-        return new DeprecationMessageBuilder.DeprecateTaskType(task.getCanonicalName(), path);
+        String taskTypeName = task.getCanonicalName();
+        if (taskTypeName.endsWith("_Decorated")) {
+            taskTypeName = taskTypeName.substring(0, taskTypeName.length() - 10);
+        }
+        return new DeprecationMessageBuilder.DeprecateTaskType(taskTypeName, path);
     }
 
     /**

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -199,6 +199,14 @@ public class DeprecationLogger {
     }
 
     /**
+     * Output: The ${task.getCanonicalName()} task type used by ${task.getPath()} has been deprecated.
+     */
+    @CheckReturnValue
+    public static DeprecationMessageBuilder.DeprecateTaskType deprecateTaskType(Class<?> task, String path) {
+        return new DeprecationMessageBuilder.DeprecateTaskType(task.getCanonicalName(), path);
+    }
+
+    /**
      * Output: The ${plugin} plugin has been deprecated.
      */
     @CheckReturnValue

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -203,11 +203,7 @@ public class DeprecationLogger {
      */
     @CheckReturnValue
     public static DeprecationMessageBuilder.DeprecateTaskType deprecateTaskType(Class<?> task, String path) {
-        String taskTypeName = task.getCanonicalName();
-        if (taskTypeName.endsWith("_Decorated")) {
-            taskTypeName = taskTypeName.substring(0, taskTypeName.length() - 10);
-        }
-        return new DeprecationMessageBuilder.DeprecateTaskType(taskTypeName, path);
+        return new DeprecationMessageBuilder.DeprecateTaskType(task.getCanonicalName(), path);
     }
 
     /**

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationLogger.java
@@ -199,7 +199,7 @@ public class DeprecationLogger {
     }
 
     /**
-     * Output: The ${task.getCanonicalName()} task type used by ${task.getPath()} has been deprecated.
+     * Output: The task type ${task.getCanonicalName()} (used by the ${task.getPath()} task) has been deprecated.
      */
     @CheckReturnValue
     public static DeprecationMessageBuilder.DeprecateTaskType deprecateTaskType(Class<?> task, String path) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -420,7 +420,6 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         }
     }
 
-
     public static class DeprecatePlugin extends WithReplacement<String, DeprecatePlugin> {
 
         private boolean externalReplacement = false;

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -410,8 +410,8 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         }
 
         @Override
-        String formatSummary(String task) {
-            return String.format("The %s task type used by %s has been deprecated.", task, path);
+        String formatSummary(String type) {
+            return String.format("The task type %s (used by the %s task) has been deprecated.", type, path);
         }
 
         @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -401,6 +401,26 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         }
     }
 
+    public static class DeprecateTaskType extends WithReplacement<Class<?>, DeprecateTaskType> {
+        private final String path;
+
+        DeprecateTaskType(String task, String path) {
+            super(task);
+            this.path = path;
+        }
+
+        @Override
+        String formatSummary(String task) {
+            return String.format("The %s task type used by %s has been deprecated.", task, path);
+        }
+
+        @Override
+        String formatAdvice(Class<?> replacement) {
+            return String.format("Please use the %s type instead.", replacement.getCanonicalName());
+        }
+    }
+
+
     public static class DeprecatePlugin extends WithReplacement<String, DeprecatePlugin> {
 
         private boolean externalReplacement = false;


### PR DESCRIPTION
`JacocoMerge` was used for merging coverage reports from different subprojects into a single report. The same functionality is also available on the `JacocoReport` task. Because of the duplication, we want to deprecate `JacocoMerge` and remove it in Gradle 8.0.

To provide a better error message, I introduced `DeprecationLogger.deprecateTaskType()`, which takes a `Class` as an argument, and can optionally specify a replacement of type `Class`. 