### PR TITLE
Fix JavaVersion Nullability Info

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java
@@ -17,6 +17,7 @@ package org.gradle.api;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,7 +129,8 @@ public enum JavaVersion {
      * @return The version, or null if the provided value is null.
      * @throws IllegalArgumentException when the provided value cannot be converted.
      */
-    public static JavaVersion toVersion(Object value) throws IllegalArgumentException {
+    @Nullable
+    public static JavaVersion toVersion(@Nullable Object value) throws IllegalArgumentException {
         if (value == null) {
             return null;
         }


### PR DESCRIPTION
This adds missing `@Nullable` annotations to `org.gradle.api.JavaVersion` for all Kotlin users who require this to avoid surprises.

Signed-off-by: Fleshgrinder <fleshgrinder@users.noreply.github.com>
