### PR TITLE
Allow rich command line arguments for compiler daemons

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/util/MergeOptionsUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/util/MergeOptionsUtil.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal.util;
 import com.google.common.collect.Sets;
 import org.gradle.api.InvalidUserDataException;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Map;
 import java.util.Set;
@@ -66,15 +67,17 @@ public class MergeOptionsUtil {
         }
     }
 
-    public static Set<String> normalized(Iterable<String> strings) {
+    public static Set<String> normalized(@Nullable Iterable<String> strings) {
         Set<String> normalized = Sets.newLinkedHashSet();
-        for (String string : strings) {
-            normalized.add(normalized(string));
+        if (strings != null) {
+            for (String string : strings) {
+                normalized.add(normalized(string));
+            }
         }
         return normalized;
     }
 
-    public static String normalized(String string) {
+    public static String normalized(@Nullable String string) {
         return nullToEmpty(string).trim();
     }
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.BaseForkOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.BaseForkOptions.xml
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>memoryInitialSize</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>memoryMaximumSize</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>jvmArgs</td>
+                <td><literal>[]</literal></td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.ForkOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.ForkOptions.xml
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>executable</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>javaHome</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>tempDir</td>
+                <td><literal>null</literal></td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.GroovyForkOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.GroovyForkOptions.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.ProviderAwareCompilerDaemonForkOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.ProviderAwareCompilerDaemonForkOptions.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>jvmArgumentProviders</td>
+                <td><literal>[]</literal></td>
+            </tr>
+            <tr>
+                <td>allJvmArgs</td>
+                <td><literal>[]</literal></td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaForkOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.scala.ScalaForkOptions.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.language.scala.tasks.BaseScalaCompileOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.language.scala.tasks.BaseScalaCompileOptions.xml
@@ -1,0 +1,92 @@
+<!--
+  ~ Copyright 2014 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default with <literal>scala</literal> plugin</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>failOnError</td>
+                <td><literal>true</literal></td>
+            </tr>
+            <tr>
+                <td>deprecation</td>
+                <td><literal>true</literal></td>
+            </tr>
+            <tr>
+                <td>unchecked</td>
+                <td><literal>true</literal></td>
+            </tr>
+            <tr>
+                <td>debugLevel</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>optimize</td>
+                <td><literal>false</literal></td>
+            </tr>
+            <tr>
+                <td>encoding</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>force</td>
+                <td><literal>false</literal></td>
+            </tr>
+            <tr>
+                <td>additionalParameters</td>
+                <td><literal>[]</literal></td>
+            </tr>
+            <tr>
+                <td>listFiles</td>
+                <td><literal>false</literal></td>
+            </tr>
+            <tr>
+                <td>loggingLevel</td>
+                <td><literal>null</literal></td>
+            </tr>
+            <tr>
+                <td>loggingPhases</td>
+                <td><literal>[]</literal></td>
+            </tr>
+            <tr>
+                <td>forkOptions</td>
+                <td/>
+            </tr>
+            <tr>
+                <td>incrementalOptions</td>
+                <td/>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -61,6 +61,44 @@ ADD RELEASE FEATURES ABOVE
 
 -->
 
+## New features and usability improvements
+
+### Better modeling of command line arguments for compiler daemons
+
+When declaring arguments for a compiler daemon using [jvmArgs](javadoc/org/gradle/api/tasks/compile/BaseForkOptions.html#getJvmArgs--), these arguments are always treated as `String` inputs to the compile task.
+However, sometimes these arguments represent additions to the classpath or input files whose contents should be included during incremental builds or when calculating a build cache key.
+Better modeling of these arguments can improve the incrementality of the compile task and avoid unnecessary cache misses.
+
+Previously, arguments for the Java compiler invocation could be declared in a rich fashion using [compiler argument providers](javadoc/org/gradle/api/tasks/compile/CompileOptions.html#getCompilerArgumentProviders--), but there was no way to do this for the command line arguments of the compiler daemon process itself.
+You can now provide these rich command line arguments to the compiler daemon for [JavaCompile](javadoc/org/gradle/api/tasks/compile/JavaCompile.html), [GroovyCompile](javadoc/org/gradle/api/tasks/compile/GroovyCompile.html), and [ScalaCompile](javadoc/org/gradle/api/tasks/scala/ScalaCompile.html) tasks using [jvmArgumentProviders](javadoc/org/gradle/api/tasks/compile/ProviderAwareForkOptions.html#getJvmArgumentProviders--).
+[CommandLineArgumentProvider](javadoc/org/gradle/process/CommandLineArgumentProvider.html) objects configured via `jvmArgumentProviders` will be interrogated for input and/or output annotations and will add these inputs/outputs to the enclosing compile task.
+
+```
+def javaAgentProvider = new JavaAgentCommandLineArgumentProvider(file('/some/path/to/agent.jar'))
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.forkOptions.jvmArgumentProviders.add(javaAgentProvider)
+}
+
+class JavaAgentCommandLineArgumentProvider implements CommandLineArgumentProvider {
+    @Internal
+    final File javaAgentJarFile
+
+    JavaAgentCommandLineArgumentProvider(File javaAgentJarFile) {
+        this.javaAgentJarFile = javaAgentJarFile
+    }
+
+    @Classpath
+    Iterable<File> getClasspath() {
+        return [javaAgentJarFile]
+    }
+
+    @Override
+    List<String> asArguments() {
+        ["-javaagent:${javaAgentJarFile.absolutePath}".toString()]
+    }
+}
+```
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -753,8 +753,11 @@ There are other task types where this kind of nested inputs are available:
 
 * link:{groovyDslPath}/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:argumentProviders[JavaExec.getArgumentProviders()] - model e.g. custom tools
 * link:{groovyDslPath}/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:jvmArgumentProviders[JavaExec.getJvmArgumentProviders()] - used for Jacoco Java agent
-* link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgumentProviders[CompileOptions.getCompilerArgumentProviders()] - model e.g annotation processors
-* link:{groovyDslPath}/org.gradle.api.tasks.Exec.html#org.gradle.api.tasks.Exec:argumentProviders[Exec.getArgumentProviders()] - model e.g custom tools
+* link:{groovyDslPath}/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:compilerArgumentProviders[CompileOptions.getCompilerArgumentProviders()] - model e.g. annotation processors
+* link:{groovyDslPath}/org.gradle.api.tasks.Exec.html#org.gradle.api.tasks.Exec:argumentProviders[Exec.getArgumentProviders()] - model e.g. custom tools
+* link:{groovyDslPath}/org.gradle.api.tasks.compile.ForkOptions.html#org.gradle.api.tasks.compile.ForkOptions:jvmArgumentProviders[JavaCompile.getOptions().getForkOptions().getJvmArgumentProviders()] - model Java compiler daemon command line arguments
+* link:{groovyDslPath}/org.gradle.api.tasks.compile.GroovyForkOptions.html#org.gradle.api.tasks.compile.GroovyForkOptions:jvmArgumentProviders[GroovyCompile.getGroovyOptions().getForkOptions().getJvmArgumentProviders()] - model Groovy compiler daemon command line arguments
+* link:{groovyDslPath}/org.gradle.api.tasks.scala.ScalaForkOptions.html#org.gradle.api.tasks.scala.ScalaForkOptions:jvmArgumentProviders[ScalaCompile.getScalaOptions().getForkOptions().getJvmArgumentProviders()] - model Scala compiler daemon command line arguments
 
 In the same way, this kind of modelling is available to custom tasks.
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.test.fixtures.file.TestFile
+
+
+abstract class ForkCapableRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
+
+    abstract String getDaemonConfiguration()
+
+    abstract String getForkOptionsObject()
+
+    String getDaemonTask() {
+        return taskName.split(':').last()
+    }
+
+    def "can provide relocatable command line arguments to forked daemons"() {
+        def originalDir = file("original-dir")
+        originalDir.file("settings.gradle") << localCacheConfiguration()
+        setupProjectWithJavaAgentIn(originalDir)
+
+        def relocatedDir = file("relocated-dir")
+        relocatedDir.file("settings.gradle") << localCacheConfiguration()
+        setupProjectWithJavaAgentIn(relocatedDir)
+
+        when:
+        inDirectory(originalDir)
+        withBuildCache().run taskName
+
+        then:
+        executedAndNotSkipped taskName
+
+        when:
+        inDirectory(originalDir)
+        withBuildCache().run taskName
+
+        then:
+        skipped taskName
+
+        when:
+        inDirectory(relocatedDir)
+        withBuildCache().run taskName
+
+        then:
+        skipped taskName
+    }
+
+    void setupProjectWithJavaAgentIn(TestFile directory) {
+        setupProjectIn(directory)
+        def javaAgent = new JavaAgentFixture()
+        javaAgent.writeProjectTo(directory.createDir('javaagent'))
+
+        directory.file('settings.gradle') << """
+            include(':javaagent')
+        """
+        directory.file('build.gradle') << """
+            configurations {
+                javaagent
+            }
+
+            dependencies {
+                javaagent project(':javaagent')
+            }
+
+            ${daemonConfiguration}
+            ${daemonTask}.dependsOn configurations.javaagent
+            ${forkOptionsObject}.jvmArgs.add("-javaagent:\${configurations.javaagent.singleFile.absolutePath}".toString())
+        """
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ForkCapableRelocationIntegrationTest.groovy
@@ -29,6 +29,7 @@ abstract class ForkCapableRelocationIntegrationTest extends AbstractProjectReloc
         return taskName.split(':').last()
     }
 
+    @ToBeFixedForConfigurationCache(bottomSpecs = ["ScalaCompileRelocationIntegrationTest"])
     def "can provide relocatable command line arguments to forked daemons"() {
         def originalDir = file("original-dir")
         originalDir.file("settings.gradle") << localCacheConfiguration()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/JavaAgentFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/JavaAgentFixture.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures
+
+import org.gradle.test.fixtures.file.TestFile
+
+
+class JavaAgentFixture {
+    void writeProjectTo(TestFile projectDir) {
+        projectDir.createDir('src/main/java')
+        projectDir.file('src/main/java/Agent.java').text = javaAgentClassContent
+        projectDir.file('build.gradle').text = buildScriptContent
+    }
+
+    String getJavaAgentClassContent() {
+        return """
+            import java.lang.instrument.Instrumentation;
+
+            public class Agent {
+                public static void premain(String args, Instrumentation instrumentation){
+                    ${agentAction}
+                }
+            }
+        """
+    }
+
+    String getAgentAction() {
+        return """System.out.println("JavaAgent configured!");"""
+    }
+
+    String getBuildScriptContent() {
+        return """
+            plugins {
+                id 'java'
+            }
+
+            jar {
+                manifest {
+                    attributes(
+                            'Premain-Class': 'Agent',
+                            'Implementation-Title': "JavaAgent",
+                            'Implementation-Version': project.version
+                    )
+                }
+            }
+        """
+    }
+}

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.language.groovy
 
-import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/language/groovy/GroovyCompileRelocationIntegrationTest.groovy
@@ -17,15 +17,26 @@
 package org.gradle.language.groovy
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 
 import static org.gradle.util.JarUtils.jarWithContents
 
-class GroovyCompileRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
+class GroovyCompileRelocationIntegrationTest extends ForkCapableRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
         return ":compile"
+    }
+
+    @Override
+    String getDaemonConfiguration() {
+        return "compile.groovyOptions.fork = true"
+    }
+
+    @Override
+    String getForkOptionsObject() {
+        return "compile.groovyOptions.forkOptions"
     }
 
     @Override

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpec.java
@@ -16,21 +16,19 @@
 
 package org.gradle.api.internal.tasks.compile;
 
-import org.gradle.api.tasks.compile.GroovyCompileOptions;
-
 import java.io.File;
 import java.util.List;
 
 public class DefaultGroovyJavaJointCompileSpec extends DefaultJavaCompileSpec implements GroovyJavaJointCompileSpec {
-    private GroovyCompileOptions groovyCompileOptions;
+    private MinimalGroovyCompileOptions groovyCompileOptions;
     private List<File> groovyClasspath;
 
     @Override
-    public GroovyCompileOptions getGroovyCompileOptions() {
+    public MinimalGroovyCompileOptions getGroovyCompileOptions() {
         return groovyCompileOptions;
     }
 
-    public void setGroovyCompileOptions(GroovyCompileOptions groovyCompileOptions) {
+    public void setGroovyCompileOptions(MinimalGroovyCompileOptions groovyCompileOptions) {
         this.groovyCompileOptions = groovyCompileOptions;
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.daemon.DaemonGroovyCompiler;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.api.tasks.compile.GroovyCompileOptions;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
@@ -63,7 +62,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
 
     @Override
     public Compiler<GroovyJavaJointCompileSpec> newCompiler(GroovyJavaJointCompileSpec spec) {
-        GroovyCompileOptions groovyOptions = spec.getGroovyCompileOptions();
+        MinimalGroovyCompileOptions groovyOptions = spec.getGroovyCompileOptions();
         WorkerFactory workerFactory;
         if (groovyOptions.isFork()) {
             workerFactory = workerDaemonFactory;

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import org.gradle.api.tasks.compile.GroovyCompileOptions;
 
 import javax.annotation.Nullable;
@@ -50,7 +50,7 @@ public class MinimalGroovyCompileOptions implements Serializable {
         this.keepStubs = compileOptions.isKeepStubs();
         this.fileExtensions = ImmutableList.copyOf(compileOptions.getFileExtensions());
         this.forkOptions = new MinimalGroovyForkOptions(compileOptions.getForkOptions());
-        this.optimizationOptions = ImmutableMap.copyOf(compileOptions.getOptimizationOptions());
+        this.optimizationOptions = Maps.newHashMap(compileOptions.getOptimizationOptions());
         this.stubDir = compileOptions.getStubDir();
         this.configurationScript = compileOptions.getConfigurationScript();
         this.javaAnnotationProcessing = compileOptions.isJavaAnnotationProcessing();

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.tasks.compile.GroovyCompileOptions;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+public class MinimalGroovyCompileOptions implements Serializable {
+    private boolean failOnError;
+    private boolean verbose;
+    private boolean listFiles;
+    private String encoding;
+    private boolean fork = true;
+    private boolean keepStubs;
+    private List<String> fileExtensions;
+    private MinimalGroovyForkOptions forkOptions;
+    private Map<String, Boolean> optimizationOptions;
+    private File stubDir;
+    private File configurationScript;
+    private boolean javaAnnotationProcessing;
+    private boolean parameters;
+
+    public MinimalGroovyCompileOptions(GroovyCompileOptions compileOptions) {
+        this.failOnError = compileOptions.isFailOnError();
+        this.verbose = compileOptions.isVerbose();
+        this.listFiles = compileOptions.isListFiles();
+        this.encoding = compileOptions.getEncoding();
+        this.fork = compileOptions.isFork();
+        this.keepStubs = compileOptions.isKeepStubs();
+        this.fileExtensions = ImmutableList.copyOf(compileOptions.getFileExtensions());
+        this.forkOptions = new MinimalGroovyForkOptions(compileOptions.getForkOptions());
+        this.optimizationOptions = ImmutableMap.copyOf(compileOptions.getOptimizationOptions());
+        this.stubDir = compileOptions.getStubDir();
+        this.configurationScript = compileOptions.getConfigurationScript();
+        this.javaAnnotationProcessing = compileOptions.isJavaAnnotationProcessing();
+        this.parameters = compileOptions.isParameters();
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public void setVerbose(boolean verbose) {
+        this.verbose = verbose;
+    }
+
+    public boolean isListFiles() {
+        return listFiles;
+    }
+
+    public void setListFiles(boolean listFiles) {
+        this.listFiles = listFiles;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public boolean isFork() {
+        return fork;
+    }
+
+    public void setFork(boolean fork) {
+        this.fork = fork;
+    }
+
+    public boolean isKeepStubs() {
+        return keepStubs;
+    }
+
+    public void setKeepStubs(boolean keepStubs) {
+        this.keepStubs = keepStubs;
+    }
+
+    public List<String> getFileExtensions() {
+        return fileExtensions;
+    }
+
+    public void setFileExtensions(List<String> fileExtensions) {
+        this.fileExtensions = fileExtensions;
+    }
+
+    public MinimalGroovyForkOptions getForkOptions() {
+        return forkOptions;
+    }
+
+    public void setForkOptions(MinimalGroovyForkOptions forkOptions) {
+        this.forkOptions = forkOptions;
+    }
+
+    @Nullable
+    public Map<String, Boolean> getOptimizationOptions() {
+        return optimizationOptions;
+    }
+
+    public void setOptimizationOptions(@Nullable Map<String, Boolean> optimizationOptions) {
+        this.optimizationOptions = optimizationOptions;
+    }
+
+    public File getStubDir() {
+        return stubDir;
+    }
+
+    public void setStubDir(File stubDir) {
+        this.stubDir = stubDir;
+    }
+
+    @Nullable
+    public File getConfigurationScript() {
+        return configurationScript;
+    }
+
+    public void setConfigurationScript(@Nullable File configurationScript) {
+        this.configurationScript = configurationScript;
+    }
+
+    public boolean isJavaAnnotationProcessing() {
+        return javaAnnotationProcessing;
+    }
+
+    public void setJavaAnnotationProcessing(boolean javaAnnotationProcessing) {
+        this.javaAnnotationProcessing = javaAnnotationProcessing;
+    }
+
+    public boolean isParameters() {
+        return parameters;
+    }
+
+    public void setParameters(boolean parameters) {
+        this.parameters = parameters;
+    }
+}

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompileOptions.java
@@ -34,7 +34,7 @@ public class MinimalGroovyCompileOptions implements Serializable {
     private boolean fork = true;
     private boolean keepStubs;
     private List<String> fileExtensions;
-    private MinimalGroovyForkOptions forkOptions;
+    private MinimalGroovyCompilerDaemonForkOptions forkOptions;
     private Map<String, Boolean> optimizationOptions;
     private File stubDir;
     private File configurationScript;
@@ -49,7 +49,7 @@ public class MinimalGroovyCompileOptions implements Serializable {
         this.fork = compileOptions.isFork();
         this.keepStubs = compileOptions.isKeepStubs();
         this.fileExtensions = ImmutableList.copyOf(compileOptions.getFileExtensions());
-        this.forkOptions = new MinimalGroovyForkOptions(compileOptions.getForkOptions());
+        this.forkOptions = new MinimalGroovyCompilerDaemonForkOptions(compileOptions.getForkOptions());
         this.optimizationOptions = Maps.newHashMap(compileOptions.getOptimizationOptions());
         this.stubDir = compileOptions.getStubDir();
         this.configurationScript = compileOptions.getConfigurationScript();
@@ -113,11 +113,11 @@ public class MinimalGroovyCompileOptions implements Serializable {
         this.fileExtensions = fileExtensions;
     }
 
-    public MinimalGroovyForkOptions getForkOptions() {
+    public MinimalGroovyCompilerDaemonForkOptions getForkOptions() {
         return forkOptions;
     }
 
-    public void setForkOptions(MinimalGroovyForkOptions forkOptions) {
+    public void setForkOptions(MinimalGroovyCompilerDaemonForkOptions forkOptions) {
         this.forkOptions = forkOptions;
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompilerDaemonForkOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompilerDaemonForkOptions.java
@@ -20,8 +20,8 @@ import org.gradle.api.tasks.compile.GroovyForkOptions;
 
 import java.io.Serializable;
 
-public class MinimalGroovyForkOptions extends MinimalBaseForkOptions implements Serializable {
-    public MinimalGroovyForkOptions(GroovyForkOptions forkOptions) {
+public class MinimalGroovyCompilerDaemonForkOptions extends MinimalBaseForkOptions implements Serializable {
+    public MinimalGroovyCompilerDaemonForkOptions(GroovyForkOptions forkOptions) {
         super(forkOptions);
         setJvmArgs(forkOptions.getAllJvmArgs());
     }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompilerDaemonForkOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyCompilerDaemonForkOptions.java
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.compile.GroovyForkOptions;
 
 import java.io.Serializable;
 
-public class MinimalGroovyCompilerDaemonForkOptions extends MinimalBaseForkOptions implements Serializable {
+public class MinimalGroovyCompilerDaemonForkOptions extends MinimalCompilerDaemonForkOptions implements Serializable {
     public MinimalGroovyCompilerDaemonForkOptions(GroovyForkOptions forkOptions) {
         super(forkOptions);
         setJvmArgs(forkOptions.getAllJvmArgs());

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyForkOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/MinimalGroovyForkOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,13 @@
 
 package org.gradle.api.internal.tasks.compile;
 
-import java.io.File;
-import java.util.List;
+import org.gradle.api.tasks.compile.GroovyForkOptions;
 
-public interface GroovyCompileSpec extends JvmLanguageCompileSpec {
-    MinimalGroovyCompileOptions getGroovyCompileOptions();
+import java.io.Serializable;
 
-    List<File> getGroovyClasspath();
-
-    void setGroovyClasspath(List<File> classpath);
-
-    boolean incrementalCompilationEnabled();
+public class MinimalGroovyForkOptions extends MinimalBaseForkOptions implements Serializable {
+    public MinimalGroovyForkOptions(GroovyForkOptions forkOptions) {
+        super(forkOptions);
+        setJvmArgs(forkOptions.getAllJvmArgs());
+    }
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -23,8 +23,8 @@ import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.ConstantsAnalysisResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
-import org.gradle.api.tasks.compile.ForkOptions;
-import org.gradle.api.tasks.compile.GroovyForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalGroovyForkOptions;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
@@ -66,13 +66,14 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
 
     @Override
     protected CompilerParameters getCompilerParameters(GroovyJavaJointCompileSpec spec) {
+
         return new GroovyCompilerParameters(compilerClass.getName(), new Object[]{classPathRegistry.getClassPath("JAVA-COMPILER-PLUGIN").getAsFiles()}, spec);
     }
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(GroovyJavaJointCompileSpec spec) {
-        ForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
-        GroovyForkOptions groovyOptions = spec.getGroovyCompileOptions().getForkOptions();
+        MinimalForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
+        MinimalGroovyForkOptions groovyOptions = spec.getGroovyCompileOptions().getForkOptions();
         // Ant is optional dependency of groovy(-all) module but mandatory dependency of Groovy compiler;
         // that's why we add it here. The following assumes that any Groovy compiler version supported by Gradle
         // is compatible with Gradle's current Ant version.

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -23,8 +23,8 @@ import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.ConstantsAnalysisResult;
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingResult;
-import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
-import org.gradle.api.internal.tasks.compile.MinimalGroovyForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalGroovyCompilerDaemonForkOptions;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
@@ -72,8 +72,8 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(GroovyJavaJointCompileSpec spec) {
-        MinimalForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
-        MinimalGroovyForkOptions groovyOptions = spec.getGroovyCompileOptions().getForkOptions();
+        MinimalJavaCompilerDaemonForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
+        MinimalGroovyCompilerDaemonForkOptions groovyOptions = spec.getGroovyCompileOptions().getForkOptions();
         // Ant is optional dependency of groovy(-all) module but mandatory dependency of Groovy compiler;
         // that's why we add it here. The following assumes that any Groovy compiler version supported by Gradle
         // is compatible with Gradle's current Ant version.

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -36,7 +36,7 @@ import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpecFa
 import org.gradle.api.internal.tasks.compile.GroovyCompilerFactory;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.HasCompileOptions;
-import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOptions;
 import org.gradle.api.internal.tasks.compile.MinimalGroovyCompileOptions;
 import org.gradle.api.internal.tasks.compile.incremental.IncrementalCompilerFactory;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.GroovyRecompilationSpecProvider;
@@ -306,7 +306,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
         }
     }
 
-    private void configureExecutable(MinimalForkOptions forkOptions) {
+    private void configureExecutable(MinimalJavaCompilerDaemonForkOptions forkOptions) {
         if (javaLauncher.isPresent()) {
             forkOptions.setExecutable(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
         } else {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -36,6 +36,8 @@ import org.gradle.api.internal.tasks.compile.DefaultGroovyJavaJointCompileSpecFa
 import org.gradle.api.internal.tasks.compile.GroovyCompilerFactory;
 import org.gradle.api.internal.tasks.compile.GroovyJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.compile.HasCompileOptions;
+import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalGroovyCompileOptions;
 import org.gradle.api.internal.tasks.compile.incremental.IncrementalCompilerFactory;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.GroovyRecompilationSpecProvider;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpecProvider;
@@ -264,7 +266,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
         spec.setAnnotationProcessorPath(Lists.newArrayList(compileOptions.getAnnotationProcessorPath() == null ? getProjectLayout().files() : compileOptions.getAnnotationProcessorPath()));
         spec.setGroovyClasspath(Lists.newArrayList(getGroovyClasspath()));
         spec.setCompileOptions(compileOptions);
-        spec.setGroovyCompileOptions(groovyCompileOptions);
+        spec.setGroovyCompileOptions(new MinimalGroovyCompileOptions(groovyCompileOptions));
         spec.getCompileOptions().setSupportsCompilerApi(true);
         if (getOptions().isIncremental()) {
             validateIncrementalCompilationOptions(sourceRoots, spec.annotationProcessingConfigured());
@@ -304,7 +306,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
         }
     }
 
-    private void configureExecutable(ForkOptions forkOptions) {
+    private void configureExecutable(MinimalForkOptions forkOptions) {
         if (javaLauncher.isPresent()) {
             forkOptions.setExecutable(javaLauncher.get().getExecutablePath().getAsFile().getAbsolutePath());
         } else {

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyForkOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyForkOptions.java
@@ -19,6 +19,6 @@ package org.gradle.api.tasks.compile;
  * Fork options for Groovy compilation. Only take effect if {@code GroovyCompileOptions.fork}
  * is {@code true}.
  */
-public class GroovyForkOptions extends BaseForkOptions {
+public class GroovyForkOptions extends ProviderAwareForkOptions {
     private static final long serialVersionUID = 0;
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyForkOptions.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyForkOptions.java
@@ -19,6 +19,6 @@ package org.gradle.api.tasks.compile;
  * Fork options for Groovy compilation. Only take effect if {@code GroovyCompileOptions.fork}
  * is {@code true}.
  */
-public class GroovyForkOptions extends ProviderAwareForkOptions {
+public class GroovyForkOptions extends ProviderAwareCompilerDaemonForkOptions {
     private static final long serialVersionUID = 0;
 }

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
@@ -32,7 +32,7 @@ class NormalizingGroovyCompilerTest extends Specification {
         spec.sourceFiles = files('House.scala', 'Person1.java', 'package.html', 'Person2.groovy')
         spec.destinationDir = new File("destinationDir")
         spec.compileOptions = new CompileOptions(TestUtil.objectFactory())
-        spec.groovyCompileOptions = new GroovyCompileOptions()
+        spec.groovyCompileOptions = new MinimalGroovyCompileOptions(new GroovyCompileOptions())
     }
 
     def "silently excludes source files not ending in .java or .groovy by default"() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.tasks.compile
 
-import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileRelocationIntegrationTest.groovy
@@ -17,15 +17,26 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 
 import static org.gradle.util.JarUtils.jarWithContents
 
-class JavaCompileRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
+class JavaCompileRelocationIntegrationTest extends ForkCapableRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
         return ":compile"
+    }
+
+    @Override
+    String getDaemonConfiguration() {
+        return "compile.options.fork = true"
+    }
+
+    @Override
+    String getForkOptionsObject() {
+        return "compile.options.forkOptions"
     }
 
     @Override

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
-import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.ExecResult;
@@ -45,7 +44,7 @@ public class CommandLineJavaCompiler implements Compiler<JavaCompileSpec>, Seria
 
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
-        final ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        final MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         String executable = forkOptions.getJavaHome() != null ? Jvm.forHome(forkOptions.getJavaHome()).getJavacExecutable().getAbsolutePath() : forkOptions.getExecutable();
         LOGGER.info("Compiling with Java command line compiler '{}'.", executable);
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CommandLineJavaCompiler.java
@@ -44,7 +44,7 @@ public class CommandLineJavaCompiler implements Compiler<JavaCompileSpec>, Seria
 
     @Override
     public WorkResult execute(JavaCompileSpec spec) {
-        final MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        final MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         String executable = forkOptions.getJavaHome() != null ? Jvm.forHome(forkOptions.getJavaHome()).getJavacExecutable().getAbsolutePath() : forkOptions.getExecutable();
         LOGGER.info("Compiling with Java command line compiler '{}'.", executable);
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
-import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.jvm.Jvm;
@@ -56,7 +55,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(JavaCompileSpec spec) {
-        ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(forkOptions);
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         javaForkOptions.setExecutable(findSuitableExecutable(spec));
@@ -72,7 +71,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
     }
 
     private File findSuitableExecutable(JavaCompileSpec spec) {
-        final ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        final MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         if (forkOptions.getExecutable() != null) {
             return new File(forkOptions.getExecutable());
         } else if (forkOptions.getJavaHome() != null) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -55,7 +55,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(JavaCompileSpec spec) {
-        MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(forkOptions);
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         javaForkOptions.setExecutable(findSuitableExecutable(spec));
@@ -71,7 +71,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
     }
 
     private File findSuitableExecutable(JavaCompileSpec spec) {
-        final MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        final MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         if (forkOptions.getExecutable() != null) {
             return new File(forkOptions.getExecutable());
         } else if (forkOptions.getJavaHome() != null) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.compile;
 import com.google.common.base.Joiner;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.internal.Cast;
 import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
@@ -123,7 +122,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        ForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         if (forkOptions.getMemoryInitialSize() != null) {
             args.add("-J-Xms" + forkOptions.getMemoryInitialSize().trim());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -122,7 +122,7 @@ public class JavaCompilerArgumentsBuilder {
             return;
         }
 
-        MinimalForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
+        MinimalJavaCompilerDaemonForkOptions forkOptions = spec.getCompileOptions().getForkOptions();
         if (forkOptions.getMemoryInitialSize() != null) {
             args.add("-J-Xms" + forkOptions.getMemoryInitialSize().trim());
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalForkOptions.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile;
+
+import org.gradle.api.tasks.compile.ForkOptions;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+public class MinimalForkOptions extends MinimalBaseForkOptions {
+    private String executable;
+
+    private String tempDir;
+
+    private File javaHome;
+
+    public MinimalForkOptions(ForkOptions forkOptions) {
+        super(forkOptions);
+        this.executable = forkOptions.getExecutable();
+        this.tempDir = forkOptions.getTempDir();
+        this.javaHome = forkOptions.getJavaHome();
+        setJvmArgs(forkOptions.getAllJvmArgs());
+    }
+
+    @Nullable
+    public String getExecutable() {
+        return executable;
+    }
+
+    public void setExecutable(@Nullable String executable) {
+        this.executable = executable;
+    }
+
+    @Nullable
+    public String getTempDir() {
+        return tempDir;
+    }
+
+    public void setTempDir(@Nullable String tempDir) {
+        this.tempDir = tempDir;
+    }
+
+    @Nullable
+    public File getJavaHome() {
+        return javaHome;
+    }
+
+    public void setJavaHome(@Nullable File javaHome) {
+        this.javaHome = javaHome;
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.DebugOptions;
-import org.gradle.api.tasks.compile.ForkOptions;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -34,7 +33,7 @@ public class MinimalJavaCompileOptions implements Serializable {
     private String encoding;
     private String bootClasspath;
     private String extensionDirs;
-    private ForkOptions forkOptions;
+    private MinimalForkOptions forkOptions;
     private DebugOptions debugOptions;
     private boolean debug;
     private boolean deprecation;
@@ -57,7 +56,7 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.encoding = compileOptions.getEncoding();
         this.bootClasspath = getAsPath(compileOptions.getBootstrapClasspath());
         this.extensionDirs = compileOptions.getExtensionDirs();
-        this.forkOptions = compileOptions.getForkOptions();
+        this.forkOptions = new MinimalForkOptions(compileOptions.getForkOptions());
         this.debugOptions = compileOptions.getDebugOptions();
         this.debug = compileOptions.isDebug();
         this.deprecation = compileOptions.isDeprecation();
@@ -117,11 +116,11 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.extensionDirs = extensionDirs;
     }
 
-    public ForkOptions getForkOptions() {
+    public MinimalForkOptions getForkOptions() {
         return forkOptions;
     }
 
-    public void setForkOptions(ForkOptions forkOptions) {
+    public void setForkOptions(MinimalForkOptions forkOptions) {
         this.forkOptions = forkOptions;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
@@ -33,7 +33,7 @@ public class MinimalJavaCompileOptions implements Serializable {
     private String encoding;
     private String bootClasspath;
     private String extensionDirs;
-    private MinimalForkOptions forkOptions;
+    private MinimalJavaCompilerDaemonForkOptions forkOptions;
     private DebugOptions debugOptions;
     private boolean debug;
     private boolean deprecation;
@@ -56,7 +56,7 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.encoding = compileOptions.getEncoding();
         this.bootClasspath = getAsPath(compileOptions.getBootstrapClasspath());
         this.extensionDirs = compileOptions.getExtensionDirs();
-        this.forkOptions = new MinimalForkOptions(compileOptions.getForkOptions());
+        this.forkOptions = new MinimalJavaCompilerDaemonForkOptions(compileOptions.getForkOptions());
         this.debugOptions = compileOptions.getDebugOptions();
         this.debug = compileOptions.isDebug();
         this.deprecation = compileOptions.isDeprecation();
@@ -116,11 +116,11 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.extensionDirs = extensionDirs;
     }
 
-    public MinimalForkOptions getForkOptions() {
+    public MinimalJavaCompilerDaemonForkOptions getForkOptions() {
         return forkOptions;
     }
 
-    public void setForkOptions(MinimalForkOptions forkOptions) {
+    public void setForkOptions(MinimalJavaCompilerDaemonForkOptions forkOptions) {
         this.forkOptions = forkOptions;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
@@ -21,14 +21,14 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import javax.annotation.Nullable;
 import java.io.File;
 
-public class MinimalForkOptions extends MinimalBaseForkOptions {
+public class MinimalJavaCompilerDaemonForkOptions extends MinimalBaseForkOptions {
     private String executable;
 
     private String tempDir;
 
     private File javaHome;
 
-    public MinimalForkOptions(ForkOptions forkOptions) {
+    public MinimalJavaCompilerDaemonForkOptions(ForkOptions forkOptions) {
         super(forkOptions);
         this.executable = forkOptions.getExecutable();
         this.tempDir = forkOptions.getTempDir();

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompilerDaemonForkOptions.java
@@ -21,7 +21,7 @@ import org.gradle.api.tasks.compile.ForkOptions;
 import javax.annotation.Nullable;
 import java.io.File;
 
-public class MinimalJavaCompilerDaemonForkOptions extends MinimalBaseForkOptions {
+public class MinimalJavaCompilerDaemonForkOptions extends MinimalCompilerDaemonForkOptions {
     private String executable;
 
     private String tempDir;

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -103,9 +103,4 @@ public class ForkOptions extends ProviderAwareForkOptions {
     public void setTempDir(@Nullable String tempDir) {
         this.tempDir = tempDir;
     }
-
-    @Override
-    protected boolean excludeFromAntProperties(String fieldName) {
-        return fieldName.equals("jvmArgs");
-    }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -26,7 +26,7 @@ import java.io.File;
 /**
  * Fork options for Java compilation. Only take effect if {@code CompileOptions.fork} is {@code true}.
  */
-public class ForkOptions extends BaseForkOptions {
+public class ForkOptions extends ProviderAwareForkOptions {
     private static final long serialVersionUID = 0;
 
     private String executable;

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/ForkOptions.java
@@ -26,7 +26,7 @@ import java.io.File;
 /**
  * Fork options for Java compilation. Only take effect if {@code CompileOptions.fork} is {@code true}.
  */
-public class ForkOptions extends ProviderAwareForkOptions {
+public class ForkOptions extends ProviderAwareCompilerDaemonForkOptions {
     private static final long serialVersionUID = 0;
 
     private String executable;

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/MinimalBaseForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/MinimalBaseForkOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile;
+
+import org.gradle.api.tasks.compile.BaseForkOptions;
+
+/**
+ * This class and its subclasses exist so that we have an isolatable instance
+ * of the fork options that can be passed along with the compilation spec to a
+ * worker executor.  Since {@link org.gradle.api.tasks.compile.ProviderAwareForkOptions}
+ * and its subclasses can accept user-defined {@link org.gradle.process.CommandLineArgumentProvider}
+ * instances, these objects may contain references to mutable objects in the
+ * Gradle model or other non-isolatable objects.
+ *
+ * Subclasses should be sure to collapse any {@link org.gradle.process.CommandLineArgumentProvider}
+ * arguments into {@link #jvmArgs} in order to capture the user-provided
+ * command line arguments.
+ */
+public class MinimalBaseForkOptions extends BaseForkOptions {
+    public MinimalBaseForkOptions(BaseForkOptions forkOptions) {
+        setJvmArgs(forkOptions.getJvmArgs());
+        setMemoryInitialSize(forkOptions.getMemoryInitialSize());
+        setMemoryMaximumSize(forkOptions.getMemoryMaximumSize());
+    }
+}

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/MinimalCompilerDaemonForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/internal/tasks/compile/MinimalCompilerDaemonForkOptions.java
@@ -17,11 +17,12 @@
 package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.BaseForkOptions;
+import org.gradle.api.tasks.compile.ProviderAwareCompilerDaemonForkOptions;
 
 /**
  * This class and its subclasses exist so that we have an isolatable instance
  * of the fork options that can be passed along with the compilation spec to a
- * worker executor.  Since {@link org.gradle.api.tasks.compile.ProviderAwareForkOptions}
+ * worker executor.  Since {@link ProviderAwareCompilerDaemonForkOptions}
  * and its subclasses can accept user-defined {@link org.gradle.process.CommandLineArgumentProvider}
  * instances, these objects may contain references to mutable objects in the
  * Gradle model or other non-isolatable objects.
@@ -30,8 +31,8 @@ import org.gradle.api.tasks.compile.BaseForkOptions;
  * arguments into {@link #jvmArgs} in order to capture the user-provided
  * command line arguments.
  */
-public class MinimalBaseForkOptions extends BaseForkOptions {
-    public MinimalBaseForkOptions(BaseForkOptions forkOptions) {
+public class MinimalCompilerDaemonForkOptions extends BaseForkOptions {
+    public MinimalCompilerDaemonForkOptions(BaseForkOptions forkOptions) {
         setJvmArgs(forkOptions.getJvmArgs());
         setMemoryInitialSize(forkOptions.getMemoryInitialSize());
         setMemoryMaximumSize(forkOptions.getMemoryMaximumSize());

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @since 7.1
  */
 @Incubating
-public class ProviderAwareForkOptions extends BaseForkOptions {
+public class ProviderAwareCompilerDaemonForkOptions extends BaseForkOptions {
 
     private final List<CommandLineArgumentProvider> jvmArgumentProviders = Lists.newArrayList();
 

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareCompilerDaemonForkOptions.java
@@ -49,6 +49,12 @@ public class ProviderAwareCompilerDaemonForkOptions extends BaseForkOptions {
         return jvmArgumentProviders;
     }
 
+    /**
+     * Returns the full set of arguments to use to launch the JVM for the compiler process. This includes arguments to define
+     * system properties, the minimum/maximum heap size, and the bootstrap classpath.
+     *
+     * @return The arguments. Returns an empty list if there are no arguments.
+     */
     @Internal
     public List<String> getAllJvmArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareForkOptions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.compile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.gradle.api.Incubating;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.util.internal.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * Fork options for compilation that can accept user-defined {@link CommandLineArgumentProvider} objects.
+ *
+ * Only take effect if {@code fork} is {@code true}.
+ *
+ * @since 7.1
+ */
+@Incubating
+public class ProviderAwareForkOptions extends BaseForkOptions {
+
+    private final List<CommandLineArgumentProvider> jvmArgumentProviders = Lists.newArrayList();
+
+    /**
+     * Returns any additional JVM argument providers for the compiler process.
+     *
+     */
+    @Optional
+    @Nested
+    public List<CommandLineArgumentProvider> getJvmArgumentProviders() {
+        return jvmArgumentProviders;
+    }
+
+    @Internal
+    public List<String> getAllJvmArgs() {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.addAll(CollectionUtils.stringize(getJvmArgs()));
+        for (CommandLineArgumentProvider argumentProvider : getJvmArgumentProviders()) {
+            builder.addAll(argumentProvider.asArguments());
+        }
+        return builder.build();
+    }
+}

--- a/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareForkOptions.java
+++ b/subprojects/language-jvm/src/main/java/org/gradle/api/tasks/compile/ProviderAwareForkOptions.java
@@ -58,4 +58,9 @@ public class ProviderAwareForkOptions extends BaseForkOptions {
         }
         return builder.build();
     }
+
+    @Override
+    protected boolean excludeFromAntProperties(String fieldName) {
+        return fieldName.equals("jvmArgumentProviders") || super.excludeFromAntProperties(fieldName);
+    }
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileRelocationIntegrationTest.groovy
@@ -17,14 +17,26 @@
 package org.gradle.scala.compile
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
+import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.scala.ScalaCompilationFixture
 import org.gradle.test.fixtures.file.TestFile
 
-class ScalaCompileRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
+class ScalaCompileRelocationIntegrationTest extends ForkCapableRelocationIntegrationTest {
 
     @Override
     protected String getTaskName() {
         return ":compileScala"
+    }
+
+    @Override
+    String getDaemonConfiguration() {
+        // Scala compiler always runs in a daemon
+        return ""
+    }
+
+    @Override
+    String getForkOptionsObject() {
+        return "compileScala.scalaCompileOptions.forkOptions"
     }
 
     @Override

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileRelocationIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ScalaCompileRelocationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.scala.compile
 
-import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.integtests.fixtures.ForkCapableRelocationIntegrationTest
 import org.gradle.scala.ScalaCompilationFixture
 import org.gradle.test.fixtures.file.TestFile

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -34,9 +34,8 @@ package org.gradle.api.internal.tasks.scala;
 
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
+import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
-import org.gradle.api.tasks.compile.ForkOptions;
-import org.gradle.api.tasks.scala.ScalaForkOptions;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
@@ -81,8 +80,8 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(T spec) {
-        ForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
-        ScalaForkOptions scalaOptions = spec.getScalaCompileOptions().getForkOptions();
+        MinimalForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
+        MinimalScalaForkOptions scalaOptions = spec.getScalaCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, scalaOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         String javaExecutable = javaOptions.getExecutable();

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -34,7 +34,7 @@ package org.gradle.api.internal.tasks.scala;
 
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.tasks.compile.BaseForkOptionsConverter;
-import org.gradle.api.internal.tasks.compile.MinimalForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalJavaCompilerDaemonForkOptions;
 import org.gradle.api.internal.tasks.compile.daemon.AbstractDaemonCompiler;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.FilteringClassLoader;
@@ -80,8 +80,8 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
 
     @Override
     protected DaemonForkOptions toDaemonForkOptions(T spec) {
-        MinimalForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
-        MinimalScalaForkOptions scalaOptions = spec.getScalaCompileOptions().getForkOptions();
+        MinimalJavaCompilerDaemonForkOptions javaOptions = spec.getCompileOptions().getForkOptions();
+        MinimalScalaCompilerDaemonForkOptions scalaOptions = spec.getScalaCompileOptions().getForkOptions();
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, scalaOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         String javaExecutable = javaOptions.getExecutable();

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpec.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpec.java
@@ -17,13 +17,12 @@
 package org.gradle.api.internal.tasks.scala;
 
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec;
-import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
 
 import java.io.File;
 import java.util.Map;
 
 public class DefaultScalaJavaJointCompileSpec extends DefaultJavaCompileSpec implements ScalaJavaJointCompileSpec {
-    private BaseScalaCompileOptions options;
+    private MinimalScalaCompileOptions options;
     private Iterable<File> scalaClasspath;
     private Iterable<File> zincClasspath;
     private Iterable<File> scalaCompilerPlugins;
@@ -33,7 +32,7 @@ public class DefaultScalaJavaJointCompileSpec extends DefaultJavaCompileSpec imp
     private long buildStartTimestamp;
 
     @Override
-    public BaseScalaCompileOptions getScalaCompileOptions() {
+    public MinimalScalaCompileOptions getScalaCompileOptions() {
         return options;
     }
 
@@ -47,7 +46,7 @@ public class DefaultScalaJavaJointCompileSpec extends DefaultJavaCompileSpec imp
         this.analysisFile = analysisFile;
     }
 
-    public void setScalaCompileOptions(BaseScalaCompileOptions options) {
+    public void setScalaCompileOptions(MinimalScalaCompileOptions options) {
         this.options = options;
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.scala;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.tasks.scala.IncrementalCompileOptions;
+import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.List;
+
+public class MinimalScalaCompileOptions implements Serializable {
+    private boolean failOnError = true;
+    private boolean deprecation = true;
+    private boolean unchecked = true;
+    private String debugLevel;
+    private boolean optimize;
+    private String encoding;
+    private boolean force;
+    private List<String> additionalParameters;
+    private boolean listFiles;
+    private String loggingLevel;
+    private List<String> loggingPhases;
+    private MinimalScalaForkOptions forkOptions;
+    private transient IncrementalCompileOptions incrementalOptions;
+
+    public MinimalScalaCompileOptions(BaseScalaCompileOptions compileOptions) {
+        this.failOnError = compileOptions.isFailOnError();
+        this.deprecation = compileOptions.isDeprecation();
+        this.unchecked = compileOptions.isUnchecked();
+        this.debugLevel = compileOptions.getDebugLevel();
+        this.optimize = compileOptions.isOptimize();
+        this.encoding = compileOptions.getEncoding();
+        this.force = compileOptions.isForce();
+        this.additionalParameters = compileOptions.getAdditionalParameters() == null ? null : ImmutableList.copyOf(compileOptions.getAdditionalParameters());
+        this.listFiles = compileOptions.isListFiles();
+        this.loggingLevel = compileOptions.getLoggingLevel();
+        this.loggingPhases = compileOptions.getLoggingPhases() == null ? null : ImmutableList.copyOf(compileOptions.getLoggingPhases());
+        this.forkOptions = new MinimalScalaForkOptions(compileOptions.getForkOptions());
+        this.incrementalOptions = compileOptions.getIncrementalOptions();
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    public boolean isDeprecation() {
+        return deprecation;
+    }
+
+    public void setDeprecation(boolean deprecation) {
+        this.deprecation = deprecation;
+    }
+
+    public boolean isUnchecked() {
+        return unchecked;
+    }
+
+    public void setUnchecked(boolean unchecked) {
+        this.unchecked = unchecked;
+    }
+
+    @Nullable
+    public String getDebugLevel() {
+        return debugLevel;
+    }
+
+    public void setDebugLevel(@Nullable String debugLevel) {
+        this.debugLevel = debugLevel;
+    }
+
+    public boolean isOptimize() {
+        return optimize;
+    }
+
+    public void setOptimize(boolean optimize) {
+        this.optimize = optimize;
+    }
+
+    @Nullable
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(@Nullable String encoding) {
+        this.encoding = encoding;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    @Nullable
+    public List<String> getAdditionalParameters() {
+        return additionalParameters;
+    }
+
+    public void setAdditionalParameters(@Nullable List<String> additionalParameters) {
+        this.additionalParameters = additionalParameters;
+    }
+
+    public boolean isListFiles() {
+        return listFiles;
+    }
+
+    public void setListFiles(boolean listFiles) {
+        this.listFiles = listFiles;
+    }
+
+    public String getLoggingLevel() {
+        return loggingLevel;
+    }
+
+    public void setLoggingLevel(String loggingLevel) {
+        this.loggingLevel = loggingLevel;
+    }
+
+    public List<String> getLoggingPhases() {
+        return loggingPhases;
+    }
+
+    public void setLoggingPhases(List<String> loggingPhases) {
+        this.loggingPhases = loggingPhases;
+    }
+
+    public MinimalScalaForkOptions getForkOptions() {
+        return forkOptions;
+    }
+
+    public void setForkOptions(MinimalScalaForkOptions forkOptions) {
+        this.forkOptions = forkOptions;
+    }
+
+    public IncrementalCompileOptions getIncrementalOptions() {
+        return incrementalOptions;
+    }
+
+    public void setIncrementalOptions(IncrementalCompileOptions incrementalOptions) {
+        this.incrementalOptions = incrementalOptions;
+    }
+}

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
@@ -36,7 +36,7 @@ public class MinimalScalaCompileOptions implements Serializable {
     private boolean listFiles;
     private String loggingLevel;
     private List<String> loggingPhases;
-    private MinimalScalaForkOptions forkOptions;
+    private MinimalScalaCompilerDaemonForkOptions forkOptions;
     private transient IncrementalCompileOptions incrementalOptions;
 
     public MinimalScalaCompileOptions(BaseScalaCompileOptions compileOptions) {
@@ -51,7 +51,7 @@ public class MinimalScalaCompileOptions implements Serializable {
         this.listFiles = compileOptions.isListFiles();
         this.loggingLevel = compileOptions.getLoggingLevel();
         this.loggingPhases = compileOptions.getLoggingPhases() == null ? null : ImmutableList.copyOf(compileOptions.getLoggingPhases());
-        this.forkOptions = new MinimalScalaForkOptions(compileOptions.getForkOptions());
+        this.forkOptions = new MinimalScalaCompilerDaemonForkOptions(compileOptions.getForkOptions());
         this.incrementalOptions = compileOptions.getIncrementalOptions();
     }
 
@@ -146,11 +146,11 @@ public class MinimalScalaCompileOptions implements Serializable {
         this.loggingPhases = loggingPhases;
     }
 
-    public MinimalScalaForkOptions getForkOptions() {
+    public MinimalScalaCompilerDaemonForkOptions getForkOptions() {
         return forkOptions;
     }
 
-    public void setForkOptions(MinimalScalaForkOptions forkOptions) {
+    public void setForkOptions(MinimalScalaCompilerDaemonForkOptions forkOptions) {
         this.forkOptions = forkOptions;
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompilerDaemonForkOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompilerDaemonForkOptions.java
@@ -21,8 +21,8 @@ import org.gradle.api.tasks.scala.ScalaForkOptions;
 
 import java.io.Serializable;
 
-public class MinimalScalaForkOptions extends MinimalBaseForkOptions implements Serializable {
-    public MinimalScalaForkOptions(ScalaForkOptions forkOptions) {
+public class MinimalScalaCompilerDaemonForkOptions extends MinimalBaseForkOptions implements Serializable {
+    public MinimalScalaCompilerDaemonForkOptions(ScalaForkOptions forkOptions) {
         super(forkOptions);
         setJvmArgs(forkOptions.getAllJvmArgs());
     }

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompilerDaemonForkOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompilerDaemonForkOptions.java
@@ -16,12 +16,12 @@
 
 package org.gradle.api.internal.tasks.scala;
 
-import org.gradle.api.internal.tasks.compile.MinimalBaseForkOptions;
+import org.gradle.api.internal.tasks.compile.MinimalCompilerDaemonForkOptions;
 import org.gradle.api.tasks.scala.ScalaForkOptions;
 
 import java.io.Serializable;
 
-public class MinimalScalaCompilerDaemonForkOptions extends MinimalBaseForkOptions implements Serializable {
+public class MinimalScalaCompilerDaemonForkOptions extends MinimalCompilerDaemonForkOptions implements Serializable {
     public MinimalScalaCompilerDaemonForkOptions(ScalaForkOptions forkOptions) {
         super(forkOptions);
         setJvmArgs(forkOptions.getAllJvmArgs());

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaForkOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaForkOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.compile;
+package org.gradle.api.internal.tasks.scala;
 
-import java.io.File;
-import java.util.List;
+import org.gradle.api.internal.tasks.compile.MinimalBaseForkOptions;
+import org.gradle.api.tasks.scala.ScalaForkOptions;
 
-public interface GroovyCompileSpec extends JvmLanguageCompileSpec {
-    MinimalGroovyCompileOptions getGroovyCompileOptions();
+import java.io.Serializable;
 
-    List<File> getGroovyClasspath();
-
-    void setGroovyClasspath(List<File> classpath);
-
-    boolean incrementalCompilationEnabled();
+public class MinimalScalaForkOptions extends MinimalBaseForkOptions implements Serializable {
+    public MinimalScalaForkOptions(ScalaForkOptions forkOptions) {
+        super(forkOptions);
+        setJvmArgs(forkOptions.getAllJvmArgs());
+    }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompileSpec.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ScalaCompileSpec.java
@@ -17,13 +17,12 @@
 package org.gradle.api.internal.tasks.scala;
 
 import org.gradle.api.internal.tasks.compile.JvmLanguageCompileSpec;
-import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
 
 import java.io.File;
 import java.util.Map;
 
 public interface ScalaCompileSpec extends JvmLanguageCompileSpec {
-    BaseScalaCompileOptions getScalaCompileOptions();
+    MinimalScalaCompileOptions getScalaCompileOptions();
 
     Iterable<File> getScalaCompilerPlugins();
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGenerator.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerArgumentsGenerator.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.scala;
 
 import com.google.common.collect.Lists;
-import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
 
 import java.io.File;
 import java.util.List;
@@ -26,7 +25,7 @@ public class ZincScalaCompilerArgumentsGenerator {
     public List<String> generate(ScalaCompileSpec spec) {
         List<String> result = Lists.newArrayList();
 
-        BaseScalaCompileOptions options = spec.getScalaCompileOptions();
+        MinimalScalaCompileOptions options = spec.getScalaCompileOptions();
         addFlag("-deprecation", options.isDeprecation(), result);
         addFlag("-unchecked", options.isUnchecked(), result);
         addConcatenatedOption("-g:", options.getDebugLevel(), result);

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaForkOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaForkOptions.java
@@ -32,12 +32,12 @@ package org.gradle.api.tasks.scala;
  * limitations under the License.
  */
 
-import org.gradle.api.tasks.compile.BaseForkOptions;
+import org.gradle.api.tasks.compile.ProviderAwareForkOptions;
 
 /**
  * Fork options for Scala compilation. Only take effect if {@code BaseScalaCompileOptions.fork}
  * is {@code true}.
  */
-public class ScalaForkOptions extends BaseForkOptions {
+public class ScalaForkOptions extends ProviderAwareForkOptions {
     private static final long serialVersionUID = 0;
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaForkOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaForkOptions.java
@@ -32,12 +32,12 @@ package org.gradle.api.tasks.scala;
  * limitations under the License.
  */
 
-import org.gradle.api.tasks.compile.ProviderAwareForkOptions;
+import org.gradle.api.tasks.compile.ProviderAwareCompilerDaemonForkOptions;
 
 /**
  * Fork options for Scala compilation. Only take effect if {@code BaseScalaCompileOptions.fork}
  * is {@code true}.
  */
-public class ScalaForkOptions extends ProviderAwareForkOptions {
+public class ScalaForkOptions extends ProviderAwareCompilerDaemonForkOptions {
     private static final long serialVersionUID = 0;
 }

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.tasks.compile.CompilerForkUtils;
 import org.gradle.api.internal.tasks.compile.HasCompileOptions;
 import org.gradle.api.internal.tasks.scala.DefaultScalaJavaJointCompileSpec;
 import org.gradle.api.internal.tasks.scala.DefaultScalaJavaJointCompileSpecFactory;
+import org.gradle.api.internal.tasks.scala.MinimalScalaCompileOptions;
 import org.gradle.api.internal.tasks.scala.ScalaCompileSpec;
 import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
 import org.gradle.api.logging.Logger;
@@ -128,7 +129,7 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
         spec.setSourceCompatibility(getSourceCompatibility());
         spec.setTargetCompatibility(getTargetCompatibility());
         spec.setCompileOptions(getOptions());
-        spec.setScalaCompileOptions(scalaCompileOptions);
+        spec.setScalaCompileOptions(new MinimalScalaCompileOptions(scalaCompileOptions));
         spec.setAnnotationProcessorPath(compileOptions.getAnnotationProcessorPath() == null
             ? ImmutableList.of()
             : ImmutableList.copyOf(compileOptions.getAnnotationProcessorPath()));

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -214,7 +214,9 @@ public class BaseScalaCompileOptions extends AbstractOptions {
         this.forkOptions = forkOptions;
     }
 
-
+    /**
+     * Options for incremental compilation of Scala code.
+     */
     @Nested
     public IncrementalCompileOptions getIncrementalOptions() {
         return incrementalOptions;


### PR DESCRIPTION
Rich compiler arguments can be passed to the java compiler via `CompileOptions.compilerArgumentProviders` but rich command line arguments for the compiler daemons themselves cannot currently be provided.

These changes add a `jvmArgumentProviders` property to the fork options for Java, Groovy, and Scala compiler daemons.  This allows rich definitions of command line arguments to provide non-trivial inputs/outputs.  In order to deal with the user-defined `CommandLineArgumentProvider` objects during isolation, we introduce new `Minimal` fork option objects following the lead of what was done with `MinimalJavaCompileOptions` to support `compilerArgumentProviders`.

Additionally, we also add a regression test for adding annotation processor options on the command line for Groovy and Scala compilation.  There was coverage for Java compilation, but not Groovy/Scala.

Fixes #16800 


