### PR TITLE
Deprecate WarPluginConvention

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/war_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/war_plugin.adoc
@@ -74,7 +74,7 @@ It is important to note that these `provided` configurations work transitively. 
 A link:{javadocPath}/org/gradle/api/component/SoftwareComponent.html[SoftwareComponent] for <<publishing_setup.adoc#publishing_overview,publishing>> the production WAR created by the `war` task.
 
 [[sec:war_convention_properties]]
-== Convention properties
+== Convention properties (deprecated)
 
 `webAppDirName` — `String`::
 _Default value_: `src/main/webapp`
@@ -87,6 +87,8 @@ _Default value_: `$webAppDirName`, e.g. _src/main/webapp_
 The path to the web application source directory.
 
 These properties are provided by a link:{groovyDslPath}/org.gradle.api.plugins.WarPluginConvention.html[WarPluginConvention] object.
+
+Configuring war tasks via convention properties is **deprecated**. If you need to set default values the `war` task then configure the task directly. If you want to configure all tasks of type `War` in the project then use link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)].
 
 [[sec:war_default_settings]]
 == War

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -267,3 +267,7 @@ configurations {
 }
 ```
 
+[[war_convention_deprecation]]
+=== Deprecated `war` plugin conventions
+
+link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `war` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each tasks of type `War`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -270,4 +270,4 @@ configurations {
 [[war_convention_deprecation]]
 === Deprecated `war` plugin conventions
 
-link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `war` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each tasks of type `War`.
+link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `war` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `War`.

--- a/subprojects/docs/src/snippets/webApplication/customized/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/webApplication/customized/groovy/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 }
 
 war {
+    webAppDir = file('src/main/webapp')
     from 'src/rootContent' // adds a file-set to the root of the archive
     webInf { from 'src/additionalWebInf' } // adds a file-set to the WEB-INF dir.
     classpath fileTree('additionalLibs') // adds a file-set to the WEB-INF/lib dir.

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -41,6 +41,7 @@ import org.gradle.plugins.ide.eclipse.model.Facet;
 import org.gradle.plugins.ide.eclipse.model.WbResource;
 import org.gradle.plugins.ide.eclipse.model.internal.WtpClasspathAttributeSupport;
 import org.gradle.plugins.ide.internal.IdePlugin;
+import org.gradle.util.internal.RelativePathUtil;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -199,8 +200,9 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("resources", new Callable<List<WbResource>>() {
                     @Override
                     public List<WbResource> call() throws Exception {
-                        @SuppressWarnings("deprecation")
-                        String webAppDirName = project.getConvention().getPlugin(org.gradle.api.plugins.WarPluginConvention.class).getWebAppDirName();
+                        File projectDir = project.getProjectDir();
+                        File webAppDir = ((War) project.getTasks().getByName("war")).getWebAppDir().get().getAsFile();
+                        String webAppDirName = RelativePathUtil.relativePath(projectDir, webAppDir);
                         return Lists.newArrayList(new WbResource("/", webAppDirName));
                     }
                 });

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -25,7 +25,6 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.WarPlugin;
-import org.gradle.api.plugins.WarPluginConvention;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.reflect.Instantiator;
@@ -200,7 +199,9 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("resources", new Callable<List<WbResource>>() {
                     @Override
                     public List<WbResource> call() throws Exception {
-                        return Lists.newArrayList(new WbResource("/", project.getConvention().getPlugin(WarPluginConvention.class).getWebAppDirName()));
+                        @SuppressWarnings("deprecation")
+                        String webAppDirName = project.getConvention().getPlugin(org.gradle.api.plugins.WarPluginConvention.class).getWebAppDirName();
+                        return Lists.newArrayList(new WbResource("/", webAppDirName));
                     }
                 });
                 convention.map("sourceDirs", new Callable<Set<File>>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.file.FileFactory;
 import org.gradle.api.internal.java.WebApplication;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.model.ObjectFactory;
@@ -51,11 +52,13 @@ public class WarPlugin implements Plugin<Project> {
 
     private final ObjectFactory objectFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private final FileFactory fileFactory;
 
     @Inject
-    public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
+    public WarPlugin(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory, FileFactory fileFactory) {
         this.objectFactory = objectFactory;
         this.attributesFactory = attributesFactory;
+        this.fileFactory = fileFactory;
     }
 
     @Override
@@ -65,7 +68,8 @@ public class WarPlugin implements Plugin<Project> {
         project.getConvention().getPlugins().put("war", pluginConvention);
 
         project.getTasks().withType(War.class).configureEach(task -> {
-            task.from((Callable) () -> pluginConvention.getWebAppDir());
+            task.getWebAppDir().convention(project.provider(() -> fileFactory.dir(pluginConvention.getWebAppDir())));
+            task.from((Callable) () -> task.getWebAppDir());
             task.dependsOn((Callable) () -> project.getExtensions()
                 .getByType(JavaPluginExtension.class)
                 .getSourceSets()

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -68,7 +68,7 @@ public class WarPlugin implements Plugin<Project> {
         project.getConvention().getPlugins().put("war", pluginConvention);
 
         project.getTasks().withType(War.class).configureEach(task -> {
-            task.getWebAppDir().convention(project.provider(() -> fileFactory.dir(pluginConvention.getWebAppDir())));
+            task.getWebAppDir().set(project.provider(() -> fileFactory.dir(pluginConvention.getWebAppDir())));
             task.from((Callable) () -> task.getWebAppDir());
             task.dependsOn((Callable) () -> project.getExtensions()
                 .getByType(JavaPluginExtension.class)

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
@@ -22,7 +22,10 @@ import java.io.File;
 
 /**
  * <p>A {@link Convention} used for the WarPlugin.</p>
+ *
+ * @deprecated Please configure the tasks directly. This class is scheduled for removal in Gradle 8.0.
  */
+@Deprecated
 public abstract class WarPluginConvention {
     /**
      * Returns the web application directory.

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -27,6 +27,7 @@ import org.gradle.api.internal.file.copy.RenamingCopyAction;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -180,7 +181,9 @@ public class War extends Jar {
      * @since 7.1
      */
     @Incubating
-    @Internal
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @InputFiles
     public DirectoryProperty getWebAppDir() {
         return webAppDir;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -17,12 +17,16 @@ package org.gradle.api.tasks.bundling;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.RenamingCopyAction;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -48,6 +52,7 @@ public class War extends Jar {
     private File webXml;
     private FileCollection classpath;
     private final DefaultCopySpec webInf;
+    private final DirectoryProperty webAppDir;
 
     public War() {
         getArchiveExtension().set(WAR_EXTENSION);
@@ -68,6 +73,9 @@ public class War extends Jar {
         renameSpec.into("");
         renameSpec.from((Callable<File>) War.this::getWebXml);
         renameSpec.appendCachingSafeCopyAction(new RenamingCopyAction(Transformers.constant("web.xml")));
+
+        ObjectFactory objectFactory = getProject().getObjects();
+        webAppDir = objectFactory.directoryProperty();
     }
 
     @Internal
@@ -166,4 +174,16 @@ public class War extends Jar {
         this.webXml = webXml;
     }
 
+    /**
+     * Returns the app directory of the task. Defaults to {@code src/main/webapp}.
+     *
+     * @return The app directory.
+     * @since 7.1
+     *
+     */
+    @Incubating
+    @InputDirectory
+    public DirectoryProperty getWebAppDir() {
+        return webAppDir;
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/bundling/War.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.file.copy.DefaultCopySpec;
 import org.gradle.api.internal.file.copy.RenamingCopyAction;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Classpath;
-import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -179,10 +178,9 @@ public class War extends Jar {
      *
      * @return The app directory.
      * @since 7.1
-     *
      */
     @Incubating
-    @InputDirectory
+    @Internal
     public DirectoryProperty getWebAppDir() {
         return webAppDir;
     }


### PR DESCRIPTION
The original idea was to get rid of the conventions by replacing them with new extensions. This is not necessary for the `war` plugin. All properties can be configured directly on the `war` task or via a `configureEach` statement.

There was only one property that wasn't configurable on the War task: `webAppDir`. This PR also fixes this issue.
