### PR TITLE
a new link to zinc compiler

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -15,6 +15,7 @@ We would like to thank the following community members for their contributions t
 [Björn Kautler](https://github.com/Vampire),
 [Sebastian Schuberth](https://github.com/sschuberth),
 [Kejn](https://github.com/kejn),
+[xhudik](https://github.com/xhudik),
 [Anuraag Agrawal](https://github.com/anuraaga),
 [Florian Schmitt](https://github.com/florianschmitt),
 [Evgeny Mandrikov](https://github.com/Godin).

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -149,7 +149,7 @@ Unless a task's `scalaClasspath` is configured explicitly, the Scala (base) plug
 [[sec:configure_zinc_compiler]]
 == Configuring the Zinc compiler
 
-The Scala plugin uses a configuration named `zinc` to resolve the https://github.com/typesafehub/zinc[Zinc compiler] and its dependencies.
+The Scala plugin uses a configuration named `zinc` to resolve the https://github.com/sbt/zinc[Zinc compiler] and its dependencies.
 Gradle will provide a default version of Zinc, but if you need to use a particular Zinc version, you can change it.
 Gradle supports version 1.2.0 of Zinc and above.
 


### PR DESCRIPTION
### Context
the original link pointed to obsolete zinc repo
original(archived project): https://github.com/typesafehub/zinc
new: https://github.com/sbt/zinc
