### PR TITLE
Add a build to rerun flaky tests when desired

### DIFF
--- a/.teamcity/src/main/kotlin/common/Jvm.kt
+++ b/.teamcity/src/main/kotlin/common/Jvm.kt
@@ -31,5 +31,4 @@ object BuildToolBuildJvm : Jvm {
         get() = JvmVersion.java11
     override val vendor: JvmVendor
         get() = JvmVendor.openjdk
-
 }

--- a/.teamcity/src/main/kotlin/common/Jvm.kt
+++ b/.teamcity/src/main/kotlin/common/Jvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,20 @@
 
 package common
 
-enum class JvmCategory(
-    override val vendor: JvmVendor,
+interface Jvm {
+    val version: JvmVersion
+    val vendor: JvmVendor
+}
+
+data class DefaultJvm(
+    override val version: JvmVersion,
+    override val vendor: JvmVendor
+) : Jvm
+
+object BuildToolBuildJvm : Jvm {
     override val version: JvmVersion
-) : Jvm {
-    MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.oracle, JvmVersion.java16),
-    EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java17)
+        get() = JvmVersion.java11
+    override val vendor: JvmVendor
+        get() = JvmVendor.openjdk
+
 }

--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -66,18 +66,10 @@ enum class Os(
     fun asName() = name.toLowerCase().capitalize()
 
     fun javaInstallationLocations(): String {
-        val paths = enumValues<JvmVersion>().map { version -> {
+        val paths = enumValues<JvmVersion>().joinToString(",") { version ->
             val vendor = if (version.major >= 11) JvmVendor.openjdk else JvmVendor.oracle
-            asPlaceholder(version, vendor)
-        }() }.joinToString(",")
+            javaHome(DefaultJvm(version, vendor), this)
+        }
         return """"-Porg.gradle.java.installations.paths=$paths""""
-    }
-
-    fun javaHomeForGradle(): String {
-        return asPlaceholder(JvmVersion.java11, JvmVendor.openjdk)
-    }
-
-    fun asPlaceholder(jvmVersion: JvmVersion, vendor: JvmVendor): String {
-        return "%${name.toLowerCase()}.$jvmVersion.$vendor.64bit%"
     }
 }

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -66,7 +66,7 @@ fun Requirements.requiresNoEc2Agent() {
 
 const val failedTestArtifactDestination = ".teamcity/gradle-logs"
 
-fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, timeout: Int = 30, versionedSettingsBranch: String? = null) {
+fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, timeout: Int = 30) {
     artifactRules = """
         build/report-* => $failedTestArtifactDestination
         build/tmp/test files/** => $failedTestArtifactDestination/test-files
@@ -79,11 +79,7 @@ fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, timeout: Int = 30, version
         root(AbsoluteId("Gradle_Branches_GradlePersonalBranches"))
         checkoutMode = CheckoutMode.ON_AGENT
 
-        branchFilter = when (versionedSettingsBranch) {
-            "master" -> branchesFilterExcluding("release")
-            "release" -> branchesFilterExcluding("master")
-            else -> branchesFilterExcluding()
-        }
+        branchFilter = branchesFilterExcluding()
     }
 
     requirements {

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -166,3 +166,17 @@ fun Dependencies.compileAllDependency(compileAllId: String) {
         artifactRules = "build-receipt.properties => incoming-distributions"
     }
 }
+
+fun BuildType.killProcessStep(stepName: String, daemon: Boolean, os: Os) {
+    steps {
+        gradleWrapper {
+            name = stepName
+            executionMode = BuildStep.ExecutionMode.ALWAYS
+            tasks = "killExistingProcessesStartedByGradle"
+            gradleParams = (
+                buildToolGradleParameters(daemon) +
+                    "-DpublishStrategy=publishOnFailure" // https://github.com/gradle/gradle-enterprise-conventions-plugin/pull/8
+                ).joinToString(separator = " ")
+        }
+    }
+}

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -176,8 +176,8 @@ fun functionalTestExtraParameters(buildScanTag: String, os: Os, testJvmVersion: 
         "coverageJvmVersion" to "java$testJvmVersion"
     )
     return (listOf(
-        "-PtestJavaVersion=${testJvmVersion}",
-        "-PtestJavaVendor=${testJvmVendor}") +
+        "-PtestJavaVersion=$testJvmVersion",
+        "-PtestJavaVendor=$testJvmVendor") +
         listOf(buildScanTag(buildScanTag)) +
         buildScanValues.map { buildScanCustomValue(it.key, it.value) }
         ).filter { it.isNotBlank() }.joinToString(separator = " ")

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -32,8 +32,6 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
         requiresNoEc2Agent()
     }
     params {
-        param("env.GRADLE_OPTS", "-Xmx1536m -XX:MaxPermSize=384m")
-        param("env.JAVA_HOME", os.javaHomeForGradle())
         param("env.BUILD_BRANCH", "%teamcity.build.branch%")
         param("env.JPROFILER_HOME", os.jprofilerHome)
         param("performance.db.username", "tcagent")

--- a/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
+++ b/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
@@ -1,10 +1,9 @@
 package configurations
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import model.CIBuildModel
 import model.Stage
 
-open class BaseGradleBuildType(model: CIBuildModel, val stage: Stage? = null, usesParentBuildCache: Boolean = false, init: BaseGradleBuildType.() -> Unit = {}) : BuildType() {
+open class BaseGradleBuildType(val stage: Stage? = null, init: BaseGradleBuildType.() -> Unit = {}) : BuildType() {
     init {
         this.init()
         params {

--- a/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
+++ b/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
@@ -6,11 +6,5 @@ import model.Stage
 open class BaseGradleBuildType(val stage: Stage? = null, init: BaseGradleBuildType.() -> Unit = {}) : BuildType() {
     init {
         this.init()
-        params {
-            param("env.BOT_TEAMCITY_GITHUB_TOKEN", "%github.bot-teamcity.token%")
-            param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
-            param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
-            param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
-        }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
@@ -4,7 +4,7 @@ import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
-class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
+class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id("${model.projectId}_BuildDistributions")
     name = "Build Distributions"
     description = "Creation and verification of the distribution and documentation"

--- a/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
+++ b/.teamcity/src/main/kotlin/configurations/BuildDistributions.kt
@@ -26,8 +26,4 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
         subprojects/distributions-full/build/distributions/*.zip => distributions
         subprojects/base-services/build/generated-resources/build-receipt/org/gradle/build-receipt.properties
     """.trimIndent()
-
-    params {
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
-    }
 })

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -4,7 +4,7 @@ import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
-class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, usesParentBuildCache = true, init = {
+class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id(buildTypeId(model))
     name = "Compile All"
     description = "Compiles all the source code and warms up the build cache"

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -1,6 +1,5 @@
 package configurations
 
-import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
@@ -8,10 +7,6 @@ class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage 
     id(buildTypeId(model))
     name = "Compile All"
     description = "Compiles all the source code and warms up the build cache"
-
-    params {
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
-    }
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -24,6 +24,7 @@ class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage 
     """.trimIndent()
 }) {
     companion object {
-        fun buildTypeId(model: CIBuildModel) = "${model.projectId}_CompileAllBuild"
+        fun buildTypeId(model: CIBuildModel) = buildTypeId(model.projectId)
+        fun buildTypeId(projectId: String) = "${projectId}_CompileAllBuild"
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -18,7 +18,7 @@ class FunctionalTest(
     extraParameters: String = "",
     extraBuildSteps: BuildSteps.() -> Unit = {},
     preBuildSteps: BuildSteps.() -> Unit = {}
-) : BaseGradleBuildType(model, stage = stage, init = {
+) : BaseGradleBuildType(stage = stage, init = {
     this.name = name
     this.description = description
     this.id(id)

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -59,14 +59,6 @@ class FunctionalTest(
             param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%e.grdev.net.access.key%")
         }
 
-        param("env.JAVA_HOME", "%${testCoverage.os.name.toLowerCase()}.${testCoverage.buildJvmVersion}.openjdk.64bit%")
-        param("env.ANDROID_HOME", testCoverage.os.androidHome)
-        param("env.ANDROID_SDK_ROOT", testCoverage.os.androidHome)
-        if (testCoverage.os == Os.MACOS) {
-            // Use fewer parallel forks on macOs, since the agents are not very powerful.
-            param("maxParallelForks", "2")
-        }
-
         if (testCoverage.testDistribution) {
             param("maxParallelForks", "16")
         }

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -1,6 +1,7 @@
 package configurations
 
 import common.Os
+import common.functionalTestExtraParameters
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import model.CIBuildModel
 import model.Stage
@@ -23,12 +24,6 @@ class FunctionalTest(
     this.description = description
     this.id(id)
     val testTasks = getTestTaskName(testCoverage, subprojects)
-    val buildScanTags = listOf("FunctionalTest")
-    val buildScanValues = mapOf(
-        "coverageOs" to testCoverage.os.name.toLowerCase(),
-        "coverageJvmVendor" to testCoverage.vendor.name,
-        "coverageJvmVersion" to testCoverage.testJvmVersion.name
-    )
 
     if (name.contains("(configuration-cache)")) {
         requirements {
@@ -42,11 +37,7 @@ class FunctionalTest(
 
     applyTestDefaults(model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
-            listOf(
-                "-PtestJavaVersion=${testCoverage.testJvmVersion.major}",
-                "-PtestJavaVendor=${testCoverage.vendor.name}") +
-                buildScanTags.map { buildScanTag(it) } +
-                buildScanValues.map { buildScanCustomValue(it.key, it.value) } +
+            listOf(functionalTestExtraParameters("FunctionalTest", testCoverage.os, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)) +
                 if (enableExperimentalTestDistribution(testCoverage, subprojects)) "-DenableTestDistribution=%enableTestDistribution%" else "" +
                     extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
@@ -20,7 +20,7 @@ import common.applyDefaultSettings
 import model.CIBuildModel
 import projects.FunctionalTestProject
 
-class FunctionalTestsPass(model: CIBuildModel, functionalTestProject: FunctionalTestProject) : BaseGradleBuildType(model, init = {
+class FunctionalTestsPass(model: CIBuildModel, functionalTestProject: FunctionalTestProject) : BaseGradleBuildType(init = {
     id("${functionalTestProject.testConfig.asId(model)}_Trigger")
     name = functionalTestProject.name + " (Trigger)"
 

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -6,6 +6,7 @@ import common.buildToolGradleParameters
 import common.checkCleanM2
 import common.compileAllDependency
 import common.gradleWrapper
+import common.killProcessStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -141,21 +142,6 @@ fun BuildType.dumpOpenFiles() {
             scriptContent = """
                 "%windows.java11.openjdk.64bit%\bin\java" gradle\DumpOpenFilesOnFailure.java
             """.trimIndent()
-        }
-    }
-}
-
-private
-fun BaseGradleBuildType.killProcessStep(stepName: String, daemon: Boolean, os: Os) {
-    steps {
-        gradleWrapper {
-            name = stepName
-            executionMode = BuildStep.ExecutionMode.ALWAYS
-            tasks = "killExistingProcessesStartedByGradle"
-            gradleParams = (
-                buildToolGradleParameters(daemon) +
-                    "-DpublishStrategy=publishOnFailure" // https://github.com/gradle/gradle-enterprise-conventions-plugin/pull/8
-                ).joinToString(separator = " ")
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -161,7 +161,7 @@ fun BaseGradleBuildType.killProcessStep(stepName: String, daemon: Boolean, os: O
 }
 
 fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: Os = Os.LINUX, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
-    buildType.applyDefaultSettings(os, timeout)
+    buildType.applyDefaultSettings(os, timeout = timeout)
 
     buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon, os)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
@@ -190,7 +190,7 @@ fun applyTestDefaults(
         buildType.params.param("env.REPO_MIRROR_URLS", "")
     }
 
-    buildType.applyDefaultSettings(os, timeout)
+    buildType.applyDefaultSettings(os, timeout = timeout)
 
     buildType.steps {
         preSteps()

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -8,7 +8,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
 import model.Stage
 
-class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
+class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id("${model.projectId}_Gradleception")
     name = "Gradleception - Java8 Linux"
     description = "Builds Gradle with the version of Gradle which is currently under development (twice)"

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -1,6 +1,5 @@
 package configurations
 
-import common.Os.LINUX
 import common.buildToolGradleParameters
 import common.customGradle
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
@@ -12,10 +11,6 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
     id("${model.projectId}_Gradleception")
     name = "Gradleception - Java8 Linux"
     description = "Builds Gradle with the version of Gradle which is currently under development (twice)"
-
-    params {
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
-    }
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
+++ b/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
@@ -20,7 +20,7 @@ import common.applyDefaultSettings
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import model.CIBuildModel
 
-class PartialTrigger<T : BuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(model, init = {
+class PartialTrigger<T : BuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(init = {
     id("${model.projectId}_${triggerId}_Trigger")
     name = "$triggerName (Trigger)"
     type = Type.COMPOSITE

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -43,7 +43,6 @@ class PerformanceTest(
     performanceTestTaskSuffix: String = "PerformanceTest",
     preBuildSteps: BuildSteps.() -> Unit = {}
 ) : BaseGradleBuildType(
-    model,
     stage = stage,
     init = {
         this.id(performanceTestBuildSpec.asConfigurationId(model, "bucket${bucketIndex + 1}"))

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -56,8 +56,6 @@ class PerformanceTest(
         params {
             param("performance.baselines", type.defaultBaselines)
             param("performance.channel", performanceTestBuildSpec.channel())
-            param("env.ANDROID_HOME", os.androidHome)
-            param("env.ANDROID_SDK_ROOT", os.androidHome)
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             when (os) {
                 Os.WINDOWS -> param("env.PATH", "%env.PATH%;C:/Program Files/7-zip")

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -24,7 +24,7 @@ import model.PerformanceTestProjectSpec
 import model.PerformanceTestType
 import projects.PerformanceTestProject
 
-class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(model, init = {
+class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(init = {
     id("${performanceTestProject.spec.asConfigurationId(model)}_Trigger")
     val performanceTestSpec = performanceTestProject.spec
     name = performanceTestProject.name + " (Trigger)"

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -34,8 +34,6 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
 
     applyDefaultSettings(os)
     params {
-        param("env.GRADLE_OPTS", "-Xmx1536m -XX:MaxPermSize=384m")
-        param("env.JAVA_HOME", os.javaHomeForGradle())
         param("env.BUILD_BRANCH", "%teamcity.build.branch%")
         param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
         param("performance.db.username", "tcagent")

--- a/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
@@ -4,7 +4,7 @@ import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
-class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, usesParentBuildCache = true, init = {
+class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id(buildTypeId(model))
     name = "Sanity Check"
     description = "Static code analysis, checkstyle, release notes verification, etc."

--- a/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
@@ -1,6 +1,5 @@
 package configurations
 
-import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
@@ -8,10 +7,6 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage
     id(buildTypeId(model))
     name = "Sanity Check"
     description = "Static code analysis, checkstyle, release notes verification, etc."
-
-    params {
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
-    }
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -5,7 +5,7 @@ import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
-class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task: String = "smokeTest") : BaseGradleBuildType(model, stage = stage, init = {
+class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task: String = "smokeTest") : BaseGradleBuildType(stage = stage, init = {
     id("${model.projectId}_${task.capitalize()}s${testJava.version.name.capitalize()}")
     name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.name.capitalize()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -1,7 +1,6 @@
 package configurations
 
 import common.JvmCategory
-import common.Os.LINUX
 import model.CIBuildModel
 import model.Stage
 
@@ -9,12 +8,6 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
     id("${model.projectId}_${task.capitalize()}s${testJava.version.name.capitalize()}")
     name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.name.capitalize()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
-
-    params {
-        param("env.ANDROID_HOME", LINUX.androidHome)
-        param("env.ANDROID_SDK_ROOT", LINUX.androidHome)
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
-    }
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -22,7 +22,7 @@ import model.StageNames
 import model.Trigger
 import projects.StageProject
 
-class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stageProject: StageProject) : BaseGradleBuildType(model, init = {
+class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stageProject: StageProject) : BaseGradleBuildType(init = {
     id(stageTriggerId(model, stage))
     name = stage.stageName.stageName + " (Trigger)"
 
@@ -64,7 +64,6 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         param("env.JAVA_HOME", LINUX.javaHomeForGradle())
     }
 
-    val baseBuildType = this
     val buildScanTags = model.buildScanTags + stage.id
 
     val defaultGradleParameters = (

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -1,6 +1,5 @@
 package configurations
 
-import common.Os.LINUX
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.gradleWrapper
@@ -58,10 +57,6 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
             param("revisionRule", "lastFinished")
             branchFilter = branchFilter(model.branch)
         }
-    }
-
-    params {
-        param("env.JAVA_HOME", LINUX.javaHomeForGradle())
     }
 
     val buildScanTags = model.buildScanTags + stage.id

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -28,7 +28,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
 import model.Stage
 
-class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage, init = {
+class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage, init = {
     val os = Os.LINUX
     val testProject = "smallJavaMultiProject"
 

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -16,7 +16,9 @@
 
 package promotion
 
+import common.BuildToolBuildJvm
 import common.Os
+import common.paramsForBuildToolBuild
 import common.requiresNoEc2Agent
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
@@ -38,11 +40,10 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
             requiresNoEc2Agent()
         }
 
+        paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)
+
         params {
             param("env.GE_GRADLE_ORG_GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%")
-            param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
-            param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
-            param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
         }
 
         features {

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -1,6 +1,9 @@
 package promotion
 
+import common.BuildToolBuildJvm
+import common.Os
 import common.VersionedSettingsBranch
+import common.javaHome
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 
 class PromotionProject(branch: VersionedSettingsBranch) : Project({
@@ -28,7 +31,7 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
         password("env.DOTCOM_DEV_DOCS_AWS_SECRET_KEY", "%dotcomDevDocsAwsSecretKey%")
         param("env.DOTCOM_DEV_DOCS_AWS_ACCESS_KEY", "AKIAX5VJCER2X7DPYFXF")
         password("env.ORG_GRADLE_PROJECT_sdkmanToken", "%sdkmanToken%")
-        param("env.JAVA_HOME", "%linux.java11.openjdk.64bit%")
+        param("env.JAVA_HOME", javaHome(BuildToolBuildJvm, Os.LINUX))
         param("env.ORG_GRADLE_PROJECT_artifactoryUserName", "bot-build-tool")
         password("env.ORG_GRADLE_PROJECT_infrastructureEmailPwd", "%infrastructureEmailPwd%")
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "8ed1a771bc236c287ad93c699bfdd2d7")

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -63,8 +63,6 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
 
         param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
         param("additional.gradle.parameters", "")
-        param("env.ANDROID_HOME", os.androidHome)
-        param("env.ANDROID_SDK_ROOT", os.androidHome)
     }
 
     steps {

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import common.BuildToolBuildJvm
+import common.Os
+import common.applyDefaultSettings
+import common.buildToolGradleParameters
+import common.checkCleanM2
+import common.compileAllDependency
+import common.gradleWrapper
+import common.killProcessStep
+import configurations.CompileAll
+import configurations.buildScanCustomValue
+import configurations.buildScanTag
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
+
+class RerunFlakyTest(os: Os) : BuildType({
+    val id = "Util_RerunFlakyTest${os.asName()}"
+    name = "Rerun Flaky Test - ${os.asName()}"
+    description = "Allows you to rerun a selected flaky test 10 times"
+    id(id)
+    val testJavaVendorParameter = "testJavaVendor"
+    val testJavaVersionParameter = "testJavaVersion"
+    val testTaskParameterName = "testTask"
+    val testTaskOptionsParameterName = "testTaskOptions"
+    val buildScanTags = listOf("RerunFlakyTest")
+    val buildScanValues = mapOf(
+        "coverageOs" to os.name.toLowerCase(),
+        "coverageJvmVendor" to "%$testJavaVendorParameter%",
+        "coverageJvmVersion" to "%$testJavaVersionParameter%"
+    )
+    val daemon = true
+    applyDefaultSettings(os, BuildToolBuildJvm, 30)
+    val extraParameters = (listOf(
+        "-PtestJavaVersion=%$testJavaVersionParameter%",
+        "-PtestJavaVendor=%$testJavaVendorParameter%") +
+        buildScanTags.map { buildScanTag(it) } +
+        buildScanValues.map { buildScanCustomValue(it.key, it.value) }
+        ).filter { it.isNotBlank() }.joinToString(separator = " ")
+
+    killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon, os)
+    steps {
+        gradleWrapper {
+            name = "SHOW_TOOLCHAINS"
+            tasks = "javaToolchains"
+            gradleParams = (
+                buildToolGradleParameters(daemon) +
+                    listOf(extraParameters) +
+                    "-PteamCityBuildId=%teamcity.build.id%" +
+                    buildScanTags.map { buildScanTag(it) } +
+                    os.javaInstallationLocations() +
+                    "-Porg.gradle.java.installations.auto-download=false"
+                ).joinToString(separator = " ")
+        }
+    }
+    (1..10).forEach { idx ->
+        steps {
+            gradleWrapper {
+                name = "GRADLE_RUNNER_$idx"
+                tasks = "%$testTaskParameterName% --rerun %$testTaskOptionsParameterName%"
+                gradleParams = (
+                    buildToolGradleParameters(daemon) +
+                        listOf(extraParameters) +
+                        "-PteamCityBuildId=%teamcity.build.id%" +
+                        buildScanTags.map { buildScanTag(it) } +
+                        os.javaInstallationLocations() +
+                        "-Porg.gradle.java.installations.auto-download=false"
+                    ).joinToString(separator = " ")
+                executionMode = BuildStep.ExecutionMode.ALWAYS
+            }
+        }
+        killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", daemon, os)
+    }
+    steps {
+        checkCleanM2(os)
+    }
+
+    params {
+        text(
+            testTaskParameterName,
+            ":core:embeddedIntegTest",
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false,
+            description = "The test task you want to run"
+        )
+        text(
+            testTaskOptionsParameterName,
+            """--tests "org.gradle.api.tasks.CachedTaskExecutionIntegrationTest.outputs are correctly loaded from cache"""",
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false,
+            description = "Options for the test task to run, like e.g. the test filter"
+        )
+        text(
+            testJavaVersionParameter,
+            "11",
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false,
+            description = "Java version to run the test with"
+        )
+        text(
+            testJavaVendorParameter,
+            "openjdk",
+            display = ParameterDisplay.PROMPT,
+            allowEmpty = false,
+            description = "Java vendor to run the test with"
+        )
+    }
+
+    dependencies {
+        compileAllDependency(CompileAll.buildTypeId("Check"))
+    }
+})

--- a/.teamcity/src/main/kotlin/util/UtilProject.kt
+++ b/.teamcity/src/main/kotlin/util/UtilProject.kt
@@ -1,10 +1,14 @@
 package util
 
+import common.Os
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 
 object UtilProject : Project({
     id("Util")
     name = "Util"
 
+    buildType(RerunFlakyTest(Os.LINUX))
+    buildType(RerunFlakyTest(Os.WINDOWS))
+    buildType(RerunFlakyTest(Os.MACOS))
     buildType(WarmupEc2Agent)
 })

--- a/.teamcity/src/main/kotlin/util/WarmupEc2Agent.kt
+++ b/.teamcity/src/main/kotlin/util/WarmupEc2Agent.kt
@@ -1,8 +1,10 @@
 package util
 
+import common.BuildToolBuildJvm
 import common.Os
 import common.buildToolGradleParameters
 import common.gradleWrapper
+import common.javaHome
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.Requirement
 import jetbrains.buildServer.configs.kotlin.v2019_2.RequirementType
@@ -25,7 +27,7 @@ object WarmupEc2Agent : BuildType({
 
     params {
         param("defaultBranchName", "master")
-        param("env.JAVA_HOME", Os.LINUX.javaHomeForGradle())
+        param("env.JAVA_HOME", javaHome(BuildToolBuildJvm, Os.LINUX))
     }
 
     steps {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -136,6 +136,6 @@ class ApplyDefaultConfigurationTest {
         val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java9.oracle.64bit%,%linux.java10.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java12.openjdk.64bit%,%linux.java13.openjdk.64bit%,%linux.java14.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%"
         val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java9.oracle.64bit%,%windows.java10.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java12.openjdk.64bit%,%windows.java13.openjdk.64bit%,%windows.java14.openjdk.64bit%,%windows.java15.openjdk.64bit%,%windows.java16.openjdk.64bit%,%windows.java17.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
-        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -s $daemon --continue $extraParameters -PteamCityBuildId=%teamcity.build.id% \"-Dscan.tag.Check\" \"-Dscan.tag.\" \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
+        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -s $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }
 }


### PR DESCRIPTION
So it is easier to reproduce flaky tests on CI. The PR also contains some cleanup to reduce code duplication.