### PR TITLE
Return same SnapshotHierarchy when nothing was invalidated

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -356,6 +356,27 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         postBuildOutputContains("Watching too many directories in the file system (watching 2, limit 1), dropping some state from the virtual file system")
     }
 
+    def "does not show unsupported watching hierarchies warning for test directory"() {
+        buildFile << """
+            task myTask {
+                def inputFile = file("input.txt")
+                def outputFile = file("output.txt")
+                inputs.file(inputFile)
+                outputs.file(outputFile)
+                doLast {
+                    outputFile.text = inputFile.text
+                }
+            }
+        """
+        file("input.txt").text = "input"
+
+        when:
+        run "myTask", "--info"
+        then:
+        assertWatchedHierarchies([testDirectory])
+        result.assertNotPostBuildOutput("Some of the file system contents retained in the virtual file system are on file systems that Gradle doesn't support watching.")
+    }
+
     void assertWatchableHierarchies(List<Set<File>> expectedWatchableHierarchies) {
         assert determineWatchableHierarchies(output) == expectedWatchableHierarchies
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ErrorsOnStdoutScrapingExecutionResult.java
@@ -112,6 +112,12 @@ public class ErrorsOnStdoutScrapingExecutionResult implements ExecutionResult {
     }
 
     @Override
+    public ExecutionResult assertNotPostBuildOutput(String expectedOutput) {
+        delegate.assertNotPostBuildOutput(expectedOutput);
+        return this;
+    }
+
+    @Override
     public ExecutionResult assertTasksExecutedInOrder(Object... taskPaths) {
         delegate.assertTasksExecutedInOrder(taskPaths);
         return this;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ExecutionResult.java
@@ -130,6 +130,13 @@ public interface ExecutionResult {
     ExecutionResult assertHasPostBuildOutput(String expectedOutput);
 
     /**
+     * Assert that the given message does not appear after the build result message.
+     *
+     * @param expectedOutput The expected log message, with line endings normalized to a newline character.
+     */
+    ExecutionResult assertNotPostBuildOutput(String expectedOutput);
+
+    /**
      * Asserts that exactly the given set of tasks have been executed in the given order.
      * Each task path can be either a String or a {@link TaskOrderSpec}.  See {@link TaskOrderSpecs} for common assertions
      * and an explanation of their usage.  Defaults to a {@link TaskOrderSpecs#exact(Object[])} assertion.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -547,6 +547,12 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         }
 
         @Override
+        public ExecutionResult assertNotPostBuildOutput(String expectedOutput) {
+            outputResult.assertNotPostBuildOutput(expectedOutput);
+            return this;
+        }
+
+        @Override
         public boolean hasErrorOutput(String expectedOutput) {
             return outputResult.hasErrorOutput(expectedOutput);
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -187,6 +187,15 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     }
 
     @Override
+    public ExecutionResult assertNotPostBuildOutput(String expectedOutput) {
+        String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
+        if (postBuild.withNormalizedEol().contains(expectedText)) {
+            failureOnUnexpectedOutput(String.format("Found unexpected text in post-build output.%nExpected not present: %s%n", expectedText));
+        }
+        return this;
+    }
+
+    @Override
     public ExecutionResult assertNotOutput(String expectedOutput) {
         String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
         if (getOutput().contains(expectedText)|| getError().contains(expectedText)) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchy.java
@@ -90,7 +90,7 @@ public class DefaultSnapshotHierarchy implements SnapshotHierarchy {
             return empty();
         }
         return rootNode.invalidate(relativePath, caseSensitivity, diffListener)
-            .<SnapshotHierarchy>map(it -> new DefaultSnapshotHierarchy(it, caseSensitivity))
+            .<SnapshotHierarchy>map(it -> (it == rootNode) ? this : new DefaultSnapshotHierarchy(it, caseSensitivity))
             .orElseGet(() -> empty(caseSensitivity));
     }
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -472,10 +472,11 @@ class DefaultSnapshotHierarchyTest extends Specification {
         def set = fileHierarchySet(file)
 
         when:
-        set = invalidate(set, invalidatedLocation)
+        def invalidatedSet = invalidate(set, invalidatedLocation)
         then:
-        snapshotPresent(set, file)
-        !snapshotPresent(set, invalidatedLocation)
+        snapshotPresent(invalidatedSet, file)
+        !snapshotPresent(invalidatedSet, invalidatedLocation)
+        invalidatedSet.is(set)
     }
 
     def "root is handled correctly"() {


### PR DESCRIPTION
So we can rely on SnapshotHierarchy being the same instance when nothing changes. We use this currently when printing the warning at the end of the build whether we dropped unsupported file systems.