### PR TITLE
Further split cross version tests

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -11,7 +11,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import java.io.File
 import java.util.LinkedList
 
-const val MAX_PROJECT_NUMBER_IN_BUCKET = 10
+const val MAX_PROJECT_NUMBER_IN_BUCKET = 11
 
 val CROSS_VERSION_BUCKETS = listOf(
     listOf("0.0", "2.8"), // 0.0 <= version < 2.8
@@ -24,7 +24,8 @@ val CROSS_VERSION_BUCKETS = listOf(
     listOf("5.4", "5.5"), // 5.4 <=version < 5.5
     listOf("5.5", "6.1"), // 5.5 <=version < 6.1
     listOf("6.1", "6.4"), // 6.1 <=version < 6.4
-    listOf("6.4", "99.0") // 6.4 <=version < 99.0
+    listOf("6.4", "6.7"), // 6.4 <=version < 6.7
+    listOf("6.7", "99.0") // 6.7 <=version < 99.0
 )
 
 typealias BuildProjectToSubprojectTestClassTimes = Map<String, Map<String, List<TestClassTime>>>


### PR DESCRIPTION
With Gradle version grows, some cross version buckets are too large, split it.
