### PR TITLE
Use correct System properties and working directory for distro download from TAPI

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ExpectMethod.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ExpectMethod.java
@@ -22,6 +22,7 @@ import com.sun.net.httpserver.HttpExchange;
 import org.gradle.test.fixtures.server.http.BlockingHttpServer.BlockingRequest;
 import org.gradle.test.fixtures.server.http.BlockingHttpServer.BuildableExpectedRequest;
 import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
 
 import java.io.File;
 import java.io.IOException;
@@ -180,8 +181,14 @@ class ExpectMethod implements ResourceHandler, BuildableExpectedRequest, Resourc
 
         @Override
         public void writeTo(int requestId, HttpExchange exchange) throws IOException {
-            if (!expectedUserAgent.matches(exchange.getRequestHeaders().getFirst("User-Agent"))) {
-                String message = "Unexpected user agent in request";
+            String actual = exchange.getRequestHeaders().getFirst("User-Agent");
+            if (!expectedUserAgent.matches(actual)) {
+                StringDescription description = new StringDescription();
+                description.appendText("Expected user agent ");
+                expectedUserAgent.describeTo(description);
+                description.appendText(" but ");
+                expectedUserAgent.describeMismatch(actual, description);
+                String message = description.toString();
                 byte[] bytes = message.getBytes(Charsets.UTF_8);
                 exchange.sendResponseHeaders(500, bytes.length);
                 exchange.getResponseBody().write(bytes);

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
@@ -189,7 +189,7 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes[0].message == 'Failed to handle GET /b'
-        e.causes[0].cause.message == 'Unexpected user agent in request'
+        e.causes[0].cause.message == 'Expected user agent "some-agent" but was "not-correct"'
         e.causes.message == [
             'Failed to handle GET /b',
             'Failed to handle GET /c'

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -32,6 +32,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.internal.consumer.ConnectionParameters
 import org.gradle.tooling.internal.consumer.Distribution
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import org.gradle.tooling.model.GradleProject
@@ -287,12 +288,12 @@ project.description = text
             return 'mock'
         }
 
-        ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, File userHomeDir, BuildCancellationToken cancellationToken) {
+        ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
             def o = progressLoggerFactory.newOperation("mock")
             operation(o)
             o.started()
             o.completed()
-            return delegate.getToolingImplementationClasspath(progressLoggerFactory, progressListener, userHomeDir, cancellationToken)
+            return delegate.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken)
         }
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
@@ -46,15 +46,12 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         assert distribution.binDistribution.exists() : "bin distribution must exist to run this test; make sure a <test>NormalizedDistribution dependency is defined."
         server.start()
         toolingApi.requireIsolatedUserHome()
+        settingsFile << ""
     }
 
     @Issue('https://github.com/gradle/gradle-private/issues/1537')
     def "downloads distribution with valid user-agent information"() {
         given:
-        settingsFile << "";
-        buildFile << "task hello { doLast { println hello } }"
-
-        and:
         server.expect(server.get("/custom-dist.zip").expectUserAgent(matchesNameAndVersion("Gradle Tooling API", GradleVersion.current().getVersion())).sendFile(distribution.binDistribution))
 
         and:
@@ -63,25 +60,69 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         }
 
         when:
-        ByteArrayOutputStream buildOutput = new ByteArrayOutputStream()
-
         toolingApi.withConnection { connection ->
-            BuildLauncher launcher = connection.newBuild().forTasks("hello")
-            launcher.standardOutput = buildOutput;
+            BuildLauncher launcher = connection.newBuild().forTasks("help")
             launcher.run()
         }
 
         then:
-        buildOutput.toString().contains('hello')
         toolingApi.gradleUserHomeDir.file("wrapper/dists/custom-dist").assertIsDir().listFiles().size() == 1
