### PR TITLE
Update and restore test filtering

### DIFF
--- a/build-logic-settings/testfiltering-plugin/build.gradle.kts
+++ b/build-logic-settings/testfiltering-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-rootProject.name = "build-logic-settings"
-
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
-    }
+plugins {
+   `kotlin-dsl`
 }
-
-include("allprojects-plugin")
-include("testfiltering-plugin")
-

--- a/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
+++ b/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-rootProject.name = "build-logic-settings"
-
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
+val testFilteringProperty = "gradle.internal.testselection.enabled"
+val gitBranchName: String? = System.getenv("BUILD_BRANCH")
+if (!System.getProperties().containsKey(testFilteringProperty) && gitBranchName != null) {
+    val protectedBranches = listOf("master", "release")
+    if (!protectedBranches.contains(gitBranchName) && !gitBranchName.startsWith("pre-test/")) {
+        System.setProperty(testFilteringProperty, "true")
     }
 }
-
-include("allprojects-plugin")
-include("testfiltering-plugin")
-

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.6.1")
         // Keep version with `settings.gradle.kts` in sync
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.3-rc-2")
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.0.3-rc-4")
         api("org.gradle.guides:gradle-guides-plugin:0.18.0")
         api("com.gradle.publish:plugin-publish-plugin:0.14.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,10 @@ plugins {
     id("com.gradle.enterprise").version("3.6.1")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
+    id("gradlebuild.internal.testfiltering")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
     id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-2")
-    id("com.gradle.internal.test-selection").version("0.5.1-rc-1")
+    id("com.gradle.internal.test-selection").version("0.5.2-rc-1")
 }
 
 includeBuild("build-logic-commons")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     id("gradlebuild.base.allprojects")
     id("gradlebuild.internal.testfiltering")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
-    id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-2")
+    id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-4")
     id("com.gradle.internal.test-selection").version("0.5.2-rc-1")
 }
 


### PR DESCRIPTION
### Context
This applies a new Test Distribution plugin which fixes an issue where the number of remote agents is incorrectly calculated. 

