### PR TITLE
Changed TaskContainer.register args to be Nullable

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -185,7 +185,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      * @since 4.7
      */
-    <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
+    <T extends Task> T create(String name, Class<T> type, @Nullable Object... constructorArgs) throws InvalidUserDataException;
 
     /**
      * <p>Creates a {@link Task} with the given name and type, configures it with the given action, and adds it to this container.</p>
@@ -261,7 +261,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws NullPointerException If any of the values in {@code constructorArgs} is null.
      * @since 4.9
      */
-    <T extends Task> TaskProvider<T> register(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
+    <T extends Task> TaskProvider<T> register(String name, Class<T> type, @Nullable Object... constructorArgs) throws InvalidUserDataException;
 
     /**
      * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link TaskCollection#getByName(java.lang.String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/TaskContainerExtensions.kt
@@ -259,7 +259,7 @@ inline fun <reified T : Task> TaskContainer.register(name: String, noinline conf
  *
  * @see [TaskContainer.register]
  */
-inline fun <reified T : Task> TaskContainer.register(name: String, vararg arguments: Any): TaskProvider<T> =
+inline fun <reified T : Task> TaskContainer.register(name: String, vararg arguments: Any?): TaskProvider<T> =
     register(name, T::class.java, *arguments)
 
 
@@ -267,5 +267,5 @@ inline fun <reified T : Task> TaskContainer.register(name: String, vararg argume
  * Creates a [Task] with the given [name] and type, passing the given arguments to the [javax.inject.Inject]-annotated constructor,
  * and adds it to this project tasks container.
  */
-inline fun <reified T : Task> TaskContainer.create(name: String, vararg arguments: Any): T =
+inline fun <reified T : Task> TaskContainer.create(name: String, vararg arguments: Any?): T =
     create(name, T::class.java, *arguments)


### PR DESCRIPTION
This changes all signatures of `TaskContainer.register` that allow passing of arguments to the constructor of the task to be nullable. Tasks are not restricted in any way to only have nonnull arguments, and these factory configuration methods therefore cannot impose this restriction on them.

This change is perfectly backward compatible, the bytecode does not change.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
