### PR TITLE
Add ApiClassExtractor to configuration hash of AbiExtractingClasspathResourceHasher

### DIFF
--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -89,5 +89,6 @@ public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
     @Override
     public void appendConfigurationToHasher(Hasher hasher) {
         hasher.putString(getClass().getName());
+        extractor.appendConfigurationToHasher(hasher);
     }
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiClassExtractor.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/normalization/java/ApiClassExtractor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.normalization.java;
 
+import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.normalization.java.impl.ApiMemberSelector;
 import org.gradle.internal.normalization.java.impl.ApiMemberWriter;
 import org.gradle.internal.normalization.java.impl.MethodStubbingApiMemberAdapter;
@@ -84,6 +85,13 @@ public class ApiClassExtractor {
             return Optional.empty();
         }
         return Optional.of(apiClassWriter.toByteArray());
+    }
+
+    public void appendConfigurationToHasher(Hasher hasher) {
+        hasher.putString(getClass().getName());
+        if (exportedPackages != null) {
+            exportedPackages.forEach(hasher::putString);
+        }
     }
 
     private static String packageNameOf(String internalClassName) {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasherTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state
+
+import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.Hashing
+import org.gradle.internal.normalization.java.ApiClassExtractor
+import spock.lang.Specification
+
+class AbiExtractingClasspathResourceHasherTest extends Specification {
+
+    def "api class extractors affect the configuration hash"() {
+        def apiClassExtractor1 = Mock(ApiClassExtractor)
+        def apiClassExtractor2 = Mock(ApiClassExtractor)
+
+        def resourceHasher1 = new AbiExtractingClasspathResourceHasher(apiClassExtractor1)
+        def resourceHasher2 = new AbiExtractingClasspathResourceHasher(apiClassExtractor2)
+
+        when:
+        def configurationHash1 = configurationHashOf(resourceHasher1)
+        def configurationHash2 = configurationHashOf(resourceHasher2)
+
+        then:
+        configurationHash1 != configurationHash2
+
+        1 * apiClassExtractor1.appendConfigurationToHasher(_) >> { args -> args[0].putString("first") }
+        1 * apiClassExtractor2.appendConfigurationToHasher(_) >> { args -> args[0].putString("second") }
+    }
+
+    private static HashCode configurationHashOf(ConfigurableNormalizer normalizer) {
+        def hasher = Hashing.md5().newHasher()
+        normalizer.appendConfigurationToHasher(hasher)
+        return hasher.hash()
+    }
+}


### PR DESCRIPTION
So we can distinguish between hashes of `ApiClassExtractor`
and of `KotlinApiClassExtractor`.

Backport of #16810 to 6.9