### PR TITLE
Make BuildScanPluginPerformanceTest baseline-aware

### DIFF
--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.performance
 
 import org.apache.commons.io.FileUtils
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
@@ -25,9 +24,6 @@ import org.gradle.profiler.Phase
 import org.gradle.profiler.ScenarioContext
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
-
-import static org.gradle.performance.fixture.BaselineVersionResolver.resolveBaselineVersions
-import static org.gradle.performance.fixture.BaselineVersionResolver.resolveVersion
 
 class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceTest {
 
@@ -41,12 +37,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
     @Unroll
     def "with and without plugin application (#scenario)"() {
         given:
-        def baselineVersions = resolveBaselineVersions(System.getProperty('org.gradle.performance.baselines'), ['last'])
-        if (baselineVersions.empty || baselineVersions.size() > 1) {
-            throw new IllegalArgumentException("Expected exactly one baseline version but got ${baselineVersions.size()}: $baselineVersions")
-        }
-
-        def dist = buildContext.distribution(resolveVersion(baselineVersions.first(), new ReleasedVersionDistributions(buildContext)))
         def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
 
         runner.baseline {

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -44,6 +44,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITHOUT_PLUGIN_LABEL)
             invocation {
+                distribution(distribution)
                 args(*jobArgs)
                 tasksToRun(*tasks)
                 if (withFailure) {
@@ -62,6 +63,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITH_PLUGIN_LABEL)
             invocation {
+                distribution(distribution)
                 args(*jobArgs)
                 args("-DenableScan=true")
                 tasksToRun(*tasks)
@@ -97,7 +99,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         "help"                                                  | MEDIAN_PERCENTAGES_SHIFT      | ['help']                           | false       | []                                                            | false
         "help - no console output"                              | MEDIAN_PERCENTAGES_SHIFT      | ['help']                           | false       | ['-DreducedOutput=true']                                      | false
     }
-
 
     static class ManageLocalCacheState implements BuildMutator {
         final File projectDir

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -44,7 +44,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITHOUT_PLUGIN_LABEL)
             invocation {
-                distribution(dist)
                 args(*jobArgs)
                 tasksToRun(*tasks)
                 if (withFailure) {
@@ -63,7 +62,6 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITH_PLUGIN_LABEL)
             invocation {
-                distribution(dist)
                 args(*jobArgs)
                 args("-DenableScan=true")
                 tasksToRun(*tasks)

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.performance
 
 import org.apache.commons.io.FileUtils
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildMutator
 import org.gradle.profiler.InvocationSettings
@@ -24,6 +25,9 @@ import org.gradle.profiler.Phase
 import org.gradle.profiler.ScenarioContext
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
+
+import static org.gradle.performance.fixture.BaselineVersionResolver.resolveBaselineVersions
+import static org.gradle.performance.fixture.BaselineVersionResolver.resolveVersion
 
 class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceTest {
 
@@ -37,6 +41,12 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
     @Unroll
     def "with and without plugin application (#scenario)"() {
         given:
+        def baselineVersions = resolveBaselineVersions(System.getProperty('org.gradle.performance.baselines'), ['last'])
+        if (baselineVersions.empty || baselineVersions.size() > 1) {
+            throw new IllegalArgumentException("Expected exactly one baseline version but got ${baselineVersions.size()}: $baselineVersions")
+        }
+
+        def distribution = buildContext.distribution(resolveVersion(baselineVersions.first(), new ReleasedVersionDistributions(buildContext)))
         def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
 
         runner.baseline {

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -46,7 +46,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             throw new IllegalArgumentException("Expected exactly one baseline version but got ${baselineVersions.size()}: $baselineVersions")
         }
 
-        def distribution = buildContext.distribution(resolveVersion(baselineVersions.first(), new ReleasedVersionDistributions(buildContext)))
+        def dist = buildContext.distribution(resolveVersion(baselineVersions.first(), new ReleasedVersionDistributions(buildContext)))
         def jobArgs = ['--continue', '-Dscan.capture-task-input-files'] + scenarioArgs
 
         runner.baseline {
@@ -54,7 +54,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITHOUT_PLUGIN_LABEL)
             invocation {
-                distribution(distribution)
+                distribution(dist)
                 args(*jobArgs)
                 tasksToRun(*tasks)
                 if (withFailure) {
@@ -73,7 +73,7 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
             invocationCount INVOCATIONS
             displayName(WITH_PLUGIN_LABEL)
             invocation {
-                distribution(distribution)
+                distribution(dist)
                 args(*jobArgs)
                 args("-DenableScan=true")
                 tasksToRun(*tasks)

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -58,6 +58,7 @@ class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
         assert buildStampJsonFile.exists()
         def buildStampJsonData = new JsonSlurper().parse(buildStampJsonFile) as Map<String, ?>
         assert buildStampJsonData.commitId
+        def pluginCommitId = buildStampJsonData.commitId as String
         runner = new BuildScanPerformanceTestRunner(new GradleBuildExperimentRunner(gradleProfilerReporter, outputDirSelector), resultStore.reportAlso(dataReporter), pluginCommitId, buildContext) {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -17,9 +17,7 @@
 package org.gradle.performance
 
 import groovy.json.JsonSlurper
-import org.gradle.integtests.fixtures.executer.GradleDistribution
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
-import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.BuildScanPerformanceTestRunner
 import org.gradle.performance.fixture.GradleBuildExperimentRunner
@@ -34,9 +32,6 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Shared
-
-import static org.gradle.performance.fixture.VersionResolver.resolveBaselineVersions
-import static org.gradle.performance.fixture.VersionResolver.resolveVersion
 
 class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
 
@@ -58,20 +53,11 @@ class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
     @Shared
     String pluginVersionNumber = resolvePluginVersion()
 
-    GradleDistribution distribution
-
     def setup() {
-        def baselineVersions = resolveBaselineVersions()
-        if (baselineVersions.empty || baselineVersions.size() > 1) {
-            throw new IllegalArgumentException("Expected exactly one baseline version but got ${baselineVersions.size()}: $baselineVersions")
-        }
-
-        distribution = buildContext.distribution(resolveVersion(baselineVersions.first(), new ReleasedVersionDistributions(buildContext)))
         def buildStampJsonFile = new File(incomingDir, "buildStamp.json")
         assert buildStampJsonFile.exists()
         def buildStampJsonData = new JsonSlurper().parse(buildStampJsonFile) as Map<String, ?>
         assert buildStampJsonData.commitId
-        def pluginCommitId = buildStampJsonData.commitId as String
         runner = new BuildScanPerformanceTestRunner(new GradleBuildExperimentRunner(gradleProfilerReporter, outputDirSelector), resultStore.reportAlso(dataReporter), pluginCommitId, buildContext) {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/AbstractBuildScanPluginPerformanceTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance
 
 import groovy.json.JsonSlurper
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
 import org.gradle.performance.fixture.BuildExperimentSpec
 import org.gradle.performance.fixture.BuildScanPerformanceTestRunner
 import org.gradle.performance.fixture.GradleBuildExperimentRunner
@@ -32,6 +33,8 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.AutoCleanup
 import spock.lang.Shared
+
+import static org.gradle.performance.fixture.BaselineVersionResolver.toBaselineVersions
 
 class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
 
@@ -54,6 +57,12 @@ class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
     String pluginVersionNumber = resolvePluginVersion()
 
     def setup() {
+        def baselineVersions = toBaselineVersions(new ReleasedVersionDistributions(buildContext), ['last'], null) as List<String>
+        if (baselineVersions.empty || baselineVersions.size() > 1) {
+            throw new IllegalArgumentException("Expected exactly one baseline version but got ${baselineVersions.size()}: $baselineVersions")
+        }
+
+        def distribution = buildContext.distribution(baselineVersions.first())
         def buildStampJsonFile = new File(incomingDir, "buildStamp.json")
         assert buildStampJsonFile.exists()
         def buildStampJsonData = new JsonSlurper().parse(buildStampJsonFile) as Map<String, ?>
@@ -64,7 +73,9 @@ class AbstractBuildScanPluginPerformanceTest extends AbstractPerformanceTest {
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {
                 super.defaultSpec(builder)
                 builder.workingDirectory = temporaryFolder.testDirectory
-                (builder.invocation as GradleInvocationSpec.InvocationBuilder).buildLog(new File(builder.workingDirectory, "build.log"))
+                def invocation = (builder.invocation as GradleInvocationSpec.InvocationBuilder)
+                invocation.buildLog(new File(builder.workingDirectory, "build.log"))
+                invocation.distribution(distribution)
             }
         }
         performanceTestIdProvider.setTestSpec(runner)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BaselineVersionResolver.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/BaselineVersionResolver.groovy
@@ -53,7 +53,7 @@ class BaselineVersionResolver {
         resolvedVersions
     }
 
-    static List<String> resolveBaselineVersions(String overrideBaselinesProperty, List<String> targetVersions) {
+    private static List<String> resolveBaselineVersions(String overrideBaselinesProperty, List<String> targetVersions) {
         List<String> versions
         if (overrideBaselinesProperty) {
             versions = resolveOverriddenVersions(overrideBaselinesProperty, targetVersions)
@@ -68,7 +68,7 @@ class BaselineVersionResolver {
         versions
     }
 
-    static String resolveVersion(String version, ReleasedVersionDistributions releases) {
+    private static String resolveVersion(String version, ReleasedVersionDistributions releases) {
         switch (version) {
             case 'last':
                 return releases.mostRecentRelease.version.version
@@ -111,7 +111,7 @@ class BaselineVersionResolver {
     }
 
     @CompileStatic(TypeCheckingMode.SKIP)
-    static boolean isRcVersionOrSnapshot(String version) {
+    private static boolean isRcVersionOrSnapshot(String version) {
         GradleVersion versionObject = GradleVersion.version(version)
         // there is no public API for checking for RC version, this is an internal way
         return versionObject.snapshot || versionObject.stage?.stage == 3

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -95,6 +95,10 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
         buildMutators.add(buildMutator)
     }
 
+    List<String> getMeasuredBuildOperations() {
+        return measuredBuildOperations
+    }
+
     CrossVersionPerformanceResults run() {
         assumeShouldRun()
 
@@ -163,6 +167,10 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
             FileUtils.cleanDirectory(perVersion)
         }
         perVersion
+    }
+
+    private static boolean versionMeetsLowerBaseVersionRequirement(String targetVersion, String minimumBaseVersion) {
+        return minimumBaseVersion == null || GradleVersion.version(targetVersion).baseVersion >= GradleVersion.version(minimumBaseVersion)
     }
 
     private void runVersion(String displayName, GradleDistribution dist, File workingDir, MeasuredOperationList results) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -17,9 +17,6 @@
 package org.gradle.performance.fixture
 
 import com.google.common.annotations.VisibleForTesting
-import com.google.common.base.Splitter
-import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
 import org.apache.commons.io.FileUtils
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.executer.GradleDistribution
@@ -47,17 +44,17 @@ import org.junit.Assume
 
 import java.util.function.Consumer
 import java.util.function.Function
-import java.util.regex.Pattern
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
+import static VersionResolver.isRcVersionOrSnapshot
+import static VersionResolver.resolveBaselineVersions
+import static VersionResolver.resolveVersion
 import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
 
 /**
  * Runs cross version performance tests using Gradle profiler.
  */
 class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
-
-    private static final Pattern COMMA_OR_SEMICOLON = Pattern.compile('[;,]')
 
     private final IntegrationTestBuildContext buildContext
     private final DataReporter<CrossVersionPerformanceResults> reporter
@@ -175,42 +172,10 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
         perVersion
     }
 
-    private static String resolveVersion(String version, ReleasedVersionDistributions releases) {
-        switch (version) {
-            case 'last':
-                return releases.mostRecentRelease.version.version
-            case 'nightly':
-                return LatestNightlyBuildDeterminer.latestNightlyVersion
-            case 'defaults':
-                throw new IllegalArgumentException("'defaults' shouldn't be used in target versions.")
-            default:
-                def releasedVersion = findRelease(releases, version)
-                if (releasedVersion) {
-                    return releasedVersion.version.version
-                } else if (isRcVersionOrSnapshot(version)) {
-                    // for snapshots, we don't have a cheap way to check if it really exists, so we'll just
-                    // blindly add it to the list and trust the test author
-                    // Only active rc versions are listed in all-released-versions.properties that ReleasedVersionDistributions uses
-                    return version
-                } else {
-                    throw new RuntimeException("Cannot find Gradle release that matches version '$version'")
-                }
-        }
-    }
-
     @VisibleForTesting
     static Iterable<String> toBaselineVersions(ReleasedVersionDistributions releases, List<String> targetVersions, String minimumBaseVersion) {
-        List<String> versions
         def overrideBaselinesProperty = System.getProperty('org.gradle.performance.baselines')
-        if (overrideBaselinesProperty) {
-            versions = resolveOverriddenVersions(overrideBaselinesProperty, targetVersions)
-        } else {
-            versions = targetVersions
-        }
-
-        if (versions.contains("none")) {
-            return []
-        }
+        def versions = resolveBaselineVersions(overrideBaselinesProperty, targetVersions)
 
         LinkedHashSet<String> resolvedVersions = versions.collect { resolveVersion(it, releases) } as LinkedHashSet<String>
 
@@ -239,34 +204,6 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
 
     private static boolean versionMeetsLowerBaseVersionRequirement(String targetVersion, String minimumBaseVersion) {
         return minimumBaseVersion == null || GradleVersion.version(targetVersion).baseVersion >= GradleVersion.version(minimumBaseVersion)
-    }
-
-    @CompileStatic(TypeCheckingMode.SKIP)
-    private static boolean isRcVersionOrSnapshot(String version) {
-        GradleVersion versionObject = GradleVersion.version(version)
-        // there is no public API for checking for RC version, this is an internal way
-        return versionObject.snapshot || versionObject.stage?.stage == 3
-    }
-
-    private static List<String> resolveOverriddenVersions(String overrideBaselinesProperty, List<String> targetVersions) {
-        def versions = Splitter.on(COMMA_OR_SEMICOLON)
-            .omitEmptyStrings()
-            .splitToList(overrideBaselinesProperty)
-        versions.collectMany([] as Set) { version -> version == 'defaults' ? targetVersions : [version] } as List
-    }
-
-    private static GradleDistribution findRelease(ReleasedVersionDistributions releases, String requested) {
-        GradleDistribution best = null
-        for (GradleDistribution release : releases.all) {
-            if (release.version.version == requested) {
-                return release
-            }
-            if (!release.version.snapshot && release.version.baseVersion.version == requested && (best == null || best.version < release.version)) {
-                best = release
-            }
-        }
-
-        best
     }
 
     private void runVersion(String displayName, GradleDistribution dist, File workingDir, MeasuredOperationList results) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/VersionResolver.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/VersionResolver.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.fixture
+
+import com.google.common.base.Splitter
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+import org.gradle.integtests.fixtures.executer.GradleDistribution
+import org.gradle.integtests.fixtures.versions.ReleasedVersionDistributions
+import org.gradle.util.GradleVersion
+
+import java.util.regex.Pattern
+
+class VersionResolver {
+
+    private static final Pattern COMMA_OR_SEMICOLON = Pattern.compile('[;,]')
+
+    static List<String> resolveBaselineVersions(String overrideBaselinesProperty = System.getProperty('org.gradle.performance.baselines'), List<String> targetVersions = []) {
+        List<String> versions
+        if (overrideBaselinesProperty) {
+            versions = resolveOverriddenVersions(overrideBaselinesProperty, targetVersions)
+        } else {
+            versions = targetVersions
+        }
+
+        if (versions.contains("none")) {
+            return []
+        }
+
+        versions
+    }
+
+    static String resolveVersion(String version, ReleasedVersionDistributions releases) {
+        switch (version) {
+            case 'last':
+                return releases.mostRecentRelease.version.version
+            case 'nightly':
+                return LatestNightlyBuildDeterminer.latestNightlyVersion
+            case 'defaults':
+                throw new IllegalArgumentException("'defaults' shouldn't be used in target versions.")
+            default:
+                def releasedVersion = findRelease(releases, version)
+                if (releasedVersion) {
+                    return releasedVersion.version.version
+                } else if (isRcVersionOrSnapshot(version)) {
+                    // for snapshots, we don't have a cheap way to check if it really exists, so we'll just
+                    // blindly add it to the list and trust the test author
+                    // Only active rc versions are listed in all-released-versions.properties that ReleasedVersionDistributions uses
+                    return version
+                } else {
+                    throw new RuntimeException("Cannot find Gradle release that matches version '$version'")
+                }
+        }
+    }
+
+    private static List<String> resolveOverriddenVersions(String overrideBaselinesProperty, List<String> targetVersions) {
+        List<String> versions = Splitter.on(COMMA_OR_SEMICOLON)
+                .omitEmptyStrings()
+                .splitToList(overrideBaselinesProperty)
+
+        versions.collectMany([] as Set) { version -> version == 'defaults' ? targetVersions : [version] } as List<String>
+    }
+
+    @CompileStatic(TypeCheckingMode.SKIP)
+    static boolean isRcVersionOrSnapshot(String version) {
+        GradleVersion versionObject = GradleVersion.version(version)
+        // there is no public API for checking for RC version, this is an internal way
+        return versionObject.snapshot || versionObject.stage?.stage == 3
+    }
+
+    private static GradleDistribution findRelease(ReleasedVersionDistributions releases, String requested) {
+        GradleDistribution best = null
+        for (GradleDistribution release : releases.all) {
+            if (release.version.version == requested) {
+                return release
+            }
+            if (!release.version.snapshot && release.version.baseVersion.version == requested && (best == null || best.version < release.version)) {
+                best = release
+            }
+        }
+
+        best
+    }
+}

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/BaselineVersionResolverTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/fixture/BaselineVersionResolverTest.groovy
@@ -25,9 +25,9 @@ import org.gradle.util.SetSystemProperties
 import org.junit.Rule
 import spock.lang.Specification
 
-import static CrossVersionPerformanceTestRunner.toBaselineVersions
+import static BaselineVersionResolver.toBaselineVersions
 
-class CrossVersionPerformanceTestRunnerTest extends Specification {
+class BaselineVersionResolverTest extends Specification {
     @Rule
     SetSystemProperties properties = new SetSystemProperties([(ResultsStoreHelper.SYSPROP_PERFORMANCE_TEST_CHANNEL): 'historical-master'])
     private ReleasedVersionDistributions distributions = Mock()
@@ -58,7 +58,7 @@ class CrossVersionPerformanceTestRunnerTest extends Specification {
         e.message.contains('No versions selected: [6.0-20190823180744+0000]')
     }
 
-    def 'lastest release is added if no versions specified'() {
+    def 'latest release is added if no versions specified'() {
         expect:
         toBaselineVersions(distributions, [], null) == ['6.1'] as LinkedHashSet
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/dotcom/issues/8347

### Context

BuildScanPluginPerformanceTest ignores `org.gradle.performance.baselines` property and always runs with latest Gradle BT changes. It is causing Performance Tests job in the GE project always being executed and "blocking" the release pipeline.

With this change we make this test baseline-aware.
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
