### PR TITLE
Display plugin in validation messages

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -90,7 +90,7 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         expect:
         fails('check')
         failureDescriptionContains(inputDoesNotExist {
-            type('Checkstyle').property('configDirectory').dir(missing)
+            inPlugin('org.gradle.checkstyle').type('org.gradle.api.plugins.quality.Checkstyle').property('configDirectory').dir(missing)
         })
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -141,8 +141,7 @@ task work {
         fails("work")
         failure.assertHasDescription("A problem was found with the configuration of task ':work' (type 'DefaultTask').")
         failureDescriptionContains(inputDoesNotExist {
-            type('DefaultTask')
-                .property('$1')
+            property('$1')
                 .file(link)
                 .includeLink()
         })

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -433,7 +433,7 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
                 - A TextResource instance."""
 
         def expectedWarning = unresolvableInput({
-            type('DefaultTask').property('invalidInputFileCollection')
+            property('invalidInputFileCollection')
             conversionProblem(rootCause.stripIndent())
             includeLink()
         }, false)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -88,7 +88,7 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec imp
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
         failureDescriptionContains(unsupportedNotation {
-            type('DefaultTask').property('input')
+            property('input')
                 .value("task ':dependencyTask'")
                 .cannotBeConvertedTo(targetType)
                 .candidates(

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -570,7 +570,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failureDescriptionContains(missingValueMessage { type('DefaultTask').property('input') })
+        failureDescriptionContains(missingValueMessage { property('input') })
     }
 
     def "optional null input properties registered via TaskInputs.property are allowed"() {
@@ -599,7 +599,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failureDescriptionContains(missingValueMessage { type('DefaultTask').property('input') })
+        failureDescriptionContains(missingValueMessage { property('input') })
 
         where:
         method << ["file", "files", "dir"]
@@ -635,7 +635,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
-        failureDescriptionContains(missingValueMessage { type('DefaultTask').property('output') })
+        failureDescriptionContains(missingValueMessage { property('output') })
 
         where:
         method << ["file", "files", "dir", "dirs"]
@@ -674,8 +674,7 @@ task someTask(type: SomeTask) {
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
         failureDescriptionContains(inputDoesNotExist {
-            type('DefaultTask')
-                .property('input')
+            property('input')
                 .kind(fileType)
                 .missing(missingFile)
                 .includeLink()
@@ -707,7 +706,7 @@ task someTask(type: SomeTask) {
         fails "test"
         failure.assertHasDescription("A problem was found with the configuration of task ':test' (type 'DefaultTask').")
         failureDescriptionContains(unexpectedInputType {
-            type('DefaultTask').property('input')
+            property('input')
                 .kind(fileType)
                 .missing(unexpected)
                 .includeLink()
@@ -737,7 +736,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failureDescriptionContains(cannotWriteToFile {
-            type('DefaultTask').property('output')
+            property('output')
                 .file(outputDir)
                 .isNotFile()
                 .includeLink()
@@ -767,7 +766,7 @@ task someTask(type: SomeTask) {
         expect:
         fails "test"
         failureDescriptionContains(cannotWriteToDir {
-            type('DefaultTask').property('output')
+            property('output')
                 .dir(outputFile)
                 .isNotDirectory()
                 .includeLink()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @NotThreadSafe
 public class DefaultPluginManager implements PluginManagerInternal {
@@ -120,6 +121,15 @@ public class DefaultPluginManager implements PluginManagerInternal {
     @Override
     public PluginContainer getPluginContainer() {
         return pluginContainer;
+    }
+
+    @Override
+    public <P extends Plugin<?>> Optional<PluginId> findPluginIdForClass(Class<P> plugin) {
+        PluginImplementation<?> pluginImplementation = plugins.get(plugin);
+        if (pluginImplementation != null) {
+            return Optional.ofNullable(pluginImplementation.getPluginId());
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/PluginManagerInternal.java
@@ -23,6 +23,8 @@ import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.plugin.use.PluginId;
 
+import java.util.Optional;
+
 public interface PluginManagerInternal extends PluginManager {
     void apply(PluginImplementation<?> plugin);
 
@@ -31,6 +33,8 @@ public interface PluginManagerInternal extends PluginManager {
     <P extends Plugin> P addImperativePlugin(Class<P> plugin);
 
     PluginContainer getPluginContainer();
+
+    <P extends Plugin<?>> Optional<PluginId> findPluginIdForClass(Class<P> plugin);
 
     DomainObjectSet<PluginWithId> pluginsForId(String id);
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -18,7 +18,6 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.Action;
 import org.gradle.api.Task;
-import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -29,7 +28,6 @@ import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.execution.WorkValidationContext;
-import org.gradle.internal.execution.impl.DefaultWorkValidationContext;
 import org.gradle.internal.resources.ResourceDeadlockException;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
@@ -50,9 +48,9 @@ public class LocalTaskNode extends TaskNode {
     private List<? extends ResourceLock> resourceLocks;
     private TaskProperties taskProperties;
 
-    public LocalTaskNode(TaskInternal task, DocumentationRegistry documentationRegistry) {
+    public LocalTaskNode(TaskInternal task, WorkValidationContext workValidationContext) {
         this.task = task;
-        this.validationContext = new DefaultWorkValidationContext(documentationRegistry);
+        this.validationContext = workValidationContext;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -17,16 +17,32 @@
 package org.gradle.execution.plan;
 
 
+import com.google.common.collect.Maps;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.plugins.PluginManagerInternal;
+import org.gradle.api.plugins.PluginContainer;
 import org.gradle.composite.internal.IncludedBuildTaskGraph;
+import org.gradle.internal.Cast;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.execution.WorkValidationContext;
+import org.gradle.internal.execution.impl.DefaultWorkValidationContext;
+import org.gradle.plugin.use.PluginId;
+import org.gradle.plugin.use.internal.DefaultPluginId;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 public class TaskNodeFactory {
@@ -35,12 +51,14 @@ public class TaskNodeFactory {
     private final GradleInternal thisBuild;
     private final BuildIdentifier currentBuildId;
     private final DocumentationRegistry documentationRegistry;
+    private final DefaultTypeOriginInspectorFactory typeOriginInspectorFactory;
 
     public TaskNodeFactory(GradleInternal thisBuild, IncludedBuildTaskGraph taskGraph) {
         this.thisBuild = thisBuild;
         this.currentBuildId = thisBuild.getServices().get(BuildState.class).getBuildIdentifier();
         this.documentationRegistry = thisBuild.getServices().get(DocumentationRegistry.class);
         this.taskGraph = taskGraph;
+        this.typeOriginInspectorFactory = new DefaultTypeOriginInspectorFactory();
     }
 
     public Set<Task> getTasks() {
@@ -51,7 +69,7 @@ public class TaskNodeFactory {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, documentationRegistry);
+                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
             } else {
                 node = TaskInAnotherBuild.of((TaskInternal) task, currentBuildId, taskGraph);
             }
@@ -64,4 +82,55 @@ public class TaskNodeFactory {
         nodes.clear();
     }
 
+    private static class DefaultTypeOriginInspectorFactory {
+        private final Map<Project, ProjectScopedTypeOriginInspector> projectToInspector = Maps.newConcurrentMap();
+        private final Map<Class<?>, File> clazzToFile = Maps.newConcurrentMap();
+
+        public ProjectScopedTypeOriginInspector forTask(Task task) {
+            return projectToInspector.computeIfAbsent(task.getProject(), ProjectScopedTypeOriginInspector::new);
+        }
+
+        @Nullable
+        private File jarFileFor(Class<?> pluginClass) {
+            return clazzToFile.computeIfAbsent(pluginClass, clazz -> toFile(pluginClass.getProtectionDomain().getCodeSource().getLocation()));
+        }
+
+        @Nullable
+        private static File toFile(URL url) {
+            try {
+                return new File(url.toURI());
+            } catch (URISyntaxException e) {
+                return null;
+            }
+        }
+
+        private class ProjectScopedTypeOriginInspector implements WorkValidationContext.TypeOriginInspector {
+            private final PluginContainer plugins;
+            private final PluginManagerInternal pluginManager;
+            private final Map<Class<?>, Optional<PluginId>> clazzToPlugin = Maps.newConcurrentMap();
+
+            private ProjectScopedTypeOriginInspector(Project project) {
+                this.plugins = project.getPlugins();
+                this.pluginManager = (PluginManagerInternal) project.getPluginManager();
+            }
+
+            @Override
+            public Optional<PluginId> findPluginDefining(Class<?> type) {
+                return clazzToPlugin.computeIfAbsent(type, clazz -> {
+                    File taskJar = jarFileFor(type);
+                    Optional<Plugin<?>> pluginForTask = Cast.uncheckedCast(plugins.stream()
+                        .filter(plugin -> Objects.equals(jarFileFor(plugin.getClass()), taskJar))
+                        .findFirst());
+                    if (pluginForTask.isPresent()) {
+                        Optional<PluginId> pluginIdForClass = pluginManager.findPluginIdForClass(pluginForTask.get().getClass());
+                        if (pluginIdForClass.isPresent()) {
+                            return pluginIdForClass;
+                        }
+                        return Optional.of(new DefaultPluginId(pluginForTask.get().getClass().getName()));
+                    }
+                    return Optional.empty();
+                });
+            }
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -96,7 +96,10 @@ public class TaskNodeFactory {
         }
 
         @Nullable
-        private static File toFile(URL url) {
+        private static File toFile(@Nullable URL url) {
+            if (url == null) {
+                return null;
+            }
             try {
                 return new File(url.toURI());
             } catch (URISyntaxException e) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -107,7 +107,7 @@ public class TaskNodeFactory {
         private class ProjectScopedTypeOriginInspector implements WorkValidationContext.TypeOriginInspector {
             private final PluginContainer plugins;
             private final PluginManagerInternal pluginManager;
-            private final Map<Class<?>, Optional<PluginId>> clazzToPlugin = Maps.newConcurrentMap();
+            private final Map<Class<?>, Optional<PluginId>> classToPlugin = Maps.newConcurrentMap();
 
             private ProjectScopedTypeOriginInspector(Project project) {
                 this.plugins = project.getPlugins();
@@ -116,7 +116,7 @@ public class TaskNodeFactory {
 
             @Override
             public Optional<PluginId> findPluginDefining(Class<?> type) {
-                return clazzToPlugin.computeIfAbsent(type, clazz -> {
+                return classToPlugin.computeIfAbsent(type, clazz -> {
                     File taskJar = jarFileFor(type);
                     Optional<Plugin<?>> pluginForTask = Cast.uncheckedCast(plugins.stream()
                         .filter(plugin -> Objects.equals(jarFileFor(plugin.getClass()), taskJar))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -670,8 +670,8 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
         then:
         def e = thrown WorkValidationException
         validateException(task, false, e,
-            missingValueMessage { type('AnnotationProcessingTasks.TaskWithNestedBeanWithPrivateClass').property('bean.inputFile').includeLink() },
-            ignoredAnnotationOnField {type('AnnotationProcessingTasks.Bean2').property('inputFile2').annotatedWith('InputFile').includeLink() })
+            missingValueMessage { type(TaskWithNestedBeanWithPrivateClass.name).property('bean.inputFile').includeLink() },
+            ignoredAnnotationOnField {type(AnnotationProcessingTasks.Bean2.name).property('inputFile2').annotatedWith('InputFile').includeLink() })
     }
 
     @ValidationTestFor(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -670,8 +670,8 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
         then:
         def e = thrown WorkValidationException
         validateException(task, false, e,
-            missingValueMessage { type(TaskWithNestedBeanWithPrivateClass.name).property('bean.inputFile').includeLink() },
-            ignoredAnnotationOnField {type(AnnotationProcessingTasks.Bean2.name).property('inputFile2').annotatedWith('InputFile').includeLink() })
+            missingValueMessage { type(TaskWithNestedBeanWithPrivateClass.canonicalName).property('bean.inputFile').includeLink() },
+            ignoredAnnotationOnField {type(Bean2.canonicalName).property('inputFile2').annotatedWith('InputFile').includeLink() })
     }
 
     @ValidationTestFor(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -42,6 +42,7 @@ import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.exceptions.MultiCauseException
 import org.gradle.internal.execution.DefaultOutputSnapshotter
 import org.gradle.internal.execution.OutputChangeListener
+import org.gradle.internal.execution.WorkValidationContext
 import org.gradle.internal.execution.history.AfterPreviousExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OverlappingOutputDetector
@@ -110,7 +111,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         getInputFileProperties() >> ImmutableSortedMap.of()
         getOutputFilesProducedByWork() >> ImmutableSortedMap.of()
     }
-    def validationContext = new DefaultWorkValidationContext(documentationRegistry)
+    def validationContext = new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP)
     def executionContext = Mock(TaskExecutionContext)
     def scriptSource = Mock(ScriptSource)
     def standardOutputCapture = Mock(StandardOutputCapture)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -204,7 +204,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def typeMetadata = metadataStore.getTypeMetadata(TypeWithCustomAnnotation)
 
         then:
-        collectProblems(typeMetadata) == [dummyValidationProblem('DefaultTypeMetadataStoreTest.TypeWithCustomAnnotation', null, 'type is broken', 'Test').trim()]
+        collectProblems(typeMetadata) == [dummyValidationProblem(TypeWithCustomAnnotation.canonicalName, null, 'type is broken', 'Test').trim()]
     }
 
     @Unroll

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.execution.plan
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.composite.internal.IncludedBuildTaskGraph
 import org.gradle.internal.build.BuildState
@@ -41,6 +42,7 @@ class TaskNodeFactoryTest extends Specification {
         services.get(BuildState) >> Stub(BuildState)
         services.get(DocumentationRegistry) >> new DocumentationRegistry()
         project.gradle >> gradle
+        project.pluginManager >> Stub(PluginManagerInternal)
 
         graph = new TaskNodeFactory(gradle, Stub(IncludedBuildTaskGraph))
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
 import org.gradle.api.internal.tasks.properties.DefaultTaskProperties
 import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.execution.ProjectExecutionServices
+import org.gradle.internal.execution.WorkValidationContext
 import org.gradle.internal.execution.impl.DefaultWorkValidationContext
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -76,7 +77,7 @@ abstract class AbstractProjectBuilderSpec extends Specification {
         def taskExecutionContext = new DefaultTaskExecutionContext(
             null,
             DefaultTaskProperties.resolve(executionServices.get(PropertyWalker), executionServices.get(FileCollectionFactory), task as TaskInternal),
-            new DefaultWorkValidationContext(documentationRegistry),
+            new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP),
             { historyMaintained, context -> }
         )
         executionServices.get(TaskExecuter).execute((TaskInternal) task, (TaskStateInternal) task.state, taskExecutionContext)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -207,7 +207,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
             def reserved = file("${it}/build/${forbiddenPath}")
             failure.assertHasDescription("A problem was found with the configuration of task ':${it}:badTask' (type 'DefaultTask').")
             failure.assertThatDescription(containsString(cannotWriteToReservedLocation {
-                type('DefaultTask').property('output')
+                property('output')
                     .forbiddenAt(reserved)
                     .includeLink()
             }))

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -607,7 +607,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            hasProblem dummyValidationProblem('Object', null, 'Validation error', 'Test').trim()
+            hasProblem dummyValidationProblem('java.lang.Object', null, 'Validation error', 'Test').trim()
         }
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkValidationContext.java
@@ -19,8 +19,10 @@ package org.gradle.internal.execution;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblem;
+import org.gradle.plugin.use.PluginId;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WorkValidationContext {
     TypeValidationContext forType(Class<?> type, boolean cacheable);
@@ -28,4 +30,13 @@ public interface WorkValidationContext {
     List<TypeValidationProblem> getProblems();
 
     ImmutableSet<Class<?>> getValidatedTypes();
+
+    interface TypeOriginInspector {
+        TypeOriginInspector NO_OP = new TypeOriginInspector() {
+        };
+
+        default Optional<PluginId> findPluginDefining(Class<?> type) {
+            return Optional.empty();
+        }
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultExecutionEngine.java
@@ -47,7 +47,7 @@ public class DefaultExecutionEngine implements ExecutionEngine {
             private ExecutionRequestContext createExecutionRequestContext() {
                 WorkValidationContext validationContext = this.validationContext != null
                     ? this.validationContext
-                    : new DefaultWorkValidationContext(documentationRegistry);
+                    : new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP);
                 return new ExecutionRequestContext() {
                     @Override
                     public Optional<String> getRebuildReason() {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
@@ -23,25 +23,30 @@ import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.reflect.ProblemRecordingTypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblem;
+import org.gradle.plugin.use.PluginId;
 
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public class DefaultWorkValidationContext implements WorkValidationContext {
     private final Set<Class<?>> types = new HashSet<>();
     private final ImmutableList.Builder<TypeValidationProblem> problems = ImmutableList.builder();
     private final DocumentationRegistry documentationRegistry;
+    private final TypeOriginInspector typeOriginInspector;
 
-    public DefaultWorkValidationContext(DocumentationRegistry documentationRegistry) {
+    public DefaultWorkValidationContext(DocumentationRegistry documentationRegistry, TypeOriginInspector typeOriginInspector) {
         this.documentationRegistry = documentationRegistry;
+        this.typeOriginInspector = typeOriginInspector;
     }
 
     @Override
     public TypeValidationContext forType(Class<?> type, boolean cacheable) {
         types.add(type);
-        return new ProblemRecordingTypeValidationContext(documentationRegistry, type) {
+        Optional<PluginId> pluginId = typeOriginInspector.findPluginDefining(type);
+        return new ProblemRecordingTypeValidationContext(documentationRegistry, type, pluginId.orElse(null)) {
 
             @Override
             protected void recordProblem(TypeValidationProblem problem) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -39,7 +39,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
 
     @Override
     protected AfterPreviousExecutionContext createContext() {
-        def validationContext = new DefaultWorkValidationContext(documentationRegistry)
+        def validationContext = new DefaultWorkValidationContext(documentationRegistry, WorkValidationContext.TypeOriginInspector.NO_OP)
         return Stub(AfterPreviousExecutionContext) {
             getValidationContext() >> validationContext
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -69,7 +69,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            def validationProblem = dummyValidationProblem('Object', null, 'Validation error', 'Test').trim()
+            def validationProblem = dummyValidationProblem('java.lang.Object', null, 'Validation error', 'Test').trim()
             hasMessage """A problem was found with the configuration of job ':test' (type 'ValidateStepTest.JobType').
   - ${validationProblem}"""
         }
@@ -93,8 +93,8 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            def validationProblem1 = dummyValidationProblem('Object', null, 'Validation error #1', 'Test')
-            def validationProblem2 = dummyValidationProblem('Object', null, 'Validation error #2', 'Test')
+            def validationProblem1 = dummyValidationProblem('java.lang.Object', null, 'Validation error #1', 'Test')
+            def validationProblem2 = dummyValidationProblem('java.lang.Object', null, 'Validation error #2', 'Test')
             hasMessage """Some problems were found with the configuration of job ':test' (types 'ValidateStepTest.JobType', 'ValidateStepTest.SecondaryJobType').
   - ${validationProblem1.trim()}
   - ${validationProblem2.trim()}"""
@@ -120,7 +120,7 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
     }
 
     def "reports deprecation warning and invalidates VFS for validation warning"() {
-        String expectedWarning = convertToSingleLine(dummyValidationProblem('Object', null, 'Validation warning', 'Test').trim())
+        String expectedWarning = convertToSingleLine(dummyValidationProblem('java.lang.Object', null, 'Validation warning', 'Test').trim())
         when:
         step.execute(work, context)
 
@@ -145,10 +145,10 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
     }
 
     def "reports deprecation warning even when there's also an error"() {
-        String expectedWarning = convertToSingleLine(dummyValidationProblem('Object', null, 'Validation warning', 'Test').trim())
+        String expectedWarning = convertToSingleLine(dummyValidationProblem('java.lang.Object', null, 'Validation warning', 'Test').trim())
         // errors are reindented but not warnings
         expectReindentedValidationMessage()
-        String expectedError = dummyValidationProblem('Object', null, 'Validation error', 'Test')
+        String expectedError = dummyValidationProblem('java.lang.Object', null, 'Validation error', 'Test')
 
         when:
         step.execute(work, context)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.java
@@ -29,5 +29,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface ValidationProblem {
-    Severity getValue() default Severity.WARNING;
+    Severity value() default Severity.WARNING;
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
@@ -67,7 +67,7 @@ class ValidationProblemPropertyAnnotationHandler implements PropertyAnnotationHa
 
     private Severity annotationValue(PropertyMetadata propertyMetadata) {
         return Optional.ofNullable((ValidationProblem) propertyMetadata.getAnnotationForCategory(AnnotationCategory.TYPE))
-            .map(ValidationProblem::getValue)
+            .map(ValidationProblem::value)
             .orElse(Severity.WARNING);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -37,7 +37,7 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
     }
 
     private DefaultTypeValidationContext(DocumentationRegistry documentationRegistry, @Nullable Class<?> rootType, boolean cacheable) {
-        super(documentationRegistry, rootType);
+        super(documentationRegistry, rootType, null);
         this.cacheable = cacheable;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
@@ -24,29 +24,33 @@ import org.gradle.internal.reflect.validation.PropertyProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeProblemBuilder;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
 import org.gradle.internal.reflect.validation.TypeValidationProblem;
+import org.gradle.plugin.use.PluginId;
 
 import javax.annotation.Nullable;
 
 abstract public class ProblemRecordingTypeValidationContext implements TypeValidationContext {
     private final DocumentationRegistry documentationRegistry;
     private final Class<?> rootType;
+    private final PluginId pluginId;
 
     public ProblemRecordingTypeValidationContext(DocumentationRegistry documentationRegistry,
-                                                 @Nullable Class<?> rootType) {
+                                                 @Nullable Class<?> rootType,
+                                                 @Nullable PluginId pluginId) {
         this.documentationRegistry = documentationRegistry;
         this.rootType = rootType;
+        this.pluginId = pluginId;
     }
 
     @Override
     public void visitTypeProblem(Action<? super TypeProblemBuilder> problemSpec) {
-        DefaultTypeValidationProblemBuilder builder = new DefaultTypeValidationProblemBuilder(documentationRegistry);
+        DefaultTypeValidationProblemBuilder builder = new DefaultTypeValidationProblemBuilder(documentationRegistry, pluginId);
         problemSpec.execute(builder);
         recordProblem(builder.build());
     }
 
     @Override
     public void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec) {
-        DefaultPropertyValidationProblemBuilder builder = new DefaultPropertyValidationProblemBuilder(documentationRegistry);
+        DefaultPropertyValidationProblemBuilder builder = new DefaultPropertyValidationProblemBuilder(documentationRegistry, pluginId);
         problemSpec.execute(builder);
         builder.forType(rootType);
         recordProblem(builder.build());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/AbstractValidationProblemBuilder.java
@@ -16,17 +16,20 @@
 package org.gradle.internal.reflect.validation;
 
 import com.google.common.collect.Lists;
-import org.gradle.problems.Solution;
 import org.gradle.api.Action;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.problems.ValidationProblemId;
+import org.gradle.plugin.use.PluginId;
+import org.gradle.problems.Solution;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Supplier;
 
 abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuilder<T>> implements ValidationProblemBuilder<T> {
     protected final DocumentationRegistry documentationRegistry;
+    protected final PluginId pluginId;
     protected ValidationProblemId problemId = null;
     protected Severity severity = Severity.WARNING;
     protected Supplier<String> shortProblemDescription;
@@ -37,8 +40,9 @@ abstract class AbstractValidationProblemBuilder<T extends ValidationProblemBuild
     protected boolean cacheabilityProblemOnly = false;
     protected boolean typeIrrelevantInErrorMessage = false;
 
-    public AbstractValidationProblemBuilder(DocumentationRegistry documentationRegistry) {
+    public AbstractValidationProblemBuilder(DocumentationRegistry documentationRegistry, @Nullable PluginId pluginId) {
         this.documentationRegistry = documentationRegistry;
+        this.pluginId = pluginId;
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.reflect.validation;
 
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.plugin.use.PluginId;
 
 import javax.annotation.Nullable;
 
@@ -24,8 +25,8 @@ public class DefaultPropertyValidationProblemBuilder extends AbstractValidationP
     private String parentProperty;
     private String property;
 
-    public DefaultPropertyValidationProblemBuilder(DocumentationRegistry documentationRegistry) {
-        super(documentationRegistry);
+    public DefaultPropertyValidationProblemBuilder(DocumentationRegistry documentationRegistry, @Nullable PluginId pluginId) {
+        super(documentationRegistry, pluginId);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class DefaultPropertyValidationProblemBuilder extends AbstractValidationP
         return new TypeValidationProblem(
             problemId,
             severity,
-            TypeValidationProblemLocation.forProperty(typeIrrelevantInErrorMessage ? null : rootType, parentProperty, property),
+            TypeValidationProblemLocation.forProperty(typeIrrelevantInErrorMessage ? null : rootType, typeIrrelevantInErrorMessage ? null : pluginId, parentProperty, property),
             shortProblemDescription,
             longDescription,
             reason,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
@@ -16,12 +16,13 @@
 package org.gradle.internal.reflect.validation;
 
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.plugin.use.PluginId;
 
 public class DefaultTypeValidationProblemBuilder extends AbstractValidationProblemBuilder<TypeProblemBuilder> implements TypeProblemBuilder {
     private Class<?> type;
 
-    public DefaultTypeValidationProblemBuilder(DocumentationRegistry documentationRegistry) {
-        super(documentationRegistry);
+    public DefaultTypeValidationProblemBuilder(DocumentationRegistry documentationRegistry, PluginId pluginId) {
+        super(documentationRegistry, pluginId);
     }
 
     @Override
@@ -43,7 +44,7 @@ public class DefaultTypeValidationProblemBuilder extends AbstractValidationProbl
         return new TypeValidationProblem(
             problemId,
             severity,
-            typeIrrelevantInErrorMessage ? TypeValidationProblemLocation.irrelevant() :  TypeValidationProblemLocation.inType(type),
+            typeIrrelevantInErrorMessage ? TypeValidationProblemLocation.irrelevant() :  TypeValidationProblemLocation.inType(type, pluginId),
             shortProblemDescription,
             longDescription,
             reason,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemLocation.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemLocation.java
@@ -15,30 +15,34 @@
  */
 package org.gradle.internal.reflect.validation;
 
+import org.gradle.plugin.use.PluginId;
+
 import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class TypeValidationProblemLocation implements Location {
     private final Class<?> type;
+    private final PluginId pluginId;
     private final String parentPropertyName;
     private final String propertyName;
 
-    private TypeValidationProblemLocation(@Nullable Class<?> type, @Nullable String parentProperty, @Nullable String property) {
+    private TypeValidationProblemLocation(@Nullable Class<?> type, @Nullable PluginId pluginId, @Nullable String parentProperty, @Nullable String property) {
         this.type = type;
+        this.pluginId = pluginId;
         this.parentPropertyName = parentProperty;
         this.propertyName = property;
     }
 
     public static TypeValidationProblemLocation irrelevant() {
-        return new TypeValidationProblemLocation(null, null, null);
+        return new TypeValidationProblemLocation(null, null, null, null);
     }
 
-    public static TypeValidationProblemLocation inType(Class<?> type) {
-        return new TypeValidationProblemLocation(type, null, null);
+    public static TypeValidationProblemLocation inType(Class<?> type, @Nullable PluginId pluginId) {
+        return new TypeValidationProblemLocation(type, pluginId, null, null);
     }
 
-    public static TypeValidationProblemLocation forProperty(@Nullable Class<?> rootType, @Nullable String parentProperty, @Nullable String property) {
-        return new TypeValidationProblemLocation(rootType, parentProperty, property);
+    public static TypeValidationProblemLocation forProperty(@Nullable Class<?> rootType, @Nullable PluginId pluginId, @Nullable String parentProperty, @Nullable String property) {
+        return new TypeValidationProblemLocation(rootType, pluginId, parentProperty, property);
     }
 
     public Optional<Class<?>> getType() {
@@ -51,5 +55,9 @@ public class TypeValidationProblemLocation implements Location {
 
     public Optional<String> getPropertyName() {
         return Optional.ofNullable(propertyName);
+    }
+
+    public Optional<PluginId> getPlugin() {
+        return Optional.ofNullable(pluginId);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemRenderer.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemRenderer.java
@@ -124,13 +124,11 @@ public class TypeValidationProblemRenderer {
     }
 
     // A heuristic to determine if the type is relevant or not.
-    // Currently we will not display the type name if the package
-    // of the class is Gradle API. We can do this because Gradle
-    // own tasks are not supposed to be invalid, yet the DefaultTask
-    // type may appear in error messages (if using "adhoc" tasks)
+    // The "DefaultTask" type may appear in error messages
+    // (if using "adhoc" tasks) but isn't visible to this
+    // class so we have to rely on text matching for now.
     private static boolean shouldRenderType(Class<?> clazz) {
-        String pkg = clazz.getPackage().getName();
-        return !pkg.startsWith("org.gradle.api");
+        return !("org.gradle.api.DefaultTask".equals(clazz.getName()));
     }
 
     private static String maybeAppendDot(String txt) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemRenderer.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblemRenderer.java
@@ -18,6 +18,7 @@ package org.gradle.internal.reflect.validation;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.model.internal.type.ModelType;
+import org.gradle.plugin.use.PluginId;
 import org.gradle.problems.Solution;
 
 import java.util.List;
@@ -84,15 +85,24 @@ public class TypeValidationProblemRenderer {
     private static String introductionFor(TypeValidationProblemLocation location) {
         StringBuilder builder = new StringBuilder();
         Class<?> rootType = location.getType().orElse(null);
+        PluginId pluginId = location.getPlugin().orElse(null);
         if (rootType != null) {
-            builder.append("Type '");
+            if (pluginId != null) {
+                builder.append("In plugin '").append(pluginId).append("' type '");
+            } else {
+                builder.append("Type '");
+            }
             builder.append(ModelType.of(rootType).getDisplayName());
             builder.append("' ");
         }
         String property = location.getPropertyName().orElse(null);
         if (property != null) {
             if (rootType == null) {
-                builder.append("Property '");
+                if (pluginId != null) {
+                    builder.append("In plugin '").append(pluginId).append("' property '");
+                } else {
+                    builder.append("Property '");
+                }
             } else {
                 builder.append("property '");
             }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -177,7 +177,7 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
         expect:
         assertProperties TypeWithFieldOnlyAnnotation, [:], [
             strict(ignoredAnnotationOnField {
-                type('DefaultTypeAnnotationMetadataStoreTest.TypeWithFieldOnlyAnnotation').property('property')
+                type(TypeWithFieldOnlyAnnotation.canonicalName).property('property')
                     .annotatedWith('Large')
                     .includeLink()
             })
@@ -741,10 +741,10 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification implements Va
     def "warns about annotations on non-getter methods"() {
         expect:
         assertProperties TypeWithAnnotatedNonGetterMethods, [:], [
-            strict(methodShouldNotBeAnnotatedMessage { type('DefaultTypeAnnotationMetadataStoreTest.TypeWithAnnotatedNonGetterMethods').kind('method').method('doSomething').annotation('Large').includeLink() }),
-            strict(methodShouldNotBeAnnotatedMessage { type('DefaultTypeAnnotationMetadataStoreTest.TypeWithAnnotatedNonGetterMethods').kind('setter').method('setSomething').annotation('Large').includeLink() }),
-            strict(methodShouldNotBeAnnotatedMessage { type('DefaultTypeAnnotationMetadataStoreTest.TypeWithAnnotatedNonGetterMethods').kind('static method').method('doStatic').annotation('Large').includeLink() }),
-            strict(methodShouldNotBeAnnotatedMessage { type('DefaultTypeAnnotationMetadataStoreTest.TypeWithAnnotatedNonGetterMethods').kind('static method').method('getStatic').annotation('Small').includeLink() }),
+            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('method').method('doSomething').annotation('Large').includeLink() }),
+            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('setter').method('setSomething').annotation('Large').includeLink() }),
+            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('static method').method('doStatic').annotation('Large').includeLink() }),
+            strict(methodShouldNotBeAnnotatedMessage { type(TypeWithAnnotatedNonGetterMethods.canonicalName).kind('static method').method('getStatic').annotation('Small').includeLink() }),
         ]
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
@@ -760,6 +760,27 @@ Reason: Some reason.
 """
     }
 
