### PR TITLE
Apply test filtering for CI branch builds

### DIFF
--- a/build-logic-settings/testfiltering-plugin/build.gradle.kts
+++ b/build-logic-settings/testfiltering-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-rootProject.name = "build-logic-settings"
-
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
-    }
+plugins {
+   `kotlin-dsl`
 }
-
-include("allprojects-plugin")
-include("testfiltering-plugin")
-

--- a/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
+++ b/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-rootProject.name = "build-logic-settings"
-
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
+val testFilteringProperty = "gradle.internal.testselection.enabled"
+val gitBranchName: String? = System.getenv("BUILD_BRANCH")
+if (!System.getProperties().containsKey(testFilteringProperty) && gitBranchName != null) {
+    val protectedBranches = listOf("master", "release")
+    if (!protectedBranches.contains(gitBranchName) && !gitBranchName.startsWith("pre-test/")) {
+        System.setProperty(testFilteringProperty, "true")
     }
 }
-
-include("allprojects-plugin")
-include("testfiltering-plugin")
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,10 @@ plugins {
     id("com.gradle.enterprise").version("3.6.1")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
+    id("gradlebuild.internal.testfiltering")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
     id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-2")
-    id("com.gradle.internal.test-selection").version("0.5.1-rc-1")
+    id("com.gradle.internal.test-selection").version("0.5.2-rc-1")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
This change applies a new Settings script plugin responsible for
configuring test filtering for custom branch CI builds.

### Context
All of the pre-tested commit infrastructure seems to be Project plugins that aren't yet available by the time it's needed to configure test filtering, so I created a small Settings plugin to get just what is needed to avoid reworking a bunch of other plugins just for this.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
