### PR TITLE
Clean and check Android user home

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -19,8 +19,8 @@ package common
 import configurations.branchesFilterExcluding
 import configurations.buildScanCustomValue
 import configurations.buildScanTag
-import configurations.cleanAndroidUserHomeScriptUnixLike
-import configurations.cleanAndroidUserHomeScriptWindows
+import configurations.checkCleanAndroidUserHomeScriptUnixLike
+import configurations.checkCleanAndroidUserHomeScriptWindows
 import configurations.m2CleanScriptUnixLike
 import configurations.m2CleanScriptWindows
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
@@ -139,20 +139,11 @@ fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os)
     }
 }
 
-fun BuildSteps.checkCleanM2(os: Os = Os.LINUX) {
+fun BuildSteps.checkCleanM2AndAndroidUserHome(os: Os = Os.LINUX) {
     script {
-        name = "CHECK_CLEAN_M2"
+        name = "CHECK_CLEAN_M2_ANDROID_USER_HOME"
         executionMode = BuildStep.ExecutionMode.ALWAYS
-        scriptContent = if (os == Os.WINDOWS) m2CleanScriptWindows else m2CleanScriptUnixLike
-    }
-}
-
-// https://github.com/gradle/gradle-private/issues/3379
-fun BuildSteps.cleanAndroidUserHome(os: Os = Os.LINUX) {
-    script {
-        name = "CLEAN_ANDROID_USER_HOME"
-        executionMode = BuildStep.ExecutionMode.ALWAYS
-        scriptContent = if (os == Os.WINDOWS) cleanAndroidUserHomeScriptWindows else cleanAndroidUserHomeScriptUnixLike
+        scriptContent = if (os == Os.WINDOWS) m2CleanScriptWindows + checkCleanAndroidUserHomeScriptWindows else m2CleanScriptUnixLike + checkCleanAndroidUserHomeScriptUnixLike
     }
 }
 
@@ -206,7 +197,7 @@ fun functionalTestParameters(os: Os): List<String> {
     )
 }
 
