### PR TITLE
Allow tests to be filtered via an internal system

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.6.1")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.2")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.3-rc-2")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.14.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,8 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0.2")
+    id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-2")
+    id("com.gradle.internal.test-selection").version("0.4.0-rc-1")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
This change applies an internal plugin that affords us better
test filtering capabilities which can be enabled for local execution.

### Context
[Passing ready for merge build](https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Stage_ReadyforMerge_Trigger/42743068)

See internal docs for using this.

### Contributor Checklist
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
