### PR TITLE
Attempt to fix flaky test for build services classloading reuse

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildServiceIntegrationTest.groovy
@@ -159,6 +159,10 @@ class ConfigurationCacheBuildServiceIntegrationTest extends AbstractConfiguratio
             """
         }
 
+        and:
+        // classloader reuse requires daemon reuse without memory pressure
+        executer.requireIsolatedDaemons()
+
         when:
         inDirectory 'root'
         configurationCacheRun ':included:classloader1:probe', ':included:boundary:classloader2:probe'


### PR DESCRIPTION
This test has been quite flaky. See https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.configurationcache.ConfigurationCacheBuildServiceIntegrationTest&tests.sortField=FLAKY&tests.unstableOnly=true