-fun BuildType.killProcessStep(stepName: String, daemon: Boolean, os: Os) {
+fun BuildType.killProcessStep(stepName: String, daemon: Boolean) {
     steps {
         gradleWrapper {
             name = stepName

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -76,8 +76,8 @@ fun BuildSteps.substDirOnWindows(os: Os) {
                 subst p: "%teamcity.build.checkoutDir%"
                 """.trimIndent()
         }
-        cleanBuildLogicBuild("P:/build-logic-commons", os)
-        cleanBuildLogicBuild("P:/build-logic", os)
+        cleanBuildLogicBuild("P:/build-logic-commons")
+        cleanBuildLogicBuild("P:/build-logic")
     }
 }
 
@@ -88,12 +88,12 @@ fun BuildSteps.removeSubstDirOnWindows(os: Os) {
             executionMode = BuildStep.ExecutionMode.ALWAYS
             scriptContent = """dir p: && subst p: /d"""
         }
-        cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic-commons", os)
-        cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic", os)
+        cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic-commons")
+        cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic")
     }
 }
 
-private fun BuildSteps.cleanBuildLogicBuild(buildDir: String, os: Os) {
+private fun BuildSteps.cleanBuildLogicBuild(buildDir: String) {
     // Gradle detects overlapping outputs when running first on a subst drive and then in the original location.
     // Even when running clean builds on CI, we don't run clean in buildSrc, so there may be stale leftover files there.
     // This means that we need to clean buildSrc before running for the first time on the subst drive

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -3,7 +3,7 @@ package configurations
 import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
-import common.checkCleanM2
+import common.checkCleanM2AndAndroidUserHome
 import common.compileAllDependency
 import common.functionalTestParameters
 import common.gradleWrapper
@@ -32,6 +32,7 @@ val m2CleanScriptUnixLike = """
     else
         echo "${'$'}REPO does not exist"
     fi
+
 """.trimIndent()
 
 val m2CleanScriptWindows = """
@@ -40,15 +41,26 @@ val m2CleanScriptWindows = """
         RMDIR /S /Q %teamcity.agent.jvm.user.home%\.m2\repository
         EXIT 1
     )
+
 """.trimIndent()
 
-val cleanAndroidUserHomeScriptUnixLike = """
-    rm -rf %teamcity.agent.jvm.user.home%/.android
+val checkCleanAndroidUserHomeScriptUnixLike = """
+    ANDROID_USER_HOME=%teamcity.agent.jvm.user.home%/.android
+    if [ -e ${'$'}ANDROID_USER_HOME ] ; then
+        tree ${'$'}ANDROID_USER_HOME
+        rm -rf ${'$'}ANDROID_USER_HOME
+        echo "${'$'}ANDROID_USER_HOME was polluted during the build"
+        # exit 1
+    else
+        echo "${'$'}ANDROID_USER_HOME does not exist"
+    fi
 """.trimIndent()
 
-val cleanAndroidUserHomeScriptWindows = """
+val checkCleanAndroidUserHomeScriptWindows = """
     IF exist %teamcity.agent.jvm.user.home%\.android (
+        TREE %teamcity.agent.jvm.user.home%\.android
         RMDIR /S /Q %teamcity.agent.jvm.user.home%\.android
+        REM EXIT 1
     )
 """.trimIndent()
 
@@ -152,12 +164,12 @@ fun BuildType.dumpOpenFiles() {
 fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: Os = Os.LINUX, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
     buildType.applyDefaultSettings(os, timeout = timeout)
 
-    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon, os)
+    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon)
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
     buildType.steps {
         extraSteps()
-        checkCleanM2(os)
+        checkCleanM2AndAndroidUserHome(os)
     }
 
     applyDefaultDependencies(model, buildType, notQuick)
@@ -189,18 +201,18 @@ fun applyTestDefaults(
         buildType.attachFileLeakDetector()
     }
 
-    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon, os)
+    buildType.killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon)
 
     buildType.gradleRunnerStep(model, gradleTasks, os, extraParameters, daemon)
 
     if (os == Os.WINDOWS) {
         buildType.dumpOpenFiles()
     }
-    buildType.killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", daemon, os)
+    buildType.killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", daemon)
 
     buildType.steps {
         extraSteps()
-        checkCleanM2(os)
+        checkCleanM2AndAndroidUserHome(os)
     }
 
     applyDefaultDependencies(model, buildType, notQuick)

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -19,8 +19,7 @@ package configurations
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
-import common.checkCleanM2
-import common.cleanAndroidUserHome
+import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killGradleProcessesStep
@@ -66,7 +65,6 @@ class PerformanceTest(
         if (testProjects.isNotEmpty()) {
             steps {
                 preBuildSteps()
-                cleanAndroidUserHome(os)
                 killGradleProcessesStep(os)
                 substDirOnWindows(os)
 
@@ -86,7 +84,7 @@ class PerformanceTest(
                         ).joinToString(separator = " ")
                 }
                 removeSubstDirOnWindows(os)
-                checkCleanM2(os)
+                checkCleanM2AndAndroidUserHome(os)
             }
         }
 

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -1,7 +1,6 @@
 package configurations
 
 import common.JvmCategory
-import common.cleanAndroidUserHome
 import model.CIBuildModel
 import model.Stage
 
@@ -23,9 +22,6 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
         extraParameters = buildScanTag("SmokeTests") +
             " -PtestJavaVersion=${testJava.version.major}" +
             " -PtestJavaVendor=${testJava.vendor.name}" +
-            " -Porg.gradle.java.installations.auto-download=false",
-        preSteps = {
-            cleanAndroidUserHome()
-        }
+            " -Porg.gradle.java.installations.auto-download=false"
     )
 })

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -19,7 +19,7 @@ package configurations
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
-import common.checkCleanM2
+import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
@@ -78,7 +78,7 @@ class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildTy
             )
         )
 
