### PR TITLE
Create tmp directory for {Groovy,Java}Compile at execution time

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -28,6 +28,7 @@ import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
 import org.gradle.api.internal.tasks.compile.CompilerForkUtils;
@@ -171,7 +172,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
     @OutputFile
     protected File getSourceClassesMappingFile() {
         if (sourceClassesMappingFile == null) {
-            sourceClassesMappingFile = new File(getTemporaryDir(), "source-classes-mapping.txt");
+            sourceClassesMappingFile = new File(getTemporaryDirWithoutCreating(), "source-classes-mapping.txt");
         }
         return sourceClassesMappingFile;
     }
@@ -184,7 +185,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
     @OutputFile
     protected File getPreviousCompilationData() {
         if (previousCompilationDataFile == null) {
-            previousCompilationDataFile = new File(getTemporaryDir(), "previous-compilation-data.bin");
+            previousCompilationDataFile = new File(getTemporaryDirWithoutCreating(), "previous-compilation-data.bin");
         }
         return previousCompilationDataFile;
     }
@@ -451,5 +452,10 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
     @Inject
     protected FeaturePreviews getFeaturePreviews() {
         throw new UnsupportedOperationException();
+    }
+
+    private File getTemporaryDirWithoutCreating() {
+        // Do not create the temporary folder, since that causes problems.
+        return getServices().get(TemporaryFileProvider.class).newTemporaryFile(getName());
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -24,6 +24,7 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.CommandLineJavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
@@ -289,7 +290,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
     @OutputFile
     protected File getSourceClassesMappingFile() {
         if (sourceClassesMappingFile == null) {
-            sourceClassesMappingFile = new File(getTemporaryDir(), "source-classes-mapping.txt");
+            sourceClassesMappingFile = new File(getTemporaryDirWithoutCreating(), "source-classes-mapping.txt");
         }
         return sourceClassesMappingFile;
     }
@@ -302,11 +303,10 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
     @OutputFile
     protected File getPreviousCompilationData() {
         if (previousCompilationDataFile == null) {
-            previousCompilationDataFile = new File(getTemporaryDir(), "previous-compilation-data.bin");
+            previousCompilationDataFile = new File(getTemporaryDirWithoutCreating(), "previous-compilation-data.bin");
         }
         return previousCompilationDataFile;
     }
-
 
     private WorkResult performCompilation(JavaCompileSpec spec, Compiler<JavaCompileSpec> compiler) {
         WorkResult result = new CompileJavaBuildOperationReportingCompiler(this, compiler, getServices().get(BuildOperationExecutor.class)).execute(spec);
@@ -401,6 +401,11 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
             spec.setSourceCompatibility(getSourceCompatibility());
         }
         spec.setCompileOptions(compileOptions);
+    }
+
+    private File getTemporaryDirWithoutCreating() {
+        // Do not create the temporary folder, since that causes problems.
+        return getServices().get(TemporaryFileProvider.class).newTemporaryFile(getName());
     }
 
     /**


### PR DESCRIPTION
and not at configuration time.

This should fix some problems we have right now when running `:performance:clean` on `master`. The problems have been introduced by #16536, which caused eager creation of the temporary directories.