### PR TITLE
Fix JDK16 flakiness in BuildScriptCompileAvoidanceIntegrationTest

### DIFF
--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -66,7 +66,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
         assumeNonEmbeddedGradleExecuter() // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
 
-        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16()
 
         withBuildScript(
             """
@@ -131,7 +131,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
     @Test
     fun `gradle kotlin dsl api is available in test-kit injected plugin classpath`() {
         assumeNonEmbeddedGradleExecuter() // requires a full distribution to run tests with test kit
-        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16()
 
         withBuildScript(
             """

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -860,7 +860,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
 
     private
     fun configureProjectAndExpectCompileAvoidanceWarnings(vararg tasks: String): BuildOperationsAssertions {
-        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
+        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16()
         val buildOperations = BuildOperationsFixture(executer, testDirectoryProvider)
         val output = executer.withArgument("--info").withTasks(*tasks).run().normalizedOutput
         return BuildOperationsAssertions(buildOperations, output, true)

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/BuildScriptCompileAvoidanceIntegrationTest.kt
@@ -229,7 +229,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 }
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("foo")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
             pluginId,
@@ -237,7 +237,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 println("bar")
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompilationAvoided().assertOutputContains("bar")
+        configureProject().assertBuildScriptCompilationAvoided().assertOutputContains("bar")
     }
 
     @ToBeFixedForConfigurationCache
@@ -257,7 +257,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 }
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("foo")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
             pluginId,
@@ -266,7 +266,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 tasks.register("foo")
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("bar")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("bar")
     }
 
     @ToBeFixedForConfigurationCache
@@ -287,7 +287,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 }
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("foo")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
             pluginId,
@@ -295,7 +295,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 tasks.register("foo") { doLast { println("bar from task") } }
             """
         )
-        configureProjectWithDebugOutput("foo").assertBuildScriptCompilationAvoided().assertOutputContains("bar from task")
+        configureProject("foo").assertBuildScriptCompilationAvoided().assertOutputContains("bar from task")
     }
 
     @ToBeFixedForConfigurationCache
@@ -318,7 +318,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 }
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("foo")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("foo")
 
         withPrecompiledScriptPluginInBuildSrc(
             pluginId,
@@ -329,7 +329,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 println("bar")
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled().assertOutputContains("bar")
+        configureProject().assertBuildScriptCompiled().assertOutputContains("bar")
     }
 
     @ToBeFixedForConfigurationCache
@@ -530,7 +530,7 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
                 }
             """
         )
-        configureProjectWithDebugOutput().assertBuildScriptCompiled()
+        configureProject().assertBuildScriptCompiled()
 
         withPrecompiledScriptPluginInBuildSrc(
             pluginId,
@@ -871,15 +871,6 @@ class BuildScriptCompileAvoidanceIntegrationTest : AbstractKotlinIntegrationTest
         val error = executer.runWithFailure().error
         assertThat(error, containsString(expectedFailure))
     }
-
-    // There seems to be a bug in BuildOperationTrace handling of projects with precompiled script plugins
-    // An assertion fails at BuildOperationTrace.java:338
-    // leaving this one as a workaround for test cases that have precompiled script plugins until the underlying issue is fixed
-    private
-    fun configureProjectWithDebugOutput(vararg tasks: String): DebugOutputFixture {
-        ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode()
-        return DebugOutputFixture(executer.withArgument("--debug").withTasks(*tasks).run().normalizedOutput)
-    }
 }
 
 
@@ -943,33 +934,5 @@ class BuildOperationsAssertions(buildOperationsFixture: BuildOperationsFixture, 
     fun assertNumberOfCompileAvoidanceWarnings(n: Int): BuildOperationsAssertions {
         assertThat(compileAvoidanceWarnings, hasSize(n))
         return this
-    }
-}
-
-
-private
-class DebugOutputFixture(val output: String) {
-    private
-    val scriptClasspathCompileOperationStartMarker = "Build operation 'Compile script build.gradle.kts (CLASSPATH)' started"
-
-    private
-    val scriptBodyCompileOperationStartMarker = "Build operation 'Compile script build.gradle.kts (BODY)' started"
-
-    fun assertBuildScriptCompiled(): DebugOutputFixture {
-        if (output.contains(scriptClasspathCompileOperationStartMarker) || output.contains(scriptBodyCompileOperationStartMarker)) {
-            return this
-        }
-        throw AssertionError("Expected script to be compiled, but it wasn't")
-    }
-
-    fun assertBuildScriptCompilationAvoided(): DebugOutputFixture {
-        if (output.contains(scriptClasspathCompileOperationStartMarker) || output.contains(scriptBodyCompileOperationStartMarker)) {
-            throw AssertionError("Expected script compilation to be avoided, but the buildscript was recompiled")
-        }
-        return this
-    }
-
-    fun assertOutputContains(expectedOutput: String) {
-        assertThat(output, containsString("[system.out] $expectedOutput"))
     }
 }

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -243,8 +243,8 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     }
 
     protected
-    fun ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16InNoDaemonMode() {
-        if (GradleContextualExecuter.isNoDaemon() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+    fun ignoreKotlinDaemonJvmDeprecationWarningsOnJdk16() {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
             executer.noDeprecationChecks()
         }
     }


### PR DESCRIPTION
https://github.com/gradle/gradle-private/issues/3356

### Ignore Kotlin daemon deprecation warning on JDK16 on all executors 
On JDK16, Gradle sets a deprecated JVM argument --illegal-access=permit for
the Kotlin compiler daemon (this will be fixed in Kotlin 1.5 line).
Some of our tests rely on --info output where this deprecation message
can be logged when a new daemon JVM happens to be spawned, making them flaky.
Initial assumption was that this happens only in no-daemon mode, but
some recent flakiness examples show that this is not the case.
Thus, for now, do not do deprecation checks on JDK16 in Kotlin DSL tests
that rely on --info output.

### Remove kotlin-dsl buildscript compilation avoidance test workaround
This workaround relied on debug output to assert whether the buildscripts or plugins blocks
were recompiled or not. This was because BuildOperationsFixture was failing an internal
assertion when precompiled script plugins were used at the time of writing.
Whatever was the root cause of failures in BuildOperationsFixture, it is now gone
and the workaround can be removed.