### PR TITLE
Update Spring Boot plugin versions in samples

### DIFF
--- a/subprojects/docs/src/samples/spring-boot-web-application/groovy/app/build.gradle
+++ b/subprojects/docs/src/samples/spring-boot-web-application/groovy/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.2.1.RELEASE'
+	id 'org.springframework.boot' version '2.4.5'
 	id 'java'
 }
 
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.springframework.boot:spring-boot-dependencies:2.2.1.RELEASE')
+    implementation platform('org.springframework.boot:spring-boot-dependencies:2.4.5')
 
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/subprojects/docs/src/samples/spring-boot-web-application/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/spring-boot-web-application/kotlin/app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version("2.2.1.RELEASE")
+    id("org.springframework.boot") version("2.4.5")
     java
 }
 
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.springframework.boot:spring-boot-dependencies:2.2.1.RELEASE"))
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:2.4.5"))
 
     implementation("org.springframework.boot:spring-boot-starter")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {

--- a/subprojects/docs/src/snippets/kotlinDsl/configuring-tasks-spring-boot/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/kotlinDsl/configuring-tasks-spring-boot/groovy/build.gradle
@@ -2,7 +2,7 @@
 // tag::accessors[]
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'org.springframework.boot' version '2.4.5'
 }
 
 // end::lazy[]

--- a/subprojects/docs/src/snippets/kotlinDsl/configuring-tasks-spring-boot/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/kotlinDsl/configuring-tasks-spring-boot/kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 // tag::accessors[]
 plugins {
     java
-    id("org.springframework.boot") version "2.3.4.RELEASE"
+    id("org.springframework.boot") version "2.4.5"
 }
 
 // end::lazy[]


### PR DESCRIPTION
While the older version does not emit deprecation warnings in our
samples tests, attempting to remove deprecated methods in
JavaExec task and JavaApplication plugin fails to apply this plugin.
Current latest version does not have this problem.
