### PR TITLE
Let CC report input properties declared as SourceDirectorySet

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheUnsupportedTypesIntegrationTest.groovy
@@ -49,6 +49,7 @@ import org.gradle.api.attributes.AttributeMatchingStrategy
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.CompatibilityRuleChain
 import org.gradle.api.attributes.DisambiguationRuleChain
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.artifacts.DefaultDependencyConstraintSet
 import org.gradle.api.internal.artifacts.DefaultDependencySet
@@ -79,6 +80,7 @@ import org.gradle.api.internal.attributes.DefaultAttributeMatchingStrategy
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.DefaultCompatibilityRuleChain
 import org.gradle.api.internal.attributes.DefaultDisambiguationRuleChain
+import org.gradle.api.internal.file.DefaultSourceDirectorySet
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.internal.tasks.DefaultSourceSet
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
@@ -292,7 +294,8 @@ class ConfigurationCacheUnsupportedTypesIntegrationTest extends AbstractConfigur
         outputContains("beanWithSameType.reference = null")
 
         where:
-        concreteType         | baseType      | reference                                    | deserializedValue
-        DefaultConfiguration | Configuration | "project.configurations.maybeCreate('some')" | 'file collection'
+        concreteType              | baseType           | reference                                            | deserializedValue
+        DefaultConfiguration      | Configuration      | "project.configurations.maybeCreate('some')"         | 'file collection'
+        DefaultSourceDirectorySet | SourceDirectorySet | "project.objects.sourceDirectorySet('some', 'more')" | 'file tree'
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanSchema.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanSchema.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache.serialization.beans
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.internal.IConventionAware
 import org.gradle.api.internal.TaskInternal
@@ -40,7 +41,8 @@ import kotlin.reflect.KClass
 
 internal
 val unsupportedFieldDeclaredTypes = listOf(
-    Configuration::class
+    Configuration::class,
+    SourceDirectorySet::class
 )
 
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -591,9 +591,10 @@ You should instead declare these as a `FileCollection` input and reference just 
 
 The same requirement applies to dependency management types with some nuances.
 
-Some types, such as `Configuration`, don't make good task input parameters, as they hold a lot of irrelevant state, and it is better to model these inputs as something more precise.
+Some types, such as `Configuration` or `SourceDirectorySet`, don't make good task input parameters, as they hold a lot of irrelevant state, and it is better to model these inputs as something more precise.
 We don't intend to make these types serializable at all.
 For example, if you reference a `Configuration` to later get the resolved files, you should instead declare a `FileCollection` as an input to your task.
+In the same vein, if you reference a `SourceDirectorySet` you should instead declare a `FileTree` as an input to your task.
 
 Referencing dependency resolution results is also disallowed (e.g. `ArtifactResolutionQuery`, `ResolvedArtifact`, `ArtifactResult` etc...).
 For example, if you reference some `ResolvedArtifactResult` instances, you should instead declare some `ArtifactCollection` as an input to your task.

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -44,18 +45,27 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
 
 ) : DefaultTask(), SharedAccessorsPackageAware {
 
+    private
+    companion object {
+        const val kotlinModuleName = "precompiled-script-plugin-plugins"
+    }
+
     @get:OutputDirectory
     abstract val outputDir: DirectoryProperty
 
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    val sourceFiles: SourceDirectorySet = project.objects.sourceDirectorySet(
-        "precompiled-script-plugin-plugins",
+    @Transient
+    private
+    val sourceDirectorySet: SourceDirectorySet = project.objects.sourceDirectorySet(
+        kotlinModuleName,
         "Precompiled script plugin plugins"
     )
 
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val sourceFiles: FileTree = sourceDirectorySet
+
     fun sourceDir(dir: Provider<Directory>) {
-        sourceFiles.srcDir(dir)
+        sourceDirectorySet.srcDir(dir)
     }
 
     @TaskAction
@@ -65,7 +75,7 @@ abstract class CompilePrecompiledScriptPluginPlugins @Inject constructor(
             if (scriptFiles.isNotEmpty())
                 compileKotlinScriptModuleTo(
                     outputDir,
-                    sourceFiles.name,
+                    kotlinModuleName,
                     scriptFiles,
                     scriptDefinitionFromTemplate(
                         CompiledKotlinPluginsBlock::class,


### PR DESCRIPTION
And recommend the supported `FileTree` instead.
In the same vein as `Configuration`/`FileCollection`.

### Context

Making some progress enabling the configuration cache for more use cases on the `gradle/gradle` build.
