### PR TITLE
Disable file system watching for builds started by testkit on Windows

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -219,6 +219,13 @@ This may cause test failures when the test expects particular file paths.
 
 If the test uses `GradleRunner.withTestKitDir(...)`, it is unaffected.
 
+==== File system watching with TestKit on Windows
+
+The file system watching implementation on Windows adds a lock to the root project directory in order to watch for changes in there.
+This may cause problems in functional tests when the root project directory is within a temporary directory which is deleted after the test.
+To avoid problems with these file locks for functional tests, <<test_kit#test_kit,TestKit>> disables file system watching for builds executed on Windows via `GradleRunner`.
+Your tests can enable file system watching by passing `--watch-fs` to `GradleRunner.withArguments()`.
+
 ==== Removal of the legacy `maven` plugin
 
 The `maven` plugin has been removed.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -221,10 +221,11 @@ If the test uses `GradleRunner.withTestKitDir(...)`, it is unaffected.
 
 ==== File system watching with TestKit on Windows
 
-The file system watching implementation on Windows adds a lock to the root project directory in order to watch for changes in there.
-This may cause problems in functional tests when the root project directory is within a temporary directory which is deleted after the test.
-To avoid problems with these file locks for functional tests, <<test_kit#test_kit,TestKit>> disables file system watching for builds executed on Windows via `GradleRunner`.
-Your tests can enable file system watching by passing `--watch-fs` to `GradleRunner.withArguments()`.
+The file system watching implementation on Windows adds a lock to the root project directory in order to watch for changes.
+This may cause errors when you try to delete the root project directory after running a build with TestKit.
+For example, tests that use TestKit together with JUnit's `@TempDir` extension, or the `TemporaryFolder` rule can run into this problem.
+To avoid problems with these file locks, `<<test_kit#test_kit,TestKit>> disables file system watching for builds executed on Windows via `GradleRunner`.
+If you'd like to override the default behavior, you can enable file system watching by passing `--watch-fs` to `GradleRunner.withArguments()`.
 
 ==== Removal of the legacy `maven` plugin
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -108,7 +108,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                     } else {
                         FileWatcherRegistry.FileWatchingStatistics statistics = watchRegistry.getAndResetStatistics();
                         if (hasDroppedStateBecauseOfErrorsReceivedWhileWatching(statistics)) {
-                            newRoot = stopWatchingAndInvalidateHierarchy(currentRoot);
+                            newRoot = stopWatchingAndInvalidateHierarchyAfterError(currentRoot);
                         } else {
                             newRoot = currentRoot;
                         }
@@ -194,7 +194,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                     } else {
                         FileWatcherRegistry.FileWatchingStatistics statistics = watchRegistry.getAndResetStatistics();
                         if (hasDroppedStateBecauseOfErrorsReceivedWhileWatching(statistics)) {
-                            newRoot = stopWatchingAndInvalidateHierarchy(currentRoot);
+                            newRoot = stopWatchingAndInvalidateHierarchyAfterError(currentRoot);
                         } else {
                             newRoot = withWatcherChangeErrorHandling(currentRoot, () -> watchRegistry.buildFinished(currentRoot, watchMode, maximumNumberOfWatchedHierarchies));
                         }
@@ -259,13 +259,13 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         }
                     } catch (Exception e) {
                         LOGGER.error("Error while processing file events", e);
-                        stopWatchingAndInvalidateHierarchy();
+                        stopWatchingAndInvalidateHierarchyAfterError();
                     }
                 }
 
                 @Override
                 public void stopWatchingAfterError() {
-                    stopWatchingAndInvalidateHierarchy();
+                    stopWatchingAndInvalidateHierarchyAfterError();
                 }
             });
             watchableHierarchies.forEach(watchableHierarchy -> watchRegistry.registerWatchableHierarchy(watchableHierarchy, currentRoot));
@@ -320,7 +320,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
             return supplier.get();
         } catch (Exception ex) {
             logWatchingError(ex, FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD);
-            return stopWatchingAndInvalidateHierarchy(currentRoot);
+            return stopWatchingAndInvalidateHierarchyAfterError(currentRoot);
         }
     }
 
@@ -345,12 +345,16 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
      * Stop watching the known areas of the file system, and invalidate
      * the parts that have been changed since calling {@link #startWatching(SnapshotHierarchy)}}.
      */
-    private void stopWatchingAndInvalidateHierarchy() {
-        rootReference.update(this::stopWatchingAndInvalidateHierarchy);
+    private void stopWatchingAndInvalidateHierarchyAfterError() {
+        rootReference.update(this::stopWatchingAndInvalidateHierarchyAfterError);
+    }
+
+    private SnapshotHierarchy stopWatchingAndInvalidateHierarchyAfterError(SnapshotHierarchy currentRoot) {
+        LOGGER.error("Stopping file watching and invalidating VFS after an error happened");
+        return stopWatchingAndInvalidateHierarchy(currentRoot);
     }
 
     private SnapshotHierarchy stopWatchingAndInvalidateHierarchy(SnapshotHierarchy currentRoot) {
-        LOGGER.error("Stopping file watching and invalidating VFS after an error happened");
         if (watchRegistry != null) {
             try {
                 FileWatcherRegistry toBeClosed = watchRegistry;

--- a/subprojects/test-kit/build.gradle.kts
+++ b/subprojects/test-kit/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(project(":base-services"))
     implementation(project(":core-api"))
     implementation(project(":core"))
+    implementation(project(":build-option"))
     implementation(project(":wrapper"))
     implementation(project(":tooling-api"))
     implementation(project(":file-temp"))

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner
+
+import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+
+@SuppressWarnings('IntegrationTestFixtures')
+class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerIntegrationTest {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id('java')
+            }
+        """
+    }
+
+    @Requires(TestPrecondition.WINDOWS)
+    def "disables file system watching on Windows"() {
+        when:
+        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true").build()
+        then:
+        !fileSystemWatchingEnabled(result)
+    }
+
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def "file system watching is enabled on non-Windows OSes"() {
+        when:
+        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true").build()
+        then:
+        fileSystemWatchingEnabled(result)
+    }
+
+    def "can enable file system watching on Windows via '#enableFlag'"() {
+        when:
+        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true", enableFlag).build()
+        then:
+        fileSystemWatchingEnabled(result)
+
+        where:
+        enableFlag << ["--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}", "-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true"]
+    }
+
+    private static boolean fileSystemWatchingEnabled(BuildResult result) {
+        result.output.contains("Virtual file system retains information")
+    }
+}

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -49,7 +49,7 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
 
     def "can enable file system watching via '#enableFlag'"() {
         when:
-        def result = runAssemble()
+        def result = runAssemble(enableFlag)
         then:
         fileSystemWatchingEnabled(result)
 
@@ -57,8 +57,8 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
         enableFlag << ["--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}", "-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true"]
     }
 
-    private BuildResult runAssemble() {
-        runner("assemble", "-D${StartParameterBuildOptions.VfsVerboseLoggingOption.GRADLE_PROPERTY}=true").build()
+    private BuildResult runAssemble(String... extraArguments) {
+        runner("assemble", "-D${StartParameterBuildOptions.VfsVerboseLoggingOption.GRADLE_PROPERTY}=true", *extraArguments).build()
     }
 
     private static boolean fileSystemWatchingEnabled(BuildResult result) {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -34,7 +34,7 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
     @Requires(TestPrecondition.WINDOWS)
     def "disables file system watching on Windows"() {
         when:
-        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true").build()
+        def result = runAssemble()
         then:
         !fileSystemWatchingEnabled(result)
     }
@@ -42,19 +42,23 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
     @Requires(TestPrecondition.NOT_WINDOWS)
     def "file system watching is enabled on non-Windows OSes"() {
         when:
-        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true").build()
+        def result = runAssemble()
         then:
         fileSystemWatchingEnabled(result)
     }
 
-    def "can enable file system watching on Windows via '#enableFlag'"() {
+    def "can enable file system watching via '#enableFlag'"() {
         when:
-        def result = runner("assemble", "-Dorg.gradle.vfs.verbose=true", enableFlag).build()
+        def result = runAssemble()
         then:
         fileSystemWatchingEnabled(result)
 
         where:
         enableFlag << ["--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}", "-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true"]
+    }
+
+    private BuildResult runAssemble() {
+        runner("assemble", "-D${StartParameterBuildOptions.VfsVerboseLoggingOption.GRADLE_PROPERTY}=true").build()
     }
 
     private static boolean fileSystemWatchingEnabled(BuildResult result) {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -122,7 +122,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
         result.tasks.empty
     }
 
-    private String missingProjectDirError(File nonExistentWorkingDir) {
+    private static String missingProjectDirError(File nonExistentWorkingDir) {
         if (gradleVersion < GradleVersion.version("4.0")) {
             return "Project directory '$nonExistentWorkingDir.absolutePath' does not exist."
         }
@@ -171,7 +171,11 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
         and:
         def output = OutputScrapingExecutionResult.from(t.message, "")
         def taskHeader = gradleVersion >= GradleVersion.version("4.0") ? "\n> Task :helloWorld" : ":helloWorld"
-        def actualArguments = OperatingSystem.current().windows ? ["-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=false"] + runner.arguments : runner.arguments
+        // GradleRunner disables FS watching on Windows by passing a command line argument, so the arguments are different for Windows and other operating systems
+        // See GradleRunner's Javadoc.
+        def actualArguments = OperatingSystem.current().windows
+            ? ["-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=false"] + runner.arguments
+            : runner.arguments
         output.normalizedOutput == """An error occurred executing build with args '${actualArguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
 $taskHeader
 Hello world!

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -17,7 +17,9 @@
 package org.gradle.testkit.runner
 
 import org.gradle.api.GradleException
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.launcher.daemon.client.DaemonDisappearedException
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
@@ -169,7 +171,8 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
         and:
         def output = OutputScrapingExecutionResult.from(t.message, "")
         def taskHeader = gradleVersion >= GradleVersion.version("4.0") ? "\n> Task :helloWorld" : ":helloWorld"
-        output.normalizedOutput == """An error occurred executing build with args '${runner.arguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
+        def actualArguments = OperatingSystem.current().windows ? ["-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=false"] + runner.arguments : runner.arguments
+        output.normalizedOutput == """An error occurred executing build with args '${actualArguments.join(' ')}' in directory '$testDirectory.canonicalPath'. Output before error:
 $taskHeader
 Hello world!
 """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerSupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerSupportedBuildJvmIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.testkit.runner
 
+import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.testkit.runner.fixtures.NoDebug
 import org.gradle.testkit.runner.fixtures.NonCrossVersion
 import org.gradle.tooling.GradleConnectionException
@@ -30,13 +32,14 @@ class GradleRunnerSupportedBuildJvmIntegrationTest extends BaseGradleRunnerInteg
     def "fails when build is configured to use Java 7 or earlier"() {
         given:
         testDirectory.file("gradle.properties").writeProperties("org.gradle.java.home": jdk.javaHome.absolutePath)
+        String args = OperatingSystem.current().windows ? "args '-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=false'" : 'no args'
 
         when:
         runner().buildAndFail()
 
         then:
         IllegalStateException e = thrown()
-        e.message.startsWith("An error occurred executing build with no args in directory ")
+        e.message.startsWith("An error occurred executing build with ${args} in directory ")
         e.cause instanceof GradleConnectionException
         e.cause.cause.message == "Gradle ${GradleVersion.current().version} requires Java 8 or later to run. Your build is currently configured to use Java ${jdk.javaVersion.majorVersion}."
 

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
@@ -47,6 +47,10 @@ import java.util.Map;
  * GradleRunner instances are not thread safe and cannot be used concurrently.
  * However, multiple instances are able to be used concurrently.
  * <p>
+ * On Windows, Gradle runner disables file system watching for the executed build, since the Windows watchers add a file lock
+ * on the root project directory, causing problems when trying to delete it. You can still enable file system watching manually
+ * for your test by adding the `--watch-fs` command line argument via {@link #withArguments(String...)}.
+ * <p>
  * Please see the Gradle <a href="https://docs.gradle.org/current/userguide/test_kit.html" target="_top">TestKit</a> User Manual chapter for more information.
  *
  * @since 2.6

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
@@ -311,22 +311,22 @@ public class DefaultGradleRunner extends GradleRunner {
 
         GradleProvider effectiveDistribution = gradleProvider == null ? findGradleInstallFromGradleRunner() : gradleProvider;
 
-        List<String> effectiveJvmArguments = new ArrayList<>();
+        List<String> effectiveArguments = new ArrayList<>();
         if (OperatingSystem.current().isWindows()) {
             // When using file system watching in Windows tests it becomes harder to delete the project directory,
             // since file system watching on Windows adds a lock on the watched directory, which is currently the project directory.
             // After deleting the contents of the watched directory, Gradle will stop watching the directory and release the file lock.
             // That may require a retry to delete the watched directory.
             // To avoid those problems for TestKit tests on Windows, we disable file system watching there.
-            effectiveJvmArguments.add("-D" + StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY + "=false");
+            effectiveArguments.add("-D" + StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY + "=false");
         }
-        effectiveJvmArguments.addAll(jvmArguments);
+        effectiveArguments.addAll(arguments);
         GradleExecutionResult execResult = gradleExecutor.run(new GradleExecutionParameters(
             effectiveDistribution,
             testKitDir,
             projectDirectory,
-            arguments,
-            effectiveJvmArguments,
+            effectiveArguments,
+            jvmArguments,
             classpath,
             debug,
             standardOutput,


### PR DESCRIPTION
so that folks using test kit don't need to deal with file locks in functional tests.

Fixes #16786.