### PR TITLE
Support Zulu-like Java distributions

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -44,26 +44,24 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/16816")
-    @Requires(TestPrecondition.SYMLINKS)
     def "can successful start after a running daemon's JDK has been removed"() {
-        // Zulu sets their Java distribution up like this
         def installedJdk = Jvm.current().javaHome
-        def removedJdk = file("removed-jdk")
-        removedJdk.mkdir()
-        new TestFile(installedJdk).copyTo(removedJdk)
+        def jdkToRemove = file("removed-jdk")
+        jdkToRemove.mkdir()
+        new TestFile(installedJdk).copyTo(jdkToRemove)
 
-        // start one JVM with the removed-jdk
-        file("gradle.properties").writeProperties("org.gradle.java.home": removedJdk.canonicalPath)
+        // start one JVM with jdk to remove
+        file("gradle.properties").writeProperties("org.gradle.java.home": jdkToRemove.canonicalPath)
         succeeds("help")
 
         when:
-        // remove the other JDK
-        removedJdk.deleteDir()
-        // try to start with the other-jdk
-        file("gradle.properties").writeProperties("org.gradle.java.home": installedJdk.canonicalPath)
+        // remove the JDK
+        jdkToRemove.deleteDir()
+        // don't ask for the removed JDK now
+        file("gradle.properties").delete()
         then:
+        // try to start another build
         succeeds("help")
-
     }
 
     @IgnoreIf({ GradleContextualExecuter.embedded }) // This test requires to start Gradle from scratch with the wrong Java version

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -43,6 +43,10 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
     }
 
+    // This test deletes a JDK installation while the daemon is running.
+    // This is difficult to setup on Windows since you can't delete files
+    // that are in use.
+    @Requires(TestPrecondition.NOT_WINDOWS)
     @Issue("https://github.com/gradle/gradle/issues/16816")
     def "can successful start after a running daemon's JDK has been removed"() {
         def installedJdk = Jvm.current().javaHome

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -51,14 +51,14 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         new TestFile(installedJdk).copyTo(jdkToRemove)
 
         // start one JVM with jdk to remove
-        file("gradle.properties").writeProperties("org.gradle.java.home": jdkToRemove.canonicalPath)
+        executer.withJavaHome(jdkToRemove)
         succeeds("help")
 
         when:
         // remove the JDK
         jdkToRemove.deleteDir()
         // don't ask for the removed JDK now
-        file("gradle.properties").delete()
+        executer.withJavaHome(installedJdk)
         then:
         // try to start another build
         succeeds("help")

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/SupportedBuildJvmIntegrationTest.groovy
@@ -19,16 +19,30 @@ package org.gradle.launcher
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.internal.jvm.Jvm
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
-@Requires(adhoc = { AvailableJavaHomes.getJdks("1.6", "1.7") })
+
 class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
 
-    @Unroll
+    @Requires(TestPrecondition.SYMLINKS)
+    def "can start Gradle with a JDK that contains symlinks"() {
+        // Zulu sets their Java distribution up like this
+        def installedJdk = Jvm.current().javaHome
+        def symlinkedJdk = file("symlink-jdk")
+        installedJdk.listFiles().each {
+            symlinkedJdk.file(it.name).createLink(it)
+        }
+        file("gradle.properties").writeProperties("org.gradle.java.home": symlinkedJdk.canonicalPath)
+        expect:
+        succeeds("help")
+    }
+
     @IgnoreIf({ GradleContextualExecuter.embedded }) // This test requires to start Gradle from scratch with the wrong Java version
+    @Requires(adhoc = { AvailableJavaHomes.getJdks("1.6", "1.7") })
     def "provides reasonable failure message when attempting to run under java #jdk.javaVersion"() {
         given:
         executer.withJavaHome(jdk.javaHome)
@@ -41,7 +55,7 @@ class SupportedBuildJvmIntegrationTest extends AbstractIntegrationSpec {
         jdk << AvailableJavaHomes.getJdks("1.6", "1.7")
     }
 
-    @Unroll
+    @Requires(adhoc = { AvailableJavaHomes.getJdks("1.6", "1.7") })
     def "fails when build is configured to use Java #jdk.javaVersion"() {
         given:
         file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.canonicalPath)

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -59,12 +59,16 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
 
     private boolean javaHomeMatches(DaemonContext potentialContext) {
         try {
-            File potentialJava = Jvm.forHome(potentialContext.getJavaHome()).getJavaExecutable();
-            File desiredJava = Jvm.forHome(desiredContext.getJavaHome()).getJavaExecutable();
-            return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
+            File potentialJavaHome = potentialContext.getJavaHome();
+            if (potentialJavaHome.exists()) {
+                File potentialJava = Jvm.forHome(potentialJavaHome).getJavaExecutable();
+                File desiredJava = Jvm.forHome(desiredContext.getJavaHome()).getJavaExecutable();
+                return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
+            }
         } catch (IOException e) {
-            return false;
+            // ignore
         }
+        return false;
     }
 
     private boolean priorityMatches(DaemonContext context) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/context/DaemonCompatibilitySpec.java
@@ -16,8 +16,11 @@
 package org.gradle.launcher.daemon.context;
 
 import org.gradle.api.internal.specs.ExplainingSpec;
+import org.gradle.internal.jvm.Jvm;
 
-import static org.gradle.internal.FileUtils.canonicalize;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
 
@@ -55,7 +58,13 @@ public class DaemonCompatibilitySpec implements ExplainingSpec<DaemonContext> {
     }
 
     private boolean javaHomeMatches(DaemonContext potentialContext) {
-        return canonicalize(potentialContext.getJavaHome()).equals(canonicalize(desiredContext.getJavaHome()));
+        try {
+            File potentialJava = Jvm.forHome(potentialContext.getJavaHome()).getJavaExecutable();
+            File desiredJava = Jvm.forHome(desiredContext.getJavaHome()).getJavaExecutable();
+            return Files.isSameFile(potentialJava.toPath(), desiredJava.toPath());
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     private boolean priorityMatches(DaemonContext context) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
When starting a Gradle daemon, we check that the Java home of the
just started daemon matches what was desired. This can be confused
by Java distributions like Zulu that structure the obvious "Java Home"
directory as several symlinks to another directory.

We end up deciding that the final target of the symlink is the real
Java Home. When we compare this to the desired Java Home by just
looking at the file path strings, these do not match and we fail
the build.

To workaround this, you can figure out the symlink yourself and
use a different (more hidden) path inside the Java distribution.

This may not fix all problems with comparing Java Home paths, but
this at least allows you to use Zulu to start a daemon.

Fixes #12840