### PR TITLE
Detect both gpg1 and gpg2 in test fixture

### DIFF
--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
@@ -22,33 +22,33 @@ import org.gradle.test.fixtures.file.TestFile
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.regex.Pattern
 
 class GpgCmdFixture {
     private static final Random RANDOM = new Random()
     private static final int ALL_DIGITS_AND_LETTERS_RADIX = 36
     private static final int MAX_RANDOM_PART_VALUE = Integer.valueOf("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX)
+    private static final Pattern GPG_VERSION_REGEX = Pattern.compile(/(?s).*gpg \(GnuPG\) (\d).\d+.\d+.*/)
 
     static String createRandomPrefix() {
         return Integer.toString(RANDOM.nextInt(MAX_RANDOM_PART_VALUE), ALL_DIGITS_AND_LETTERS_RADIX)
     }
 
-    static String getAvailableGpg() {
-        if (tryRun('gpg2')) {
-            return 'gpg2'
-        } else if (tryRun('gpg')) {
-            return 'gpg'
+    static GpgCmdAndVersion getAvailableGpg() {
+        GpgCmdAndVersion gpg2 = tryRun("gpg2")
+        if (gpg2 == null) {
+            return tryRun("gpg")
         } else {
-            return null
+            return gpg2
         }
     }
 
-    static boolean tryRun(String cmd) {
+    static GpgCmdAndVersion tryRun(String cmd) {
         try {
-            "${cmd} --version".execute()
-            return true
-        }
-        catch (IOException e) {
-            return false
+            String output = "${cmd} --version".execute().text
+            return new GpgCmdAndVersion(executable: cmd, version: (output =~ GPG_VERSION_REGEX)[0][1].toInteger())
+        } catch (Exception ignored) {
+            return null
         }
     }
 
@@ -56,10 +56,10 @@ class GpgCmdFixture {
         def gpgHomeSymlink = prepareGnupgHomeSymlink(buildDir.file('gnupg-home'))
         Properties properties = new Properties()
         properties.load(buildDir.file('gradle.properties').newInputStream())
-        String client = GpgCmdFixture.getAvailableGpg()
+        GpgCmdAndVersion client = getAvailableGpg()
         assert client
-        properties.put('signing.gnupg.executable', client)
-        properties.put('signing.gnupg.useLegacyGpg', (client == 'gpg').toString())
+        properties.put('signing.gnupg.executable', client.executable)
+        properties.put('signing.gnupg.useLegacyGpg', (client.version == 1).toString())
         properties.put('signing.gnupg.homeDir', gpgHomeSymlink.toAbsolutePath().toString())
         properties.remove('signing.gnupg.optionsFile')
         properties.store(buildDir.file('gradle.properties').newOutputStream(), '')
@@ -77,4 +77,11 @@ class GpgCmdFixture {
         Path tmpLink = Paths.get(SystemProperties.getInstance().getJavaIoTmpDir()).resolve(createRandomPrefix())
         return Files.createSymbolicLink(tmpLink, gpgHomeInTest.toPath())
     }
+}
+
+class GpgCmdAndVersion {
+    // gpg or gpg2
+    String executable
+    // 1 or 2
+    int version
 }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
@@ -35,12 +35,7 @@ class GpgCmdFixture {
     }
 
     static GpgCmdAndVersion getAvailableGpg() {
-        GpgCmdAndVersion gpg2 = tryRun("gpg2")
-        if (gpg2 == null) {
-            return tryRun("gpg")
-        } else {
-            return gpg2
-        }
+        return tryRun("gpg2") ?: tryRun("gpg")
     }
 
     static GpgCmdAndVersion tryRun(String cmd) {

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsWithGpgCmdIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningConfigurationsWithGpgCmdIntegrationSpec.groovy
@@ -18,10 +18,8 @@ package org.gradle.plugins.signing
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvider
 import org.gradle.util.Requires
-import spock.lang.Ignore
 
 @Requires(adhoc = { GpgCmdFixture.getAvailableGpg() != null })
-@Ignore('https://github.com/gradle/gradle-private/issues/3370')
 class SigningConfigurationsWithGpgCmdIntegrationSpec extends SigningConfigurationsIntegrationSpec {
     SignMethod getSignMethod() {
         return SignMethod.GPG_CMD

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningSamplesSpec.groovy
@@ -23,10 +23,8 @@ import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.util.Requires
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore('https://github.com/gradle/gradle-private/issues/3370')
 class SigningSamplesSpec extends AbstractSampleIntegrationTest {
     @Rule
     public final Sample sample = new Sample(testDirectoryProvider)

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
@@ -20,12 +20,10 @@ import org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvide
 import org.gradle.plugins.signing.signatory.pgp.PgpSignatoryProvider
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
-import spock.lang.Ignore
 
 import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.GPG_CMD
 import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.OPEN_GPG
 
-@Ignore('https://github.com/gradle/gradle-private/issues/3370')
 class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
     @ToBeFixedForConfigurationCache

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksWithGpgCmdIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksWithGpgCmdIntegrationSpec.groovy
@@ -16,10 +16,8 @@
 package org.gradle.plugins.signing
 
 import org.gradle.util.Requires
-import spock.lang.Ignore
 
 @Requires(adhoc = { GpgCmdFixture.getAvailableGpg() != null })
-@Ignore('https://github.com/gradle/gradle-private/issues/3370')
 class SigningTasksWithGpgCmdIntegrationSpec extends SigningTasksIntegrationSpec {
     SignMethod getSignMethod() {
         return SignMethod.GPG_CMD


### PR DESCRIPTION
Previously, we detect "gpg" as gpg1, and "gpg2" as gpg2 in test fixtures.
This is not enough for newer ubuntu machine which has default gpg2 installed as "gpg".
This PR fixes it by recognizing `gpg --version` output.

Fixes https://github.com/gradle/gradle-private/issues/3370