+    }
+
+    def "loads credentials from gradle.properties"() {
+        given:
+        server.withBasicAuthentication("username", "password")
+        file("gradle.properties") << """
+            systemProp.gradle.wrapperUser=username
+            systemProp.gradle.wrapperPassword=password
+        """.stripIndent()
+        server.expect(server.get("/custom-dist.zip").sendFile(distribution.binDistribution))
+
+        and:
+        def distUri = URI.create("http://localhost:${server.port}/custom-dist.zip")
+        toolingApi.withConnector { GradleConnector connector ->
+            connector.useDistribution(distUri)
+        }
+
+        when:
+        toolingApi.withConnection { connection ->
+            BuildLauncher launcher = connection.newBuild().forTasks("help")
+            launcher.run()
+        }
+
+        then:
+        toolingApi.gradleUserHomeDir.file("wrapper/dists/custom-dist").assertIsDir().listFiles().size() == 1
+    }
+
+    def "supports project-relative distribution download dir"() {
+        given:
+        server.expect(server.get("/custom-dist.zip").sendFile(distribution.binDistribution))
+        file("gradle/wrapper/gradle-wrapper.properties") << """
+            distributionBase=PROJECT
+            distributionPath=wrapper/dists
+            distributionUrl=http\\://localhost:${server.port}/custom-dist.zip
+            zipStoreBase=PROJECT
+            zipStorePath=wrapper/dists
+        """
+
+        and:
+        toolingApi.withConnector { GradleConnector connector ->
+            connector.useBuildDistribution()
+        }
+
+        when:
+        toolingApi.withConnection { connection ->
+            BuildLauncher launcher = connection.newBuild().forTasks("help")
+            launcher.run()
+        }
+
+        then:
+        file("wrapper/dists/custom-dist").assertIsDir().listFiles().size() == 1
     }
 
     @Issue('https://github.com/gradle/gradle-private/issues/1537')
     def "receives distribution download progress events"() {
         given:
-        settingsFile << ""
-
-        and:
         server.expect(server.get("/custom-dist.zip").sendFile(distribution.binDistribution))
 
         and:
@@ -159,8 +200,6 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         def userHomeDir = file("user-home-dir")
 
         given:
-        settingsFile << "";
-        buildFile << "task hello { doLast { println hello } }"
         def tokenSource = new DefaultCancellationTokenSource()
         def distUri = server.uri("cancelled-dist.zip")
 
@@ -179,7 +218,7 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         def handler = new TestResultHandler()
         toolingApi.withConnection { ProjectConnection connection ->
             connection.newBuild()
-                .forTasks("hello")
+                .forTasks("help")
                 .withCancellationToken(tokenSource.token())
                 .addProgressListener(events)
                 .run(handler)

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionParameters.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionParameters.java
@@ -46,4 +46,6 @@ public interface ConnectionParameters extends org.gradle.tooling.internal.protoc
      * Whether to log debug statements eagerly
      */
     boolean getVerboseLogging();
+
+    File getDistributionBaseDir();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultConnectionParameters.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultConnectionParameters.java
@@ -30,6 +30,7 @@ public class DefaultConnectionParameters implements ConnectionParameters {
     private final TimeUnit daemonMaxIdleTimeUnits;
     private final File daemonBaseDir;
     private final boolean verboseLogging;
+    private final File distributionBaseDir;
 
     public static Builder builder() {
         return new Builder();
@@ -44,6 +45,7 @@ public class DefaultConnectionParameters implements ConnectionParameters {
         private boolean verboseLogging;
         private File daemonBaseDir;
         private Boolean searchUpwards;
+        private File distributionBaseDir;
 
         protected Builder() {
         }
@@ -88,14 +90,18 @@ public class DefaultConnectionParameters implements ConnectionParameters {
             return this;
         }
 
+        public void setDistributionBaseDir(File distributionBaseDir) {
+            this.distributionBaseDir = distributionBaseDir;
+        }
+
         public DefaultConnectionParameters build() {
-            return new DefaultConnectionParameters(projectDir, gradleUserHomeDir, embedded, daemonMaxIdleTimeValue, daemonMaxIdleTimeUnits, daemonBaseDir, verboseLogging, searchUpwards);
+            return new DefaultConnectionParameters(projectDir, gradleUserHomeDir, embedded, daemonMaxIdleTimeValue, daemonMaxIdleTimeUnits, daemonBaseDir, verboseLogging, searchUpwards, distributionBaseDir);
         }
     }
 
     private DefaultConnectionParameters(File projectDir, File gradleUserHomeDir, Boolean embedded,
                                         Integer daemonMaxIdleTimeValue, TimeUnit daemonMaxIdleTimeUnits, File daemonBaseDir,
-                                        boolean verboseLogging, Boolean searchUpwards) {
+                                        boolean verboseLogging, Boolean searchUpwards, File distributionBaseDir) {
         this.projectDir = projectDir;
         this.gradleUserHomeDir = gradleUserHomeDir;
         this.embedded = embedded;
@@ -104,6 +110,7 @@ public class DefaultConnectionParameters implements ConnectionParameters {
         this.daemonBaseDir = daemonBaseDir;
         this.verboseLogging = verboseLogging;
         this.searchUpwards = searchUpwards;
+        this.distributionBaseDir = distributionBaseDir;
     }
 
     @Override
@@ -149,5 +156,10 @@ public class DefaultConnectionParameters implements ConnectionParameters {
     @Override
     public Boolean isSearchUpwards() {
         return searchUpwards;
+    }
+
+    @Override
+    public File getDistributionBaseDir() {
+        return distributionBaseDir;
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultGradleConnector.java
@@ -110,7 +110,7 @@ public class DefaultGradleConnector extends GradleConnector implements ProjectCo
     }
 
     public GradleConnector useDistributionBaseDir(File distributionBaseDir) {
-        distributionFactory.setDistributionBaseDir(distributionBaseDir);
+        connectionParamsBuilder.setDistributionBaseDir(distributionBaseDir);
         return this;
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/Distribution.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/Distribution.java
@@ -20,11 +20,9 @@ import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 
-import java.io.File;
-
 public interface Distribution {
     String getDisplayName();
 
     ClassPath getToolingImplementationClasspath(
-        ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, File userHomeDir, BuildCancellationToken cancellationToken);
+        ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken);
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DistributionFactory.java
@@ -29,6 +29,7 @@ import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 import org.gradle.util.internal.DistributionLocator;
 import org.gradle.util.GradleVersion;
 import org.gradle.wrapper.GradleUserHomeLookup;
+import org.gradle.wrapper.SystemPropertiesHandler;
 import org.gradle.wrapper.WrapperConfiguration;
 import org.gradle.wrapper.WrapperExecutor;
 
@@ -37,20 +38,17 @@ import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
 
 import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DistributionFactory {
     private final Clock clock;
-    private File distributionBaseDir;
 
     public DistributionFactory(Clock clock) {
         this.clock = clock;
-    }
-
-    public void setDistributionBaseDir(File distributionBaseDir) {
-        this.distributionBaseDir = distributionBaseDir;
     }
 
     /**
@@ -60,7 +58,7 @@ public class DistributionFactory {
         BuildLayout layout = new BuildLayoutFactory().getLayoutFor(projectDir, searchUpwards);
         WrapperExecutor wrapper = WrapperExecutor.forProjectDirectory(layout.getRootDirectory());
         if (wrapper.getDistribution() != null) {
-            return new ZippedDistribution(wrapper.getConfiguration(), distributionBaseDir, clock);
+            return new ZippedDistribution(wrapper.getConfiguration(), clock);
         }
         return getDownloadedDistribution(GradleVersion.current().getVersion());
     }
@@ -86,7 +84,7 @@ public class DistributionFactory {
     public Distribution getDistribution(URI gradleDistribution) {
         WrapperConfiguration configuration = new WrapperConfiguration();
         configuration.setDistribution(gradleDistribution);
-        return new ZippedDistribution(configuration, distributionBaseDir, clock);
+        return new ZippedDistribution(configuration, clock);
     }
 
     /**
@@ -104,12 +102,10 @@ public class DistributionFactory {
     private static class ZippedDistribution implements Distribution {
         private InstalledDistribution installedDistribution;
         private final WrapperConfiguration wrapperConfiguration;
-        private final File distributionBaseDir;
         private final Clock clock;
 
-        private ZippedDistribution(WrapperConfiguration wrapperConfiguration, File distributionBaseDir, Clock clock) {
+        private ZippedDistribution(WrapperConfiguration wrapperConfiguration, Clock clock) {
             this.wrapperConfiguration = wrapperConfiguration;
-            this.distributionBaseDir = distributionBaseDir;
             this.clock = clock;
         }
 
@@ -119,7 +115,7 @@ public class DistributionFactory {
         }
 
         @Override
-        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, final InternalBuildProgressListener progressListener, final File userHomeDir, BuildCancellationToken cancellationToken) {
+        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, final InternalBuildProgressListener progressListener, final ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
             if (installedDistribution == null) {
                 final DistributionInstaller installer = new DistributionInstaller(progressLoggerFactory, progressListener, clock);
                 File installDir;
@@ -130,7 +126,7 @@ public class DistributionFactory {
                             installer.cancel();
                         }
                     });
-                    installDir = installer.install(determineRealUserHomeDir(userHomeDir), wrapperConfiguration);
+                    installDir = installer.install(determineRealUserHomeDir(connectionParameters), determineRootDir(connectionParameters), wrapperConfiguration, determineSystemProperties(connectionParameters));
                 } catch (CancellationException e) {
                     throw new BuildCancelledException(String.format("Distribution download cancelled. Using distribution from '%s'.", wrapperConfiguration.getDistribution()), e);
                 } catch (FileNotFoundException e) {
@@ -140,14 +136,32 @@ public class DistributionFactory {
                 }
                 installedDistribution = new InstalledDistribution(installDir, getDisplayName(), getDisplayName());
             }
-            return installedDistribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, userHomeDir, cancellationToken);
+            return installedDistribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
         }
 
-        private File determineRealUserHomeDir(final File userHomeDir) {
+        private Map<String, String> determineSystemProperties(ConnectionParameters connectionParameters) {
+            Map<String, String> systemProperties = new HashMap<String, String>();
+            for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+                systemProperties.put(entry.getKey().toString(), entry.getValue() == null ? null : entry.getValue().toString());
+            }
+            systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(determineRootDir(connectionParameters), "gradle.properties")));
+            systemProperties.putAll(SystemPropertiesHandler.getSystemProperties(new File(determineRealUserHomeDir(connectionParameters), "gradle.properties")));
+            return systemProperties;
+        }
+
+        private File determineRootDir(ConnectionParameters connectionParameters) {
+            return new BuildLayoutFactory().getLayoutFor(
+                connectionParameters.getProjectDir(),
+                connectionParameters.isSearchUpwards() != null ? connectionParameters.isSearchUpwards() : true
+            ).getRootDirectory();
+        }
+
+        private File determineRealUserHomeDir(ConnectionParameters connectionParameters) {
+            File distributionBaseDir = connectionParameters.getDistributionBaseDir();
             if (distributionBaseDir != null) {
                 return distributionBaseDir;
             }
-
+            File userHomeDir = connectionParameters.getGradleUserHomeDir();
             return userHomeDir != null ? userHomeDir : GradleUserHomeLookup.gradleUserHome();
         }
     }
@@ -169,7 +183,7 @@ public class DistributionFactory {
         }
 
         @Override
-        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, File userHomeDir, BuildCancellationToken cancellationToken) {
+        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
             if (!gradleHomeDir.exists()) {
                 throw new IllegalArgumentException(String.format("The specified %s does not exist.", locationDisplayName));
             }
@@ -199,7 +213,7 @@ public class DistributionFactory {
         }
 
         @Override
-        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, File userHomeDir, BuildCancellationToken cancellationToken) {
+        public ClassPath getToolingImplementationClasspath(ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
             DefaultModuleRegistry registry = new DefaultModuleRegistry(null);
             return registry.getModule("gradle-launcher").getAllRequiredModulesClasspath();
         }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoader.java
@@ -38,7 +38,7 @@ public class CachingToolingImplementationLoader implements ToolingImplementation
 
     @Override
     public ConsumerConnection create(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
-        ClassPath classpath = distribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters.getGradleUserHomeDir(), cancellationToken);
+        ClassPath classpath = distribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
 
         ConsumerConnection connection = connections.get(classpath);
         if (connection == null) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
@@ -52,8 +52,6 @@ import org.gradle.tooling.internal.protocol.test.InternalTestExecutionConnection
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-
 /**
  * Loads the tooling API implementation of the Gradle version that will run the build (the "provider").
  * Adapts the rather clunky cross-version interface to the more readable interface of the TAPI client.
@@ -73,7 +71,7 @@ public class DefaultToolingImplementationLoader implements ToolingImplementation
     @Override
     public ConsumerConnection create(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
         LOGGER.debug("Using tooling provider from {}", distribution.getDisplayName());
-        ClassLoader serviceClassLoader = createImplementationClassLoader(distribution, progressLoggerFactory, progressListener, connectionParameters.getGradleUserHomeDir(), cancellationToken);
+        ClassLoader serviceClassLoader = createImplementationClassLoader(distribution, progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
         ServiceLocator serviceLocator = new DefaultServiceLocator(serviceClassLoader);
         try {
             Factory<ConnectionVersion4> factory = serviceLocator.findFactory(ConnectionVersion4.class);
@@ -110,8 +108,8 @@ public class DefaultToolingImplementationLoader implements ToolingImplementation
         return new ParameterValidatingConsumerConnection(versionDetails, adaptedConnection);
     }
 
-    private ClassLoader createImplementationClassLoader(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, File userHomeDir, BuildCancellationToken cancellationToken) {
-        ClassPath implementationClasspath = distribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, userHomeDir, cancellationToken);
+    private ClassLoader createImplementationClassLoader(Distribution distribution, ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken) {
+        ClassPath implementationClasspath = distribution.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken);
         LOGGER.debug("Using tooling provider classpath: {}", implementationClasspath);
         FilteringClassLoader.Spec filterSpec = new FilteringClassLoader.Spec();
         filterSpec.allowPackage("org.gradle.tooling.internal.protocol");

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -33,6 +33,7 @@ import spock.lang.Specification
 
 class DistributionFactoryTest extends Specification {
     @Rule final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+    final ConnectionParameters connectionParameters = DefaultConnectionParameters.builder().setProjectDir(tmpDir.testDirectory).build()
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final ProgressLogger progressLogger = Mock()
     final BuildCancellationToken cancellationToken = Mock()
@@ -78,7 +79,7 @@ class DistributionFactoryTest extends Specification {
 
         expect:
         def dist = factory.getDistribution(tmpDir.testDirectory)
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken).asFiles as Set == [libA, libB] as Set
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken).asFiles as Set == [libA, libB] as Set
     }
 
     def failsWhenInstallationDirectoryDoesNotExist() {
@@ -86,7 +87,7 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(distDir)
 
         when:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken)
 
         then:
         IllegalArgumentException e = thrown()
@@ -98,7 +99,7 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(distDir)
 
         when:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken)
 
         then:
         IllegalArgumentException e = thrown()
@@ -110,7 +111,7 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(distDir)
 
         when:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken)
 
         then:
         IllegalArgumentException e = thrown()
@@ -134,11 +135,14 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(zipFile.toURI())
 
         expect:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken).asFiles.name as Set == ['gradle-core-0.9.jar', 'gradle-launcher-0.9.jar'] as Set
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken).asFiles.name as Set == ['gradle-core-0.9.jar', 'gradle-launcher-0.9.jar'] as Set
     }
 
     def usesWrapperDistributionInstalledIntoSpecifiedUserHomeDirAsImplementationClasspath() {
-        File customUserHome = tmpDir.file('customUserHome')
+        ConnectionParameters customUserHome = DefaultConnectionParameters.builder().
+            setProjectDir(tmpDir.testDirectory)
+            .setGradleUserHomeDir(tmpDir.file('customUserHome'))
+            .build()
         def zipFile = createZip {
             lib {
                 file("gradle-core-0.9.jar")
@@ -155,7 +159,10 @@ class DistributionFactoryTest extends Specification {
     }
 
     def usesZipDistributionInstalledIntoSpecifiedUserHomeDirAsImplementationClasspath() {
-        File customUserHome = tmpDir.file('customUserHome')
+        ConnectionParameters customUserHome = DefaultConnectionParameters.builder().
+            setProjectDir(tmpDir.testDirectory)
+            .setGradleUserHomeDir(tmpDir.file('customUserHome'))
+            .build()
         def zipFile = createZip {
             lib {
                 file("gradle-core-0.9.jar")
@@ -171,7 +178,10 @@ class DistributionFactoryTest extends Specification {
     }
 
     def reportsZipDownload() {
-        File customUserHome = tmpDir.file('customUserHome')
+        ConnectionParameters customUserHome = DefaultConnectionParameters.builder().
+            setProjectDir(tmpDir.testDirectory)
+            .setGradleUserHomeDir(tmpDir.file('customUserHome'))
+            .build()
         def zipFile = createZip {
             lib {
                 file("gradle-launcher-0.9.jar")
@@ -206,7 +216,7 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(zipFile)
 
         when:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken)
 
         then:
         IllegalArgumentException e = thrown()
@@ -218,7 +228,7 @@ class DistributionFactoryTest extends Specification {
         def dist = factory.getDistribution(zipFile.toURI())
 
         when:
-        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
+        dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, connectionParameters, cancellationToken)
 
         then:
         1 * cancellationToken.addCallback(_)

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoaderTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/CachingToolingImplementationLoaderTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.initialization.BuildCancellationToken
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.tooling.internal.consumer.ConnectionParameters
+import org.gradle.tooling.internal.consumer.DefaultConnectionParameters
 import org.gradle.tooling.internal.consumer.Distribution
 import org.gradle.tooling.internal.consumer.connection.ConsumerConnection
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
@@ -28,14 +29,13 @@ class CachingToolingImplementationLoaderTest extends Specification {
     final ToolingImplementationLoader target = Mock()
     final ProgressLoggerFactory loggerFactory = Mock()
     final InternalBuildProgressListener progressListener = Mock()
-    final ConnectionParameters params = Mock()
+    final ConnectionParameters params = DefaultConnectionParameters.builder().build()
     final BuildCancellationToken cancellationToken = Mock()
     final CachingToolingImplementationLoader loader = new CachingToolingImplementationLoader(target)
 
     def delegatesToTargetLoaderToCreateImplementation() {
         def distribution = Mock(Distribution)
         def connection = Mock(ConsumerConnection)
-        def userHomeDir = new File("user-home")
 
         when:
         def impl = loader.create(distribution, loggerFactory, progressListener, params, cancellationToken)
@@ -43,15 +43,13 @@ class CachingToolingImplementationLoaderTest extends Specification {
         then:
         impl == connection
         1 * target.create(distribution, loggerFactory, progressListener, params, cancellationToken) >> connection
-        1 * params.getGradleUserHomeDir() >> userHomeDir
-        _ * distribution.getToolingImplementationClasspath(loggerFactory, progressListener, userHomeDir, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
+        _ * distribution.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
         0 * _._
     }
 
     def reusesImplementationWithSameClasspath() {
         def distribution = Mock(Distribution)
         def connection = Mock(ConsumerConnection)
-        def userHomeDir = new File("user-home")
 
         when:
         def impl = loader.create(distribution, loggerFactory, progressListener, params, cancellationToken)
@@ -61,8 +59,7 @@ class CachingToolingImplementationLoaderTest extends Specification {
         impl == connection
         impl2 == connection
         1 * target.create(distribution, loggerFactory, progressListener, params, cancellationToken) >> connection
-        2 * params.getGradleUserHomeDir() >> userHomeDir
-        _ * distribution.getToolingImplementationClasspath(loggerFactory, progressListener, userHomeDir, cancellationToken) >> { DefaultClassPath.of(new File('a.jar')) }
+        _ * distribution.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> { DefaultClassPath.of(new File('a.jar')) }
         0 * _._
     }
 
@@ -81,9 +78,8 @@ class CachingToolingImplementationLoaderTest extends Specification {
         impl2 == connection2
         1 * target.create(distribution1, loggerFactory, progressListener, params, cancellationToken) >> connection1
         1 * target.create(distribution2, loggerFactory, progressListener, params, cancellationToken) >> connection2
-        2 * params.getGradleUserHomeDir() >> null
-        _ * distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, null, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
-        _ * distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, null, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
+        _ * distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
+        _ * distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
         0 * _._
     }
 
@@ -101,8 +97,8 @@ class CachingToolingImplementationLoaderTest extends Specification {
         _ * target.create(distribution1, loggerFactory, progressListener, params, cancellationToken) >> connection1
         _ * target.create(distribution2, loggerFactory, progressListener, params, cancellationToken) >> connection2
         _ * params.getGradleUserHomeDir() >> null
-        _ * distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, null, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
-        _ * distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, null, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
+        _ * distribution1.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('a.jar'))
+        _ * distribution2.getToolingImplementationClasspath(loggerFactory, progressListener, params, cancellationToken) >> DefaultClassPath.of(new File('b.jar'))
 
         when:
         loader.close()

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoaderTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.internal.consumer.ConnectionParameters
+import org.gradle.tooling.internal.consumer.DefaultConnectionParameters
 import org.gradle.tooling.internal.consumer.Distribution
 import org.gradle.tooling.internal.consumer.connection.NoToolingApiConnection
 import org.gradle.tooling.internal.consumer.connection.ParameterAcceptingConsumerConnection
@@ -71,16 +72,16 @@ class DefaultToolingImplementationLoaderTest extends Specification {
     Distribution distribution = Mock()
     ProgressLoggerFactory loggerFactory = Mock()
     InternalBuildProgressListener progressListener = Mock()
-    ConnectionParameters connectionParameters = Stub() {
-        getVerboseLogging() >> true
-    }
-    File userHomeDir = Mock()
+    ConnectionParameters connectionParameters = DefaultConnectionParameters.builder()
+        .setProjectDir(tmpDir.testDirectory)
+        .setVerboseLogging(true)
+        .build()
     final BuildCancellationToken cancellationToken = Mock()
     final loader = new DefaultToolingImplementationLoader()
 
     def "locates connection implementation using meta-inf service then instantiates and configures the connection"() {
         given:
-        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, userHomeDir, cancellationToken) >> DefaultClassPath.of(
+        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, connectionParameters, cancellationToken) >> DefaultClassPath.of(
             getToolingApiResourcesDir(connectionImplementation),
             ClasspathUtil.getClasspathForClass(TestConnection.class),
             ClasspathUtil.getClasspathForClass(ActorFactory.class),
@@ -105,7 +106,7 @@ class DefaultToolingImplementationLoaderTest extends Specification {
 
     def "locates connection implementation using meta-inf service for deprecated connection"() {
         given:
-        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, userHomeDir, cancellationToken) >> DefaultClassPath.of(
+        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, connectionParameters, cancellationToken) >> DefaultClassPath.of(
             getToolingApiResourcesDir(connectionImplementation),
             ClasspathUtil.getClasspathForClass(TestConnection.class),
             ClasspathUtil.getClasspathForClass(ActorFactory.class),
@@ -139,7 +140,7 @@ class DefaultToolingImplementationLoaderTest extends Specification {
         def loader = new DefaultToolingImplementationLoader()
 
         given:
-        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, userHomeDir, cancellationToken) >> ClassPath.EMPTY
+        distribution.getToolingImplementationClasspath(loggerFactory, progressListener, connectionParameters, cancellationToken) >> ClassPath.EMPTY
 
         expect:
         loader.create(distribution, loggerFactory, progressListener, connectionParameters, cancellationToken) instanceof NoToolingApiConnection

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -54,7 +54,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 58 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 59 * 1024
     }
 
     def "generated wrapper scripts for given version from command-line"() {
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "47a62eb8a42fe3739dbc2c594f1f49f45ef5de951f88aa9568c2fd45f2025447"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -62,7 +62,7 @@ public class GradleWrapperMain {
         WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile);
         wrapperExecutor.execute(
                 args,
-                new Install(logger, new Download(logger, "gradlew", UNKNOWN_VERSION), new PathAssembler(gradleUserHome)),
+                new Install(logger, new Download(logger, "gradlew", UNKNOWN_VERSION), new PathAssembler(gradleUserHome, rootDir)),
                 new BootstrapMainStarter());
     }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/PathAssembler.java
@@ -24,13 +24,12 @@ public class PathAssembler {
     public static final String GRADLE_USER_HOME_STRING = "GRADLE_USER_HOME";
     public static final String PROJECT_STRING = "PROJECT";
 
-    private File gradleUserHome;
+    private final File gradleUserHome;
+    private final File projectDirectory;
 
-    public PathAssembler() {
-    }
-
-    public PathAssembler(File gradleUserHome) {
+    public PathAssembler(File gradleUserHome, File projectDirectory) {
         this.gradleUserHome = gradleUserHome;
+        this.projectDirectory = projectDirectory;
     }
 
     /**
@@ -92,7 +91,7 @@ public class PathAssembler {
         if (base.equals(GRADLE_USER_HOME_STRING)) {
             return gradleUserHome;
         } else if (base.equals(PROJECT_STRING)) {
-            return new File(System.getProperty("user.dir"));
+            return projectDirectory;
         } else {
             throw new RuntimeException("Base: " + base + " is unknown");
         }

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/PathAssemblerTest.java
@@ -22,11 +22,14 @@ import java.io.File;
 import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class PathAssemblerTest {
     public static final String TEST_GRADLE_USER_HOME = "someUserHome";
-    private PathAssembler pathAssembler = new PathAssembler(new File(TEST_GRADLE_USER_HOME));
+    public static final String TEST_PROJECT_DIR = "someProjectDir";
+    private PathAssembler pathAssembler = new PathAssembler(new File(TEST_GRADLE_USER_HOME), new File(TEST_PROJECT_DIR));
     final WrapperConfiguration configuration = new WrapperConfiguration();
 
     @Before
@@ -53,7 +56,7 @@ public class PathAssemblerTest {
 
         File distributionDir = pathAssembler.getDistribution(configuration).getDistributionDir();
         assertThat(distributionDir.getName(), equalTo("emn8ua2x0re2y4jlewhnxhasz"));
-        assertThat(distributionDir.getParentFile(), equalTo(file(currentDirPath() + "/somePath/gradle-0.9-bin")));
+        assertThat(distributionDir.getParentFile(), equalTo(file(TEST_PROJECT_DIR + "/somePath/gradle-0.9-bin")));
     }
 
     @Test
@@ -100,14 +103,10 @@ public class PathAssemblerTest {
         File dist = pathAssembler.getDistribution(configuration).getZipFile();
         assertThat(dist.getName(), equalTo("gradle-1.0.zip"));
         assertThat(dist.getParentFile().getName(), equalTo("98xa9n94mamfu7vl4mzwomw11"));
-        assertThat(dist.getParentFile().getParentFile(), equalTo(file(currentDirPath() + "/somePath/gradle-1.0")));
+        assertThat(dist.getParentFile().getParentFile(), equalTo(file(TEST_PROJECT_DIR + "/somePath/gradle-1.0")));
     }
 
     private File file(String path) {
         return new File(path);
-    }
-
-    private String currentDirPath() {
-        return System.getProperty("user.dir");
     }
 }


### PR DESCRIPTION
The TAPI wasn't reading gradle.properties when downloading the Gradle wrapper,
so it didn't pick up authentication properties listed there. It also used the client's CWD
as the wrapper base dir, when it should have been using the project directory. Both of
these are now fixed.

Fixes #12060

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
