### PR TITLE
Check that the Java home for the potential compatible daemon still exists

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -44,26 +44,24 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/16816")
-    @Requires(TestPrecondition.SYMLINKS)
     def "can successful start after a running daemon's JDK has been removed"() {
-        // Zulu sets their Java distribution up like this
         def installedJdk = Jvm.current().javaHome
-        def removedJdk = file("removed-jdk")
-        removedJdk.mkdir()
-        new TestFile(installedJdk).copyTo(removedJdk)
+        def jdkToRemove = file("removed-jdk")
+        jdkToRemove.mkdir()
+        new TestFile(installedJdk).copyTo(jdkToRemove)
 
-        // start one JVM with the removed-jdk
-        file("gradle.properties").writeProperties("org.gradle.java.home": removedJdk.canonicalPath)
+        // start one JVM with jdk to remove
+        file("gradle.properties").writeProperties("org.gradle.java.home": jdkToRemove.canonicalPath)
         succeeds("help")
 
         when:
-        // remove the other JDK
-        removedJdk.deleteDir()
-        // try to start with the other-jdk
-        file("gradle.properties").writeProperties("org.gradle.java.home": installedJdk.canonicalPath)
+        // remove the JDK
+        jdkToRemove.deleteDir()
+        // don't ask for the removed JDK now
+        file("gradle.properties").delete()
         then:
+        // try to start another build
         succeeds("help")
-
     }
 
     @IgnoreIf({ GradleContextualExecuter.embedded }) // This test requires to start Gradle from scratch with the wrong Java version

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -43,6 +43,10 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
     }
 
+    // This test deletes a JDK installation while the daemon is running.
+    // This is difficult to setup on Windows since you can't delete files
+    // that are in use.
+    @Requires(TestPrecondition.NOT_WINDOWS)
     @Issue("https://github.com/gradle/gradle/issues/16816")
     def "can successful start after a running daemon's JDK has been removed"() {
         def installedJdk = Jvm.current().javaHome

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -51,14 +51,14 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         new TestFile(installedJdk).copyTo(jdkToRemove)
 
         // start one JVM with jdk to remove
-        file("gradle.properties").writeProperties("org.gradle.java.home": jdkToRemove.canonicalPath)
+        executer.withJavaHome(jdkToRemove)
         succeeds("help")
 
         when:
         // remove the JDK
         jdkToRemove.deleteDir()
         // don't ask for the removed JDK now
-        file("gradle.properties").delete()
+        executer.withJavaHome(installedJdk)
         then:
         // try to start another build
         succeeds("help")

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -59,12 +59,16 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
 
     private boolean javaHomeMatches(DaemonContext potentialContext) {
         try {
-            File potentialJava = Jvm.forHome(potentialContext.getJavaHome()).getJavaExecutable();
-            File desiredJava = Jvm.forHome(desiredContext.getJavaHome()).getJavaExecutable();
-            return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
+            File potentialJavaHome = potentialContext.getJavaHome();
+            if (potentialJavaHome.exists()) {
+                File potentialJava = Jvm.forHome(potentialJavaHome).getJavaExecutable();
+                File desiredJava = Jvm.forHome(desiredContext.getJavaHome()).getJavaExecutable();
+                return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
+            }
         } catch (IOException e) {
-            return false;
+            // ignore
         }
+        return false;
     }
 
     private boolean priorityMatches(DaemonContext context) {


### PR DESCRIPTION


When a Gradle build runs with JDK-A, we insert this into the daemon registry as a
potential compatible daemon for later.

If JDK-A is then deleted but the registry entry still exists, subsequent Gradle
builds will try to see if they are compatible with this entry and fail because
they cannot find JDK-A anymore.

This change checks that the JDK installation directory still exists before probing
further.

fixes #16816

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
