### PR TITLE
Only consider successful tasks for cache misses

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -99,7 +99,7 @@ fun buildCacheEnabled() = gradle.startParameter.isBuildCacheEnabled
 
 fun isNotTaggedYet() = cacheMissTagged.compareAndSet(false, true)
 
-fun Task.isCacheMiss() = !state.skipped && (isCompileCacheMiss() || isAsciidoctorCacheMiss())
+fun Task.isCacheMiss() = !state.skipped && state.failure == null && (isCompileCacheMiss() || isAsciidoctorCacheMiss())
 
 fun Task.isCompileCacheMiss() = isMonitoredCompileTask() && !isExpectedCompileCacheMiss()
 


### PR DESCRIPTION
When dependency verification fails, the task fails
before we can load from the cache. Such a build
would be tagged as `CACHE_MISS`. See for example
https://ge.gradle.org/s/jf3w72vetqguy/timeline?cacheability=unknown_reason&details=parupel2amtcy&hide-timeline&outcome=SUCCESS,FAILED&sort=longest
