### PR TITLE
Fix flaky parallel task execution test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -264,9 +264,13 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
         withParallelThreads(3)
 
         expect:
-        2.times {
-            blockingServer.expectConcurrent(":a:aSerialPing")
-            blockingServer.expectConcurrent(":b:aPing", ":b:bPing")
+        blockingServer.expectConcurrent(":a:aSerialPing")
+        blockingServer.expectConcurrent(":b:aPing", ":b:bPing")
+        run ":a:aSerialPing", ":b:aPing", ":b:bPing"
+
+        // when configuration is loaded from configuration cache, all tasks are executed in parallel
+        if (GradleContextualExecuter.configCache) {
+            blockingServer.expectConcurrent(":a:aSerialPing", ":b:aPing", ":b:bPing")
             run ":a:aSerialPing", ":b:aPing", ":b:bPing"
         }
     }


### PR DESCRIPTION
When configuration is loaded from configuration cache, the tasks are always executed in parallel.
This change adjusts the test to only do the second iteration when running in config-cache mode
and adjusts assertions of that second iteration to expect all tasks to be parallel.
