### PR TITLE
Create Public API for GradleVersion

### DIFF
--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -33,4 +33,9 @@ dependencies {
     jmh(libs.guava)
 }
 
+classycle {
+    // Needed for the factory methods in the base class
+    excludePatterns.add("org/gradle/util/GradleVersion**")
+}
+
 jmh.include = listOf("HashingAlgorithmsBenchmark")

--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,83 +16,52 @@
 
 package org.gradle.util;
 
-import org.gradle.api.GradleException;
-import org.gradle.internal.UncheckedException;
+import org.gradle.util.internal.DefaultGradleVersion;
 
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Properties;
-import java.util.TimeZone;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+/**
+ * Represents a Gradle version.
+ */
+public abstract class GradleVersion implements Comparable<GradleVersion> {
 
-import static java.lang.String.format;
-import static org.gradle.internal.IoActions.uncheckedClose;
-
-public class GradleVersion implements Comparable<GradleVersion> {
+    /**
+     * This field only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
     public static final String URL = "https://www.gradle.org";
-    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\w+))?(-(SNAPSHOT|\\d{14}([-+]\\d{4})?))?");
-    private static final int STAGE_MILESTONE = 0;
-    private static final int STAGE_UNKNOWN = 1;
-    private static final int STAGE_PREVIEW = 2;
-    private static final int STAGE_RC = 3;
 
-    private final String version;
-    private final int majorPart;
-    private final String buildTime;
-    private final String commitId;
-    private final Long snapshot;
-    private final String versionPart;
-    private final Stage stage;
-    private static final GradleVersion CURRENT;
-
+    /**
+     * This field only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
     public static final String RESOURCE_NAME = "/org/gradle/build-receipt.properties";
+
+    /**
+     * This field only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
     public static final String VERSION_OVERRIDE_VAR = "GRADLE_VERSION_OVERRIDE";
+
+    /**
+     * This field only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
     public static final String VERSION_NUMBER_PROPERTY = "versionNumber";
 
-    static {
-        URL resource = GradleVersion.class.getResource(RESOURCE_NAME);
-        if (resource == null) {
-            throw new GradleException(format("Resource '%s' not found.", RESOURCE_NAME));
-        }
-
-        InputStream inputStream = null;
-        try {
-            URLConnection connection = resource.openConnection();
-            connection.setUseCaches(false);
-            inputStream = connection.getInputStream();
-            Properties properties = new Properties();
-            properties.load(inputStream);
-
-            String version = properties.get(VERSION_NUMBER_PROPERTY).toString();
-
-            // We allow the gradle version to be overridden for tests that are sensitive
-            // to the version and need to test with various different version patterns.
-            // We use an env variable because these are easy to set on daemon startup,
-            // whereas system properties are scrubbed at daemon startup.
-            String overrideVersion = System.getenv(VERSION_OVERRIDE_VAR);
-            if (overrideVersion != null) {
-                version = overrideVersion;
-            }
-
-            String buildTimestamp = properties.get("buildTimestampIso").toString();
-            String commitId = properties.get("commitId").toString();
-
-            CURRENT = new GradleVersion(version, "unknown".equals(buildTimestamp) ? null : buildTimestamp, commitId);
-        } catch (Exception e) {
-            throw new GradleException(format("Could not load version details from resource '%s'.", resource), e);
-        } finally {
-            if (inputStream != null) {
-                uncheckedClose(inputStream);
-            }
-        }
-    }
-
+    /**
+     * Returns the current Gradle version.
+     *
+     * @return The current Gradle version.
+     */
     public static GradleVersion current() {
-        return CURRENT;
+        return DefaultGradleVersion.current();
     }
 
     /**
@@ -101,231 +70,64 @@ public class GradleVersion implements Comparable<GradleVersion> {
      * @throws IllegalArgumentException On unrecognized version string.
      */
     public static GradleVersion version(String version) throws IllegalArgumentException {
-        return new GradleVersion(version, null, null);
+        return DefaultGradleVersion.version(version);
     }
 
-    private GradleVersion(String version, String buildTime, String commitId) {
-        this.version = version;
-        this.buildTime = buildTime;
-        Matcher matcher = VERSION_PATTERN.matcher(version);
-        if (!matcher.matches()) {
-            throw new IllegalArgumentException(format("'%s' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')", version));
-        }
+    /**
+     * Returns the string that represents this version.
+     *
+     * @return this Gradle version in string format.
+     */
+    public abstract String getVersion();
 
-        versionPart = matcher.group(1);
-        majorPart = Integer.parseInt(matcher.group(2), 10);
+    /**
+     * This method only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
+    public abstract String getBuildTime();
 
-        this.commitId = setOrParseCommitId(commitId, matcher);
-        this.stage = parseStage(matcher);
-        this.snapshot = parseSnapshot(matcher);
-    }
+    /**
+     * This method only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
+    public abstract String getRevision();
 
-    private Long parseSnapshot(Matcher matcher) {
-        if ("snapshot".equals(matcher.group(5)) || isCommitVersion(matcher)) {
-            return 0L;
-        } else if (matcher.group(8) == null) {
-            return null;
-        } else if ("SNAPSHOT".equals(matcher.group(8))) {
-            return 0L;
-        } else {
-            try {
-                if (matcher.group(9) != null) {
-                    return new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
-                } else {
-                    SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
-                    format.setTimeZone(TimeZone.getTimeZone("UTC"));
-                    return format.parse(matcher.group(8)).getTime();
-                }
-            } catch (ParseException e) {
-                throw UncheckedException.throwAsUncheckedException(e);
-            }
-        }
-    }
-
-    private Stage parseStage(Matcher matcher) {
-        if (matcher.group(4) == null || isCommitVersion(matcher)) {
-            return null;
-        } else if (isStage("milestone", matcher)) {
-            return Stage.from(STAGE_MILESTONE, matcher.group(6));
-        } else if (isStage("preview", matcher)) {
-            return Stage.from(STAGE_PREVIEW, matcher.group(6));
-        } else if (isStage("rc", matcher)) {
-            return Stage.from(STAGE_RC, matcher.group(6));
-        } else {
-            return Stage.from(STAGE_UNKNOWN, matcher.group(6));
-        }
-    }
-
-    private boolean isCommitVersion(Matcher matcher) {
-        return "commit".equals(matcher.group(5));
-    }
-
-    private boolean isStage(String stage, Matcher matcher) {
-        return stage.equals(matcher.group(5));
-    }
-
-    private String setOrParseCommitId(String commitId, Matcher matcher) {
-        if (commitId != null || !isCommitVersion(matcher)) {
-            return commitId;
-        } else {
-            return matcher.group(6);
-        }
-    }
-
-    @Override
-    public String toString() {
-        return "Gradle " + version;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getBuildTime() {
-        return buildTime;
-    }
-
-    public String getRevision() {
-        return commitId;
-    }
-
-    public boolean isSnapshot() {
-        return snapshot != null;
-    }
+    /**
+     * Returns {@code true} if this instance represent a snapshot version (e.g. 7.0-20210406233629+0000).
+     *
+     * @return Whether the current instance is a snapshot version
+     */
+    public abstract boolean isSnapshot();
 
     /**
      * The base version of this version. For pre-release versions, this is the target version.
      *
-     * For example, the version base of '1.2-rc-1' is '1.2'.
+     * For example, the version base of '7.0-rc-1' is '7.0'.
      *
      * @return The version base
      */
-    public GradleVersion getBaseVersion() {
-        if (stage == null && snapshot == null) {
-            return this;
-        }
-        return version(versionPart);
-    }
+    public abstract GradleVersion getBaseVersion();
 
-    public GradleVersion getNextMajor() {
-        return version((majorPart + 1) + ".0");
-    }
+    /**
+     * This method only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
+    public abstract GradleVersion getNextMajor();
 
-    @Override
-    public int compareTo(GradleVersion gradleVersion) {
-        String[] majorVersionParts = versionPart.split("\\.");
-        String[] otherMajorVersionParts = gradleVersion.versionPart.split("\\.");
-
-        for (int i = 0; i < majorVersionParts.length && i < otherMajorVersionParts.length; i++) {
-            int part = Integer.parseInt(majorVersionParts[i]);
-            int otherPart = Integer.parseInt(otherMajorVersionParts[i]);
-
-            if (part > otherPart) {
-                return 1;
-            }
-            if (otherPart > part) {
-                return -1;
-            }
-        }
-        if (majorVersionParts.length > otherMajorVersionParts.length) {
-            return 1;
-        }
-        if (majorVersionParts.length < otherMajorVersionParts.length) {
-            return -1;
-        }
-
-        if (stage != null && gradleVersion.stage != null) {
-            int diff = stage.compareTo(gradleVersion.stage);
-            if (diff != 0) {
-                return diff;
-            }
-        }
-        if (stage == null && gradleVersion.stage != null) {
-            return 1;
-        }
-        if (stage != null && gradleVersion.stage == null) {
-            return -1;
-        }
-
-        Long thisSnapshot = snapshot == null ? Long.MAX_VALUE : snapshot;
-        Long theirSnapshot = gradleVersion.snapshot == null ? Long.MAX_VALUE : gradleVersion.snapshot;
-
-        if (thisSnapshot.equals(theirSnapshot)) {
-            return version.compareTo(gradleVersion.version);
-        } else {
-            return thisSnapshot.compareTo(theirSnapshot);
-        }
-    }
+    /**
+     * This method only kept here to maintain binary compatibility.
+     *
+     * @deprecated will be removed in Gradle 8.
+     */
+    @Deprecated
+    public abstract boolean isValid();
 
     @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        if (o == null || o.getClass() != getClass()) {
-            return false;
-        }
-        GradleVersion other = (GradleVersion) o;
-        return version.equals(other.version);
-    }
-
-    @Override
-    public int hashCode() {
-        return version.hashCode();
-    }
-
-    public boolean isValid() {
-        return versionPart != null;
-    }
-
-    static final class Stage implements Comparable<Stage> {
-        final int stage;
-        final int number;
-        final Character patchNo;
-
-        private Stage(int stage, int number, Character patchNo) {
-            this.stage = stage;
-            this.number = number;
-            this.patchNo = patchNo;
-        }
-
-        static Stage from(int stage, String stageString) {
-            Matcher m = Pattern.compile("(\\d+)([a-z])?").matcher(stageString);
-            int number;
-            if (m.matches()) {
-                number = Integer.parseInt(m.group(1));
-            } else {
-                return null;
-            }
-
-            if (m.groupCount() == 2 && m.group(2) != null) {
-                return new Stage(stage, number, m.group(2).charAt(0));
-            } else {
-                return new Stage(stage, number, '_');
-            }
-        }
-
-        @Override
-        public int compareTo(Stage other) {
-            if (stage > other.stage) {
-                return 1;
-            }
-            if (stage < other.stage) {
-                return -1;
-            }
-            if (number > other.number) {
-                return 1;
-            }
-            if (number < other.number) {
-                return -1;
-            }
-            if (patchNo > other.patchNo) {
-                return 1;
-            }
-            if (patchNo < other.patchNo) {
-                return -1;
-            }
-            return 0;
-        }
-    }
+    public abstract int compareTo(GradleVersion o);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/util/internal/DefaultGradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/internal/DefaultGradleVersion.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.util.internal;
+
+
+import org.gradle.api.GradleException;
+import org.gradle.internal.UncheckedException;
+import org.gradle.util.GradleVersion;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static org.gradle.internal.IoActions.uncheckedClose;
+
+public final class DefaultGradleVersion extends GradleVersion {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\w+))?(-(SNAPSHOT|\\d{14}([-+]\\d{4})?))?");
+    private static final int STAGE_MILESTONE = 0;
+    private static final int STAGE_UNKNOWN = 1;
+    private static final int STAGE_PREVIEW = 2;
+    private static final int STAGE_RC = 3;
+
+    private final String version;
+    private final int majorPart;
+    private final String buildTime;
+    private final String commitId;
+    private final Long snapshot;
+    private final String versionPart;
+    private final Stage stage;
+    private static final DefaultGradleVersion CURRENT;
+
+    public static final String RESOURCE_NAME = "/org/gradle/build-receipt.properties";
+    public static final String VERSION_OVERRIDE_VAR = "GRADLE_VERSION_OVERRIDE";
+    public static final String VERSION_NUMBER_PROPERTY = "versionNumber";
+
+    static {
+        URL resource = DefaultGradleVersion.class.getResource(RESOURCE_NAME);
+        if (resource == null) {
+            throw new GradleException(format("Resource '%s' not found.", RESOURCE_NAME));
+        }
+
+        InputStream inputStream = null;
+        try {
+            URLConnection connection = resource.openConnection();
+            connection.setUseCaches(false);
+            inputStream = connection.getInputStream();
+            Properties properties = new Properties();
+            properties.load(inputStream);
+
+            String version = properties.get(VERSION_NUMBER_PROPERTY).toString();
+
+            // We allow the gradle version to be overridden for tests that are sensitive
+            // to the version and need to test with various different version patterns.
+            // We use an env variable because these are easy to set on daemon startup,
+            // whereas system properties are scrubbed at daemon startup.
+            String overrideVersion = System.getenv(VERSION_OVERRIDE_VAR);
+            if (overrideVersion != null) {
+                version = overrideVersion;
+            }
+
+            String buildTimestamp = properties.get("buildTimestampIso").toString();
+            String commitId = properties.get("commitId").toString();
+
+            CURRENT = new DefaultGradleVersion(version, "unknown".equals(buildTimestamp) ? null : buildTimestamp, commitId);
+        } catch (Exception e) {
+            throw new GradleException(format("Could not load version details from resource '%s'.", resource), e);
+        } finally {
+            if (inputStream != null) {
+                uncheckedClose(inputStream);
+            }
+        }
+    }
+
+    public static DefaultGradleVersion current() {
+        return CURRENT;
+    }
+
+    /**
+     * Parses the given string into a GradleVersion.
+     *
+     * @throws IllegalArgumentException On unrecognized version string.
+     */
+    public static DefaultGradleVersion version(String version) throws IllegalArgumentException {
+        return new DefaultGradleVersion(version, null, null);
+    }
+
+    private DefaultGradleVersion(String version, String buildTime, String commitId) {
+        this.version = version;
+        this.buildTime = buildTime;
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(format("'%s' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')", version));
+        }
+
+        versionPart = matcher.group(1);
+        majorPart = Integer.parseInt(matcher.group(2), 10);
+
+        this.commitId = setOrParseCommitId(commitId, matcher);
+        this.stage = parseStage(matcher);
+        this.snapshot = parseSnapshot(matcher);
+    }
+
+    private Long parseSnapshot(Matcher matcher) {
+        if ("snapshot".equals(matcher.group(5)) || isCommitVersion(matcher)) {
+            return 0L;
+        } else if (matcher.group(8) == null) {
+            return null;
+        } else if ("SNAPSHOT".equals(matcher.group(8))) {
+            return 0L;
+        } else {
+            try {
+                if (matcher.group(9) != null) {
+                    return new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
+                } else {
+                    SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
+                    format.setTimeZone(TimeZone.getTimeZone("UTC"));
+                    return format.parse(matcher.group(8)).getTime();
+                }
+            } catch (ParseException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
+    }
+
+    private Stage parseStage(Matcher matcher) {
+        if (matcher.group(4) == null || isCommitVersion(matcher)) {
+            return null;
+        } else if (isStage("milestone", matcher)) {
+            return Stage.from(STAGE_MILESTONE, matcher.group(6));
+        } else if (isStage("preview", matcher)) {
+            return Stage.from(STAGE_PREVIEW, matcher.group(6));
+        } else if (isStage("rc", matcher)) {
+            return Stage.from(STAGE_RC, matcher.group(6));
+        } else {
+            return Stage.from(STAGE_UNKNOWN, matcher.group(6));
+        }
+    }
+
+    private boolean isCommitVersion(Matcher matcher) {
+        return "commit".equals(matcher.group(5));
+    }
+
+    private boolean isStage(String stage, Matcher matcher) {
+        return stage.equals(matcher.group(5));
+    }
+
+    private String setOrParseCommitId(String commitId, Matcher matcher) {
+        if (commitId != null || !isCommitVersion(matcher)) {
+            return commitId;
+        } else {
+            return matcher.group(6);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Gradle " + version;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    @Deprecated
+    public String getBuildTime() {
+        return getBuildTimestamp();
+    }
+
+    public String getBuildTimestamp() {
+        return buildTime;
+    }
+
+    @Override
+    @Deprecated
+    public String getRevision() {
+        return getGitRevision();
+    }
+
+    public String getGitRevision() {
+        return commitId;
+    }
+
+    @Override
+    public boolean isSnapshot() {
+        return snapshot != null;
+    }
+
+    public GradleVersion getBaseVersion() {
+        if (stage == null && snapshot == null) {
+            return this;
+        }
+        return version(versionPart);
+    }
+
+    @Override
+    @Deprecated
+    public GradleVersion getNextMajor() {
+        return getNextMajorVersion();
+    }
+
+    public DefaultGradleVersion getNextMajorVersion() {
+        return version((majorPart + 1) + ".0");
+    }
+
+    @Override
+    public int compareTo(GradleVersion gv) {
+        if (!(gv instanceof DefaultGradleVersion)) {
+            throw new RuntimeException("Unexpected GradleVersion subclass: " + gv.getClass().getCanonicalName());
+        }
+
+        DefaultGradleVersion gradleVersion = (DefaultGradleVersion) gv;
+
+        String[] majorVersionParts = versionPart.split("\\.");
+        String[] otherMajorVersionParts = gradleVersion.versionPart.split("\\.");
+
+        for (int i = 0; i < majorVersionParts.length && i < otherMajorVersionParts.length; i++) {
+            int part = Integer.parseInt(majorVersionParts[i]);
+            int otherPart = Integer.parseInt(otherMajorVersionParts[i]);
+
+            if (part > otherPart) {
+                return 1;
+            }
+            if (otherPart > part) {
+                return -1;
+            }
+        }
+        if (majorVersionParts.length > otherMajorVersionParts.length) {
+            return 1;
+        }
+        if (majorVersionParts.length < otherMajorVersionParts.length) {
+            return -1;
+        }
+
+        if (stage != null && gradleVersion.stage != null) {
+            int diff = stage.compareTo(gradleVersion.stage);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        if (stage == null && gradleVersion.stage != null) {
+            return 1;
+        }
+        if (stage != null && gradleVersion.stage == null) {
+            return -1;
+        }
+
+        Long thisSnapshot = snapshot == null ? Long.MAX_VALUE : snapshot;
+        Long theirSnapshot = gradleVersion.snapshot == null ? Long.MAX_VALUE : gradleVersion.snapshot;
+
+        if (thisSnapshot.equals(theirSnapshot)) {
+            return version.compareTo(gradleVersion.version);
+        } else {
+            return thisSnapshot.compareTo(theirSnapshot);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null || o.getClass() != getClass()) {
+            return false;
+        }
+        DefaultGradleVersion other = (DefaultGradleVersion) o;
+        return version.equals(other.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return version.hashCode();
+    }
+
+    @Override
+    @Deprecated
+    public boolean isValid() {
+        return versionPart != null;
+    }
+
+    static final class Stage implements Comparable<Stage> {
+        final int stage;
+        final int number;
+        final Character patchNo;
+
+        private Stage(int stage, int number, Character patchNo) {
+            this.stage = stage;
+            this.number = number;
+            this.patchNo = patchNo;
+        }
+
+        static Stage from(int stage, String stageString) {
+            Matcher m = Pattern.compile("(\\d+)([a-z])?").matcher(stageString);
+            int number;
+            if (m.matches()) {
+                number = Integer.parseInt(m.group(1));
+            } else {
+                return null;
+            }
+
+            if (m.groupCount() == 2 && m.group(2) != null) {
+                return new Stage(stage, number, m.group(2).charAt(0));
+            } else {
+                return new Stage(stage, number, '_');
+            }
+        }
+
+        @Override
+        public int compareTo(Stage other) {
+            if (stage > other.stage) {
+                return 1;
+            }
+            if (stage < other.stage) {
+                return -1;
+            }
+            if (number > other.number) {
+                return 1;
+            }
+            if (number < other.number) {
+                return -1;
+            }
+            if (patchNo > other.patchNo) {
+                return 1;
+            }
+            if (patchNo < other.patchNo) {
+                return -1;
+            }
+            return 0;
+        }
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.util
 
+import org.gradle.util.internal.DefaultGradleVersion
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -43,7 +44,7 @@ class GradleVersionTest extends Specification {
     def "current version has non-null parts"() {
         expect:
         version.version
-        version.nextMajor
+        version.nextMajorVersion
         version.baseVersion
     }
 
@@ -56,7 +57,7 @@ class GradleVersionTest extends Specification {
     def "build time should always print in UTC"() {
         expect:
         // Note: buildTime is null when running a local build
-        version.buildTime == null || version.buildTime.endsWith("UTC")
+        version.buildTimestamp == null || version.buildTimestamp.endsWith("UTC")
     }
 
     def equalsAndHashCode() {
@@ -235,7 +236,7 @@ class GradleVersionTest extends Specification {
 
     def "can get next major version"() {
         expect:
-        GradleVersion.version(v).nextMajor == GradleVersion.version(major)
+        DefaultGradleVersion.version(v).nextMajorVersion == GradleVersion.version(major)
 
         where:
         v                                     | major

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.IoActions;
 import org.gradle.util.GradleVersion;
+import org.gradle.util.internal.DefaultGradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,7 @@ public class WrapperDistributionCleanupAction implements DirectoryCleanupAction 
     private static final Logger LOGGER = LoggerFactory.getLogger(WrapperDistributionCleanupAction.class);
 
     private static final ImmutableMap<String, Pattern> JAR_FILE_PATTERNS_BY_PREFIX;
-    private static final String BUILD_RECEIPT_ZIP_ENTRY_PATH = StringUtils.removeStart(GradleVersion.RESOURCE_NAME, "/");
+    private static final String BUILD_RECEIPT_ZIP_ENTRY_PATH = StringUtils.removeStart(DefaultGradleVersion.RESOURCE_NAME, "/");
 
     static {
         Set<String> prefixes = ImmutableSet.of(
@@ -210,7 +211,7 @@ public class WrapperDistributionCleanupAction implements DirectoryCleanupAction 
         try {
             Properties properties = new Properties();
             properties.load(in);
-            String versionString = properties.getProperty(GradleVersion.VERSION_NUMBER_PROPERTY);
+            String versionString = properties.getProperty(DefaultGradleVersion.VERSION_NUMBER_PROPERTY);
             return GradleVersion.version(versionString);
         } finally {
             in.close();

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupActionTest.groovy
@@ -49,7 +49,7 @@ class VersionSpecificCacheCleanupActionTest extends Specification implements Gra
         def oldestCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.2.3"), NOT_USED_WITHIN_30_DAYS)
         def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), USED_TODAY)
         def oldCacheDir = createVersionSpecificCacheDir(GradleVersion.version("2.3.4"), NOT_USED_WITHIN_30_DAYS)
-        def newerCacheDir = createVersionSpecificCacheDir(currentVersion.getNextMajor(), NOT_USED_WITHIN_30_DAYS)
+        def newerCacheDir = createVersionSpecificCacheDir(currentVersion.getNextMajorVersion(), NOT_USED_WITHIN_30_DAYS)
 
         when:
         def cleanedUp = cleanupAction.execute(progressMonitor)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.GradleVersion
 import org.gradle.util.JarUtils
+import org.gradle.util.internal.DefaultGradleVersion
 import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Subject
@@ -43,7 +44,7 @@ class WrapperDistributionCleanupActionTest extends Specification implements Grad
         def usedVersion = GradleVersion.version("3.4.5")
         def stillUsedDist = createDistributionChecksumDir(usedVersion)
         def currentDist = createDistributionChecksumDir(currentVersion)
-        def unusedFutureDist = createDistributionChecksumDir(currentVersion.nextMajor)
+        def unusedFutureDist = createDistributionChecksumDir(currentVersion.nextMajorVersion)
 
         when:
         cleanupAction.execute(progressMonitor)
@@ -153,7 +154,7 @@ class WrapperDistributionCleanupActionTest extends Specification implements Grad
         given:
         def versionToCleanUp = GradleVersion.version("2.3.4")
         def distributionWithInvalidVersion = createCustomDistributionChecksumDir("gradle-1-invalid-all", versionToCleanUp, DEFAULT_JAR_PREFIX, System.currentTimeMillis()) { version, jarFile ->
-            jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME.substring(1)): "${GradleVersion.VERSION_NUMBER_PROPERTY}: foo")
+            jarFile << JarUtils.jarWithContents((DefaultGradleVersion.RESOURCE_NAME.substring(1)): "${DefaultGradleVersion.VERSION_NUMBER_PROPERTY}: foo")
         }
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/layout/ProjectCacheDirTest.groovy
@@ -49,7 +49,7 @@ class ProjectCacheDirTest extends Specification implements VersionSpecificCacheC
         def oldButRecentlyUsedCacheDir = createVersionSpecificCacheDir(GradleVersion.version("1.4.5"), USED_TODAY)
         def oldCacheDir = createVersionSpecificCacheDir(GradleVersion.version("2.3.4"), NOT_USED_WITHIN_7_DAYS)
         def currentCacheDir = createVersionSpecificCacheDir(currentVersion, NOT_USED_WITHIN_7_DAYS)
-        def newerCacheDir = createVersionSpecificCacheDir(currentVersion.getNextMajor(), NOT_USED_WITHIN_7_DAYS)
+        def newerCacheDir = createVersionSpecificCacheDir(currentVersion.getNextMajorVersion(), NOT_USED_WITHIN_7_DAYS)
 
         when:
         projectCacheDir.stop()

--- a/subprojects/core/src/test/groovy/org/gradle/util/StageTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/StageTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.util
 
-import org.gradle.util.GradleVersion.Stage
+import org.gradle.util.internal.DefaultGradleVersion.Stage
 import spock.lang.Specification
 
 class StageTest extends Specification {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/GradleUserHomeCleanupFixture.groovy
@@ -20,6 +20,7 @@ import org.gradle.internal.BiAction
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
 import org.gradle.util.JarUtils
+import org.gradle.util.internal.DefaultGradleVersion
 
 import java.util.concurrent.TimeUnit
 
@@ -28,7 +29,7 @@ import static org.gradle.cache.internal.WrapperDistributionCleanupAction.WRAPPER
 trait GradleUserHomeCleanupFixture implements VersionSpecificCacheCleanupFixture {
 
     private static final BiAction<GradleVersion, File> DEFAULT_JAR_WRITER = { version, jarFile ->
-        jarFile << JarUtils.jarWithContents((GradleVersion.RESOURCE_NAME.substring(1)): "${GradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")
+        jarFile << JarUtils.jarWithContents((DefaultGradleVersion.RESOURCE_NAME.substring(1)): "${DefaultGradleVersion.VERSION_NUMBER_PROPERTY}: ${version.version}")
     }
     static final String DEFAULT_JAR_PREFIX = 'gradle-base-services'
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/VersionSpecificCacheCleanupFixture.groovy
@@ -19,6 +19,7 @@ package org.gradle.cache.internal
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DefaultGradleVersion
 
 import java.util.concurrent.TimeUnit
 
@@ -28,8 +29,8 @@ import static org.gradle.cache.internal.VersionSpecificCacheCleanupFixture.Marke
 @CleanupTestDirectory
 trait VersionSpecificCacheCleanupFixture {
 
-    GradleVersion getCurrentVersion() {
-        GradleVersion.current()
+    DefaultGradleVersion getCurrentVersion() {
+        DefaultGradleVersion.current()
     }
 
     TestFile createVersionSpecificCacheDir(GradleVersion version, MarkerFileType type = MISSING_MARKER_FILE) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/util/Git.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/util/Git.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.performance.util
 
-import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DefaultGradleVersion
 
 class Git {
     static final Git INSTANCE = new Git()
@@ -28,7 +28,7 @@ class Git {
     }
 
     private Git() {
-        commitId = System.getProperty("gradleBuildCommitId", GradleVersion.current().revision)
+        commitId = System.getProperty("gradleBuildCommitId", DefaultGradleVersion.current().gitRevision)
         branchName = System.getProperty("gradleBuildBranch", "unknown-branch")
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.launcher.daemon
 import org.apache.commons.lang.LocaleUtils
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
 import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DefaultGradleVersion
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -92,7 +93,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
         Locale locale = Locale.ENGLISH
         buildScript """
             import org.gradle.util.GradleVersion
-            
+
             task printLocale {
                 doFirst {
                     println "GradleVersion: " + GradleVersion.current()
@@ -102,7 +103,7 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
         """
 
         when:
-        executer.withEnvironmentVars(("${GradleVersion.VERSION_OVERRIDE_VAR}".toString()): overrideVersion)
+        executer.withEnvironmentVars(("${DefaultGradleVersion.VERSION_OVERRIDE_VAR}".toString()): overrideVersion)
         runWithLocale(locale)
 
         then:

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -37,14 +37,14 @@ import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.launcher.bootstrap.CommandLineActionFactory;
 import org.gradle.launcher.bootstrap.ExecutionListener;
-import org.gradle.launcher.configuration.AllProperties;
 import org.gradle.launcher.cli.converter.BuildLayoutConverter;
-import org.gradle.launcher.configuration.BuildLayoutResult;
 import org.gradle.launcher.cli.converter.BuildOptionBackedConverter;
-import org.gradle.launcher.configuration.InitialProperties;
 import org.gradle.launcher.cli.converter.InitialPropertiesConverter;
 import org.gradle.launcher.cli.converter.LayoutToPropertiesConverter;
-import org.gradle.util.GradleVersion;
+import org.gradle.launcher.configuration.AllProperties;
+import org.gradle.launcher.configuration.BuildLayoutResult;
+import org.gradle.launcher.configuration.InitialProperties;
+import org.gradle.util.internal.DefaultGradleVersion;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -155,15 +155,15 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
     private static class ShowVersionAction implements Runnable {
         @Override
         public void run() {
-            GradleVersion currentVersion = GradleVersion.current();
+            DefaultGradleVersion currentVersion = DefaultGradleVersion.current();
 
             final StringBuilder sb = new StringBuilder();
             sb.append("%n------------------------------------------------------------%nGradle ");
             sb.append(currentVersion.getVersion());
             sb.append("%n------------------------------------------------------------%n%nBuild time:   ");
-            sb.append(currentVersion.getBuildTime());
+            sb.append(currentVersion.getBuildTimestamp());
             sb.append("%nRevision:     ");
-            sb.append(currentVersion.getRevision());
+            sb.append(currentVersion.getGitRevision());
             sb.append("%n%nKotlin:       ");
             sb.append(KotlinDslVersion.current().getKotlinVersion());
             sb.append("%nGroovy:       ");

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -33,9 +33,9 @@ import org.gradle.internal.service.ServiceRegistry
 import org.gradle.launcher.bootstrap.CommandLineActionFactory
 import org.gradle.launcher.bootstrap.ExecutionListener
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.GradleVersion
 import org.gradle.util.internal.RedirectStdOutAndErr
 import org.gradle.util.SetSystemProperties
+import org.gradle.util.internal.DefaultGradleVersion
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -217,15 +217,15 @@ class DefaultCommandLineActionFactoryTest extends Specification {
     }
 
     def "displays version message"() {
-        def version = GradleVersion.current()
+        def version = DefaultGradleVersion.current()
         def expectedText = [
             "",
             "------------------------------------------------------------",
             "Gradle ${version.version}",
             "------------------------------------------------------------",
             "",
-            "Build time:   $version.buildTime",
-            "Revision:     $version.revision",
+            "Build time:   $version.buildTimestamp",
+            "Revision:     $version.gitRevision",
             "",
             "Kotlin:       ${KotlinDslVersion.current().kotlinVersion}",
             "Groovy:       $GroovySystem.version",

--- a/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/DeprecationHandlingIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle
 import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler
-import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DefaultGradleVersion
 import spock.lang.Unroll
 
 class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
@@ -123,7 +123,7 @@ class DeprecationHandlingIntegrationTest extends AbstractIntegrationSpec {
 
         and:
         if (warnings == WarningMode.Fail) {
-            failure.assertHasDescription("Deprecated Gradle features were used in this build, making it incompatible with ${GradleVersion.current().nextMajor}")
+            failure.assertHasDescription("Deprecated Gradle features were used in this build, making it incompatible with ${DefaultGradleVersion.current().nextMajorVersion}")
         }
 
         where:

--- a/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/featurelifecycle/LoggingDeprecatedFeatureHandler.java
@@ -23,7 +23,7 @@ import org.gradle.internal.SystemProperties;
 import org.gradle.internal.deprecation.DeprecatedFeatureUsage;
 import org.gradle.internal.logging.LoggingConfigurationBuildOptions;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
-import org.gradle.util.GradleVersion;
+import org.gradle.util.internal.DefaultGradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +76,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
             }
             if (warningMode == WarningMode.Fail) {
                 if (error == null) {
-                    error = new GradleException(WARNING_SUMMARY + " " + GradleVersion.current().getNextMajor().getVersion());
+                    error = new GradleException(WARNING_SUMMARY + " " + DefaultGradleVersion.current().getNextMajorVersion().getVersion());
                 }
             }
         }
@@ -98,7 +98,7 @@ public class LoggingDeprecatedFeatureHandler implements FeatureHandler<Deprecate
     public void reportSuppressedDeprecations() {
         if (warningMode == WarningMode.Summary && !messages.isEmpty()) {
             LOGGER.warn("\n{} {}.\n\nYou can use '--{} {}' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\n{} {}",
-                WARNING_SUMMARY, GradleVersion.current().getNextMajor().getVersion(),
+                WARNING_SUMMARY, DefaultGradleVersion.current().getNextMajorVersion().getVersion(),
                 LoggingConfigurationBuildOptions.WarningsOption.LONG_OPTION, WarningMode.All.name().toLowerCase(),
                 WARNING_LOGGING_DOCS_MESSAGE, DOCUMENTATION_REGISTRY.getDocumentationFor("command_line_interface", "sec:command_line_warnings"));
         }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/DeprecationLoggerTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.internal.logging.CollectingTestOutputEventListener
 import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
-import org.gradle.util.GradleVersion
+import org.gradle.util.internal.DefaultGradleVersion
 import org.junit.Rule
 import spock.lang.Subject
 
@@ -149,7 +149,7 @@ class DeprecationLoggerTest extends ConcurrentSpec {
         def events = outputEventListener.events
         events.size() == 1
         events[0].message == """
-Deprecated Gradle features were used in this build, making it incompatible with ${GradleVersion.current().nextMajor}.
+Deprecated Gradle features were used in this build, making it incompatible with ${DefaultGradleVersion.current().nextMajorVersion}.
 
 You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CacheVersionMappingTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/CacheVersionMappingTest.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.cache.internal
 
-import org.gradle.util.GradleVersion
+
+import org.gradle.util.internal.DefaultGradleVersion
 import spock.lang.Specification
 
 import static org.gradle.util.GradleVersion.version
@@ -93,7 +94,7 @@ class CacheVersionMappingTest extends Specification {
     def "throws exception if base version of Gradle version is greater than base version of current Gradle version"() {
         when:
         CacheVersionMapping.introducedIn("1.0")
-            .changedTo(2, GradleVersion.current().nextMajor.version)
+            .changedTo(2, DefaultGradleVersion.current().nextMajorVersion.version)
 
         then:
         def e = thrown(IllegalArgumentException)


### PR DESCRIPTION
This PR extracts converts `GradleVersion` to an abstract class and hides the implementation details in the `org.gradle.util.internal.DefaultGradleVersion` class. The change is implemented in a backward-compatible way. All methods that not meant to be public, are now deprecated and scheduled for removal in Gradle 8. Also, all internal usages are replaced with calls to `DefaultGradleVersion` methods.

`GradleVersion` cannot be converted to an interface with default implementation as the container module has Java 6 source compatibility.

I've [searched](https://grep.app/search?q=org.gradle.util.GradleVersion) the public GitHub repositories for `GradleVersion` usages. It seems it is only used for comparing Gradle versions and nothing else. I've also tried to compile the code in those repositories with a locally-built Gradle distribution from which I've removed the deprecated methods. The compilation still succeeded, but I chose the pessimistic approach and still kept the deprecated methods (and fields).