### PR TITLE
Use lenient dependency verification for EC2 warmup builds

### DIFF
--- a/.teamcity/src/main/kotlin/util/WarmupEc2Agent.kt
+++ b/.teamcity/src/main/kotlin/util/WarmupEc2Agent.kt
@@ -35,7 +35,7 @@ object WarmupEc2Agent : BuildType({
             name = "Resolve all dependencies"
             tasks = "resolveAllDependencies"
             gradleParams = (
-                buildToolGradleParameters(isContinue = false)
+                buildToolGradleParameters(isContinue = false) + listOf("--dependency-verification", "lenient")
                 ).joinToString(separator = " ")
         }
     }


### PR DESCRIPTION
We run a `resolveAllDependencies` build to warm up the EC2 agent image.
However, sometimes the build fails with dependency verification failures,
which is not required because we just want to download all artifacts.

Example: https://builds.gradle.org/buildConfiguration/Gradle_Master_Util_WarmupEc2Agent/42994715?buildTab=log&focusLine=2&linesState=1616

The `resolveAllDependencies` task is injected by the baker: https://github.com/gradle/dev-infrastructure/blob/0b8b41ee845bd8b49cce1b3f86eb8754ebcbbe21/salt/ami-baker/ec2-build-vm-baker/provision_by_salt.sh#L150-L166