### PR TITLE
Update Kotlin version in GMM smoke test

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -34,8 +34,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         given:
         BuildResult result
         useSample("gmm-example")
-        // TODO Test Kotlin 1.4
-        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.3")
+        def kotlinVersion = TestedVersions.kotlin.latest()
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.1")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -34,7 +34,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         given:
         BuildResult result
         useSample("gmm-example")
-        def kotlinVersion = TestedVersions.kotlin.latest()
+        def kotlinVersion = TestedVersions.kotlin.latestStartsWith("1.4")
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.1")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.module
@@ -10,8 +10,7 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
@@ -28,11 +27,11 @@
         {
           "name": "android-kotlin-library-1.0-debug.aar",
           "url": "android-kotlin-library-1.0-debug.aar",
-          "size": 2108,
-          "sha512": "6285c2a221d819ed3d87a3a1652f5f57c9212d74b5fbf8a1f536b041d6734cd1bed47c3d96e13c15d91986db82da3e97e2e4a15926c1c722c69e257b7a207c54",
-          "sha256": "9ecf17ef7d638182768be4ce71a809caa5527e8de8de27d2d525a07030c90065",
-          "sha1": "fb066af3c5b457f7ed79efcf17cf7453aebb6884",
-          "md5": "c8282720dff92465fb2a1fd4347d3d56"
+          "size": 2266,
+          "sha512": "90cfb9bbfe79be18936d64f04ffc39ad8f76a8fa805ec2f9eb0d147bb6631431fecc2d1dd134563c4b2bd6514ac3fbb0ba9ed564a0f5219d399e709fa9c4c237",
+          "sha256": "eb65738fe98b87c71ec97a3209067db264c0bdf747c5a70818a4937d56df7ce5",
+          "sha1": "f14d4462f414b8c0442f749f286584e87ceb6561",
+          "md5": "ccd1f4d05caf016378548d8e150303c6"
         }
       ]
     },
@@ -50,7 +49,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -58,11 +57,11 @@
         {
           "name": "android-kotlin-library-1.0-debug.aar",
           "url": "android-kotlin-library-1.0-debug.aar",
-          "size": 2108,
-          "sha512": "6285c2a221d819ed3d87a3a1652f5f57c9212d74b5fbf8a1f536b041d6734cd1bed47c3d96e13c15d91986db82da3e97e2e4a15926c1c722c69e257b7a207c54",
-          "sha256": "9ecf17ef7d638182768be4ce71a809caa5527e8de8de27d2d525a07030c90065",
-          "sha1": "fb066af3c5b457f7ed79efcf17cf7453aebb6884",
-          "md5": "c8282720dff92465fb2a1fd4347d3d56"
+          "size": 2266,
+          "sha512": "90cfb9bbfe79be18936d64f04ffc39ad8f76a8fa805ec2f9eb0d147bb6631431fecc2d1dd134563c4b2bd6514ac3fbb0ba9ed564a0f5219d399e709fa9c4c237",
+          "sha256": "eb65738fe98b87c71ec97a3209067db264c0bdf747c5a70818a4937d56df7ce5",
+          "sha1": "f14d4462f414b8c0442f749f286584e87ceb6561",
+          "md5": "ccd1f4d05caf016378548d8e150303c6"
         }
       ]
     },
@@ -79,11 +78,11 @@
         {
           "name": "android-kotlin-library-1.0-release.aar",
           "url": "android-kotlin-library-1.0-release.aar",
-          "size": 2011,
-          "sha512": "00a9a38504266e38898f44300c06d350a5c4a08bebdf8d316f7212c330699adb7f0837f1187a908b4a0d7818144e846a3f937bd824361261d275d40af26ec690",
-          "sha256": "aa8fd2d336459320754e1ba404782038d9a7fbd499249b897761a21ca037a77a",
-          "sha1": "1c7f39d735f3ce3e4f70643b78bf736cbeb81782",
-          "md5": "42cc48ea3cdf8603fe334692acfdf15b"
+          "size": 2160,
+          "sha512": "3d0edf831c8e7056938f8fbdf4313c73c9dcf994d6f3680eddda37c751dfc8940fb14f27537deebe0b122537c1705136f38e4bb2d6724933942b875999daf999",
+          "sha256": "e1514488fd5148cc27a4cd7ca50d64d3f86c88c8864f3d1299674b613812f6c9",
+          "sha1": "c7150a223cb7fb9eba4a77cf9c07702465552195",
+          "md5": "fec5ff5e45f41602786bbe52de3fb25a"
         }
       ]
     },
@@ -101,7 +100,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -109,11 +108,11 @@
         {
           "name": "android-kotlin-library-1.0-release.aar",
           "url": "android-kotlin-library-1.0-release.aar",
-          "size": 2011,
-          "sha512": "00a9a38504266e38898f44300c06d350a5c4a08bebdf8d316f7212c330699adb7f0837f1187a908b4a0d7818144e846a3f937bd824361261d275d40af26ec690",
-          "sha256": "aa8fd2d336459320754e1ba404782038d9a7fbd499249b897761a21ca037a77a",
-          "sha1": "1c7f39d735f3ce3e4f70643b78bf736cbeb81782",
-          "md5": "42cc48ea3cdf8603fe334692acfdf15b"
+          "size": 2160,
+          "sha512": "3d0edf831c8e7056938f8fbdf4313c73c9dcf994d6f3680eddda37c751dfc8940fb14f27537deebe0b122537c1705136f38e4bb2d6724933942b875999daf999",
+          "sha256": "e1514488fd5148cc27a4cd7ca50d64d3f86c88c8864f3d1299674b613812f6c9",
+          "sha1": "c7150a223cb7fb9eba4a77cf9c07702465552195",
+          "md5": "fec5ff5e45f41602786bbe52de3fb25a"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/android-kotlin-library-1.0.pom
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.module
@@ -10,8 +10,7 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
@@ -30,11 +29,11 @@
         {
           "name": "kotlin-library-1.0.jar",
           "url": "kotlin-library-1.0.jar",
-          "size": 1529,
-          "sha512": "26f2d67f59ac64dfc1b3d72f7e878f5dac37e11d2bb179b9dc593d2cda95504f49ce009955836bf17a8ca5cbb44986abc22ace39bff62a2fa50b8ce855b01886",
-          "sha256": "03482ab9209fb26c3453c24da922bc8900e2f55e4c5bc1192fddee312e29b60d",
-          "sha1": "b6f6ca8d5b8af9386dfd53f7eb880ba09d64d32b",
-          "md5": "4682c4bcd13f4b27ab2ecc1e8a57c985"
+          "size": 1584,
+          "sha512": "0a3226549086a24c0d5a51a3b1d5f797f8c49050a3e5e9dbd24fa7cff47149e54b5340a48a5b2d145e05f02fa064958e99f2abd2d2d8b26af23da742a28d2b49",
+          "sha256": "da7493510ed11ce52c2aaa73bc834618fbbcc8ceea0c0c37f4396a0f9dcfd7c1",
+          "sha1": "59828ea026330ef117e4627b0dfce3ad20223dc6",
+          "md5": "b62ee53fe148f8f7c28db5dff28883d7"
         }
       ]
     },
