### PR TITLE
Use Test Distribution plugin in more places with remote execution disabled

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -273,7 +273,7 @@ fun removeTeamcityTempProperty() {
     }
 }
 
-fun Project.enableExperimentalTestFiltering() = !setOf("kotlin-dsl", "performance", "smoke-test").contains(name)
+fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name)
 
 val Project.maxParallelForks: Int
     get() = if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("gradlebuild.internal.testfiltering")
     // Keep version with `build-logic/build-platform/buildSrc.gradle.kts` in sync
     id("com.gradle.enterprise.test-distribution").version("2.0.3-rc-4")
-    id("com.gradle.internal.test-selection").version("0.5.2-rc-1")
+    id("com.gradle.internal.test-selection").version("0.5.3-rc-1")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
### Context
This change enables the use of the Test Distribution plugin for all `Test` tasks in the `gradle/gradle` build itself, but sets remote executors to 0 in places where remote distribution is disabled. 

Functionally, this should not be any different to the build today but will enable us to make further optimizations in the future.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
