### PR TITLE
Make build-init plugin use JUnit Jupiter by default

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -56,7 +56,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("some.thing.AppTest", "testAppHasAGreeting")
+        assertTestPassed("some.thing.AppTest", "appHasAGreeting")
 
         when:
         run("run")
@@ -152,14 +152,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        switch (testFramework) {
-            case BuildInitTestFramework.JUNIT:
-                assertTestPassed("my.app.AppTest", "testAppHasAGreeting")
-                break
-            case BuildInitTestFramework.TESTNG:
-                assertTestPassed("my.app.AppTest", "appHasAGreeting")
-                break
-        }
+        assertTestPassed("my.app.AppTest", "appHasAGreeting")
 
         when:
         run("run")

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -60,7 +60,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("some.thing.LibraryTest", "testSomeLibraryMethod")
+        assertTestPassed("some.thing.LibraryTest", "someLibraryMethodReturnsTrue")
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
@@ -134,7 +134,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("some.thing.LibraryTest", "testSomeLibraryMethod")
+        assertTestPassed("some.thing.LibraryTest", "someLibraryMethodReturnsTrue")
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
@@ -156,14 +156,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        switch (testFramework) {
-            case BuildInitTestFramework.JUNIT:
-                assertTestPassed("my.lib.LibraryTest", "testSomeLibraryMethod")
-                break
-            case BuildInitTestFramework.TESTNG:
-                assertTestPassed("my.lib.LibraryTest", "someLibraryMethodReturnsTrue")
-                break
-        }
+        assertTestPassed("my.lib.LibraryTest", "someLibraryMethodReturnsTrue")
 
         where:
         [scriptDsl, testFramework] << [ScriptDslFixture.SCRIPT_DSLS, [BuildInitTestFramework.JUNIT, BuildInitTestFramework.TESTNG]].combinations()

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -222,7 +222,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
-    private void buildFileSeparatesImplementationAndApi(ScriptDslFixture dslFixture, String testFramework = 'junit:junit:') {
+    private static void buildFileSeparatesImplementationAndApi(ScriptDslFixture dslFixture, String testFramework = 'org.junit.jupiter') {
         dslFixture.buildFile.assertContents(
             allOf(
                 dslFixture.containsConfigurationDependencyNotation('api', 'org.apache.commons:commons-math3'),

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -55,7 +55,7 @@ class KotlinApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("some.thing.AppTest", "testAppHasAGreeting")
+        assertTestPassed("some.thing.AppTest", "appHasAGreeting")
 
         when:
         run("run")
@@ -83,7 +83,7 @@ class KotlinApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("my.app.AppTest", "testAppHasAGreeting")
+        assertTestPassed("my.app.AppTest", "appHasAGreeting")
 
         when:
         run("run")

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -55,7 +55,7 @@ class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("some.thing.LibraryTest", "testSomeLibraryMethod")
+        assertTestPassed("some.thing.LibraryTest", "someLibraryMethodReturnsTrue")
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
@@ -77,7 +77,7 @@ class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         run("build")
 
         then:
-        assertTestPassed("my.lib.LibraryTest", "testSomeLibraryMethod")
+        assertTestPassed("my.lib.LibraryTest", "someLibraryMethodReturnsTrue")
 
         where:
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JavaGradlePluginProjectInitDescriptor.java
@@ -43,18 +43,21 @@ public class JavaGradlePluginProjectInitDescriptor extends JvmGradlePluginProjec
 
     @Override
     public BuildInitTestFramework getDefaultTestFramework() {
-        return BuildInitTestFramework.JUNIT;
+        return BuildInitTestFramework.JUNIT_JUPITER;
     }
 
     @Override
     public Set<BuildInitTestFramework> getTestFrameworks() {
-        return ImmutableSet.of(BuildInitTestFramework.JUNIT);
+        return ImmutableSet.of(BuildInitTestFramework.JUNIT_JUPITER);
     }
 
     @Override
     public void generateProjectBuildScript(String projectName, InitSettings settings, BuildScriptBuilder buildScriptBuilder) {
         super.generateProjectBuildScript(projectName, settings, buildScriptBuilder);
-        buildScriptBuilder.testImplementationDependency("Use JUnit test framework for unit tests", "junit:junit:" + libraryVersionProvider.getVersion("junit"));
+        buildScriptBuilder.testImplementationDependency(
+            "Use JUnit Jupiter for testing.",
+            "org.junit.jupiter:junit-jupiter:" + libraryVersionProvider.getVersion("junit-jupiter")
+        );
     }
 
     @Override

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmGradlePluginProjectInitDescriptor.java
@@ -68,13 +68,13 @@ public abstract class JvmGradlePluginProjectInitDescriptor extends LanguageLibra
         BuildScriptBuilder.Expression functionalTest = buildScriptBuilder.taskRegistration("Add a task to run the functional tests", "functionalTest", "Test", b -> {
             b.propertyAssignment(null, "testClassesDirs", buildScriptBuilder.propertyExpression(functionalTestSourceSet, "output.classesDirs"), true);
             b.propertyAssignment(null, "classpath", buildScriptBuilder.propertyExpression(functionalTestSourceSet, "runtimeClasspath"), true);
-            if(getTestFrameworks().contains(BuildInitTestFramework.SPOCK)) {
+            if(getTestFrameworks().contains(BuildInitTestFramework.SPOCK) || getTestFrameworks().contains(BuildInitTestFramework.JUNIT_JUPITER)) {
                 b.methodInvocation(null, "useJUnitPlatform");
             }
         });
         buildScriptBuilder.taskMethodInvocation("Run the functional tests as part of `check`", "check", "Task", "dependsOn", functionalTest);
-        if(getTestFrameworks().contains(BuildInitTestFramework.SPOCK)) {
-            buildScriptBuilder.taskMethodInvocation("Use junit platform for unit tests.", "test", "Test", "useJUnitPlatform");
+        if(getTestFrameworks().contains(BuildInitTestFramework.SPOCK) || getTestFrameworks().contains(BuildInitTestFramework.JUNIT_JUPITER)) {
+            buildScriptBuilder.taskMethodInvocation("Use JUnit Platform for unit tests.", "test", "Test", "useJUnitPlatform");
         }
     }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
@@ -224,8 +224,8 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
                         "org.spockframework:spock-core:" + libraryVersionProvider.getVersion("spock"),
                         "junit:junit:" + libraryVersionProvider.getVersion("junit"))
                     .taskMethodInvocation(
-                "Use junit platform for unit tests.",
-                "test", "Test", "useJUnitPlatform");
+                        "Use JUnit Platform for unit tests.",
+                        "test", "Test", "useJUnitPlatform");
                 break;
             case TESTNG:
                 buildScriptBuilder
@@ -239,15 +239,11 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
             case JUNIT_JUPITER:
                 buildScriptBuilder
                     .testImplementationDependency(
-                        "Use JUnit Jupiter API for testing.",
-                        "org.junit.jupiter:junit-jupiter-api:" + libraryVersionProvider.getVersion("junit-jupiter")
-                    ).testRuntimeOnlyDependency(
-                    "Use JUnit Jupiter Engine for testing.",
-                    "org.junit.jupiter:junit-jupiter-engine"
-                ).taskMethodInvocation(
-                    "Use junit platform for unit tests.",
-                    "test", "Test", "useJUnitPlatform"
-                );
+                        "Use JUnit Jupiter for testing.",
+                        "org.junit.jupiter:junit-jupiter:" + libraryVersionProvider.getVersion("junit-jupiter"))
+                    .taskMethodInvocation(
+                        "Use JUnit Platform for unit tests.",
+                        "test", "Test", "useJUnitPlatform");
                 break;
             case SCALATEST:
                 String scalaVersion = libraryVersionProvider.getVersion("scala");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/model/Description.java
@@ -36,7 +36,7 @@ import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFrame
 public class Description {
     public final static Description JAVA = new Description(
         Language.JAVA,
-        JUNIT,
+        JUNIT_JUPITER,
         Arrays.asList(JUNIT, JUNIT_JUPITER, TESTNG, SPOCK),
         null, null
     );

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/AppTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/AppTest.java.template
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class AppTest {
-    @Test public void testAppHasAGreeting() {
+    @Test public void appHasAGreeting() {
         App classUnderTest = new App();
         assertNotNull("app should have a greeting", classUnderTest.getGreeting());
     }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/multi/app/junit5/MessageUtilsTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/multi/app/junit5/MessageUtilsTest.java.template
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MessageUtilsTest {
-    @Test public void testGetMessage() {
+class MessageUtilsTest {
+    @Test void testGetMessage() {
         assertEquals("Hello      World!", MessageUtils.getMessage());
     }
 }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/multi/list/junit5/LinkedListTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javaapplication/multi/list/junit5/LinkedListTest.java.template
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class LinkedListTest {
-    @Test public void testConstructor() {
+class LinkedListTest {
+    @Test void testConstructor() {
         LinkedList list = new LinkedList();
         assertEquals(0, list.size());
     }
 
-    @Test public void testAdd() {
+    @Test void testAdd() {
         LinkedList list = new LinkedList();
 
         list.add("one");
@@ -24,7 +24,7 @@ public class LinkedListTest {
         assertEquals("two", list.get(1));
     }
 
-    @Test public void testRemove() {
+    @Test void testRemove() {
         LinkedList list = new LinkedList();
 
         list.add("one");

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/LibraryTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/LibraryTest.java.template
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class LibraryTest {
-    @Test public void testSomeLibraryMethod() {
+    @Test public void someLibraryMethodReturnsTrue() {
         Library classUnderTest = new Library();
         assertTrue("someLibraryMethod should return 'true'", classUnderTest.someLibraryMethod());
     }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/junitjupiter/LibraryTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/javalibrary/junitjupiter/LibraryTest.java.template
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class LibraryTest {
-    @Test void testSomeLibraryMethod() {
+    @Test void someLibraryMethodReturnsTrue() {
         Library classUnderTest = new Library();
         assertTrue(classUnderTest.someLibraryMethod(), "someLibraryMethod should return 'true'");
     }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinapplication/AppTest.kt.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinapplication/AppTest.kt.template
@@ -6,7 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 
 class AppTest {
-    @Test fun testAppHasAGreeting() {
+    @Test fun appHasAGreeting() {
         val classUnderTest = App()
         assertNotNull(classUnderTest.greeting, "app should have a greeting")
     }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinlibrary/LibraryTest.kt.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/kotlinlibrary/LibraryTest.kt.template
@@ -6,7 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class LibraryTest {
-    @Test fun testSomeLibraryMethod() {
+    @Test fun someLibraryMethodReturnsTrue() {
         val classUnderTest = Library()
         assertTrue(classUnderTest.someLibraryMethod(), "someLibraryMethod should return 'true'")
     }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
@@ -15,8 +15,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * A simple functional test for the '${pluginId.value}' plugin.
  */
-public class ${className.javaIdentifier} {
-    @Test public void canRunTask() throws IOException {
+class ${className.javaIdentifier} {
+    @Test void canRunTask() throws IOException {
         // Setup the test build
         File projectDir = new File("build/functionalTest");
         Files.createDirectories(projectDir.toPath());

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
@@ -9,8 +9,8 @@ import java.io.FileWriter;
 import java.nio.file.Files;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.BuildResult;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A simple functional test for the '${pluginId.value}' plugin.

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginTest.java.template
@@ -4,8 +4,8 @@
 ${packageDecl.javaStatement}
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.api.Project;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A simple unit test for the '${pluginId.value}' plugin.

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginTest.java.template
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * A simple unit test for the '${pluginId.value}' plugin.
  */
-public class ${className.javaIdentifier} {
-    @Test public void pluginRegistersATask() {
+class ${className.javaIdentifier} {
+    @Test void pluginRegistersATask() {
         // Create a test project and apply the plugin
         Project project = ProjectBuilder.builder().build();
         project.getPlugins().apply("${pluginId.value}");


### PR DESCRIPTION
### Context

Make JUnit Jupiter the default choice when generating a Java library project and use it when generating a Gradle plugin project in Java. Please see individual commits for details about additional cleanup steps.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
