### PR TITLE
More reorganization of build tree lifecycle 

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
@@ -48,7 +48,7 @@ public class CompositeBuildClassPathInitializer implements ScriptClassPathInitia
         }
         if (found) {
             List<Throwable> taskFailures = new ArrayList<>();
-            includedBuildTaskGraph.awaitTaskCompletion(taskFailures);
+            includedBuildTaskGraph.awaitTaskCompletion(taskFailures::add);
             if (!taskFailures.isEmpty()) {
                 throw new MultipleBuildFailures(taskFailures);
             }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -219,10 +219,6 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
         gradleLauncher.scheduleTasks(tasks);
     }
 
-    protected final GradleLauncher getGradleLauncher() {
-        return gradleLauncher;
-    }
-
     protected GradleInternal getGradle() {
         return gradleLauncher.getGradle();
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
@@ -29,7 +29,6 @@ import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -89,7 +88,7 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
     }
 
     @Override
-    public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
+    public void awaitTaskCompletion(Consumer<? super Throwable> taskFailures) {
         for (IncludedBuildController buildController : buildControllers.values()) {
             buildController.awaitTaskCompletion(taskFailures);
         }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.CompositeBuildParticipantBuildState;
 
-import java.util.Collection;
+import java.util.function.Consumer;
 
 
 public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
@@ -54,7 +54,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
     }
 
     @Override
