### PR TITLE
Add missing property to DSL reference

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
@@ -77,6 +77,10 @@
                 <td><literal><replaceable>sourceSet</replaceable>.annotationProcessorPath</literal></td>
             </tr>
             <tr>
+                <td>generatedSourceOutputDirectory</td>
+                <td><literal><replaceable>${project.buildDir}</replaceable>/generated/sources/annotationProcessor/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
+            </tr>
+            <tr>
                 <td>annotationProcessorGeneratedSourcesDirectory</td>
                 <td><literal><replaceable>${project.buildDir}</replaceable>/generated/sources/annotationProcessor/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
             </tr>


### PR DESCRIPTION
CompileOptions.annotationProcessorGeneratedSourcesDirectory is
deprecated in favor of generatedSourceOutputDirectory property.
The latter was missing from the DSL reference.

https://github.com/gradle/gradle/issues/15681