### PR TITLE
Limit output event queue size

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ThrottlingOutputEventListener.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/console/ThrottlingOutputEventListener.java
@@ -68,8 +68,7 @@ public class ThrottlingOutputEventListener implements OutputEventListener {
         synchronized (lock) {
             queue.add(newEvent);
 
-            if (newEvent instanceof UpdateNowEvent) {
-                // Flush any buffered events and update the clock
+            if (queue.size() == 10000 || newEvent instanceof UpdateNowEvent) {
                 renderNow();
                 return;
             }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ThrottlingOutputEventListenerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ThrottlingOutputEventListenerTest.groovy
@@ -102,6 +102,22 @@ class ThrottlingOutputEventListenerTest extends OutputSpecification {
         0 * _
     }
 
+    def "flushes events when queue gets too big"() {
+        when:
+        (1..9999).each {
+            renderer.onOutput(event("Event $it"))
+        }
+
+        then:
+        0 * _
+
+        when:
+        renderer.onOutput(event("Event 10_000"))
+
+        then:
+        10_000 * listener.onOutput(_)
+    }
+
     def "background flush does nothing when events already flushed"() {
         def event1 = event('1')
         def event2 = event('2')


### PR DESCRIPTION
To prevent the Gradle client from running out of memory
if a task produces large amounts of output in a short time.
The daemon is less affected by this since it usually has a
much larger heap size and can deal even with hundreds
of thousands of events. But the client only has 64m by
default and needs to flush more eagerly.

This is by no means fool-proof. There could still be a process
generating a single line that contains so much text that the
client runs out of memory. But that seems pretty rare compared
to creating lots of separate lines in a short time.

The particular use case was a Webpack task with verbose logging.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
