### PR TITLE
Make JacocoCoverageVerification cacheable

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -507,6 +507,12 @@
             "changes": [
                 "Constructor has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.testing.jacoco.tasks.JacocoCoverageVerification",
+            "member": "Method org.gradle.testing.jacoco.tasks.JacocoCoverageVerification.getDummyOutputFile()",
+            "acceptation": "This method is for internal use only",
+            "changes": []
         }
     ]
 }

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
@@ -44,10 +44,10 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
 
     def "jacoco file results are cached"() {
         when:
-        withBuildCache().run "test", "jacocoTestReport"
+        withBuildCache().run "test", "jacocoTestReport", "jacocoTestCoverageVerification"
         def snapshot = reportFile.snapshot()
         then:
-        executedAndNotSkipped ":test", ":jacocoTestReport"
+        executedAndNotSkipped ":test", ":jacocoTestReport", ":jacocoTestCoverageVerification"
         reportFile.assertIsFile()
 
         when:
@@ -56,9 +56,9 @@ class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements Di
         reportFile.assertDoesNotExist()
 
         when:
-        withBuildCache().run "jacocoTestReport"
+        withBuildCache().run "jacocoTestReport", "jacocoTestCoverageVerification"
         then:
-        skipped ":test", ":jacocoTestReport"
+        skipped ":test", ":jacocoTestReport", ":jacocoTestCoverageVerification"
         reportFile.assertContentsHaveNotChangedSince(snapshot)
     }
 


### PR DESCRIPTION
### Context
This task is one of the few ones in a customer's build that runs even when nothing has changed. It's expensive enough to be worth avoiding. Doing so is easy - it already has all the input declarations it needs, so we just need to give it a dummy output file, so that Gradle will consider it up-to-date/cacheable.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
