### PR TITLE
Let instrumenting transformer use the cross version file locking protocol

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -111,7 +111,7 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
     private FileLock exclusiveLockFor(File file) {
         return fileLockManager.lock(
             file,
-            mode(FileLockManager.LockMode.Exclusive),
+            mode(FileLockManager.LockMode.Exclusive).useCrossVersionImplementation(),
             "instrumented jar cache"
         );
     }


### PR DESCRIPTION
As most (if not all) flaky test failures seem to happen when running the cross version tests.