### PR TITLE
Fix reading the timestamp for BuildSessionScopeFileTimeStampInspector

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
@@ -31,7 +31,7 @@ import java.io.File;
 public class BuildSessionScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
     public BuildSessionScopeFileTimeStampInspector(File workDir) {
         super(workDir);
-        // `afterStart` is called to early for this build session scope service to capture it.
+        // `afterStart` is called too early for this build session scope service to capture it.
         updateOnStartBuild();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspector.java
@@ -31,6 +31,8 @@ import java.io.File;
 public class BuildSessionScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
     public BuildSessionScopeFileTimeStampInspector(File workDir) {
         super(workDir);
+        // `afterStart` is called to early for this build session scope service to capture it.
+        updateOnStartBuild();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTimeStampInspector.java
@@ -57,7 +57,7 @@ public abstract class FileTimeStampInspector {
         workDir.mkdirs();
 
         if (markerFile.exists()) {
-            lastBuildTimestamp = readBuildTimestampFromMarkerFile();
+            lastBuildTimestamp = timestampOfMarkerFile();
         } else {
             lastBuildTimestamp = 0;
         }
@@ -73,13 +73,13 @@ public abstract class FileTimeStampInspector {
             throw new UncheckedIOException("Could not update " + markerFile, e);
         }
 
-        lastBuildTimestamp = readBuildTimestampFromMarkerFile();
+        lastBuildTimestamp = timestampOfMarkerFile();
     }
 
     protected long currentTimestamp() {
         File file = temporaryFileProvider.createTemporaryFile("this-build", "bin");
         try {
-            return readTimestampFrom(file);
+            return timestampOf(file);
         } finally {
             file.delete();
         }
@@ -93,11 +93,11 @@ public abstract class FileTimeStampInspector {
         return timestamp != lastBuildTimestamp;
     }
 
-    private long readBuildTimestampFromMarkerFile() {
-        return readTimestampFrom(markerFile);
+    private long timestampOfMarkerFile() {
+        return timestampOf(markerFile);
     }
 
-    private long readTimestampFrom(File file) {
+    private long timestampOf(File file) {
         return file.lastModified();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/FileTimeStampInspector.java
@@ -57,14 +57,14 @@ public abstract class FileTimeStampInspector {
         workDir.mkdirs();
 
         if (markerFile.exists()) {
-            lastBuildTimestamp = markerFile.lastModified();
+            lastBuildTimestamp = readBuildTimestampFromMarkerFile();
         } else {
             lastBuildTimestamp = 0;
         }
     }
 
     protected void updateOnFinishBuild() {
-        markerFile.getParentFile().mkdirs();
+        workDir.mkdirs();
         try {
             try (FileOutputStream outputStream = new FileOutputStream(markerFile)) {
                 outputStream.write(0);
@@ -73,13 +73,13 @@ public abstract class FileTimeStampInspector {
             throw new UncheckedIOException("Could not update " + markerFile, e);
         }
 
-        lastBuildTimestamp = markerFile.lastModified();
+        lastBuildTimestamp = readBuildTimestampFromMarkerFile();
     }
 
     protected long currentTimestamp() {
         File file = temporaryFileProvider.createTemporaryFile("this-build", "bin");
         try {
-            return file.lastModified();
+            return readTimestampFrom(file);
         } finally {
             file.delete();
         }
@@ -91,5 +91,13 @@ public abstract class FileTimeStampInspector {
     public boolean timestampCanBeUsedToDetectFileChange(String file, long timestamp) {
         // Do not use a timestamp that is the same as the end of the last build or the start of this build
         return timestamp != lastBuildTimestamp;
+    }
+
+    private long readBuildTimestampFromMarkerFile() {
+        return readTimestampFrom(markerFile);
+    }
+
+    private long readTimestampFrom(File file) {
+        return file.lastModified();
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FileSystemWatchingHelper.java
@@ -16,17 +16,13 @@
 
 package org.gradle.integtests.fixtures;
 
-import org.gradle.api.JavaVersion;
 import org.gradle.initialization.StartParameterBuildOptions;
-import org.gradle.internal.os.OperatingSystem;
 
 import static org.gradle.internal.service.scopes.VirtualFileSystemServices.VFS_DROP_PROPERTY;
 
 public class FileSystemWatchingHelper {
 
-    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = (OperatingSystem.current().isWindows() || JavaVersion.current().isJava11Compatible())
-        ? 120
-        : 500;
+    private static final int WAIT_FOR_CHANGES_PICKED_UP_MILLIS = 120;
 
     public static void waitForChangesToBePickedUp() throws InterruptedException {
         Thread.sleep(WAIT_FOR_CHANGES_PICKED_UP_MILLIS);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DaemonGradleExecuter.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.integtests.fixtures.executer;
 
-import org.gradle.integtests.fixtures.FileSystemWatchingHelper;
-import org.gradle.internal.UncheckedException;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.util.GradleVersion;
@@ -38,18 +36,6 @@ public class DaemonGradleExecuter extends NoDaemonGradleExecuter {
     public DaemonGradleExecuter(GradleDistribution distribution, TestDirectoryProvider testDirectoryProvider, GradleVersion gradleVersion, IntegrationTestBuildContext buildContext) {
         super(distribution, testDirectoryProvider, gradleVersion, buildContext);
         super.requireDaemon();
-        waitForChangesToBePickedUpBeforeExecution();
-    }
-
-    private void waitForChangesToBePickedUpBeforeExecution() {
-        // File system watching is now on by default, so we need to wait for changes to be picked up before each execution.
-        beforeExecute(executer -> {
-            try {
-                FileSystemWatchingHelper.waitForChangesToBePickedUp();
-            } catch (InterruptedException e) {
-                throw UncheckedException.throwAsUncheckedException(e);
-            }
-        });
     }
 
     @Override


### PR DESCRIPTION
Because of some changes (probably https://github.com/gradle/gradle/pull/16846), we don't read the build time stamp for the last build in `BuildSessionScopeFileTimeStampInspector`. That causes Gradle to not detect changes when the timestamp and the length of the changed file remain the same.

This PR works around the problem by reading the timestamp in the constructor of `BuildSessionScopeFileTimeStampInspector`.

This is the actual fix for https://github.com/gradle/gradle-private/issues/3365 and https://github.com/gradle/gradle-private/issues/3364.