### PR TITLE
Add all ConfigCache tests trigger

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -381,6 +381,7 @@ enum class Trigger {
     never, eachCommit, daily, weekly
 }
 
+const val GRADLE_BUILD_SMOKE_TEST_NAME = "gradleBuildSmokeTest"
 enum class SpecificBuild {
     CompileAll {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
@@ -419,7 +420,7 @@ enum class SpecificBuild {
     },
     GradleBuildSmokeTests {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
-            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, "gradleBuildSmokeTest")
+            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, GRADLE_BUILD_SMOKE_TEST_NAME)
         }
     },
     ConfigCacheSmokeTestsMinJavaVersion {

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -17,6 +17,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import model.CIBuildModel
 import model.FlameGraphGeneration
 import model.FunctionalTestBucketProvider
+import model.GRADLE_BUILD_SMOKE_TEST_NAME
 import model.PerformanceTestBucketProvider
 import model.PerformanceTestCoverage
 import model.SpecificBuild
@@ -90,6 +91,12 @@ class StageProject(model: CIBuildModel, functionalTestBucketProvider: Functional
             val crossVersionTests = functionalTests.filter { it.testCoverage.testType in setOf(TestType.allVersionsCrossVersion, TestType.quickFeedbackCrossVersion) }
             if (crossVersionTests.size > 1) {
                 buildType(PartialTrigger("All Cross-Version Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_CrossVersionTests", model, crossVersionTests))
+            }
+
+            // in gradleBuildSmokeTest, most of the tests are for using the configuration cache on gradle/gradle
+            val configCacheTests = (functionalTests + specificBuildTypes).filter { it.name.toLowerCase().contains("configcache") || it.name.contains(GRADLE_BUILD_SMOKE_TEST_NAME) }
+            if (configCacheTests.size > 1) {
+                buildType(PartialTrigger("All ConfigCache Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_ConfigCacheTests", model, configCacheTests))
             }
             if (specificBuildTypes.size > 1) {
                 buildType(PartialTrigger("All Specific Builds for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_SpecificBuilds", model, specificBuildTypes))


### PR DESCRIPTION
This PR adds a composite build consist of following builds:

- QuickFeedbackLinux
- All configCacheSmoke tests
- gradleBuildSmokeTest
- `ConfigCache Java8 Oracle Linux`