-    public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
+    public void awaitTaskCompletion(Consumer<? super Throwable> taskFailures) {
         // Start task execution if necessary: this is required for building plugin artifacts,
         // since these are built on-demand prior to the regular start signal for included builds.
         includedBuilds.populateTaskGraphs();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -76,11 +76,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         IncludedBuildControllers controllers = gradleLauncher.getGradle().getServices().get(IncludedBuildControllers.class);
         IncludedBuildControllers noFinishController = new DoNoFinishIncludedBuildControllers(controllers);
         GradleBuildController buildController = new GradleBuildController(gradleLauncher, noFinishController);
-        try {
-            return buildAction.apply(buildController);
-        } finally {
-            buildController.stop();
-        }
+        return buildAction.apply(buildController);
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
@@ -105,7 +106,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
 
     @Override
     public File getBuildRootDir() {
-        return gradleLauncher.getBuildRootDir();
+        return gradleLauncher.getGradle().getServices().get(BuildLayout.class).getRootDirectory();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -32,7 +32,6 @@ import org.gradle.internal.invocation.GradleBuildController;
 import org.gradle.util.Path;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -137,7 +136,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         }
 
         @Override
-        public void awaitTaskCompletion(Collection<? super Throwable> taskFailures) {
+        public void awaitTaskCompletion(Consumer<? super Throwable> taskFailures) {
             controllers.awaitTaskCompletion(taskFailures);
         }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -79,8 +79,8 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
 
     @Override
     public <T> T run(Function<? super BuildController, T> action) {
-        GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         RootBuildLifecycleListener buildLifecycleListener = listenerManager.getBroadcaster(RootBuildLifecycleListener.class);
+        GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         GradleInternal gradle = buildController.getGradle();
         buildLifecycleListener.afterStart(gradle);
         try {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -27,6 +27,7 @@ import org.gradle.initialization.GradleLauncherFactory;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RootBuildLifecycleListener;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.concurrent.Stoppable;
@@ -68,7 +69,7 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
 
     @Override
     public File getBuildRootDir() {
-        return gradleLauncher.getBuildRootDir();
+        return gradleLauncher.getGradle().getServices().get(BuildLayout.class).getRootDirectory();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
 import org.gradle.initialization.RunNestedBuildBuildOperationType;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.build.AbstractBuildState;
 import org.gradle.internal.build.BuildState;
@@ -102,7 +103,7 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
 
     @Override
     public File getBuildRootDir() {
-        return gradleLauncher.getBuildRootDir();
+        return gradleLauncher.getGradle().getServices().get(BuildLayout.class).getRootDirectory();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -108,8 +108,8 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
 
     @Override
     public <T> T run(Function<? super BuildController, T> action) {
-        final GradleBuildController buildController = new GradleBuildController(gradleLauncher);
         try {
+            final GradleBuildController buildController = new GradleBuildController(gradleLauncher);
             final GradleInternal gradle = gradleLauncher.getGradle();
             BuildOperationExecutor executor = gradle.getServices().get(BuildOperationExecutor.class);
             return executor.call(new CallableBuildOperation<T>() {
@@ -139,7 +139,7 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
                 }
             });
         } finally {
-            buildController.stop();
+            gradleLauncher.stop();
         }
     }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -76,7 +76,6 @@ class DefaultNestedBuildTest extends Specification {
         1 * action.apply(!null) >> { BuildController controller ->
             '<result>'
         }
-        1 * launcher.stop()
     }
 
     def "can have null result"() {
@@ -90,6 +89,5 @@ class DefaultNestedBuildTest extends Specification {
         1 * action.apply(!null) >> { BuildController controller ->
             return null
         }
-        1 * launcher.stop()
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -70,6 +70,7 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheHost::class.java)
             add(ConfigurationCacheIO::class.java)
             add(DefaultConfigurationCache::class.java)
+            add(DefaultBuildModelControllerFactory::class.java)
         }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerFactory.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.configuration.ProjectsPreparer
+import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
+import org.gradle.initialization.BuildModelController
+import org.gradle.initialization.BuildModelControllerFactory
+import org.gradle.initialization.ConfigurationCache
+import org.gradle.initialization.ConfigurationCacheAwareBuildModelController
+import org.gradle.initialization.SettingsPreparer
+import org.gradle.initialization.TaskExecutionPreparer
+import org.gradle.initialization.VintageBuildModelController
+
+
+class DefaultBuildModelControllerFactory(
+    val startParameter: ConfigurationCacheStartParameter,
+    val projectsPreparer: ProjectsPreparer,
+    val settingsPreparer: SettingsPreparer,
+    val taskExecutionPreparer: TaskExecutionPreparer,
+    val configurationCache: ConfigurationCache
+) : BuildModelControllerFactory {
+    override fun create(gradle: GradleInternal): BuildModelController {
+        val vintageController = VintageBuildModelController(gradle, projectsPreparer, settingsPreparer, taskExecutionPreparer)
+        return if (startParameter.isEnabled) {
+            ConfigurationCacheAwareBuildModelController(gradle, vintageController, configurationCache)
+        } else {
+            vintageController
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildController.java
@@ -17,7 +17,7 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.internal.TaskInternal;
 
-import java.util.Collection;
+import java.util.function.Consumer;
 
 public interface IncludedBuildController {
     void queueForExecution(String taskPath);
@@ -33,5 +33,5 @@ public interface IncludedBuildController {
     /**
      * Awaits completion of task execution, collecting any task failures into the given collection.
      */
-    void awaitTaskCompletion(Collection<? super Throwable> taskFailures);
+    void awaitTaskCompletion(Consumer<? super Throwable> taskFailures);
 }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildControllers.java
@@ -19,7 +19,6 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import java.util.Collection;
 import java.util.function.Consumer;
 
 @ServiceScope(Scopes.BuildTree.class)
@@ -43,7 +42,7 @@ public interface IncludedBuildControllers {
     /**
      * Blocks until all scheduled tasks have completed.
      */
-    void awaitTaskCompletion(Collection<? super Throwable> taskFailures);
+    void awaitTaskCompletion(Consumer<? super Throwable> taskFailures);
 
     /**
      * Completes the build, blocking until complete.

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskGraph.java
@@ -21,7 +21,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-import java.util.Collection;
+import java.util.function.Consumer;
 
 @ServiceScope(Scopes.BuildTree.class)
 public interface IncludedBuildTaskGraph {
@@ -30,7 +30,7 @@ public interface IncludedBuildTaskGraph {
     /**
      * Awaits completion of task execution, collecting any task failures into the given collection.
      */
-    void awaitTaskCompletion(Collection<? super Throwable> taskFailures);
+    void awaitTaskCompletion(Consumer<? super Throwable> taskFailures);
 
     IncludedBuildTaskResource.State getTaskState(BuildIdentifier targetBuild, String taskPath);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildModelController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+
+/**
+ * Transitions the build model through its lifecycle.
+ */
+public interface BuildModelController {
+    /**
+     * Ensures the build's settings object has been configured.
+     *
+     * @return The settings.
+     */
+    SettingsInternal getLoadedSettings();
+
+    /**
+     * Ensures the build's projects have been configured.
+     *
+     * @return The gradle instance.
+     */
+    GradleInternal getConfiguredModel();
+
+    /**
+     * Schedules the given tasks. May configure the build, if required.
+     */
+    void scheduleTasks(Iterable<String> tasks);
+
+    /**
+     * Schedules the user requested tasks for this build. May configure the build, if required.
+     */
+    void scheduleRequestedTasks();
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildModelController.java
@@ -20,7 +20,8 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 
 /**
- * Transitions the build model through its lifecycle.
+ * Transitions the model of an individual build in the build tree through its lifecycle.
+ * See {@link org.gradle.internal.invocation.BuildController}
  */
 public interface BuildModelController {
     /**

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildModelControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildModelControllerFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scopes.Gradle.class)
+public interface BuildModelControllerFactory {
+    /**
+     * Creates the {@link BuildModelController} for the given build model instance.
+     */
+    BuildModelController create(GradleInternal gradle);
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/ConfigurationCache.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ConfigurationCache.java
@@ -16,6 +16,11 @@
 
 package org.gradle.initialization;
 
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+
+@ServiceScope(Scopes.Gradle.class)
 public interface ConfigurationCache {
 
     boolean canLoad();

--- a/subprojects/core/src/main/java/org/gradle/initialization/ConfigurationCacheAwareBuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ConfigurationCacheAwareBuildModelController.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+
+public class ConfigurationCacheAwareBuildModelController implements BuildModelController {
+    private enum State {
+        Created, Loaded, DoNotReuse
+    }
+
+    private final GradleInternal model;
+    private final BuildModelController delegate;
+    private final ConfigurationCache configurationCache;
+    private State state = State.Created;
+
+    public ConfigurationCacheAwareBuildModelController(GradleInternal model, BuildModelController delegate, ConfigurationCache configurationCache) {
+        this.model = model;
+        this.delegate = delegate;
+        this.configurationCache = configurationCache;
+    }
+
+    @Override
+    public SettingsInternal getLoadedSettings() {
+        if (maybeLoadFromCache()) {
+            return model.getSettings();
+        } else {
+            return delegate.getLoadedSettings();
+        }
+    }
+
+    @Override
+    public GradleInternal getConfiguredModel() {
+        if (maybeLoadFromCache()) {
+            throw new IllegalStateException("Cannot query configured model when model has been loaded from configuration cache.");
+        } else {
+            return delegate.getConfiguredModel();
+        }
+    }
+
+    @Override
+    public void scheduleTasks(Iterable<String> tasks) {
+        if (maybeLoadFromCache()) {
+            throw new IllegalStateException("Cannot schedule specific tasks when model has been loaded from configuration cache.");
+        } else {
+            delegate.scheduleTasks(tasks);
+        }
+    }
+
+    @Override
+    public void scheduleRequestedTasks() {
+        if (!maybeLoadFromCache()) {
+            delegate.scheduleRequestedTasks();
+            configurationCache.save();
+        } // Else, already scheduled
+    }
+
+    private boolean maybeLoadFromCache() {
+        synchronized (this) {
+            switch (state) {
+                case Created:
+                    if (configurationCache.canLoad()) {
+                        configurationCache.load();
+                        state = State.Loaded;
+                        return true;
+                    } else {
+                        configurationCache.prepareForConfiguration();
+                        state = State.DoNotReuse;
+                        return false;
+                    }
+                case Loaded:
+                    return true;
+                case DoNotReuse:
+                    return false;
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -24,12 +24,10 @@ import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.internal.InternalBuildFinishedListener;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -98,11 +96,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
     @Override
     public GradleInternal getGradle() {
         return gradle;
-    }
-
-    @Override
-    public File getBuildRootDir() {
-        return buildServices.get(BuildLayout.class).getRootDirectory();
     }
 
     @Override
@@ -220,7 +213,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
     private void prepareTaskExecution() {
         if (stage == Stage.Configure) {
             taskExecutionPreparer.prepareForTaskExecution(gradle);
-
             stage = Stage.TaskGraph;
         }
     }
@@ -231,10 +223,6 @@ public class DefaultGradleLauncher implements GradleLauncher {
         if (!added) {
             return;
         }
-        reevaluateTaskGraph();
-    }
-
-    private void reevaluateTaskGraph() {
         // Force back to configure so that task graph will get reevaluated
         stage = Stage.Configure;
         doBuildStages(Stage.TaskGraph);

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -19,7 +19,6 @@ import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.configuration.ProjectsPreparer;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.MultipleBuildFailures;
 import org.gradle.initialization.exception.ExceptionAnalyser;
@@ -63,7 +62,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
 
     public DefaultGradleLauncher(
         GradleInternal gradle,
-        ProjectsPreparer projectsPreparer,
+        BuildModelController buildModelController,
         ExceptionAnalyser exceptionAnalyser,
         BuildListener buildListener,
         BuildCompletionListener buildCompletionListener,
@@ -71,15 +70,10 @@ public class DefaultGradleLauncher implements GradleLauncher {
         BuildWorkExecutor buildExecuter,
         BuildScopeServices buildServices,
         List<?> servicesToStop,
-        SettingsPreparer settingsPreparer,
-        TaskExecutionPreparer taskExecutionPreparer,
-        ConfigurationCache configurationCache,
         BuildOptionBuildOperationProgressEventsEmitter buildOptionBuildOperationProgressEventsEmitter
     ) {
         this.gradle = gradle;
-        this.modelController = new ConfigurationCacheAwareBuildModelController(gradle,
-            new VintageBuildModelController(gradle, projectsPreparer, settingsPreparer, taskExecutionPreparer),
-            configurationCache);
+        this.modelController = buildModelController;
         this.exceptionAnalyser = exceptionAnalyser;
         this.buildListener = buildListener;
         this.buildExecuter = buildExecuter;

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -17,11 +17,9 @@ package org.gradle.initialization;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.concurrent.Stoppable;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.function.Consumer;
 
 /**
@@ -44,13 +42,6 @@ public interface GradleLauncher extends Stoppable {
      * @return The configured Gradle build instance.
      */
     GradleInternal getConfiguredBuild();
-
-    /**
-     * The root directory of the build, never null.
-     *
-     * @see BuildLayout#getRootDirectory()
-     */
-    File getBuildRootDir();
 
     /**
      * Schedules the specified tasks for this build.

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -30,7 +30,7 @@ public interface GradleLauncher extends Stoppable {
     GradleInternal getGradle();
 
     /**
-     * Evaluates the settings for this build, if not already available.
+     * Configures the settings for this build, if not already available.
      *
      * @return The loaded settings instance.
      */
@@ -44,17 +44,17 @@ public interface GradleLauncher extends Stoppable {
     GradleInternal getConfiguredBuild();
 
     /**
-     * Schedules the specified tasks for this build.
+     * Schedules the specified tasks for this build. Configures the build, if necessary.
      */
     void scheduleTasks(final Iterable<String> tasks);
 
     /**
-     * Schedule requested tasks.
+     * Schedule requested tasks, as defined in the {@link org.gradle.StartParameter} for this build. Configures the build, if necessary.
      */
     void scheduleRequestedTasks();
 
     /**
-     * Executes the tasks scheduled for this build.
+     * Executes the tasks scheduled for this build. Does not automatically configure the build or schedule any tasks.
      */
     void executeTasks();
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -59,7 +59,7 @@ public interface GradleLauncher extends Stoppable {
     void executeTasks();
 
     /**
-     * Stops task execution threads and calls the `buildFinished` hooks and other user code clean up.
+     * Calls the `buildFinished` hooks and other user code clean up.
      * Failures to finish the build are passed to the given consumer rather than thrown.
      *
      * @param failure The build failure that should be reported to the buildFinished hooks. When null, this launcher may use whatever failure it has already collected.

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncherFactory.java
@@ -18,6 +18,8 @@ package org.gradle.initialization;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildTreeState;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 /**
  * <p>A {@code GradleLauncherFactory} is responsible for creating a {@link GradleLauncher} instance for a root build.
@@ -26,6 +28,7 @@ import org.gradle.internal.buildtree.BuildTreeState;
  *
  * Note: you should be using {@link org.gradle.internal.build.BuildStateRegistry} instead of this interface to create builds.
  */
+@ServiceScope(Scopes.BuildSession.class)
 public interface GradleLauncherFactory {
     GradleLauncher newInstance(BuildDefinition buildDefinition, RootBuildState build, BuildTreeState owner);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/VintageBuildModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/VintageBuildModelController.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.configuration.ProjectsPreparer;
+
+public class VintageBuildModelController implements BuildModelController {
+    private enum Stage {
+        Created, LoadSettings, Configure, TaskGraph
+    }
+
+    private final ProjectsPreparer projectsPreparer;
+    private final GradleInternal gradle;
+    private final SettingsPreparer settingsPreparer;
+    private final TaskExecutionPreparer taskExecutionPreparer;
+
+    private Stage stage = Stage.Created;
+
+    public VintageBuildModelController(
+        GradleInternal gradle,
+        ProjectsPreparer projectsPreparer,
+        SettingsPreparer settingsPreparer,
+        TaskExecutionPreparer taskExecutionPreparer
+    ) {
+        this.gradle = gradle;
+        this.projectsPreparer = projectsPreparer;
+        this.settingsPreparer = settingsPreparer;
+        this.taskExecutionPreparer = taskExecutionPreparer;
+    }
+
+    @Override
+    public SettingsInternal getLoadedSettings() {
+        doBuildStages(Stage.LoadSettings);
+        return gradle.getSettings();
+    }
+
+    @Override
+    public GradleInternal getConfiguredModel() {
+        doBuildStages(Stage.Configure);
+        return gradle;
+    }
+
+    @Override
+    public void scheduleRequestedTasks() {
+        doBuildStages(Stage.TaskGraph);
+    }
+
+    private void doBuildStages(Stage upTo) {
+        prepareSettings();
+        if (upTo == Stage.LoadSettings) {
+            return;
+        }
+        prepareProjects();
+        if (upTo == Stage.Configure) {
+            return;
+        }
+        prepareTaskExecution();
+    }
+
+    private void prepareSettings() {
+        if (stage == Stage.Created) {
+            settingsPreparer.prepareSettings(gradle);
+            stage = Stage.LoadSettings;
+        }
+    }
+
+    private void prepareProjects() {
+        if (stage == Stage.LoadSettings) {
+            projectsPreparer.prepareProjects(gradle);
+            stage = Stage.Configure;
+        }
+    }
+
+    private void prepareTaskExecution() {
+        if (stage == Stage.Configure) {
+            taskExecutionPreparer.prepareForTaskExecution(gradle);
+            stage = Stage.TaskGraph;
+        }
+    }
+
+    @Override
+    public void scheduleTasks(final Iterable<String> taskPaths) {
+        boolean added = getConfiguredModel().getStartParameter().addTaskNames(taskPaths);
+        if (!added) {
+            return;
+        }
+        // Force back to configure so that task graph will get reevaluated
+        stage = Stage.Configure;
+        doBuildStages(Stage.TaskGraph);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
@@ -17,9 +17,12 @@
 package org.gradle.internal.invocation;
 
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
+
+import java.util.function.Function;
 
 /**
- * This is intended to eventually replace {@link org.gradle.initialization.GradleLauncher} internally. It's pretty rough at the moment.
+ * Controls the lifecycle of a build, allowing a single action to be run against the build.
  */
 public interface BuildController {
 
@@ -27,6 +30,12 @@ public interface BuildController {
      * @return The {@link org.gradle.api.internal.GradleInternal} object that represents the build invocation.
      */
     GradleInternal getGradle();
+
+    /**
+     * Runs the given action against an empty build model. Does not attempt to perform any configuration or run any tasks.
+     * When this method returns, all user code will have completed, including 'build finished' hooks.
+     */
+    <T> T withEmptyBuild(Function<SettingsInternal, T> action);
 
     /**
      * Creates the task graph for the tasks specified in the {@link org.gradle.StartParameter} associated with the build, runs the tasks and finishes up the build.

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/BuildController.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.SettingsInternal;
 import java.util.function.Function;
 
 /**
- * Controls the lifecycle of a build, allowing a single action to be run against the build.
+ * Controls the lifecycle of the build tree, allowing a single action to be run against the root build.
  */
 public interface BuildController {
 

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -20,7 +20,6 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.exception.ExceptionAnalyser;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.ArrayList;
@@ -29,7 +28,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class GradleBuildController implements BuildController, Stoppable {
+public class GradleBuildController implements BuildController {
     private enum State {Created, Running, Completed}
 
     private State state = State.Created;
@@ -124,11 +123,6 @@ public class GradleBuildController implements BuildController, Stoppable {
         } finally {
             state = State.Completed;
         }
-    }
-
-    @Override
-    public void stop() {
-        gradleLauncher.stop();
     }
 
     private interface BuildAction<T> {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -71,6 +71,17 @@ class DefaultGradleLauncherSpec extends Specification {
             settingsPreparerMock, taskExecutionPreparerMock, configurationCache, Mock(BuildOptionBuildOperationProgressEventsEmitter))
     }
 
+    void testCanFinishBuildWhenNothingHasBeenDone() {
+        def gradleLauncher = launcher()
+
+        when:
+        gradleLauncher.finishBuild(null, consumer)
+
+        then:
+        0 * buildBroadcaster._
+        0 * consumer._
+    }
+
     void testScheduleAndRunRequestedTasks() {
         expect:
         isRootBuild()
@@ -97,6 +108,22 @@ class DefaultGradleLauncherSpec extends Specification {
         DefaultGradleLauncher gradleLauncher = launcher()
         gradleLauncher.scheduleRequestedTasks()
         gradleLauncher.executeTasks()
+        gradleLauncher.finishBuild(null, consumer)
+    }
+
+    void testGetLoadedSettings() {
+        when:
+        isRootBuild()
+        expectSettingsBuilt()
+
+        DefaultGradleLauncher gradleLauncher = launcher()
+        def result = gradleLauncher.getLoadedSettings()
+
+        then:
+        result == settingsMock
+
+        expect:
+        expectBuildFinished("Configure")
         gradleLauncher.finishBuild(null, consumer)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherTest.groovy
@@ -19,10 +19,8 @@ package org.gradle.initialization
 import org.gradle.BuildListener
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
-import org.gradle.configuration.ProjectsPreparer
 import org.gradle.execution.BuildWorkExecutor
 import org.gradle.execution.MultipleBuildFailures
-import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.initialization.exception.ExceptionAnalyser
 import org.gradle.initialization.internal.InternalBuildFinishedListener
 import org.gradle.internal.concurrent.Stoppable
@@ -34,23 +32,19 @@ import java.util.function.Consumer
 
 import static org.gradle.util.Path.path
 
-class DefaultGradleLauncherSpec extends Specification {
-    def settingsPreparerMock = Mock(SettingsPreparer)
-    def taskExecutionPreparerMock = Mock(TaskExecutionPreparer)
-    def taskGraphMock = Mock(TaskExecutionGraphInternal)
-    def buildConfigurerMock = Mock(ProjectsPreparer)
+class DefaultGradleLauncherTest extends Specification {
     def buildBroadcaster = Mock(BuildListener)
     def buildExecuter = Mock(BuildWorkExecutor)
 
     def settingsMock = Mock(SettingsInternal.class)
     def gradleMock = Mock(GradleInternal.class)
 
-    def exceptionAnalyserMock = Mock(ExceptionAnalyser)
+    def buildModelController = Mock(BuildModelController)
+    def exceptionAnalyser = Mock(ExceptionAnalyser)
     def buildCompletionListener = Mock(BuildCompletionListener.class)
     def buildFinishedListener = Mock(InternalBuildFinishedListener.class)
     def buildServices = Mock(BuildScopeServices.class)
     def otherService = Mock(Stoppable)
-    def configurationCache = Mock(ConfigurationCache)
     def consumer = Mock(Consumer)
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
 
@@ -58,17 +52,13 @@ class DefaultGradleLauncherSpec extends Specification {
     def transformedException = new RuntimeException("transformed")
 
     def setup() {
-        _ * exceptionAnalyserMock.transform(failure) >> transformedException
-
-        _ * gradleMock.taskGraph >> taskGraphMock
-        _ * gradleMock.settings >> settingsMock
-        _ * gradleMock.buildListenerBroadcaster >> buildBroadcaster
+        _ * exceptionAnalyser.transform(failure) >> transformedException
     }
 
     DefaultGradleLauncher launcher() {
-        return new DefaultGradleLauncher(gradleMock, buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
+        return new DefaultGradleLauncher(gradleMock, buildModelController, exceptionAnalyser, buildBroadcaster,
             buildCompletionListener, buildFinishedListener, buildExecuter, buildServices, [otherService],
-            settingsPreparerMock, taskExecutionPreparerMock, configurationCache, Mock(BuildOptionBuildOperationProgressEventsEmitter))
+            Mock(BuildOptionBuildOperationProgressEventsEmitter))
     }
 
     void testCanFinishBuildWhenNothingHasBeenDone() {
@@ -85,7 +75,6 @@ class DefaultGradleLauncherSpec extends Specification {
     void testScheduleAndRunRequestedTasks() {
         expect:
         isRootBuild()
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
         expectBuildFinished()
@@ -100,7 +89,6 @@ class DefaultGradleLauncherSpec extends Specification {
         expect:
         isNestedBuild()
 
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
         expectBuildFinished()
@@ -134,8 +122,8 @@ class DefaultGradleLauncherSpec extends Specification {
         isRootBuild()
 
         and:
-        1 * settingsPreparerMock.prepareSettings(gradleMock) >> { throw failure }
-        1 * exceptionAnalyserMock.transform({ it == failure }) >> transformedException
+        1 * buildModelController.loadedSettings >> { throw failure }
+        1 * exceptionAnalyser.transform({ it == failure }) >> transformedException
 
         DefaultGradleLauncher gradleLauncher = launcher()
         gradleLauncher.getLoadedSettings()
@@ -155,10 +143,9 @@ class DefaultGradleLauncherSpec extends Specification {
     void testGetConfiguredBuild() {
         when:
         isRootBuild()
-        expectSettingsBuilt()
 
         and:
-        1 * buildConfigurerMock.prepareProjects(gradleMock)
+        1 * buildModelController.configuredModel >> gradleMock
 
         DefaultGradleLauncher gradleLauncher = launcher()
         def result = gradleLauncher.getConfiguredBuild()
@@ -176,11 +163,10 @@ class DefaultGradleLauncherSpec extends Specification {
 
         when:
         isRootBuild()
-        expectSettingsBuilt()
 
         and:
-        1 * buildConfigurerMock.prepareProjects(gradleMock) >> { throw failure }
-        1 * exceptionAnalyserMock.transform({ it == failure }) >> transformedException
+        1 * buildModelController.configuredModel >> { throw failure }
+        1 * exceptionAnalyser.transform({ it == failure }) >> transformedException
 
         DefaultGradleLauncher gradleLauncher = launcher()
         gradleLauncher.getConfiguredBuild()
@@ -219,7 +205,7 @@ class DefaultGradleLauncherSpec extends Specification {
         isRootBuild()
 
         and:
-        1 * settingsPreparerMock.prepareSettings(gradleMock) >> { throw failure }
+        1 * buildModelController.scheduleRequestedTasks() >> { throw failure }
 
         when:
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -240,12 +226,11 @@ class DefaultGradleLauncherSpec extends Specification {
     void testNotifiesListenerOnTaskExecutionFailure() {
         given:
         isRootBuild()
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure)
 
         and:
-        1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.cause == failure }) >> transformedException
+        1 * exceptionAnalyser.transform({ it instanceof MultipleBuildFailures && it.cause == failure }) >> transformedException
 
         when:
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -269,12 +254,11 @@ class DefaultGradleLauncherSpec extends Specification {
 
         given:
         isRootBuild()
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure, failure2)
 
         and:
-        1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
+        1 * exceptionAnalyser.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
 
         when:
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -298,7 +282,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         given:
         isRootBuild()
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRun()
 
@@ -322,12 +305,11 @@ class DefaultGradleLauncherSpec extends Specification {
 
         given:
         isRootBuild()
-        expectSettingsBuilt()
         expectTaskGraphBuilt()
         expectTasksRunWithFailure(failure, failure2)
 
         and:
-        1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
+        1 * exceptionAnalyser.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
 
         and:
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -372,11 +354,11 @@ class DefaultGradleLauncherSpec extends Specification {
     }
 
     private void expectSettingsBuilt() {
-        1 * settingsPreparerMock.prepareSettings(gradleMock)
+        1 * buildModelController.loadedSettings >> settingsMock
     }
 
     private void expectTaskGraphBuilt() {
-        1 * taskExecutionPreparerMock.prepareForTaskExecution(gradleMock)
+        1 * buildModelController.scheduleRequestedTasks()
     }
 
     private void expectTasksRun() {

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -48,7 +48,6 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.concurrent.CompositeStoppable.stoppable
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.invocation.GradleBuildController
 import org.gradle.internal.resource.TextFileResourceLoader
 import org.gradle.kotlin.dsl.accessors.AccessorFormats
 import org.gradle.kotlin.dsl.accessors.ProjectSchemaProvider
@@ -322,10 +321,8 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
         val projectDir = uniqueTempDirectory()
         val startParameter = projectSchemaBuildStartParameterFor(projectDir)
         return createNestedRootBuild("$path:${projectDir.name}", startParameter, services).run { controller ->
-            require(controller is GradleBuildController)
-            controller.doBuild {
+            controller.withEmptyBuild { settings ->
                 Try.ofFailable {
-                    val settings = controller.launcher.loadedSettings
                     val gradle = settings.gradle
                     val baseScope = coreAndPluginsScopeOf(gradle).createChild("accessors-classpath").apply {
                         // we export the build logic classpath to the base scope here so that all referenced plugins

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -354,8 +354,7 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
 
     private
     fun projectSchemaBuildStartParameterFor(projectDir: File): ProjectSchemaBuildStartParameter =
-        services.get<StartParameter>().let { startParameter ->
-            require(startParameter is StartParameterInternal)
+        services.get<StartParameterInternal>().let { startParameter ->
             ProjectSchemaBuildStartParameter(
                 BuildLayoutParameters(
                     startParameter.gradleHomeDir,


### PR DESCRIPTION

### Context

Some further restructuring, continuing the work from #16724. In this PR, split up the logic that coordinates the lifecycle of each build in the tree into 3 pieces: one that applies the "vintage" lifecycle to a build, one that applies the configuration cache lifecycle to a build, and the remaining pieces that don't care either way. This should make it easier to add additional lifecycles  in the future and to further tease apart the logic which applies to the build tree as a whole from that which applies to a build in the tree.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
