### PR TITLE
Add modules to Eclipse classpath only if project is modular 

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseJavaModulesIntegrationTest.groovy
@@ -27,21 +27,7 @@ import static org.gradle.test.fixtures.jpms.ModuleJarFixture.traditionalJar
 @Requires(TestPrecondition.JDK9_OR_LATER)
 class EclipseJavaModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
 
-    private MavenModule publishJavaModule(String name) {
-        mavenRepo.module('org', name, '1.0').mainArtifact(content: moduleJar(name)).publish()
-    }
-
-    private MavenModule publishJavaLibrary(String name) {
-        mavenRepo.module('org', name, '1.0').mainArtifact(content: traditionalJar(name)).publish()
-    }
-
-    private MavenModule publishAutoModule(String name) {
-        mavenRepo.module('org', name, '1.0').mainArtifact(content: autoModuleJar(name)).publish()
-    }
-
-    @ToBeFixedForConfigurationCache
-    def "Marks modules on classpath as such"() {
-        given:
+    def setup() {
         publishJavaModule('jmodule')
         publishAutoModule('jautomodule')
         publishJavaLibrary('jlib')
@@ -61,7 +47,27 @@ class EclipseJavaModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
                 implementation 'org:jlib:1.0'
             }
         """
+    }
 
+    @ToBeFixedForConfigurationCache
+    def "dependencies are not marked as modules if the project itself is not modular"() {
+        when:
+        succeeds "eclipse"
+
+        then:
+        def libraries = classpath.libs
+        libraries.size() == 3
+        libraries[0].jarName == 'jmodule-1.0.jar'
+        libraries[0].assertHasNoAttribute('module', 'true')
+        libraries[1].jarName == 'jautomodule-1.0.jar'
+        libraries[1].assertHasNoAttribute('module', 'true')
+        libraries[2].jarName == 'jlib-1.0.jar'
+        libraries[2].assertHasNoAttribute('module', 'true')
+    }
+
+    @ToBeFixedForConfigurationCache
+    def "Marks modules on classpath as such"() {
+        setup:
         file("src/main/java/module-info.java") << """
             module my.module {
                 requires jmodule
@@ -81,5 +87,17 @@ class EclipseJavaModulesIntegrationTest extends AbstractEclipseIntegrationSpec {
         libraries[1].assertHasAttribute('module', 'true')
         libraries[2].jarName == 'jlib-1.0.jar'
         libraries[2].assertHasNoAttribute('module', 'true')
+    }
+
+    private MavenModule publishJavaModule(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: moduleJar(name)).publish()
+    }
+
+    private MavenModule publishJavaLibrary(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: traditionalJar(name)).publish()
+    }
+
+    private MavenModule publishAutoModule(String name) {
+        mavenRepo.module('org', name, '1.0').mainArtifact(content: autoModuleJar(name)).publish()
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -22,12 +22,15 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.internal.tasks.compile.CompilationSourceDirs;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.model.internal.ClasspathFactory;
@@ -339,9 +342,14 @@ public class EclipseClasspath {
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
         ProjectStateRegistry projectRegistry = projectInternal.getServices().get(ProjectStateRegistry.class);
         boolean inferModulePath = false;
-        Task compileJava = project.getTasks().findByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
-        if (compileJava instanceof JavaCompile) {
-            inferModulePath = ((JavaCompile) compileJava).getModularity().getInferModulePath().get();
+        Task javaCompileTask = project.getTasks().findByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
+        if (javaCompileTask instanceof JavaCompile) {
+            JavaCompile javaCompile = (JavaCompile) javaCompileTask;
+            inferModulePath = javaCompile.getModularity().getInferModulePath().get();
+            if (inferModulePath) {
+                List<File> sourceRoots = CompilationSourceDirs.inferSourceRoots((FileTreeInternal) javaCompile.getSource());
+                inferModulePath = JavaModuleDetector.isModuleSource(true, sourceRoots);
+            }
         }
         ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, projectRegistry, new DefaultGradleApiSourcesResolver(project), inferModulePath);
         return classpathFactory.createEntries();


### PR DESCRIPTION
If the current project is not modular (i.e. does not define a `module-info.java` file) then none of its dependencies should be marked as a module.