+    @ValidationTestFor(
+        ValidationProblemId.TEST_PROBLEM
+    )
+    def "displays plugin id when available"() {
+        when:
+        render dummyValidationProblem {
+            inPlugin 'com.foo.bar'
+            type 'Foo'
+            property 'bar'
+            description 'with some description'
+            reason 'some reason'
+        }
+
+        then:
+        outputEquals """
+In plugin 'com.foo.bar' type 'Foo' property 'bar' with some description.
+
+Reason: Some reason.
+"""
+    }
+
     private File dummyLocation(String path = '/tmp/foo') {
         Stub(File) {
             getAbsolutePath() >> path

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -332,6 +332,19 @@ trait ValidationMessageChecker {
         }.render()
     }
 
+    @ValidationTestFor(
+        ValidationProblemId.TEST_PROBLEM
+    )
+    String dummyValidationProblem(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        display(SimpleMessage, 'dummy') {
+            type('InvalidTask').property('dummy')
+            description('test problem')
+            reason('this is a test')
+            spec.delegate = delegate
+            spec()
+        }.render()
+    }
+
     void expectThatExecutionOptimizationDisabledWarningIsDisplayed(GradleExecuter executer,
                                                                    String message,
                                                                    String docId = 'more_about_tasks',

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.reflect.validation
 
 class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayConfiguration<T>> {
     private final ValidationMessageChecker checker
+    String pluginId
     boolean hasIntro = true
     private String description
     private String reason
@@ -31,6 +32,11 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     String property
     String section
     boolean includeLink = false
+
+    T inPlugin(String pluginId) {
+        this.pluginId = pluginId
+        this
+    }
 
     T description(String description) {
         this.description = description
@@ -73,7 +79,12 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
 
     private String getIntro() {
         if (hasIntro) {
-            typeName ? "Type '$typeName' ${property ? "${propertyIntro} '${property}' " : ''}" : (property ? "${propertyIntro.capitalize()} '${property}' " : "")
+            String intro = typeName ? "Type '$typeName' ${property ? "${propertyIntro} '${property}' " : ''}" : (property ? "${propertyIntro.capitalize()} '${property}' " : "")
+            if (pluginId) {
+                return "In plugin '${pluginId}' ${intro.uncapitalize()}"
+            } else {
+                return intro
+            }
         } else {
             ''
         }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -126,6 +126,6 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
             sb.append(newLine)
             sb.append(outro)
         }
-        sb.toString()
+        sb.toString().trim()
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/PluginUnderTestMetadataIntegrationTest.groovy
@@ -49,7 +49,7 @@ class PluginUnderTestMetadataIntegrationTest extends AbstractIntegrationSpec imp
         fails TASK_NAME
 
         then:
-        failureDescriptionContains(missingValueMessage { type(PluginUnderTestMetadata.simpleName).property('outputDirectory').includeLink() })
+        failureDescriptionContains(missingValueMessage { type(PluginUnderTestMetadata.name).property('outputDirectory').includeLink() })
     }
 
     def "implementation-classpath entry in metadata is empty if there is no classpath"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugin.devel.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.internal.reflect.problems.ValidationProblemId
+import org.gradle.internal.reflect.validation.ValidationMessageChecker
+import org.gradle.internal.reflect.validation.ValidationTestFor
+import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Requires
+
+@Requires({ GradleContextualExecuter.embedded })
+// this test only works in embedded mode because of the use of validation test fixtures
+class TaskFromPluginValidationIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+
+    def setup() {
+        expectReindentedValidationMessage()
+    }
+
+    @ValidationTestFor(
+        ValidationProblemId.TEST_PROBLEM
+    )
+    def "detects that a problem is from a task declared in a precompiled script plugin"() {
+        withPrecompiledScriptPlugins()
+        def pluginFile = file("buildSrc/src/main/groovy/org.gradle.demo.plugin.gradle")
+        writeTaskInto(pluginFile)
+        pluginFile << """
+            tasks.register("myTask", SomeTask) {
+                input.set("hello")
+                output.set(layout.buildDirectory.file("out.txt"))
+            }
+        """
+
+        buildFile """plugins {
+            id 'org.gradle.demo.plugin'
+        }"""
+
+        when:
+        fails ':myTask'
+
+        then:
+        failureDescriptionContains(dummyValidationProblem {
+            inPlugin('org.gradle.demo.plugin')
+            type('SomeTask').property('input')
+        }.trim())
+    }
+
+    @ValidationTestFor(
+        ValidationProblemId.TEST_PROBLEM
+    )
+    def "detects that a problem is from a task declared in plugin"() {
+        settingsFile << """
+            includeBuild 'my-plugin'
+        """
+        copyValidationProblemClass()
+        def pluginFile = file("my-plugin/src/main/groovy/org/gradle/demo/plugin/MyTask.groovy")
+        writeTaskInto("""package org.gradle.demo.plugin
+
+            import org.gradle.api.*
+            import org.gradle.api.file.*
+            import org.gradle.api.provider.*
+            import org.gradle.api.tasks.*
+        """, pluginFile)
+
+        file("my-plugin/build.gradle") << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+
+            gradlePlugin {
+                plugins {
+                    create("simplePlugin") {
+                        id = "org.gradle.demo.plugin"
+                        implementationClass = "org.gradle.demo.plugin.MyPlugin"
+                    }
+                }
+            }
+        """
+        file("my-plugin/settings.gradle") << """
+            rootProject.name = "my-plugin"
+        """
+        file("my-plugin/src/main/groovy/org/gradle/demo/plugin/MyPlugin.groovy") << """package org.gradle.demo.plugin
+            import org.gradle.api.*
+            class MyPlugin implements Plugin<Project> {
+                void apply(Project p) {
+                    p.tasks.register("myTask", SomeTask) {
+                        it.input.set("hello")
+                        it.output.set(p.layout.buildDirectory.file("out.txt"))
+                    }
+                }
+            }
+        """
+
+        buildFile """plugins {
+            id 'org.gradle.demo.plugin'
+        }"""
+
+        when:
+        fails ':myTask'
+
+        then:
+        failureDescriptionContains(dummyValidationProblem {
+            inPlugin('org.gradle.demo.plugin')
+            type('SomeTask').property('input')
+        }.trim())
+    }
+
+    /**
+     * This method creates a dummy ValidationProblem class in the plugin source set, because
+     * the test fixture is not visible at compile time for included builds like they are
+     * typically for precompiled script plugins.
+     * This is really a workaround for the test setup, which doesn't bring any value to the
+     * test itself and therefore is separated for readability.
+     */
+    private void copyValidationProblemClass() {
+        file("my-plugin/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblem.groovy") << """
+package org.gradle.integtests.fixtures.validation;
+
+import org.gradle.internal.reflect.validation.Severity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A dummy annotation which is used to trigger validation problems
+ * during tests
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.METHOD, ElementType.FIELD])
+public @interface ValidationProblem {
+    Severity value() default Severity.WARNING;
+}
+        """
+    }
+
+    private TestFile withPrecompiledScriptPlugins() {
+        file("buildSrc/build.gradle") << """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+        """
+    }
+
+    private void writeTaskInto(@GroovyBuildScriptLanguage String header = "", TestFile testFile) {
+        testFile << """$header
+            import org.gradle.integtests.fixtures.validation.ValidationProblem
+            import org.gradle.internal.reflect.validation.Severity
+
+            abstract class SomeTask extends DefaultTask {
+                @ValidationProblem(value=Severity.ERROR)
+                abstract Property<String> getInput()
+
+                @OutputFile
+                abstract RegularFileProperty getOutput()
+
+                @TaskAction
+                void doSomething() {}
+            }
+        """
+    }
+}

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/TaskFromPluginValidationIntegrationTest.groovy
@@ -117,8 +117,8 @@ class TaskFromPluginValidationIntegrationTest extends AbstractIntegrationSpec im
         then:
         failureDescriptionContains(dummyValidationProblem {
             inPlugin('org.gradle.demo.plugin')
-            type('SomeTask').property('input')
-        }.trim())
+            type('org.gradle.demo.plugin.SomeTask').property('input')
+        })
     }
 
     /**

--- a/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
+++ b/subprojects/plugin-development/src/testFixtures/groovy/org/gradle/plugin/devel/tasks/TaskValidationReportFixture.groovy
@@ -32,8 +32,8 @@ class TaskValidationReportFixture {
             .collect { message, severity ->
                 "$severity: $message"
             }
-            .join("\n--------\n")
-        def reportText = reportFile.text.replaceAll("\r\n", "\n")
+            .join("\n--------\n").replaceAll("\n+", "\n")
+        def reportText = reportFile.text.replaceAll("\r\n", "\n").replaceAll("\n+", "\n")
         assert reportText == expectedReportContents
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -679,7 +679,7 @@ class JarIntegrationTest extends AbstractIntegrationSpec implements ValidationMe
         fails('jar')
 
         then:
-        failureDescriptionContains(missingValueMessage { type('Jar').property('archiveFile') })
+        failureDescriptionContains(missingValueMessage { type('org.gradle.api.tasks.bundling.Jar').property('archiveFile') })
     }
 
     def "can use Provider values in manifest attribute"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -390,7 +390,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         def configFile = file('groovycompilerconfig.groovy')
         fails("compileGroovy")
         failureDescriptionContains(inputDoesNotExist {
-            type('GroovyCompile')
+            type('org.gradle.api.tasks.compile.GroovyCompile')
                 .property('groovyOptions.configurationScript')
                 .file(configFile)
                 .includeLink()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -59,8 +59,8 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
         validatePlugins {
             onPlugins(failingAndroidPlugins) {
                 failsWith([
-                    (missingAnnotationMessage { type('TaskManager.ConfigAttrTask').property('consumable').missingInputOrOutput().includeLink() }): ERROR,
-                    (missingAnnotationMessage { type('TaskManager.ConfigAttrTask').property('resolvable').missingInputOrOutput().includeLink() }): ERROR,
+                    (missingAnnotationMessage { type('com.android.build.gradle.internal.TaskManager.ConfigAttrTask').property('consumable').missingInputOrOutput().includeLink() }): ERROR,
+                    (missingAnnotationMessage { type('com.android.build.gradle.internal.TaskManager.ConfigAttrTask').property('resolvable').missingInputOrOutput().includeLink() }): ERROR,
                 ])
             }
             switch (testedPluginId) {
@@ -70,7 +70,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
                     }
                     onPlugins([SENTRY_PLUGIN_ID]) {
                         failsWith([
-                            (missingAnnotationMessage { type('SentryProguardConfigTask').property('applicationVariant').missingInputOrOutput().includeLink() }): ERROR,
+                            (missingAnnotationMessage { type('io.sentry.android.gradle.SentryProguardConfigTask').property('applicationVariant').missingInputOrOutput().includeLink() }): ERROR,
                         ])
                     }
                     break

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -446,8 +446,8 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
                 }
                 onPlugins(failingPlugins) {
                     failsWith([
-                        (missingAnnotationMessage { type('TaskManager.ConfigAttrTask').property('consumable').missingInputOrOutput().includeLink() }): ERROR,
-                        (missingAnnotationMessage { type('TaskManager.ConfigAttrTask').property('resolvable').missingInputOrOutput().includeLink() }): ERROR,
+                        (missingAnnotationMessage { type('com.android.build.gradle.internal.TaskManager.ConfigAttrTask').property('consumable').missingInputOrOutput().includeLink() }): ERROR,
+                        (missingAnnotationMessage { type('com.android.build.gradle.internal.TaskManager.ConfigAttrTask').property('resolvable').missingInputOrOutput().includeLink() }): ERROR,
                     ])
                 }
             } else {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildExternalPluginsValidationSmokeTest.groovy
@@ -71,7 +71,7 @@ class GradleBuildExternalPluginsValidationSmokeTest extends AbstractGradleceptio
         inProject(":") {
             onPlugin('org.jetbrains.gradle.plugin.idea-ext') {
                 failsWith([
-                    (missingAnnotationMessage { type('BuildIdeArtifact').property('artifact').missingInputOrOutput().includeLink() }): ERROR,
+                    (missingAnnotationMessage { type('org.jetbrains.gradle.ext.BuildIdeArtifact').property('artifact').missingInputOrOutput().includeLink() }): ERROR,
                 ])
             }
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NodePluginsSmokeTest.groovy
@@ -38,9 +38,9 @@ class NodePluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements 
             if (testedPluginId == 'com.moowork.node') {
                 onPlugin('com.moowork.node') {
                     failsWith([
-                        (missingAnnotationMessage { type('NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
-                        (methodShouldNotBeAnnotatedMessage {type('NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
-                        (missingAnnotationMessage { type('YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                        (missingAnnotationMessage { type('com.moowork.gradle.node.npm.NpmSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
+                        (methodShouldNotBeAnnotatedMessage {type('com.moowork.gradle.node.npm.NpmSetupTask').kind('setter').method('setArgs').annotation('Internal').includeLink()}): ERROR,
+                        (missingAnnotationMessage { type('com.moowork.gradle.node.yarn.YarnSetupTask').property('args').missingInputOrOutput().includeLink() }): ERROR,
                     ])
                 }
             } else {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProguardSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProguardSmokeTest.groovy
@@ -114,7 +114,7 @@ class ProguardSmokeTest extends AbstractPluginValidatingSmokeTest implements Val
             }
             onPlugin("proguard") {
                 failsWith(propertiesWithoutAnnotations.collectEntries { propertyName ->
-                    [(missingAnnotationMessage { type('ProGuardTask').property(propertyName).missingInputOrOutput().includeLink() }): ERROR]
+                    [(missingAnnotationMessage { type('proguard.gradle.ProGuardTask').property(propertyName).missingInputOrOutput().includeLink() }): ERROR]
                 })
             }
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpringBootPluginSmokeTest.groovy
@@ -78,7 +78,7 @@ class SpringBootPluginSmokeTest extends AbstractPluginValidatingSmokeTest implem
                 // This is not a problem, since this task type is only used for Gradle versions < 6.4.
                 // See https://github.com/spring-projects/spring-boot/blob/038ae9340644f0128ed6f29d9e5eb7e6c359f291/spring-boot-project/spring-boot-tools/spring-boot-gradle-plugin/src/main/java/org/springframework/boot/gradle/plugin/ApplicationPluginAction.java#L85
                 failsWith incompatibleAnnotations {
-                    type'CreateBootStartScripts'
+                    type'org.springframework.boot.gradle.tasks.application.CreateBootStartScripts'
                     property 'mainClassName'
                     annotatedWith 'Optional'
                     incompatibleWith 'ReplacedBy'


### PR DESCRIPTION
This commit adds more context to type validation problems, by
trying to identify to which plugin a type belongs. Unfortunately
there's no reliable way to associate a particular type to a plugin.

The way this change works is that whenever a type is validated, we
identify the jar to which it belongs. Then we look at the loaded
plugins, and for each known plugin class, we identify the jar they
are defined in. If we find that the type belongs to the same jar,
then we ask Gradle in which plugin the plugin class is defined and
use this as the plugin id.

This wouldn't work if, for example, a plugin uses multiple jars and
that the type we're validating is not in the _same jar_ as the plugin
itself.

If a jar contains multiple plugins, then we would pick the first one
which matches.

Last but not least, if a jar actually only contains types and no
concrete `Plugin<...>` implementation (for example if a plugin only
contribute task types), then we wouldn't be able to identify the
owner of a type.

Fixes #16904
