### PR TITLE
Avoid allocating two arrays when inserting into ListChildMap

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractListChildMap.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/AbstractListChildMap.java
@@ -122,7 +122,8 @@ public abstract class AbstractListChildMap<T> implements ChildMap<T> {
     }
 
     protected ChildMap<T> withNewChild(int insertBefore, String path, T newChild) {
-        List<Entry<T>> newChildren = new ArrayList<>(entries);
+        List<Entry<T>> newChildren = new ArrayList<>(entries.size() + 1);
+        newChildren.addAll(entries);
         newChildren.add(insertBefore, new Entry<>(path, newChild));
         return ChildMapFactory.childMapFromSorted(newChildren);
     }


### PR DESCRIPTION
By allocating an array list of the right size and then inserting into it, we should avoid allocating an extra array list while still using arraycopy under the hood.