### PR TITLE
Emit deprecation warning when only the settings file is missing

### DIFF
--- a/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
+++ b/subprojects/build-events/src/integTest/groovy/org/gradle/build/event/BuildEventsIntegrationTest.groovy
@@ -149,10 +149,12 @@ class BuildEventsIntegrationTest extends AbstractIntegrationSpec {
         file("a/build.gradle") << """
             task thing
         """
+        file("a/settings.gradle").touch()
+
         file("b/build.gradle") << """
             task thing
         """
-
+        file("b/settings.gradle").touch()
         when:
         run("thing")
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
@@ -83,6 +83,9 @@ class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConf
         settingsFile << """
             includeBuild 'build-logic'
         """
+
+        file("build-logic/settings.gradle").touch()
+
         buildFile << """
             plugins { id('$fixture.pluginId') }
         """
@@ -158,9 +161,12 @@ class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConf
                 }
             }
         """
+
         settingsFile << """
             includeBuild 'build-logic'
         """
+        file("build-logic/settings.gradle").touch()
+
         buildFile << """
             plugins { id('$fixture.pluginId') }
         """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -30,6 +30,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(testDirectory)
         assertNoDefinedBuild(testDirectory)
         executer.ignoreMissingSettingsFile()
+        file("build.gradle").touch()
     }
 
     private static void assertNoDefinedBuild(TestFile testDirectory) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -639,6 +639,8 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         file('included/build.gradle') << """
             tasks.create('foo')
         """
+        file("included/settings.gradle") << 'rootProject.name = "included"'
+
         buildFile << "tasks.help.dependsOn(gradle.includedBuild('included').task(':foo'))"
 
         when:
@@ -799,8 +801,8 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         { s -> s.details.targetType == 'gradle' } as Spec<? super BuildOperationRecord>
     }
 
-    private static Spec<? super BuildOperationRecord> targetsSettings() {
-        { s -> s.details.targetType == 'settings' } as Spec<? super BuildOperationRecord>
+    private static Spec<? super BuildOperationRecord> targetsSettings(String buildPath=":") {
+        { s -> s.details.targetType == 'settings' && s.details.buildPath == buildPath} as Spec<? super BuildOperationRecord>
     }
 
     private static Spec<? super BuildOperationRecord> targetsProject(String projectPath) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CalculateTaskGraphBuildOperationIntegrationTest.groovy
@@ -163,6 +163,7 @@ class CalculateTaskGraphBuildOperationIntegrationTest extends AbstractIntegratio
         settingsFile << """
             includeBuild 'included-build'
         """
+        file("included-build/settings.gradle").touch()
 
         buildFile << """
             apply plugin:'java-library'

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -110,6 +110,7 @@ plugins {
 group = "buildlogic"
 
 """
+        file("included/settings.gradle").touch()
         buildFile << '''
 plugins {
     id('buildlogic.foo')

--- a/subprojects/core/src/main/java/org/gradle/execution/DeprecateUndefinedBuildWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DeprecateUndefinedBuildWorkExecutor.java
@@ -45,7 +45,7 @@ public class DeprecateUndefinedBuildWorkExecutor implements BuildWorkExecutor {
     }
 
     private static boolean isUndefinedBuild(GradleInternal gradle) {
-        return !isBuildSrcExecution(gradle) && !gradle.getRootProject().getBuildFile().exists() && isUndefinedResource(gradle.getSettings().getSettingsScript().getResource());
+        return !isBuildSrcExecution(gradle) && isUndefinedResource(gradle.getSettings().getSettingsScript().getResource());
     }
 
     private static boolean isUndefinedResource(TextResource settingsScript) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -849,6 +849,7 @@ settingsEvaluated {
             }
         }
         """
+        file("my-plugin/settings.gradle").touch()
     }
 
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -651,6 +651,7 @@ If the artifacts are trustworthy, you will need to update the gradle/verificatio
             package org.included;
             public class Included {}
         """
+        file("included/settings.gradle").touch()
 
         when:
         fails "compileJava", "--include-build", "included"

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/legacy/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -118,6 +118,7 @@ notified
             }
             task t
         """
+        file("child/settings.gradle").touch()
 
         runAndFail("t")
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppDependenciesIntegrationTest.groovy
@@ -132,6 +132,7 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
                 api 'org.gradle.cpp:log:latest.integration'
             }
         """
+        libraryPath.file("settings.gradle").touch()
     }
 
     private writeLogLibrary(TestFile dir = testDirectory) {
@@ -142,5 +143,6 @@ class CppDependenciesIntegrationTest extends AbstractInstalledToolChainIntegrati
             group = 'org.gradle.cpp'
             version = '1.0'
         """
+        logPath.file("settings.gradle").touch()
     }
 }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/MappingSourceDependencyMultiprojectIntegrationTest.groovy
@@ -76,11 +76,13 @@ class MappingSourceDependencyMultiprojectIntegrationTest extends AbstractSourceD
             group = 'org.test'
             version = '2.0'
         """
+        repo.file("foo/settings.gradle").touch()
         repo.file("bar/build.gradle") << """
             apply plugin: 'java'
             group = 'org.test'
             version = '3.0'
         """
+        repo.file("bar/settings.gradle").touch()
         repo.commit('updated')
 
         settingsFile << """

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorCompositeBuildIntegrationTest.groovy
@@ -40,6 +40,8 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
         withLegacyWorkerPluginInPluginBuild()
         withTypedWorkerPluginInPluginBuild()
 
+        plugin.file("settings.gradle").touch()
+
         lib.file("build.gradle") << """
             buildscript {
                 dependencies {
@@ -59,6 +61,7 @@ class WorkerExecutorCompositeBuildIntegrationTest extends AbstractIntegrationSpe
                 from runWork
             }
         """
+        lib.file("settings.gradle").touch()
 
         buildFile << """
             plugins {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
