### PR TITLE
Deprecate EarPluginConvention

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -67,7 +67,7 @@ _Depends on_: `ear`.
 The Ear plugin adds two dependency configurations: `deploy` and `earlib`. All dependencies in the `deploy` configuration are placed in the root of the EAR archive, and are _not_ transitive. All dependencies in the `earlib` configuration are placed in the 'lib' directory in the EAR archive and _are_ transitive.
 
 [[sec:ear_convention_properties]]
-== Convention properties
+== Convention properties (ear)
 
 `appDirName` — `String`::
 The name of the application source directory, relative to the project directory. _Default value: `src/main/application`_.
@@ -82,6 +82,9 @@ Metadata to generate a deployment descriptor file, e.g. `application.xml`. _Defa
 Specifies if deploymentDescriptor should be generated. _Default value: `true`_.
 
 These properties are provided by a link:{groovyDslPath}/org.gradle.plugins.ear.EarPluginConvention.html[EarPluginConvention] convention object.
+
+Configuring ear tasks via convention properties is **deprecated**. If you need to set default values the `ear` task then configure the task directly. If you want to configure all tasks of type `Ear` in the project then use link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)].
+
 
 [[sec:ear_default_settings]]
 == Ear

--- a/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -83,7 +83,7 @@ Specifies if deploymentDescriptor should be generated. _Default value: `true`_.
 
 These properties are provided by a link:{groovyDslPath}/org.gradle.plugins.ear.EarPluginConvention.html[EarPluginConvention] convention object.
 
-Configuring ear tasks via convention properties is **deprecated**. If you need to set default values the `ear` task then configure the task directly. If you want to configure all tasks of type `Ear` in the project then use link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)].
+Configuring ear tasks via convention properties is **deprecated**. If you need to set default values for the `ear` task then configure the task directly. If you want to configure all tasks of type `Ear` in the project then use link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)].
 
 
 [[sec:ear_default_settings]]

--- a/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/ear_plugin.adoc
@@ -83,8 +83,7 @@ Specifies if deploymentDescriptor should be generated. _Default value: `true`_.
 
 These properties are provided by a link:{groovyDslPath}/org.gradle.plugins.ear.EarPluginConvention.html[EarPluginConvention] convention object.
 
-Configuring ear tasks via convention properties is **deprecated**. If you need to set default values for the `ear` task then configure the task directly. If you want to configure all tasks of type `Ear` in the project then use link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)].
-
+Configuring the ear tasks via the plugin's convention properties is **deprecated**. If you need to change from the default values, configure the appropriate tasks directly. If you want to configure all `Ear` tasks in the project, use  link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(Ear.class).configureEach(...)].
 
 [[sec:ear_default_settings]]
 == Ear

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -275,4 +275,4 @@ link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConv
 [[ear_convention_deprecation]]
 === Deprecated `ear` plugin conventions
 
-link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(Ear.class).configureEach(...)] can be used to configure each task of type `Ear`.
+link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `Ear`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -275,4 +275,4 @@ link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConv
 [[ear_convention_deprecation]]
 === Deprecated `ear` plugin conventions
 
-link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each tasks of type `Ear`.
+link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `Ear`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -271,3 +271,8 @@ configurations {
 === Deprecated `war` plugin conventions
 
 link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `war` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `War`.
+
+[[ear_convention_deprecation]]
+=== Deprecated `ear` plugin conventions
+
+link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each tasks of type `Ear`.

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -275,4 +275,4 @@ link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConv
 [[ear_convention_deprecation]]
 === Deprecated `ear` plugin conventions
 
-link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `Ear`.
+link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(Ear.class).configureEach(...)] can be used to configure each task of type `Ear`.

