### PR TITLE
Normalize JARs produced by MavenJarCreator

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/action/AnnotationGeneratorWorkAction.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/action/AnnotationGeneratorWorkAction.kt
@@ -123,9 +123,12 @@ ${groovyProjectAccessors()}
         val objectMethods = Any::class.java.declaredMethods.toList()
         return Project::class
             .memberFunctions
+            .asSequence()
             .mapNotNull { it.javaMethod }
             .filterNot { objectMethods.contains(it) }
-            .joinToString(separator = "\n") { it.toGroovyScriptString() }
+            .map { it.toGroovyScriptString() }
+            .sorted()
+            .joinToString(separator = "\n")
     }
 
     private

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
@@ -17,10 +17,10 @@
 package gradlebuild.performance.generator
 
 import java.nio.file.attribute.FileTime
-import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
-import java.util.jar.Manifest
 import java.util.zip.Deflater
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 class MavenJarCreator {
     int minimumSizeKB = 0
@@ -31,10 +31,10 @@ class MavenJarCreator {
     void createJar(MavenModule mavenModule, File artifactFile) {
         try {
             artifactFile.withOutputStream { stream ->
-                JarOutputStream out = new JarOutputStream(stream, new Manifest());
+                ZipOutputStream out = new ZipOutputStream(stream)
                 out.setLevel(Deflater.NO_COMPRESSION)
                 try {
-                    addJarEntry(out, artifactFile.name + ".properties", "testcontent")
+                    addZipEntry(out, artifactFile.name + ".properties", "testcontent")
                     if (minimumSizeKB > 0) {
                         int sizeInBytes
                         if(maximumSizeKB > minimumSizeKB) {
@@ -42,7 +42,7 @@ class MavenJarCreator {
                         } else {
                             sizeInBytes = minimumSizeKB * 1024
                         }
-                        addGeneratedUncompressedJarEntry(out, "generated.txt", sizeInBytes)
+                        addGeneratedUncompressedZipEntry(out, "generated.txt", sizeInBytes)
                     }
                 } finally {
                     out.close()
@@ -54,9 +54,9 @@ class MavenJarCreator {
         }
     }
 
-    private void addJarEntry(JarOutputStream out, String name, String content) {
+    private void addZipEntry(ZipOutputStream out, String name, String content) {
         // Add archive entry
-        JarEntry entry = new NormalizedJarEntry(name)
+        ZipEntry entry = new NormalizedZipEntry(name)
         out.putNextEntry(entry)
 
         // Write file to archive
@@ -64,8 +64,8 @@ class MavenJarCreator {
         out.write(contentBytes, 0, contentBytes.length)
     }
 
-    private void addGeneratedUncompressedJarEntry(JarOutputStream out, String name, int sizeInBytes) {
-        JarEntry entry = new NormalizedJarEntry(name)
+    private void addGeneratedUncompressedZipEntry(ZipOutputStream out, String name, int sizeInBytes) {
+        ZipEntry entry = new NormalizedZipEntry(name)
         out.putNextEntry(entry)
 
         for (int i = 0; i < sizeInBytes; i++) {
@@ -74,8 +74,8 @@ class MavenJarCreator {
     }
 
 
-    class NormalizedJarEntry extends JarEntry {
-        NormalizedJarEntry(String name) {
+    class NormalizedZipEntry extends ZipEntry {
+        NormalizedZipEntry(String name) {
             super(name)
             creationTime = FileTime.fromMillis(0)
             lastAccessTime = FileTime.fromMillis(0)

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
@@ -16,6 +16,7 @@
 
 package gradlebuild.performance.generator
 
+import java.nio.file.attribute.FileTime
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
@@ -55,8 +56,7 @@ class MavenJarCreator {
 
     private void addJarEntry(JarOutputStream out, String name, String content) {
         // Add archive entry
-        JarEntry entry = new JarEntry(name)
-        entry.setTime(System.currentTimeMillis())
+        JarEntry entry = new NormalizedJarEntry(name)
         out.putNextEntry(entry)
 
         // Write file to archive
@@ -65,12 +65,22 @@ class MavenJarCreator {
     }
 
     private void addGeneratedUncompressedJarEntry(JarOutputStream out, String name, int sizeInBytes) {
-        JarEntry entry = new JarEntry(name)
-        entry.setTime(System.currentTimeMillis())
+        JarEntry entry = new NormalizedJarEntry(name)
         out.putNextEntry(entry)
 
         for (int i = 0; i < sizeInBytes; i++) {
             out.write(charsToUse, i % charsToUse.length, 1)
         }
     }
+
+
+    class NormalizedJarEntry extends JarEntry {
+        NormalizedJarEntry(String name) {
+            super(name)
+            creationTime = FileTime.fromMillis(0)
+            lastAccessTime = FileTime.fromMillis(0)
+            lastModifiedTime = FileTime.fromMillis(0)
+        }
+    }
 }
+

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
@@ -73,7 +73,6 @@ class MavenJarCreator {
         }
     }
 
-
     class NormalizedZipEntry extends ZipEntry {
         NormalizedZipEntry(String name) {
             super(name)

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
@@ -56,7 +56,7 @@ class MavenJarCreator {
 
     private void addZipEntry(ZipOutputStream out, String name, String content) {
         // Add archive entry
-        ZipEntry entry = new NormalizedZipEntry(name)
+        ZipEntry entry = normalizedZipEntry(name)
         out.putNextEntry(entry)
 
         // Write file to archive
@@ -65,7 +65,7 @@ class MavenJarCreator {
     }
 
     private void addGeneratedUncompressedZipEntry(ZipOutputStream out, String name, int sizeInBytes) {
-        ZipEntry entry = new NormalizedZipEntry(name)
+        ZipEntry entry = normalizedZipEntry(name)
         out.putNextEntry(entry)
 
         for (int i = 0; i < sizeInBytes; i++) {
@@ -73,9 +73,8 @@ class MavenJarCreator {
         }
     }
 
-    class NormalizedZipEntry extends ZipEntry {
-        NormalizedZipEntry(String name) {
-            super(name)
+    private static ZipEntry normalizedZipEntry(String name) {
+        new ZipEntry(name).tap {
             creationTime = FileTime.fromMillis(0)
             lastAccessTime = FileTime.fromMillis(0)
             lastModifiedTime = FileTime.fromMillis(0)

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/MavenJarCreator.groovy
@@ -17,7 +17,6 @@
 package gradlebuild.performance.generator
 
 import java.nio.file.attribute.FileTime
-import java.util.jar.JarOutputStream
 import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream


### PR DESCRIPTION
### Context
As part of https://github.com/gradle/dotcom/issues/8347 we noticed that Performance Tests are not properly cacheable.
One of the reasons was that this test is generating plenty of test JARs and they are not normalized correctly: https://e.grdev.net/c/j35kx4okgjbvo/wmbty2mtvklr2/task-inputs?expanded=WyJra2lxd2V0eGh4NHhvLXRlc3RQcm9qZWN0RmlsZXMtMC0wIiwia2tpcXdldHhoeDR4by10ZXN0UHJvamVjdEZpbGVzLTAtMC0wIiwia2tpcXdldHhoeDR4by10ZXN0cHJvamVjdGZpbGVzIl0#change-kkiqwetxhx4xo-testProjectFiles-0-0-0

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
