### PR TITLE
Let the configuration cache serialization support URL instances

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -418,6 +418,8 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         Double.name                          | "12.1"                                                        | "12.1"
         double.name                          | "12.1"                                                        | "12.1"
         Class.name                           | "SomeBean"                                                    | "class SomeBean"
+        URL.name                             | "new URL('https://gradle.org/')"                              | "https://gradle.org/"
+        URI.name                             | "URI.create('https://gradle.org/')"                           | "https://gradle.org/"
         "SomeEnum"                           | "SomeEnum.Two"                                                | "Two"
         "SomeEnum[]"                         | "[SomeEnum.Two] as SomeEnum[]"                                | "[Two]"
         "List<String>"                       | "['a', 'b', 'c']"                                             | "[a, b, c]"

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -294,6 +294,7 @@ class Codecs(
 
         bind(EnumCodec)
         bind(RegexpPatternCodec)
+        bind(UrlCodec)
 
         javaTimeTypes()
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UrlCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/UrlCodec.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import java.net.URL
+
+
+object UrlCodec : Codec<URL> {
+
+    override suspend fun WriteContext.encode(value: URL) {
+        writeString(value.toExternalForm())
+    }
+
+    override suspend fun ReadContext.decode(): URL =
+        URL(readString())
+}


### PR DESCRIPTION
Case found while exploring using the configuration cache on the `gradle/gradle` build.

Storing [cc-report.zip](https://github.com/gradle/gradle/files/6284541/cc-report.zip)
Loading https://ge.gradle.org/s/k2xhubhh24rik/failure?anchor=e30&focused-exception-line=0-0#1

See e.g. `org.gradle.api.internal.plugins.PluginDescriptor.propertiesFileUrl`