-        checkCleanM2(os)
+        checkCleanM2AndAndroidUserHome(os)
     }
 
     applyDefaultDependencies(model, this, true)

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -292,7 +292,7 @@ class SubprojectTestClassTime(val subProject: GradleSubproject, private val test
             // R List<TestClassTime>
             val list = LinkedList(testClassTimes.sortedBy { -it.buildTimeMs })
             val toIntFunction = TestClassTime::buildTimeMs
-            val largeElementSplitFunction: (TestClassTime, Int) -> List<List<TestClassTime>> = { testClassTime: TestClassTime, number: Int -> listOf(listOf(testClassTime)) }
+            val largeElementSplitFunction: (TestClassTime, Int) -> List<List<TestClassTime>> = { testClassTime: TestClassTime, _: Int -> listOf(listOf(testClassTime)) }
             val smallElementAggregateFunction: (List<TestClassTime>) -> List<TestClassTime> = { it }
 
             val buckets: List<List<TestClassTime>> = splitIntoBuckets(list, toIntFunction, largeElementSplitFunction, smallElementAggregateFunction, expectedBucketNumber, Integer.MAX_VALUE)

--- a/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
+++ b/.teamcity/src/main/kotlin/model/GradleSubprojectProvider.kt
@@ -32,7 +32,7 @@ interface GradleSubprojectProvider {
 }
 
 data class JsonBasedGradleSubprojectProvider(private val jsonFile: File) : GradleSubprojectProvider {
-    override val subprojects = JSON.parseArray(jsonFile.readText()).map { toSubproject(it as Map<String, Object>) }
+    override val subprojects = JSON.parseArray(jsonFile.readText()).map { toSubproject(it as Map<String, Any>) }
     private val nameToSubproject = subprojects.map { it.name to it }.toMap()
 
     override fun getSubprojectsFor(testConfig: TestCoverage, stage: Stage) =
@@ -42,7 +42,7 @@ data class JsonBasedGradleSubprojectProvider(private val jsonFile: File) : Gradl
     override fun getSubprojectByName(name: String) = nameToSubproject[name]
 
     private
-    fun toSubproject(subproject: Map<String, Object>): GradleSubproject {
+    fun toSubproject(subproject: Map<String, Any>): GradleSubproject {
         val name = subproject["name"] as String
         val unitTests = !ignoredSubprojects.contains(name) && subproject["unitTests"] as Boolean
         val functionalTests = !ignoredSubprojects.contains(name) && subproject["functionalTests"] as Boolean

--- a/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
+++ b/.teamcity/src/main/kotlin/util/AdHocPerformanceScenario.kt
@@ -3,7 +3,7 @@ package util
 import common.Os
 import common.applyPerformanceTestSettings
 import common.buildToolGradleParameters
-import common.checkCleanM2
+import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
 import common.killGradleProcessesStep
@@ -82,7 +82,7 @@ abstract class AdHocPerformanceScenario(os: Os) : BuildType({
                 ).joinToString(separator = " ")
         }
         removeSubstDirOnWindows(os)
-        checkCleanM2(os)
+        checkCleanM2AndAndroidUserHome(os)
     }
 })
 

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -20,7 +20,7 @@ import common.BuildToolBuildJvm
 import common.Os
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
-import common.checkCleanM2
+import common.checkCleanM2AndAndroidUserHome
 import common.compileAllDependency
 import common.functionalTestExtraParameters
 import common.functionalTestParameters
@@ -50,7 +50,7 @@ class RerunFlakyTest(os: Os) : BuildType({
             functionalTestParameters(os)
         ).joinToString(separator = " ")
 
-    killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon, os)
+    killProcessStep("KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS", daemon)
     steps {
         gradleWrapper {
             name = "SHOW_TOOLCHAINS"
@@ -67,10 +67,10 @@ class RerunFlakyTest(os: Os) : BuildType({
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
         }
-        killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", daemon, os)
+        killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", daemon)
     }
     steps {
-        checkCleanM2(os)
+        checkCleanM2AndAndroidUserHome(os)
     }
 
     params {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -72,7 +72,7 @@ class ApplyDefaultConfigurationTest {
             "KILL_LEAKED_PROCESSES_FROM_PREVIOUS_BUILDS",
             "SHOW_TOOLCHAINS",
             "GRADLE_RUNNER",
-            "CHECK_CLEAN_M2"
+            "CHECK_CLEAN_M2_ANDROID_USER_HOME"
         ), steps.items.map(BuildStep::name))
         assertEquals(expectedRunnerParam(), getGradleStep("GRADLE_RUNNER").gradleParams)
     }
@@ -92,7 +92,7 @@ class ApplyDefaultConfigurationTest {
             "SHOW_TOOLCHAINS",
             "GRADLE_RUNNER",
             "KILL_PROCESSES_STARTED_BY_GRADLE",
-            "CHECK_CLEAN_M2"
+            "CHECK_CLEAN_M2_ANDROID_USER_HOME"
         ), steps.items.map(BuildStep::name))
         verifyGradleRunnerParams(extraParameters, expectedDaemonParam)
     }
