### PR TITLE
Increase wait time between builds for embedded runner

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
@@ -22,7 +22,7 @@ import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_D
 
 public class FileSystemWatchingHelper {
 
-    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 120;
+    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 500;
 
     public static void waitForChangesToBePickedUp() throws InterruptedException {
         Thread.sleep(WAIT_FOR_CHANGES_PICKED_UP_MILLIS);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
@@ -16,13 +16,17 @@
 
 package org.gradle.integtests.fixtures;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.initialization.StartParameterBuildOptions;
+import org.gradle.internal.os.OperatingSystem;
 
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_DROP_PROPERTY;
 
 public class FileSystemWatchingHelper {
 
-    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 500;
+    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = (OperatingSystem.current().isWindows() || JavaVersion.current().isJava11Compatible())
+        ? 120
+        : 500;
 
     public static void waitForChangesToBePickedUp() throws InterruptedException {
         Thread.sleep(WAIT_FOR_CHANGES_PICKED_UP_MILLIS);

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -17,9 +17,6 @@
 
 package org.gradle.java.compile.incremental
 
-import spock.lang.Ignore
-
-@Ignore("https://github.com/gradle/gradle-private/issues/3364")
 class CrossTaskIncrementalJavaCompilationIntegrationTest extends AbstractCrossTaskIncrementalJavaCompilationIntegrationTest {
     boolean useJar = true
 }


### PR DESCRIPTION
So the file timestamps can be used to distinguish between the output
files since the optimized incremental Java compilation now made
builds too fast so this is a problem now.

Fixes gradle/gradle-private#3364