### PR TITLE
Set JAVA_HOME for PerformanceTestsPass job

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -35,6 +35,7 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
     applyDefaultSettings(os)
     params {
         param("env.GRADLE_OPTS", "-Xmx1536m -XX:MaxPermSize=384m")
+        param("env.JAVA_HOME", os.javaHomeForGradle())
         param("env.BUILD_BRANCH", "%teamcity.build.branch%")
         param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
         param("performance.db.username", "tcagent")


### PR DESCRIPTION
so we don't have build cache misses there.