### PR TITLE
Report actual test results even if fail-fast stops execution

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternal.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternal.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import org.gradle.api.internal.tasks.testing.results.DefaultTestResult;
 import org.gradle.api.internal.tasks.testing.results.TestListenerInternal;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestResult;
@@ -41,16 +40,7 @@ public class FailFastTestListenerInternal implements TestListenerInternal {
 
     @Override
     public void completed(TestDescriptorInternal testDescriptor, TestResult testResult, TestCompleteEvent completeEvent) {
-        TestResult delegateResult = testResult;
-        if (failed) {
-            if (testDescriptor.isComposite()) {
-                delegateResult = new DefaultTestResult(TestResult.ResultType.FAILURE, testResult.getStartTime(), testResult.getEndTime(), testResult.getTestCount(), testResult.getSuccessfulTestCount(), testResult.getFailedTestCount(), testResult.getExceptions());
-            } else {
-                delegateResult = new DefaultTestResult(TestResult.ResultType.SKIPPED, testResult.getStartTime(), testResult.getEndTime(), testResult.getTestCount(), testResult.getSuccessfulTestCount(), testResult.getFailedTestCount(), testResult.getExceptions());
-            }
-        }
-
-        delegate.completed(testDescriptor, delegateResult, completeEvent);
+        delegate.completed(testDescriptor, testResult, completeEvent);
 
         if (!failed && testResult.getResultType() == TestResult.ResultType.FAILURE) {
             failed = true;

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternalTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/FailFastTestListenerInternalTest.groovy
@@ -79,46 +79,6 @@ class FailFastTestListenerInternalTest extends Specification {
         1 * delegate.completed(testDescriptor, testResult, completeEvent)
 
         where:
-        result << TestResult.ResultType.values()
-    }
-
-    @Unroll
-    def "after failure completed indicates failure on composite for result #result"() {
-        TestResult failedResult = new SimpleTestResult()
-        failedResult.resultType = TestResult.ResultType.FAILURE
-        testDescriptor.composite = true
-        testResult.resultType = result
-
-        given:
-        unit.completed(testDescriptor, failedResult, completeEvent)
-
-        when:
-        unit.completed(testDescriptor, testResult, completeEvent)
-
-        then:
-        1 * delegate.completed(testDescriptor, { it.getResultType() == TestResult.ResultType.FAILURE }, completeEvent)
-
-        where:
-        result << TestResult.ResultType.values()
-    }
-
-    @Unroll
-    def "after failure completed indicates skipped on non-composite for result #result"() {
-        TestResult failedResult = new SimpleTestResult()
-        failedResult.resultType = TestResult.ResultType.FAILURE
-        testDescriptor.composite = false
-        testResult.resultType = result
-
-        given:
-        unit.completed(testDescriptor, failedResult, completeEvent)
-
-        when:
-        unit.completed(testDescriptor, testResult, completeEvent)
-
-        then:
-        1 * delegate.completed(testDescriptor, { it.getResultType() == TestResult.ResultType.SKIPPED }, completeEvent)
-
-        where:
-        result << TestResult.ResultType.values()
+        result << TestResult.ResultType.values().toList()
     }
 }


### PR DESCRIPTION
The intention of using `--fail-fast` on a `Test` task is to stop as soon as possible after the first test failed. This is implemented by calling `TestExecuter.stopNow()` which eventually leads to the forked JVM closing the socket connection. In the meantime, test are still being executed and results are being reported. However, instead of reporting those actual results, `FailFastTestListenerInternal` currently replaces them with skipped/failed results. That can lead to confusing results, e.g. test logging reporting a test as skipped but including an exception which is then no longer present in the resulting HTML report or build scan. In the case of Test Distribution, this problem is even more severe as it currently doesn't support fail-fast. However, even if it did the situation is similar to when using `maxParallelForks` > 1: It takes time to stop all forks/executors. Rather than discarding valid test results, we should report them.

The current logic in `FailFastTestListenerInternal` is unnecessary since `StateTrackingTestResultProcessor` already ensures that all started tests are reported as skipped should they not be completed and that composites with failed children are reported as failed.