### PR TITLE
Update unit and TAPI tests to avoid deprecated method calls

### DIFF
--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -286,7 +286,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         when:
         project.pluginManager.apply(JavaBasePlugin)
         project.sourceSets.create('custom')
-        project.sourceSets.custom.java.outputDir = classesDir
+        project.sourceSets.custom.java.destinationDirectory.set(classesDir)
         project.sourceSets.custom.output.resourcesDir = resourcesDir
 
         then:

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/TestLauncherSpec.groovy
@@ -171,11 +171,12 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
         settingsFile << "rootProject.name = 'testproject'\n"
         buildFile.text = simpleJavaProject()
 
+        def classesDir = 'file("build/classes/moreTests")'
         buildFile << """
             sourceSets {
                 moreTests {
                     java.srcDir "src/test"
-                    ${separateClassesDirs(targetVersion) ? "java.outputDir" : "output.classesDir"} = file("build/classes/moreTests")
+                    ${destinationDirectoryCode(classesDir)}
                     compileClasspath = compileClasspath + sourceSets.test.compileClasspath
                     runtimeClasspath = runtimeClasspath + sourceSets.test.runtimeClasspath
                 }
@@ -224,6 +225,17 @@ abstract class TestLauncherSpec extends ToolingApiSpecification implements WithO
 
     static boolean separateClassesDirs(GradleVersion version) {
         version.baseVersion >= GradleVersion.version("4.0")
+    }
+
+    String destinationDirectoryCode(String destinationDirectory) {
+        //${separateClassesDirs(targetVersion) ? "java.outputDir" : "output.classesDir"} = file("build/classes/moreTests")
+        if (!separateClassesDirs(targetVersion)) {
+            return "output.classesDir = $destinationDirectory"
+        }
+        if (targetVersion.baseVersion < GradleVersion.version("6.1")) {
+            return "java.outputDir = $destinationDirectory"
+        }
+        return "java.destinationDirectory.set($destinationDirectory)"
     }
 
     def changeTestSource() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -450,11 +450,12 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
         settingsFile << "rootProject.name = 'testproject'\n"
         buildFile.text = simpleJavaProject()
 
+        def classesDir = 'file("build/classes/moreTests")'
         buildFile << """
             sourceSets {
                 moreTests {
                     java.srcDir "src/test"
-                    ${separateClassesDirs(targetVersion) ? "java.outputDir" : "output.classesDir"} = file("build/classes/moreTests")
+                    ${destinationDirectoryCode(classesDir)}
                     compileClasspath = compileClasspath + sourceSets.test.compileClasspath
                     runtimeClasspath = runtimeClasspath + sourceSets.test.runtimeClasspath
                 }


### PR DESCRIPTION
Spiking removal of deprecated SourceDirectorySet methods
relvealed that the changed tests were depending on this method.
This change updates the tests to not use deprecated to-be-removed
methods when replacement is available.

https://github.com/gradle/gradle/issues/15681