### PR TITLE
Prepare BuildProfile earlier than beforeSettings

### DIFF
--- a/subprojects/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/BuildProfileServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.profile;
 
+import org.gradle.StartParameter;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.event.ListenerManager;
@@ -47,8 +48,8 @@ public class BuildProfileServices extends AbstractPluginServiceRegistry {
                 return new ReportGeneratingProfileListener(styledTextOutputFactory);
             }
 
-            public ProfileEventAdapter createProfileEventAdapter(BuildStartedTime buildStartedTime, Clock clock, ListenerManager listenerManager) {
-                return new ProfileEventAdapter(buildStartedTime, clock, listenerManager.getBroadcaster(ProfileListener.class));
+            public ProfileEventAdapter createProfileEventAdapter(BuildStartedTime buildStartedTime, Clock clock, ListenerManager listenerManager, StartParameter startParameter) {
+                return new ProfileEventAdapter(buildStartedTime, clock, listenerManager.getBroadcaster(ProfileListener.class), startParameter);
             }
         });
     }

--- a/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -16,6 +16,7 @@
 package org.gradle.profile;
 
 import org.gradle.BuildResult;
+import org.gradle.StartParameter;
 import org.gradle.api.Describable;
 import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
@@ -43,18 +44,17 @@ public class ProfileEventAdapter implements InternalBuildListener, ProjectEvalua
     private final ThreadLocal<ContinuousOperation> currentTransformation = new ThreadLocal<ContinuousOperation>();
     private BuildProfile buildProfile;
 
-    public ProfileEventAdapter(BuildStartedTime buildStartedTime, Clock clock, ProfileListener listener) {
+    public ProfileEventAdapter(BuildStartedTime buildStartedTime, Clock clock, ProfileListener listener, StartParameter startParameter) {
         this.buildStartedTime = buildStartedTime;
         this.clock = clock;
         this.listener = listener;
+        this.buildProfile = new BuildProfile(startParameter);
     }
 
     // BuildListener
-
     @Override
     public void beforeSettings(Settings settings) {
         long now = clock.getCurrentTime();
-        buildProfile = new BuildProfile(settings.getStartParameter());
         buildProfile.setBuildStarted(now);
         buildProfile.setProfilingStarted(buildStartedTime.getStartTime());
     }


### PR DESCRIPTION
beforeSettings is too late to start capturing BuildProfile data
because init scripts can cause activity the BuildProfile wants to
capture
<!--- The issue this PR addresses -->
Fixes #16872