@@ -54,7 +53,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -62,11 +61,11 @@
         {
           "name": "kotlin-library-1.0.jar",
           "url": "kotlin-library-1.0.jar",
-          "size": 1529,
-          "sha512": "26f2d67f59ac64dfc1b3d72f7e878f5dac37e11d2bb179b9dc593d2cda95504f49ce009955836bf17a8ca5cbb44986abc22ace39bff62a2fa50b8ce855b01886",
-          "sha256": "03482ab9209fb26c3453c24da922bc8900e2f55e4c5bc1192fddee312e29b60d",
-          "sha1": "b6f6ca8d5b8af9386dfd53f7eb880ba09d64d32b",
-          "md5": "4682c4bcd13f4b27ab2ecc1e8a57c985"
+          "size": 1584,
+          "sha512": "0a3226549086a24c0d5a51a3b1d5f797f8c49050a3e5e9dbd24fa7cff47149e54b5340a48a5b2d145e05f02fa064958e99f2abd2d2d8b26af23da742a28d2b49",
+          "sha256": "da7493510ed11ce52c2aaa73bc834618fbbcc8ceea0c0c37f4396a0f9dcfd7c1",
+          "sha1": "59828ea026330ef117e4627b0dfce3ad20223dc6",
+          "md5": "b62ee53fe148f8f7c28db5dff28883d7"
         }
       ]
     },
@@ -83,10 +82,10 @@
           "name": "kotlin-library-1.0-sources.jar",
           "url": "kotlin-library-1.0-sources.jar",
           "size": 722,
-          "sha512": "f9cc9a3851a086534744ac60941231fc209bf170d5562f44c19f22d726746cb6169bd6a2b511101bcfac7f3d3d17fbf5ee935bcd028ef6f5ca6849246a7eb805",
-          "sha256": "c2a0cd71bdfb19d5f2ef5248c55730959b47b1d2bd4b617f1018bd9b93fc9485",
-          "sha1": "748b070f9b82eb77a8e3690f6d3f3bcbdf16b895",
-          "md5": "741e87aafda3ee581708a6d01f56b3c4"
+          "sha512": "75bf3bd4b89bdbfbbbfa3a007056635cb92b9c3ac1a86c9bb98eeb6affb71128b0bd44a3a549e0719b56d7c6c121e4d9a3154419dbcb883c1df419ede50a613b",
+          "sha256": "7b865958f0c65fd199f3483e7e194e285d950053ad479fd36da3543c75dcd224",
+          "sha1": "c94da4655009742200a60e577b3d675ca5cffbff",
+          "md5": "b9add99d10c49f6d2de3008155962fcf"
         }
       ]
     },
@@ -103,10 +102,10 @@
           "name": "kotlin-library-1.0-javadoc.jar",
           "url": "kotlin-library-1.0-javadoc.jar",
           "size": 261,
