### PR TITLE
Revert "Ignore CppIncrementalBuildIntegrationTest for now"

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -22,12 +22,10 @@ import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.junit.Assume.assumeFalse
 
-@Ignore('https://github.com/gradle/gradle-private/issues/3365')
 class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
     private static final String LIBRARY = ':library'


### PR DESCRIPTION
This reverts commit 983644ae0dbae1c6aff8955756a75bdf2d57cfd4.

To check if #16876 fixes the problems in `CppIncrementalBuildIntegrationTest` as well

Fixes https://github.com/gradle/gradle-private/issues/3365