### PR TITLE
Make sure we can iterate on entries of a version catalog

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -20,6 +20,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.provider.Provider;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -50,4 +51,28 @@ public interface VersionCatalog extends Named {
      * @param name the name of the version
      */
     Optional<VersionConstraint> findVersion(String name);
+
+    /**
+     * Returns the list of aliases defined in this version catalog.
+     * @return the list of dependency aliases
+     *
+     * @since 7.1
+     */
+    List<String> getDependencyAliases();
+
+    /**
+     * Returns the list of bundles defined in this version catalog.
+     * @return the list of bundle aliases
+     *
+     * @since 7.1
+     */
+    List<String> getBundleAliases();
+
+    /**
+     * Returns the list of version aliases defined in this version catalog.
+     * @return the list of version aliases
+     *
+     * @since 7.1
+     */
+    List<String> getVersionAliases();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1152,6 +1152,15 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                     assert !libs.findBundle('missing').present
                     assert other.findVersion('ver').present
                     assert !other.findVersion('missing').present
+
+                    assert libs.dependencyAliases == ['lib', 'lib2']
+                    assert libs.bundleAliases == ['all']
+                    assert libs.versionAliases == []
+
+                    assert other.dependencyAliases == ['lib']
+                    assert other.bundleAliases == []
+                    assert other.versionAliases == ['ver']
+
                 }
             }
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Optional;
 
 public abstract class AbstractExternalDependencyFactory implements ExternalModuleDependencyFactory {
@@ -102,6 +103,21 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
     @Override
     public final String getName() {
         return config.getName();
+    }
+
+    @Override
+    public List<String> getDependencyAliases() {
+        return config.getDependencyAliases();
+    }
+
+    @Override
+    public List<String> getBundleAliases() {
+        return config.getBundleAliases();
+    }
+
+    @Override
+    public List<String> getVersionAliases() {
+        return config.getVersionAliases();
     }
 
     public static class VersionFactory {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
@@ -61,6 +61,21 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         public String getName() {
             return owner.getName();
         }
+
+        @Override
+        public List<String> getDependencyAliases() {
+            return owner.getDependencyAliases();
+        }
+
+        @Override
+        public List<String> getBundleAliases() {
+            return owner.getBundleAliases();
+        }
+
+        @Override
+        public List<String> getVersionAliases() {
+            return owner.getVersionAliases();
+        }
     }
 
     @Inject


### PR DESCRIPTION
The unsafe API makes it possible to access a version catalog
using a type-unsafe (but null-safe) API. However it requires
one to actually know what is in the catalog.

With this commit it's now possible to iterate over the entries
of a catalog by querying the aliases.

Closes #16784
