### PR TITLE
Added support for network retry

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.resource.transport.http;
 
+import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.gradle.internal.resource.ReadableContent;
@@ -42,6 +44,8 @@ public class HttpResourceUploader implements ExternalResourceUploader {
                 URI effectiveUri = response.getEffectiveUri();
                 throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
             }
+        } catch (NoHttpResponseException e) {
+            throw new HttpErrorStatusCodeException("PUT", destination.toString(), HttpStatus.SC_REQUEST_TIMEOUT, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Kenny Stridh <kenny.stridh@gmail.com>

<!--- The issue this PR addresses -->
Fixes #?

### Context
Better support for unreliable network

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
