### PR TITLE
Restore ktlint task dependencies

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -51,6 +51,10 @@ tasks.runKtlintCheckOverKotlinScripts {
     setIncludes(listOf("*.gradle.kts"))
 }
 
+tasks.codeQuality {
+    dependsOn(tasks.ktlintCheck)
+}
+
 tasks.validatePlugins {
     failOnWarning.set(true)
     enableStricterValidation.set(true)

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
-import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 
 plugins {
     kotlin("js")
@@ -48,19 +47,17 @@ tasks {
         }
     }
 
-    val ktlintCheckTasks = withType<KtLintCheckTask>()
-
     withType<Test>().configureEach {
-        shouldRunAfter(ktlintCheckTasks)
+        shouldRunAfter(ktlintCheck)
     }
 
-    named("codeQuality") {
-        dependsOn(ktlintCheckTasks)
+    codeQuality {
+        dependsOn(ktlintCheck)
     }
 
     register("quickTest") {
         dependsOn(named("test"))
-        dependsOn(ktlintCheckTasks)
+        dependsOn(ktlintCheck)
     }
 
     register("platformTest")

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -17,7 +17,6 @@
 import gradlebuild.basics.accessors.kotlin
 import org.gradle.api.internal.initialization.DefaultClassLoaderScope
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jlleitschuh.gradle.ktlint.tasks.KtLintCheckTask
 
 
 plugins {
@@ -26,7 +25,7 @@ plugins {
     id("org.gradle.kotlin-dsl.ktlint-convention")
 }
 
-val transitiveSourcesElements by configurations.getting {
+configurations.transitiveSourcesElements {
     val main = sourceSets.main.get()
     main.kotlin.srcDirs.forEach {
         outgoing.artifact(it)
@@ -44,10 +43,8 @@ tasks {
         }
     }
 
-    val ktlintCheckTasks = withType<KtLintCheckTask>()
-
-    named("codeQuality") {
-        dependsOn(ktlintCheckTasks)
+    codeQuality {
+        dependsOn(ktlintCheck)
     }
 
     runKtlintCheckOverKotlinScripts {
@@ -57,7 +54,7 @@ tasks {
 
     withType<Test>().configureEach {
 
-        shouldRunAfter(ktlintCheckTasks)
+        shouldRunAfter(ktlintCheck)
 
         // enables stricter ClassLoaderScope behaviour
         systemProperty(

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -59,7 +59,6 @@ import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.execution.BuildOutputCleanupRegistry
-import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.plugin.management.internal.PluginRequests

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/fixtures/GradleApiExtensionsFixture.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/fixtures/GradleApiExtensionsFixture.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.kotlin.dsl.fixtures
 
-import org.assertj.core.util.Files.newFolder
 import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -157,7 +157,9 @@ class GenerateProjectAccessors(
 
     override fun visitIdentityInputs(visitor: InputVisitor) {
         visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY) { hashCodeFor(projectSchema) }
-        visitor.visitInputFileProperty(CLASSPATH_INPUT_PROPERTY, NON_INCREMENTAL,
+        visitor.visitInputFileProperty(
+            CLASSPATH_INPUT_PROPERTY,
+            NON_INCREMENTAL,
             FileValueSupplier(
                 classPath,
                 ClasspathNormalizer::class.java,


### PR DESCRIPTION
This PR restores the wiring of ktlint task dependencies to our `codeQuality` tasks and fix formating issues that went unnoticed.