### PR TITLE
Fix native tests on Ubuntu 20.04

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppToolChainChangesIntegrationTest.groovy
@@ -129,11 +129,12 @@ class CppToolChainChangesIntegrationTest extends AbstractIntegrationSpec {
         }
         int numberOfToolChains = availableToolChains.size()
         Assume.assumeTrue('2 or more tool chains are required for this test', numberOfToolChains >= 2)
-        (0..<(numberOfToolChains - 1)).collectMany { first ->
-            ((first+1)..<numberOfToolChains).collect { second ->
+        List<List<InstalledToolChain>> result = (0..<(numberOfToolChains - 1)).collectMany { first ->
+            ((first + 1)..<numberOfToolChains).collect { second ->
                 [availableToolChains[first], availableToolChains[second]]
             }
         }
+        // To avoid [gcc, g++] pair because they have same display name
+        return result.findAll { it[0].displayName != it[1].displayName }
     }
-
 }

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -181,7 +181,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_3)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 5 source code on Swift 3 compiler"() {
         given:
         makeSingleProject()
@@ -211,7 +210,6 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     }
 
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
-    @ToBeFixedForConfigurationCache
     def "throws exception with meaningful message when building Swift 5 source code on Swift 4 compiler"() {
         given:
         makeSingleProject()

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
@@ -144,7 +144,7 @@ public class GccMetadataProvider extends AbstractMetadataProvider<GccMetadata> {
                     if (isCygwin) {
                         include = mapCygwinPath(cygpathExe, include);
                     }
-                    builder.add(FileUtils.normalize(new File(include)));
+                    builder.add(FileUtils.normalize(new File(include).toPath().toRealPath().toFile()));
                 }
             }
             return builder.build();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProvider.java
@@ -37,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -144,7 +145,13 @@ public class GccMetadataProvider extends AbstractMetadataProvider<GccMetadata> {
                     if (isCygwin) {
                         include = mapCygwinPath(cygpathExe, include);
                     }
-                    builder.add(FileUtils.normalize(new File(include).toPath().toRealPath().toFile()));
+                    File realPath = new File(include);
+                    try {
+                        realPath = realPath.toPath().toRealPath().toFile();
+                    } catch (NoSuchFileException ignore) {
+                        // resolve the potential symlink, if not found, fallback to do nothing.
+                    }
+                    builder.add(FileUtils.normalize(realPath));
                 }
             }
             return builder.build();

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -160,10 +160,14 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
     // compiling Objective-C and Objective-Cpp with clang generates
     // random different object files (related to ASLR settings)
     // We saw this behaviour only on linux so far.
+    // 2021-4-15: recent GCC also enable ASLR by default:
+    // https://wiki.ubuntu.com/Security/Features
     boolean isObjectiveCWithAslr() {
         return (sourceType == "Objc" || sourceType == "Objcpp") &&
             OperatingSystem.current().isLinux() &&
-            toolChain.displayName.startsWith("clang")
+            (toolChain.displayName.startsWith("clang") ||
+                // GCC 9 or later
+                toolChain.displayName ==~ /gcc (9|\d\d+).*/)
     }
 
     protected void maybeWait() {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentWithTestedComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentWithTestedComponentIntegrationTest.groovy
@@ -32,6 +32,7 @@ import static org.junit.Assume.assumeTrue
 abstract class AbstractSwiftXCTestComponentWithTestedComponentIntegrationTest extends AbstractSwiftXCTestComponentIntegrationTest implements XCTestExecutionResult {
     // TODO: This test can be generalized so it's not opinionated on Swift 4.x but could also work on Swift 5.x
     @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC_4)
+    @ToBeFixedForConfigurationCache
     def "take swift source compatibility from tested component"() {
         given:
         makeSingleProject()


### PR DESCRIPTION
This PR fixes the failing tests on Ubuntu 2004 and new swift/gcc/clang toolchains.