-          "sha512": "56e0622e43f57ef875e1215ea6e19509c25130fbd5752f9d32d21c4e04e9bcab30fe34cdd3c1930e4281fb43128873109ebf2df3d73a6d3e749927566d735253",
-          "sha256": "32088e4485133bc6561e8b7685c0fb37ff22e8ff3dd6020a4930c4dc6dee7109",
-          "sha1": "84269fbcb2aa0e813f1354bef38e0f4fd3e88d0d",
-          "md5": "bf79b9a9abdacd2cca4c4ec707480da1"
+          "sha512": "78214cf7a5c8d131eea070ae1e1d399e8abed99852b13e1822bd07c0e604245d211b0c8f1944cf65f96c78cf612724363ba72c8a6c3441899f03924ed7ef4e37",
+          "sha256": "27b6b9f0ffff5da92ef43741067d75aa929c6427ed3403105c4bc6d9e180c1e3",
+          "sha1": "75efa6402c8c2496257eeec57b7fdab8ef2c1a63",
+          "md5": "bdd5855930004f4406b6c48cc59c4ae6"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-library-1.0.pom
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.module
@@ -10,143 +10,161 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "android-demoDebugApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "demoDebug",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoDebugRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "demoDebug",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullDebugApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "fullDebug",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullDebugRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "debug",
-        "com.android.build.api.attributes.VariantAttr": "fullDebug",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full-debug",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoReleaseApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "demoRelease",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-demoReleaseRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "demoRelease",
-        "org.gradle.example.my-own-flavor": "demo",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-demo",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullReleaseApiElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "fullRelease",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-api",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "android-fullReleaseRuntimeElements",
-      "attributes": {
-        "com.android.build.api.attributes.BuildTypeAttr": "release",
-        "com.android.build.api.attributes.VariantAttr": "fullRelease",
-        "org.gradle.example.my-own-flavor": "full",
-        "org.gradle.usage": "java-runtime",
-        "org.jetbrains.kotlin.platform.type": "androidJvm"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-android-full",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "js-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "files": [
+        {
+          "name": "kotlin-multiplatform-android-library-metadata-1.0.jar",
+          "url": "kotlin-multiplatform-android-library-1.0.jar",
+          "size": 1096,
+          "sha512": "8521c2f0acd9a0026c3225f35e735874f4a9e9e521ca17fb51ff05f2a9a1cc7d74a560c62a3215504c59ba70bd49fc69ea7332fb0bab19b20b172c2017603d5d",
+          "sha256": "d0afaa260187935b851f4510ccf7ddb98a88c7a594e5b5af78966011aa2b859e",
+          "sha1": "2438124313565116a4ccbd7adae94f2619c889c6",
+          "md5": "b7d07612b92573c052f946c6c61dabe6"
+        }
+      ]
+    },
+    {
+      "name": "demoDebugApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "demoDebug",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoDebugRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "demoDebug",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo-debug/1.0/kotlin-multiplatform-android-library-android-demo-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullDebugApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "fullDebug",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullDebugRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "debug",
+        "com.android.build.api.attributes.VariantAttr": "fullDebug",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full-debug/1.0/kotlin-multiplatform-android-library-android-full-debug-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full-debug",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoReleaseApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "demoRelease",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "demoReleaseRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "demoRelease",
+        "org.gradle.example.my-own-flavor": "demo",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-demo/1.0/kotlin-multiplatform-android-library-android-demo-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-demo",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullReleaseApiElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "fullRelease",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "fullReleaseRuntimeElements-published",
+      "attributes": {
+        "com.android.build.api.attributes.BuildTypeAttr": "release",
+        "com.android.build.api.attributes.VariantAttr": "fullRelease",
+        "org.gradle.example.my-own-flavor": "full",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "androidJvm"
+      },
+      "available-at": {
+        "url": "../../kotlin-multiplatform-android-library-android-full/1.0/kotlin-multiplatform-android-library-android-full-1.0.module",
+        "group": "example",
+        "module": "kotlin-multiplatform-android-library-android-full",
+        "version": "1.0"
+      }
+    },
+    {
+      "name": "jsApiElements-published",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -157,9 +175,10 @@
       }
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -170,8 +189,9 @@
       }
     },
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -184,7 +204,7 @@
       }
     },
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
@@ -194,19 +214,6 @@
         "url": "../../kotlin-multiplatform-android-library-macosx64/1.0/kotlin-multiplatform-android-library-macosx64-1.0.module",
         "group": "example",
         "module": "kotlin-multiplatform-android-library-macosx64",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "metadata-api",
-      "attributes": {
-        "org.gradle.usage": "kotlin-api",
-        "org.jetbrains.kotlin.platform.type": "common"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-android-library-metadata/1.0/kotlin-multiplatform-android-library-metadata-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-android-library-metadata",
         "version": "1.0"
       }
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-1.0.pom
@@ -10,5 +10,4 @@
   <groupId>example</groupId>
   <artifactId>kotlin-multiplatform-android-library</artifactId>
   <version>1.0</version>
