### PR TITLE
Revert "Ignore CppIncrementalBuildIntegrationTest for now"

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildIntegrationTest.groovy
@@ -22,12 +22,10 @@ import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.junit.Assume.assumeFalse
 
-@Ignore('https://github.com/gradle/gradle-private/issues/3365')
 class CppIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec implements CppTaskNames {
 
     private static final String LIBRARY = ':library'


### PR DESCRIPTION
The test has been ignored on `release` as well and then
got disabled on `master` by the merge.

This reverts commit 8c1c7de9bc8b5aa5355d6b8138ba79b873446dd8.

Fixes gradle/gradle-private#3365.