@@ -115,7 +115,7 @@ class ApplyDefaultConfigurationTest {
             "SET_BUILD_SUCCESS_ENV",
             "DUMP_OPEN_FILES_ON_FAILURE",
             "KILL_PROCESSES_STARTED_BY_GRADLE",
-            "CHECK_CLEAN_M2"
+            "CHECK_CLEAN_M2_ANDROID_USER_HOME"
         ), steps.items.map(BuildStep::name))
         verifyGradleRunnerParams(extraParameters, expectedDaemonParam, Os.WINDOWS)
     }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -70,10 +70,9 @@ class PerformanceTestBuildTypeTest {
 
         assertEquals(
             listOf(
-                "CLEAN_ANDROID_USER_HOME",
                 "KILL_GRADLE_PROCESSES",
                 "GRADLE_RUNNER",
-                "CHECK_CLEAN_M2"
+                "CHECK_CLEAN_M2_ANDROID_USER_HOME"
             ), performanceTest.steps.items.map(BuildStep::name)
         )
 

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -209,6 +209,7 @@ fun configureTests() {
     }
 
     tasks.withType<Test>().configureEach {
+        configureAndroidUserHome()
         filterEnvironmentVariables()
 
         maxParallelForks = project.maxParallelForks
@@ -317,4 +318,11 @@ fun TaskContainer.registerCITestDistributionLifecycleTasks() {
         description = "Runs all integration tests with the dependency management engine in 'force component realization' mode"
         group = ciGroup
     }
+}
+
+// https://github.com/gradle/gradle-private/issues/3380
+fun Test.configureAndroidUserHome() {
+    val androidUserHomeForTest = project.layout.buildDirectory.dir("androidUserHomeForTest/$name").get().asFile.absolutePath
+    environment["ANDROID_PREFS_ROOT"] = androidUserHomeForTest
+    environment["ANDROID_USER_HOME"] = androidUserHomeForTest
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -32,6 +32,9 @@ val propagatedEnvironmentVariables = listOf(
     // For Android tests
     "ANDROID_HOME",
     "ANDROID_SDK_ROOT",
+    // legacy and new android user home
+    "ANDROID_USER_HOME",
+    "ANDROID_PREFS_ROOT",
 
     // Used by Visual Studio
     "USERNAME",


### PR DESCRIPTION
Previously, the Android tests might pollute global ~/.android, resulting
in unexpected failures. This PR set Android user home to test temp directory,
and check Android user home after the build.

Closes https://github.com/gradle/gradle-private/issues/3380