-  <packaging>pom</packaging>
 </project>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.module
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "android-demoReleaseApiElements",
+      "name": "demoReleaseApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "demoRelease",
@@ -29,16 +28,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-release.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-1.0.aar",
-          "size": 2100,
-          "sha512": "031fb487590d4f0336bf73f1546ed5faed8790c72ed55c1de6ae3b5c4110805821a8612c3cc037927207361dc53ab3115087867d882ba174825c8aaecabfe03e",
-          "sha256": "ef15d2dd149a3bdcd45545fb947c14869ec3f9af3a8b56c40ccad57e76c696b3",
-          "sha1": "d6b44b28b762d12f38515433b69dca5138da2d0b",
-          "md5": "006ca0248394cade0cf573d20c1b345b"
+          "size": 2261,
+          "sha512": "7a32f1ed173a562976e914a6ac060caa23f653dd738fc44dc84fb86f722063faaf9f0d3718885501168d15503b2128b1a22a29cf5e93875c4c076d7b18fc31c4",
+          "sha256": "bd941d94ea1bb503154210cc0dd000b0341f18b6921c12accf5e14ac15c6dae8",
+          "sha1": "b462820a36c5158b6ea409b4d4cf0b36b14271e8",
+          "md5": "c43e048c0c0da449e431d28d81023e70"
         }
       ]
     },
     {
-      "name": "android-demoReleaseRuntimeElements",
+      "name": "demoReleaseRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "demoRelease",
@@ -49,16 +48,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -66,16 +65,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-release.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-1.0.aar",
-          "size": 2100,
-          "sha512": "031fb487590d4f0336bf73f1546ed5faed8790c72ed55c1de6ae3b5c4110805821a8612c3cc037927207361dc53ab3115087867d882ba174825c8aaecabfe03e",
-          "sha256": "ef15d2dd149a3bdcd45545fb947c14869ec3f9af3a8b56c40ccad57e76c696b3",
-          "sha1": "d6b44b28b762d12f38515433b69dca5138da2d0b",
-          "md5": "006ca0248394cade0cf573d20c1b345b"
+          "size": 2261,
+          "sha512": "7a32f1ed173a562976e914a6ac060caa23f653dd738fc44dc84fb86f722063faaf9f0d3718885501168d15503b2128b1a22a29cf5e93875c4c076d7b18fc31c4",
+          "sha256": "bd941d94ea1bb503154210cc0dd000b0341f18b6921c12accf5e14ac15c6dae8",
+          "sha1": "b462820a36c5158b6ea409b4d4cf0b36b14271e8",
+          "md5": "c43e048c0c0da449e431d28d81023e70"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.module
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "android-demoDebugApiElements",
+      "name": "demoDebugApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "demoDebug",
@@ -29,16 +28,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-debug-1.0.aar",
-          "size": 2196,
-          "sha512": "28f2feaa7ad4df3c1c83d4245473cafdbc9654f784f8eba03781488d408a74a180c52f39d1fd864318fab1e4caa83f614b107bc062b2cafd371f264bb5992643",
-          "sha256": "a17f98ed9bed5e6cd2cb947bf83520eea9e977708b46ba355b4e5e74b2fe3a23",
-          "sha1": "6f46553340b5e4c15209b480f80ff5b9562be1ed",
-          "md5": "9727c05ed9695e7fd1dd23dbe8892e4d"
+          "size": 2361,
+          "sha512": "50d999f4f0e8b5ce4cd40c423f4e993abf51d7944a699d1afdef466a0389511889a219a3cd78cd617742e44d5121833a8cd53def7366952b18af10245b6558dd",
+          "sha256": "1fcc5eefa4ffb8353827c854814ea2e2de18b0142b1b196cc7a65ae9d57b1c7a",
+          "sha1": "f2eaf3e2b184d8bb648733bafd70ee03dc3c38c2",
+          "md5": "8ca861047da176c00157b937ec382bd6"
         }
       ]
     },
     {
-      "name": "android-demoDebugRuntimeElements",
+      "name": "demoDebugRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "demoDebug",
@@ -49,16 +48,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -66,16 +65,16 @@
         {
           "name": "kotlin-multiplatform-android-library-demo-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-demo-debug-1.0.aar",
-          "size": 2196,
-          "sha512": "28f2feaa7ad4df3c1c83d4245473cafdbc9654f784f8eba03781488d408a74a180c52f39d1fd864318fab1e4caa83f614b107bc062b2cafd371f264bb5992643",
-          "sha256": "a17f98ed9bed5e6cd2cb947bf83520eea9e977708b46ba355b4e5e74b2fe3a23",
-          "sha1": "6f46553340b5e4c15209b480f80ff5b9562be1ed",
-          "md5": "9727c05ed9695e7fd1dd23dbe8892e4d"
+          "size": 2361,
+          "sha512": "50d999f4f0e8b5ce4cd40c423f4e993abf51d7944a699d1afdef466a0389511889a219a3cd78cd617742e44d5121833a8cd53def7366952b18af10245b6558dd",
+          "sha256": "1fcc5eefa4ffb8353827c854814ea2e2de18b0142b1b196cc7a65ae9d57b1c7a",
+          "sha1": "f2eaf3e2b184d8bb648733bafd70ee03dc3c38c2",
+          "md5": "8ca861047da176c00157b937ec382bd6"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-demo-debug-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.module
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "android-fullReleaseApiElements",
+      "name": "fullReleaseApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "fullRelease",
@@ -29,16 +28,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-release.aar",
           "url": "kotlin-multiplatform-android-library-android-full-1.0.aar",
-          "size": 2100,
-          "sha512": "3a1988390706b449d41d9b1c12471ed8fa4cfd876ec72b82991f4dbc6c40859d49f1a1cb3da6ad1e053ca5096b8e430e53a737bdd8d9b65b70b1a70a08751eff",
-          "sha256": "ec40bf4e51487a673886baa48bf31ad4b77df2e1a8961c334638828418e6ee19",
-          "sha1": "0785402e008ed74c66dba20872f16f77d8791b88",
-          "md5": "fcc77bda4c0ee6ff6833e8f468b852a1"
+          "size": 2265,
+          "sha512": "d294833d960347986008d48fb7705de2920f2486a3fae5c4acb7401b06c2d568a797ea3c61f1ae5c845dab9f60857facb415253b317cd362fa616b16c590f228",
+          "sha256": "8543269660d3b5108c1cb735f3513743d383afdf176571cfd54dd6f9869188f4",
+          "sha1": "704ed198d18d80adc2fcc2d2c7e1347335af344c",
+          "md5": "4018d82b5bbdd40f314fff4e06a12dd3"
         }
       ]
     },
     {
-      "name": "android-fullReleaseRuntimeElements",
+      "name": "fullReleaseRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "release",
         "com.android.build.api.attributes.VariantAttr": "fullRelease",
@@ -49,16 +48,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -66,16 +65,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-release.aar",
           "url": "kotlin-multiplatform-android-library-android-full-1.0.aar",
-          "size": 2100,
-          "sha512": "3a1988390706b449d41d9b1c12471ed8fa4cfd876ec72b82991f4dbc6c40859d49f1a1cb3da6ad1e053ca5096b8e430e53a737bdd8d9b65b70b1a70a08751eff",
-          "sha256": "ec40bf4e51487a673886baa48bf31ad4b77df2e1a8961c334638828418e6ee19",
-          "sha1": "0785402e008ed74c66dba20872f16f77d8791b88",
-          "md5": "fcc77bda4c0ee6ff6833e8f468b852a1"
+          "size": 2265,
+          "sha512": "d294833d960347986008d48fb7705de2920f2486a3fae5c4acb7401b06c2d568a797ea3c61f1ae5c845dab9f60857facb415253b317cd362fa616b16c590f228",
+          "sha256": "8543269660d3b5108c1cb735f3513743d383afdf176571cfd54dd6f9869188f4",
+          "sha1": "704ed198d18d80adc2fcc2d2c7e1347335af344c",
+          "md5": "4018d82b5bbdd40f314fff4e06a12dd3"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.module
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "android-fullDebugApiElements",
+      "name": "fullDebugApiElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "fullDebug",
@@ -29,16 +28,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-full-debug-1.0.aar",
-          "size": 2194,
-          "sha512": "5350742ada8d754cc6a2c5d9919e0aaa5b87a39eefee2e76e915b04bfeeb461255d867d932c4efbc0eba75cba21e0cf1a08a2772af8946115a1a244bba3bbf0a",
-          "sha256": "c98095ae96e5d5835b4b032bfc53a26f852d71b7c7475b9249e985e4a5e5eaf5",
-          "sha1": "5a2386911dc426cb5bc123bbb9b2c5067fcaa390",
-          "md5": "5a6bf7331536ebb785dca1249a7c500c"
+          "size": 2359,
+          "sha512": "0d5223a1106b58764b552ecb4b769ecc691a351c01cc7e270144f6a7047a92cd23d9dcdbf6e38f22a6dc2f05abac8ab1df554b3f4a379f3be2a1372b7fa0dda2",
+          "sha256": "0090eeefef4b165ffc0e978007c90248efdcc4289e8dc237388475169b2d645e",
+          "sha1": "2d8cc6e70b12ad98483d9d0087406fb00ddc06a1",
+          "md5": "d3a512030f5505f84ed2e6975f9ad5e7"
         }
       ]
     },
     {
-      "name": "android-fullDebugRuntimeElements",
+      "name": "fullDebugRuntimeElements-published",
       "attributes": {
         "com.android.build.api.attributes.BuildTypeAttr": "debug",
         "com.android.build.api.attributes.VariantAttr": "fullDebug",
@@ -49,16 +48,16 @@
       "dependencies": [
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib-common",
+          "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
-          "module": "kotlin-stdlib",
+          "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -66,16 +65,16 @@
         {
           "name": "kotlin-multiplatform-android-library-full-debug.aar",
           "url": "kotlin-multiplatform-android-library-android-full-debug-1.0.aar",
-          "size": 2194,
-          "sha512": "5350742ada8d754cc6a2c5d9919e0aaa5b87a39eefee2e76e915b04bfeeb461255d867d932c4efbc0eba75cba21e0cf1a08a2772af8946115a1a244bba3bbf0a",
-          "sha256": "c98095ae96e5d5835b4b032bfc53a26f852d71b7c7475b9249e985e4a5e5eaf5",
-          "sha1": "5a2386911dc426cb5bc123bbb9b2c5067fcaa390",
-          "md5": "5a6bf7331536ebb785dca1249a7c500c"
+          "size": 2359,
+          "sha512": "0d5223a1106b58764b552ecb4b769ecc691a351c01cc7e270144f6a7047a92cd23d9dcdbf6e38f22a6dc2f05abac8ab1df554b3f4a379f3be2a1372b7fa0dda2",
+          "sha256": "0090eeefef4b165ffc0e978007c90248efdcc4289e8dc237388475169b2d645e",
+          "sha1": "2d8cc6e70b12ad98483d9d0087406fb00ddc06a1",
+          "md5": "d3a512030f5505f84ed2e6975f9ad5e7"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-android-full-debug-1.0.pom
@@ -13,14 +13,14 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.module
@@ -11,33 +11,34 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "jsApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "files": [
         {
           "name": "kotlin-multiplatform-android-library-js-1.0.jar",
           "url": "kotlin-multiplatform-android-library-js-1.0.jar",
-          "size": 3988,
-          "sha512": "bd1bbf23bdcf7bb7e622b429c068de6d39eab7df7277bd0758e45e3e7baef9d621b4c707a32b2009537f5371b0ce88cf48db2a0f82b9b4064ef5c5edfef1e44c",
-          "sha256": "def48cf63cde9b2bd017e60dc4de5e80520b0333370ab74673d1dba450b261f7",
-          "sha1": "63e84689aeae3d53ae3d4f5f2f244d776470df14",
-          "md5": "24f384b206943d643fdb2badf762deb5"
+          "size": 4002,
+          "sha512": "1a36678787fe1f12dd1a10f25e0a54566db6f9b66d2d8a8bdb915fc76e17aaf43e666fce711179f7d8067c891934839d38949c2301761b514f15040b7cc61347",
+          "sha256": "b3e8694eb309df07a87e017bfe6c4539a894b1b6e8a4f473255517348d89ee32",
+          "sha1": "6abd39e09f592f518560309e215b7e1157623fc7",
+          "md5": "cf8be76656f8ae56765fe5d90ce7b2ea"
         }
       ]
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "dependencies": [
@@ -45,14 +46,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -60,16 +61,16 @@
         {
           "name": "kotlin-multiplatform-android-library-js-1.0.jar",
           "url": "kotlin-multiplatform-android-library-js-1.0.jar",
-          "size": 3988,
-          "sha512": "bd1bbf23bdcf7bb7e622b429c068de6d39eab7df7277bd0758e45e3e7baef9d621b4c707a32b2009537f5371b0ce88cf48db2a0f82b9b4064ef5c5edfef1e44c",
-          "sha256": "def48cf63cde9b2bd017e60dc4de5e80520b0333370ab74673d1dba450b261f7",
-          "sha1": "63e84689aeae3d53ae3d4f5f2f244d776470df14",
-          "md5": "24f384b206943d643fdb2badf762deb5"
+          "size": 4002,
+          "sha512": "1a36678787fe1f12dd1a10f25e0a54566db6f9b66d2d8a8bdb915fc76e17aaf43e666fce711179f7d8067c891934839d38949c2301761b514f15040b7cc61347",
+          "sha256": "b3e8694eb309df07a87e017bfe6c4539a894b1b6e8a4f473255517348d89ee32",
+          "sha1": "6abd39e09f592f518560309e215b7e1157623fc7",
+          "md5": "cf8be76656f8ae56765fe5d90ce7b2ea"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.module
@@ -11,14 +11,14 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -36,16 +36,16 @@
         {
           "name": "kotlin-multiplatform-android-library.klib",
           "url": "kotlin-multiplatform-android-library-linuxx64-1.0.klib",
-          "size": 5523,
-          "sha512": "d06545d65fac01c09a030199efa6cf2240f95a13d2b203c5f57e4896344ebb10cb8fa799e67d176e223bd1a859704e88f3259dfe9c688d34a2537bf6a1f57d76",
-          "sha256": "d3984fb54f3215281ce6538c5cdcf7fefbd41949f83a70d442ccb802ee58d7f6",
-          "sha1": "4b1e499ef68e1154ec9db055a441bc0074e4d9b5",
-          "md5": "c5c6a530ac9f68c6b1aff415e4d70567"
+          "size": 5184,
+          "sha512": "caa37bda64573c856a8067801cef5f09a9d36138069fbfec6d9e677f8f4b46a5e0d0fe2d8ec201e7555bc48891ead68119801fbc61d184d5291c55df7b1fb047",
+          "sha256": "8de9e7271c412ab47f437b6a961ada584aaa937f6233f680fd7854b0e046b44c",
+          "sha1": "ae43cf87848c0d0a2561b7e1460b4a49d9bea046",
+          "md5": "ae2d437f3aeb2b03f22ea4b842af6338"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.module
@@ -11,14 +11,14 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -36,16 +36,16 @@
         {
           "name": "kotlin-multiplatform-android-library.klib",
           "url": "kotlin-multiplatform-android-library-macosx64-1.0.klib",
-          "size": 5523,
-          "sha512": "7529de431f5c410b65c3aaf96bf7ec9e23027d947787a39d580d3c779d9f72e81484bf5482c03f8773e5ca522193182b0ef0ce6737aed0bc5f6e2e90c8df84e6",
-          "sha256": "65669a4fb8aca3e9b4a86da97086f79fd9bdf7dca26994331a840fc51dd78268",
-          "sha1": "57ca2e8adbfbb3430fa6e6c2a63ca2f91b23b7cd",
-          "md5": "c5905bb74cdd1a694bae761d975f5997"
+          "size": 5184,
+          "sha512": "caa37bda64573c856a8067801cef5f09a9d36138069fbfec6d9e677f8f4b46a5e0d0fe2d8ec201e7555bc48891ead68119801fbc61d184d5291c55df7b1fb047",
+          "sha256": "8de9e7271c412ab47f437b6a961ada584aaa937f6233f680fd7854b0e046b44c",
+          "sha1": "ae43cf87848c0d0a2561b7e1460b4a49d9bea046",
+          "md5": "ae2d437f3aeb2b03f22ea4b842af6338"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-metadata-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-android-library-metadata-1.0.module
@@ -1,9 +1,9 @@
 {
   "formatVersion": "1.1",
   "component": {
-    "url": "../../kotlin-multiplatform-android-library-macosx64/1.0/kotlin-multiplatform-android-library-macosx64-1.0.module",
+    "url": "../../kotlin-multiplatform-android-library-linuxx64/1.0/kotlin-multiplatform-android-library-linuxx64-1.0.module",
     "group": "example",
-    "module": "kotlin-multiplatform-android-library-macosx64",
+    "module": "kotlin-multiplatform-android-library-linuxx64",
     "version": "1.0",
     "attributes": {
       "org.gradle.status": "release"
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"
@@ -26,11 +25,11 @@
         {
           "name": "kotlin-multiplatform-android-library-metadata-1.0.jar",
           "url": "kotlin-multiplatform-android-library-metadata-1.0.jar",
-          "size": 1091,
-          "sha512": "8f12d8c41d65ff8b92584890846fdafa4f68a386a0a869057ae7742050f8a545116b0961e0a5e5eb4b41b5c9a99e26bd2fad2a1311c971712f5ba04a5fc898d4",
-          "sha256": "da18462c050f0aa06d360be7b794e34d2d74da4a108a2c47dfad9c71a7ec3a07",
-          "sha1": "af49280392293c96787ef51a37b03c5d025b99de",
-          "md5": "8f64c10e6dc60240a17547e8b71f14b3"
+          "size": 1096,
+          "sha512": "2b9032bba8ab4f0d93d0fe0a289420e13fd46284c95b0acaea9962682f8472b48b341c36bc264b3986bf8fba61abec0f7121f9c6b721e32fef29c71f61979680",
+          "sha256": "fa720f34db545452c5c3f8110c9827cb1eca7c28421ad1afb2f6c682d07a99ef",
+          "sha1": "b3188bd466b07e4fc963910a8bbbc5d9af12927c",
+          "md5": "0ad01056471780ab4898f7090a14f33a"
         }
       ]
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.module
@@ -10,15 +10,33 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "files": [
+        {
+          "name": "kotlin-multiplatform-library-metadata-1.0.jar",
+          "url": "kotlin-multiplatform-library-1.0.jar",
+          "size": 1031,
+          "sha512": "d14d257029c1786f03315d970e7f78425e6e12bc0ea15883e2f432dce12638aea9a27eafe7d758d3af5ec2a51b91c196ff2b344e8b723f6fd3f613242a1163f5",
+          "sha256": "93d5c8a809c536f2fad956dd5c3dd2129c593c189d568a87d007d950adcb9f0b",
+          "sha1": "56ef39d9ddf424002281729c3e33bcc8b65b86cd",
+          "md5": "6cb4717aa4606913062e2590b3a3ee56"
+        }
+      ]
+    },
+    {
+      "name": "jsApiElements-published",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -29,9 +47,10 @@
       }
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "available-at": {
@@ -42,7 +61,7 @@
       }
     },
     {
-      "name": "jvm-api",
+      "name": "jvmApiElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-api",
@@ -56,7 +75,7 @@
       }
     },
     {
-      "name": "jvm-runtime",
+      "name": "jvmRuntimeElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-runtime",
@@ -70,8 +89,9 @@
       }
     },
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -84,7 +104,7 @@
       }
     },
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "macos_x64",
@@ -94,19 +114,6 @@
         "url": "../../kotlin-multiplatform-library-macosx64/1.0/kotlin-multiplatform-library-macosx64-1.0.module",
         "group": "example",
         "module": "kotlin-multiplatform-library-macosx64",
-        "version": "1.0"
-      }
-    },
-    {
-      "name": "metadata-api",
-      "attributes": {
-        "org.gradle.usage": "kotlin-api",
-        "org.jetbrains.kotlin.platform.type": "common"
-      },
-      "available-at": {
-        "url": "../../kotlin-multiplatform-library-metadata/1.0/kotlin-multiplatform-library-metadata-1.0.module",
-        "group": "example",
-        "module": "kotlin-multiplatform-library-metadata",
         "version": "1.0"
       }
     }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-1.0.pom
@@ -10,5 +10,4 @@
   <groupId>example</groupId>
   <artifactId>kotlin-multiplatform-library</artifactId>
   <version>1.0</version>
-  <packaging>pom</packaging>
 </project>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.module
@@ -11,33 +11,34 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "js-api",
+      "name": "jsApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "files": [
         {
           "name": "kotlin-multiplatform-library-js-1.0.jar",
           "url": "kotlin-multiplatform-library-js-1.0.jar",
-          "size": 3771,
-          "sha512": "ce01625dccb9bbf8f988ac21ece2b4912545dd2d9f2be5f3ebf0d5894d343c150d81b822cc7d02cea83d5b69ac00c379b57429255390d82fced02b315c40cbbd",
-          "sha256": "eb7ba7d5066b14562785942fd66b83bd67566be02c5d638867e505741dc60e4a",
-          "sha1": "06079e5bf82e6af07a871f1be766f14f43d1923f",
-          "md5": "7e574193359cb4f746f1863236ece113"
+          "size": 3783,
+          "sha512": "a06bfd22332fa26c80b190db16b622b47b68a2dabb8206ebcdc753142b610cebba88bf17b2eee6a27f0aaf749180fae80bfb8309ed93bc1637664a22641b6050",
+          "sha256": "f1aac487d446e13af19693c9de2ca89c9206386a64955255e7d6b060fd212b5c",
+          "sha1": "d3326d0f50737a338b46d6813bcd75d13b91f5aa",
+          "md5": "77f4ccbe1924971d6c98d18fdfbd39d9"
         }
       ]
     },
     {
-      "name": "js-runtime",
+      "name": "jsRuntimeElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.js.compiler": "legacy",
         "org.jetbrains.kotlin.platform.type": "js"
       },
       "dependencies": [
@@ -45,14 +46,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-js",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -60,16 +61,16 @@
         {
           "name": "kotlin-multiplatform-library-js-1.0.jar",
           "url": "kotlin-multiplatform-library-js-1.0.jar",
-          "size": 3771,
-          "sha512": "ce01625dccb9bbf8f988ac21ece2b4912545dd2d9f2be5f3ebf0d5894d343c150d81b822cc7d02cea83d5b69ac00c379b57429255390d82fced02b315c40cbbd",
-          "sha256": "eb7ba7d5066b14562785942fd66b83bd67566be02c5d638867e505741dc60e4a",
-          "sha1": "06079e5bf82e6af07a871f1be766f14f43d1923f",
-          "md5": "7e574193359cb4f746f1863236ece113"
+          "size": 3783,
+          "sha512": "a06bfd22332fa26c80b190db16b622b47b68a2dabb8206ebcdc753142b610cebba88bf17b2eee6a27f0aaf749180fae80bfb8309ed93bc1637664a22641b6050",
+          "sha256": "f1aac487d446e13af19693c9de2ca89c9206386a64955255e7d6b060fd212b5c",
+          "sha1": "d3326d0f50737a338b46d6813bcd75d13b91f5aa",
+          "md5": "77f4ccbe1924971d6c98d18fdfbd39d9"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-js-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-js</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.module
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "jvm-api",
+      "name": "jvmApiElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-api",
@@ -27,16 +26,16 @@
         {
           "name": "kotlin-multiplatform-library-jvm-1.0.jar",
           "url": "kotlin-multiplatform-library-jvm-1.0.jar",
-          "size": 1614,
-          "sha512": "af0ea7e99721bbf266b2ea1700c893e21ed33ab617d9fd34a4c361ebd8ba140777f8d7a4ff1ba3f77d218fb44889a2a1c6140825adb752d59335a70697fa50d6",
-          "sha256": "fb06a82b1e2117660c4e8cf4248d9f04098b49a5c033491caba18a9d525e4bec",
-          "sha1": "65f4fb4e927a9ffc2c9d05a82e9721ccf4bb7b4d",
-          "md5": "4ee4bc056a9e3837289c37e53d4d00e7"
+          "size": 1670,
+          "sha512": "0cc934ea92442f77e2aef215567318debf848ded407e4bc572c53f711e6a692a550cf0863a79cb91cc4b256c477cb38b70f37042194f2fb4fcda2856ed602e34",
+          "sha256": "4e7b409753359f56ce32bf3476e7c135233250eb380f56d88d71e551727fabc4",
+          "sha1": "ffd0f6302d80a4d9713da640c5a09c73c407261d",
+          "md5": "723d60bd14e0bc442dc050600ddacc92"
         }
       ]
     },
     {
-      "name": "jvm-runtime",
+      "name": "jvmRuntimeElements-published",
       "attributes": {
         "org.gradle.libraryelements": "jar",
         "org.gradle.usage": "java-runtime",
@@ -47,14 +46,14 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         },
         {
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -62,16 +61,16 @@
         {
           "name": "kotlin-multiplatform-library-jvm-1.0.jar",
           "url": "kotlin-multiplatform-library-jvm-1.0.jar",
-          "size": 1614,
-          "sha512": "af0ea7e99721bbf266b2ea1700c893e21ed33ab617d9fd34a4c361ebd8ba140777f8d7a4ff1ba3f77d218fb44889a2a1c6140825adb752d59335a70697fa50d6",
-          "sha256": "fb06a82b1e2117660c4e8cf4248d9f04098b49a5c033491caba18a9d525e4bec",
-          "sha1": "65f4fb4e927a9ffc2c9d05a82e9721ccf4bb7b4d",
-          "md5": "4ee4bc056a9e3837289c37e53d4d00e7"
+          "size": 1670,
+          "sha512": "0cc934ea92442f77e2aef215567318debf848ded407e4bc572c53f711e6a692a550cf0863a79cb91cc4b256c477cb38b70f37042194f2fb4fcda2856ed602e34",
+          "sha256": "4e7b409753359f56ce32bf3476e7c135233250eb380f56d88d71e551727fabc4",
+          "sha1": "ffd0f6302d80a4d9713da640c5a09c73c407261d",
+          "md5": "723d60bd14e0bc442dc050600ddacc92"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-jvm-1.0.pom
@@ -13,13 +13,13 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.module
@@ -11,14 +11,14 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "linuxX64-api",
+      "name": "linuxX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -36,16 +36,16 @@
         {
           "name": "kotlin-multiplatform-library.klib",
           "url": "kotlin-multiplatform-library-linuxx64-1.0.klib",
-          "size": 5437,
-          "sha512": "3a5c3f67392016bc90735bacc4788b823e155ddf714919d75d1590b0148f5b63d98f53b832c412dcb411fd8f53270c52e2dd83408739be146b550c56c02a9340",
-          "sha256": "7dd6266ed30d631f6c2b95fb92946126ff711b3405a11f6a16ea3cc9b836b3a3",
-          "sha1": "d3c8aa8a265013414bfbb7b457fa5b66d86d062a",
-          "md5": "dd9099c1af5d8dc5b51b42d368d9977d"
+          "size": 5079,
+          "sha512": "dc32805b962dbaa6da1388e4a42071398dd9c093416db261ba101699e10f89b5ad0a6917c8943cb60e09149e95018a71039fc4ccd7cab20c5104c6ec28f8d93a",
+          "sha256": "dfd1e2f9085c398398ab1e24fbe14b7ee85c0b1b867db0a7f6c42b10f0061655",
+          "sha1": "112689f6aaae7ca45bc251d4366a6e266971dcbb",
+          "md5": "0e7f673c2440c54235d8cc3d425ac943"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-linuxx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.module
@@ -11,16 +11,16 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "macosX64-api",
+      "name": "macosX64ApiElements-published",
       "attributes": {
+        "artifactType": "org.jetbrains.kotlin.klib",
         "org.gradle.usage": "kotlin-api",
-        "org.jetbrains.kotlin.native.target": "macos_x64",
+        "org.jetbrains.kotlin.native.target": "linux_x64",
         "org.jetbrains.kotlin.platform.type": "native"
       },
       "dependencies": [
@@ -28,7 +28,7 @@
           "group": "org.jetbrains.kotlin",
           "module": "kotlin-stdlib-common",
           "version": {
-            "requires": "1.3.72"
+            "requires": "1.4.31"
           }
         }
       ],
@@ -36,16 +36,16 @@
         {
           "name": "kotlin-multiplatform-library.klib",
           "url": "kotlin-multiplatform-library-macosx64-1.0.klib",
-          "size": 5437,
-          "sha512": "cf6097c614c452dbf4933242a80a3339a9361e2d77febb78a4d3543f68d7cc0ec370a392f8813ad4a36d42da6cc1245888ee204fcf327070abff9e08edc5ab3f",
-          "sha256": "842613d67c34a9da15ede4cf465fc8420ac0b7439173086abcf443f72c45fd3f",
-          "sha1": "082370a48c327a8104ba4809470b7eec729a8edc",
-          "md5": "e27f4e03644ad77d47c9b07e0d21d4d3"
+          "size": 5079,
+          "sha512": "dc32805b962dbaa6da1388e4a42071398dd9c093416db261ba101699e10f89b5ad0a6917c8943cb60e09149e95018a71039fc4ccd7cab20c5104c6ec28f8d93a",
+          "sha256": "dfd1e2f9085c398398ab1e24fbe14b7ee85c0b1b867db0a7f6c42b10f0061655",
+          "sha1": "112689f6aaae7ca45bc251d4366a6e266971dcbb",
+          "md5": "0e7f673c2440c54235d8cc3d425ac943"
         }
       ]
     },
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-macosx64-1.0.pom
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-common</artifactId>
-      <version>1.3.72</version>
+      <version>1.4.31</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-metadata-1.0.module
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/gmm-example/expected-metadata/kotlin-multiplatform-library-metadata-1.0.module
@@ -1,9 +1,9 @@
 {
   "formatVersion": "1.1",
   "component": {
-    "url": "../../kotlin-multiplatform-library-macosx64/1.0/kotlin-multiplatform-library-macosx64-1.0.module",
+    "url": "../../kotlin-multiplatform-library-linuxx64/1.0/kotlin-multiplatform-library-linuxx64-1.0.module",
     "group": "example",
-    "module": "kotlin-multiplatform-library-macosx64",
+    "module": "kotlin-multiplatform-library-linuxx64",
     "version": "1.0",
     "attributes": {
       "org.gradle.status": "release"
@@ -11,13 +11,12 @@
   },
   "createdBy": {
     "gradle": {
-      "version": "6.1.1",
-      "buildId": "pr4n4lpg5ja6re27qc3piepc4q"
+      "version": "7.1"
     }
   },
   "variants": [
     {
-      "name": "metadata-api",
+      "name": "metadataApiElements-published",
       "attributes": {
         "org.gradle.usage": "kotlin-api",
         "org.jetbrains.kotlin.platform.type": "common"
@@ -26,11 +25,11 @@
         {
           "name": "kotlin-multiplatform-library-metadata-1.0.jar",
           "url": "kotlin-multiplatform-library-metadata-1.0.jar",
-          "size": 1026,
-          "sha512": "0528314a4128405d736d9736c2ab17d419318d9ffca4eb821cfb76fc0c8534b9b354db672161c300a799ca15b7b906c161c16cf63ab7d69ce977994ca9732de7",
-          "sha256": "5d8b2e57a1d366beba255299a7ee7df82d06dd838b5a390dfd6ed7c0089dc51c",
-          "sha1": "feab845e50c07d1ddb6c1f1cbd0e96d6133b9959",
-          "md5": "3b2e8efc39ef8e12ce24f4c5d48d982e"
+          "size": 1031,
+          "sha512": "d14d257029c1786f03315d970e7f78425e6e12bc0ea15883e2f432dce12638aea9a27eafe7d758d3af5ec2a51b91c196ff2b344e8b723f6fd3f613242a1163f5",
+          "sha256": "93d5c8a809c536f2fad956dd5c3dd2129c593c189d568a87d007d950adcb9f0b",
+          "sha1": "56ef39d9ddf424002281729c3e33bcc8b65b86cd",
+          "md5": "6cb4717aa4606913062e2590b3a3ee56"
         }
       ]
     }


### PR DESCRIPTION
This makes the test compatible with Gradle 8.0.
Earlier version of Kotlin uses deprecated methods that will be removed in Gradle 8.0.