--- a/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
+++ b/subprojects/docs/src/snippets/ear/earCustomized/groovy/ear/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 ear {
-    appDirName 'src/main/app'  // use application metadata found in this folder
+    appDirectory = file('src/main/app')  // use application metadata found in this folder
     // put dependent libraries into APP-INF/lib inside the generated EAR
     libDirName 'APP-INF/lib'
     deploymentDescriptor {  // custom entries for application.xml:

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
@@ -15,8 +15,11 @@ dependencies {
     earlib(group = "log4j", name = "log4j", version = "1.2.15", ext = "jar")
 }
 
-ear {
+tasks.named<Ear>("ear") {
     appDirectory.set(file("src/main/app"))  // use application metadata found in this folder
+}
+
+ear {
     // put dependent libraries into APP-INF/lib inside the generated EAR
     libDirName = "APP-INF/lib"
     deploymentDescriptor {  // custom entries for application.xml:

--- a/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
+++ b/subprojects/docs/src/snippets/ear/earCustomized/kotlin/ear/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 }
 
 ear {
-    appDirName = "src/main/app"  // use application metadata found in this folder
+    appDirectory.set(file("src/main/app"))  // use application metadata found in this folder
     // put dependent libraries into APP-INF/lib inside the generated EAR
     libDirName = "APP-INF/lib"
     deploymentDescriptor {  // custom entries for application.xml:

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -276,13 +276,15 @@ public class Ear extends Jar {
     }
 
     /**
-     * The name of the application directory, relative to the project directory.
-     * Default is "src/main/application".
+     * The name of the application directory, relative to the project directory.. Added to the output ear archive by default.
+     * <p>
+     * The {@code ear} plugin sets the default value for all {@code Ear} tasks to {@code src/main/application}.
+     * <p>
+     * Note, that if the {@code ear} plugin is not applied then this property is ignored.
      *
      * @since 7.1
      */
-    @Input
-    @Optional
+    @Internal
     @Incubating
     public Property<String> getAppDirName() {
         return appDirName;

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.FileTree;
@@ -64,7 +65,7 @@ public class Ear extends Jar {
     private final Property<Boolean> generateDeploymentDescriptor;
     private DeploymentDescriptor deploymentDescriptor;
     private CopySpec lib;
-    private final Property<String> appDirName;
+    private final DirectoryProperty appDir;
 
     public Ear() {
         getArchiveExtension().set(EAR_EXTENSION);
@@ -121,7 +122,7 @@ public class Ear extends Jar {
             return null;
         });
 
-        appDirName = getObjectFactory().property(String.class);
+        appDir = getObjectFactory().directoryProperty();
     }
 
     private Cached<byte[]> cachedContentsOf(DeploymentDescriptor descriptor) {
@@ -276,7 +277,7 @@ public class Ear extends Jar {
     }
 
     /**
-     * The name of the application directory, relative to the project directory.. Added to the output ear archive by default.
+     * The application directory. Added to the produced archive by default.
      * <p>
      * The {@code ear} plugin sets the default value for all {@code Ear} tasks to {@code src/main/application}.
      * <p>
@@ -286,7 +287,7 @@ public class Ear extends Jar {
      */
     @Internal
     @Incubating
-    public Property<String> getAppDirName() {
-        return appDirName;
+    public DirectoryProperty getAppDirectory() {
+        return appDir;
     }
 }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ear;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DuplicatesStrategy;
@@ -63,6 +64,7 @@ public class Ear extends Jar {
     private final Property<Boolean> generateDeploymentDescriptor;
     private DeploymentDescriptor deploymentDescriptor;
     private CopySpec lib;
+    private final Property<String> appDirName;
 
     public Ear() {
         getArchiveExtension().set(EAR_EXTENSION);
@@ -118,6 +120,8 @@ public class Ear extends Jar {
 
             return null;
         });
+
+        appDirName = getObjectFactory().property(String.class);
     }
 
     private Cached<byte[]> cachedContentsOf(DeploymentDescriptor descriptor) {
@@ -271,4 +275,15 @@ public class Ear extends Jar {
         this.deploymentDescriptor = deploymentDescriptor;
     }
 
+    /**
+     * The name of the application directory, relative to the project directory.
+     * Default is "src/main/application".
+     *
+     * @since 7.1
+     */
+    @Input
+    @Incubating
+    public Property<String> getAppDirName() {
+        return appDirName;
+    }
 }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -282,6 +282,7 @@ public class Ear extends Jar {
      * @since 7.1
      */
     @Input
+    @Optional
     @Incubating
     public Property<String> getAppDirName() {
         return appDirName;

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -34,7 +34,6 @@ import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
-import org.gradle.plugins.ear.internal.DefaultEarPluginConvention;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -46,6 +45,7 @@ import java.util.concurrent.Callable;
  *
  * @see <a href="https://docs.gradle.org/current/userguide/ear_plugin.html">EAR plugin reference</a>
  */
+@SuppressWarnings("deprecation")
 public class EarPlugin implements Plugin<Project> {
 
     public static final String EAR_TASK_NAME = "ear";
@@ -73,7 +73,7 @@ public class EarPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(BasePlugin.class);
 
-        EarPluginConvention earPluginConvention = objectFactory.newInstance(DefaultEarPluginConvention.class);
+        EarPluginConvention earPluginConvention = objectFactory.newInstance(org.gradle.plugins.ear.internal.DefaultEarPluginConvention.class);
         project.getConvention().getPlugins().put("ear", earPluginConvention);
         earPluginConvention.setLibDirName(DEFAULT_LIB_DIR_NAME);
         earPluginConvention.setAppDirName("src/main/application");

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -115,7 +115,7 @@ public class EarPlugin implements Plugin<Project> {
                 plugins.withType(JavaPlugin.class, javaPlugin -> {
                     final JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
                     SourceSet sourceSet = mainSourceSetOf(javaPluginExtension);
-                    sourceSet.getResources().srcDir(ear.getAppDirName());
+                    sourceSet.getResources().srcDir(ear.getAppDirectory());
                 });
             }
         });
@@ -143,7 +143,7 @@ public class EarPlugin implements Plugin<Project> {
         project.getTasks().withType(Ear.class).configureEach(new Action<Ear>() {
             @Override
             public void execute(Ear task) {
-                task.getAppDirName().convention(project.provider(() -> earConvention.getAppDirName()));
+                task.getAppDirectory().convention(project.provider(() -> project.getLayout().getProjectDirectory().dir(earConvention.getAppDirName())));
                 task.getConventionMapping().map("libDirName", new Callable<String>() {
                     @Override
                     public String call() throws Exception {
@@ -161,7 +161,7 @@ public class EarPlugin implements Plugin<Project> {
                     if (project.getPlugins().hasPlugin(JavaPlugin.class)) {
                         return null;
                     } else {
-                        return project.fileTree(task.getAppDirName());
+                        return task.getAppDirectory().getAsFileTree();
                     }
                 });
 

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -22,7 +22,10 @@ import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 
 /**
  * Ear Plugin Convention.
+ *
+ * @deprecated Instead of using conventions, configure the tasks directly. This class is scheduled for removal in Gradle 8.0.
  */
+@Deprecated
 public abstract class EarPluginConvention {
     /**
      * The name of the application directory, relative to the project directory.

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
@@ -21,7 +21,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
-import org.gradle.plugins.ear.EarPluginConvention;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
 import org.gradle.util.internal.ConfigureUtil;
@@ -31,7 +30,8 @@ import java.io.File;
 
 import static org.gradle.api.reflect.TypeOf.typeOf;
 
-public class DefaultEarPluginConvention extends EarPluginConvention implements HasPublicType {
+@Deprecated
+public class DefaultEarPluginConvention extends org.gradle.plugins.ear.EarPluginConvention implements HasPublicType {
     private ObjectFactory objectFactory;
 
     private DeploymentDescriptor deploymentDescriptor;
@@ -51,7 +51,7 @@ public class DefaultEarPluginConvention extends EarPluginConvention implements H
 
     @Override
     public TypeOf<?> getPublicType() {
-        return typeOf(EarPluginConvention.class);
+        return typeOf(org.gradle.plugins.ear.EarPluginConvention.class);
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -41,6 +41,7 @@ import org.gradle.plugins.ide.eclipse.model.WbResource;
 import org.gradle.plugins.ide.eclipse.model.internal.WtpClasspathAttributeSupport;
 import org.gradle.plugins.ide.internal.IdePlugin;
 import org.gradle.util.internal.RelativePathUtil;
+import org.gradle.util.internal.WrapUtil;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -240,7 +241,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("sourceDirs", new Callable<Set<File>>() {
                     @Override
                     public Set<File> call() throws Exception {
-                        return ((Ear) project.getTasks().findByName(EarPlugin.EAR_TASK_NAME)).getAppDirectory().get().getAsFileTree().getFiles();
+                        return WrapUtil.toSet(((Ear) project.getTasks().findByName(EarPlugin.EAR_TASK_NAME)).getAppDirectory().get().getAsFile());
                     }
                 });
                 project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -31,7 +31,6 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ear.Ear;
 import org.gradle.plugins.ear.EarPlugin;
-import org.gradle.plugins.ear.EarPluginConvention;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.plugins.ide.eclipse.internal.AfterEvaluateHelper;
 import org.gradle.plugins.ide.eclipse.model.Classpath;
@@ -241,7 +240,9 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("sourceDirs", new Callable<Set<File>>() {
                     @Override
                     public Set<File> call() throws Exception {
-                        return project.getLayout().files(project.getConvention().getPlugin(EarPluginConvention.class).getAppDirName()).getFiles();
+                        @SuppressWarnings("deprecation")
+                        String appDirName = project.getConvention().getPlugin(org.gradle.plugins.ear.EarPluginConvention.class).getAppDirName();
+                        return project.getLayout().files(appDirName).getFiles();
                     }
                 });
                 project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -240,8 +240,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("sourceDirs", new Callable<Set<File>>() {
                     @Override
                     public Set<File> call() throws Exception {
-                        String appDirName = ((Ear) project.getTasks().findByName(EarPlugin.EAR_TASK_NAME)).getAppDirName().get();
-                        return project.getLayout().files(appDirName).getFiles();
+                        return ((Ear) project.getTasks().findByName(EarPlugin.EAR_TASK_NAME)).getAppDirectory().get().getAsFileTree().getFiles();
                     }
                 });
                 project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipseWtpPlugin.java
@@ -240,8 +240,7 @@ public class EclipseWtpPlugin extends IdePlugin {
                 convention.map("sourceDirs", new Callable<Set<File>>() {
                     @Override
                     public Set<File> call() throws Exception {
-                        @SuppressWarnings("deprecation")
-                        String appDirName = project.getConvention().getPlugin(org.gradle.plugins.ear.EarPluginConvention.class).getAppDirName();
+                        String appDirName = ((Ear) project.getTasks().findByName(EarPlugin.EAR_TASK_NAME)).getAppDirName().get();
                         return project.getLayout().files(appDirName).getFiles();
                     }
                 });


### PR DESCRIPTION
The original idea was to get rid of the conventions by replacing them with new extensions. This is not necessary for the ear plugin. All properties can be configured directly on the `ear` task or via a `configureEach` statement. This PR also introduces the `appDirName` property on the `Ear` task type, to allow users to completely replace conventions.