### PR TITLE
Support ignoring bucketed performance test

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/IgnorePerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/IgnorePerformanceTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.annotations
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@ExtensionAnnotation(IgnorePerformanceTestExtension.class)
+@interface IgnorePerformanceTest {
+    /**
+     * The reason for ignoring this element.
+     *
+     * @return the reason for ignoring this element
+     */
+    String value() default ""
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/IgnorePerformanceTestExtension.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/annotations/IgnorePerformanceTestExtension.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.annotations
+
+
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
+
+class IgnorePerformanceTestExtension implements IAnnotationDrivenExtension<IgnorePerformanceTest> {
+    public static final String DEFAULT_REASON = "Ignored via @Ignore";
+
+    @Override
+    public void visitSpecAnnotation(IgnorePerformanceTest ignore, SpecInfo spec) {
+        if (!RunForExtension.writingPerformanceJson && spec.getIsBottomSpec()) {
+            spec.skip(ignore.value().isEmpty() ? DEFAULT_REASON : ignore.value())
+        }
+    }
+
+    @Override
+    public void visitFeatureAnnotation(IgnorePerformanceTest ignore, FeatureInfo feature) {
+        if (!RunForExtension.writingPerformanceJson) {
+            feature.skip(ignore.value().isEmpty() ? DEFAULT_REASON : ignore.value())
+        }
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinition.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinition.groovy
@@ -52,7 +52,7 @@ class PerformanceTestScenarioDefinition {
         }
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        @EqualsAndHashCode
+        @EqualsAndHashCode(includes = ["testProject", "comment", "coverage"])
         static class GroupsBean {
             /**
              * testProject : largeJavaMultiProject
@@ -63,6 +63,13 @@ class PerformanceTestScenarioDefinition {
             String comment
 
             TreeMap<String, List<String>> coverage
+
+            private boolean ignored
+
+            // when false, we deliberately make it `null` so that it will be ignored by JSON serializer
+            Boolean isIgnored() {
+                return !ignored ? null : true
+            }
         }
     }
 


### PR DESCRIPTION
Previously, we can't simply ignore the performance test because that
would make bucket JSON inconsistent with the performance tests, which
fails sanityCheck. But sometimes we do want to ignore a performance
test temporarily - that's why this PR exists.

This PR introduces a `@IgnorePerformanceTest` annotation, which adds
a `ignore` field to JSON. The ignored performance test will still be put
into bucket, but at the runtime it will be skipped.
