### PR TITLE
Deprecation warning when extending deprecated configuration

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedConfigurationsIntegrationTest.groovy
@@ -29,28 +29,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
                 maven { url "${mavenRepo.uri}" }
             }
             allprojects {
-                configurations {
-                    implementation
-                    compile.deprecateForDeclaration("implementation")
-                    compile.deprecateForConsumption("compileElements")
-                    compile.deprecateForResolution("compileClasspath")
-                    compileOnly.deprecateForConsumption("compileElements")
-                    compileOnly.deprecateForResolution("compileClasspath")
-                    apiElements {
-                        canBeConsumed = true
-                        canBeResolved = false
-                        extendsFrom compile
-                        extendsFrom compileOnly
-                        extendsFrom implementation
-                    }
-                    compileClasspath {
-                        canBeConsumed = false
-                        canBeResolved = true
-                        extendsFrom compile
-                        extendsFrom compileOnly
-                        extendsFrom implementation
-                    }
-                }
+                apply plugin: 'java-library'
             }
         """
     }
@@ -65,7 +44,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. " +
-            "Please use the implementation configuration instead. " +
+            "Please use the implementation or api configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
         then:
@@ -84,7 +63,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. " +
-            "Please use the implementation configuration instead. " +
+            "Please use the implementation or api configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
         then:
@@ -101,7 +80,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("The compile configuration has been deprecated for artifact declaration. This will fail with an error in Gradle 7.0. " +
-            "Please use the implementation or compileElements configuration instead. " +
+            "Please use the implementation or api or apiElements configuration instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations")
 
         then:
@@ -146,7 +125,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. " +
-            "Please use attributes to consume the compileElements configuration instead. " +
+            "Please use attributes to consume the apiElements configuration instead. " +
             "See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph for more details.")
 
         then:
@@ -174,7 +153,7 @@ class DeprecatedConfigurationsIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning("The compileOnly configuration has been deprecated for consumption. This will fail with an error in Gradle 7.0. " +
-            "Please use attributes to consume the compileElements configuration instead. " +
+            "Please use attributes to consume the apiElements configuration instead. " +
             "See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph for more details.")
 
         then:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -396,7 +396,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 if (inheritedDependencyConstraints != null) {
                     inheritedDependencyConstraints.addCollection(configuration.getAllDependencyConstraints());
                 }
-                ((ConfigurationInternal) configuration).addMutationValidator(parentMutationValidator);
+                ConfigurationInternal internalConfiguration = (ConfigurationInternal) configuration;
+                internalConfiguration.addMutationValidator(parentMutationValidator);
+                if (internalConfiguration.isFullyDeprecated()) {
+                    DeprecationLogger.deprecateBehaviour("Configuration '" + getName() + "' extends deprecated configuration '" + configuration.getName() + "'. This will fail or cause unintended side effects in future Gradle versions.")
+                        .willBeRemovedInGradle7().withUpgradeGuideSection(5, "dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations").nagUser();
+                }
             }
         }
         return this;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.JUnitXmlReport;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.jvm.toolchain.JavaInstallationRegistry;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
@@ -156,7 +157,7 @@ public class JavaBasePlugin implements Plugin<Project> {
 
             ConfigurationContainer configurations = project.getConfigurations();
 
-            defineConfigurationsForSourceSet(sourceSet, configurations);
+            DeprecationLogger.whileDisabled(() -> defineConfigurationsForSourceSet(sourceSet, configurations));
             definePathsForSourceSet(sourceSet, outputConventionMapping, project);
 
             createProcessResourcesTask(sourceSet, sourceSet.getResources(), project);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -55,6 +55,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.internal.Cast;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.TextUtil;
@@ -102,7 +103,7 @@ public class JvmPluginsHelper {
 
         @SuppressWarnings("deprecation")
         Configuration compileConfiguration = configurations.getByName(sourceSet.getCompileConfigurationName());
-        apiConfiguration.extendsFrom(compileConfiguration);
+        DeprecationLogger.whileDisabled(() -> apiConfiguration.extendsFrom(compileConfiguration));
 
         return apiConfiguration;
     }


### PR DESCRIPTION
This use case was missed when the different deprecation warnings on this
topic were introduced. The main problematic use case is that with the
Groovy DSL, the `extendsFrom` can result in a silent configuration
creation ... which will be quite different from the one removed.