### PR TITLE
Move EC2 warmup script into GBT build

### DIFF
--- a/build-logic/root-build/src/main/kotlin/gradlebuild.warmup-ec2.gradle.kts
+++ b/build-logic/root-build/src/main/kotlin/gradlebuild.warmup-ec2.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,18 @@
  * limitations under the License.
  */
 
-plugins {
-    id("gradlebuild.buildscan") // Reporting: Add more data through custom tags to build scans
-    id("gradlebuild.ide") // Local development: Tweak IDEA import
-    id("gradlebuild.dependency-analysis") // Auditing dependencies to find unused libraries
-    id("gradlebuild.warmup-ec2") // Warm up EC2 AMI
+tasks.register("resolveAllDependencies") {
+    doLast {
+        allprojects {
+            configurations.forEach { c ->
+                if (c.isCanBeResolved) {
+                    println("Downloading dependencies for '$path' - ${c.name}")
+                    val result = c.incoming.artifactView { lenient(true) }.artifacts
+                    result.failures.forEach {
+                        println("- Ignoring Error: ${it.message}")
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Previously the warmup script was in AMI baker, which makes it a bit
magical.