### PR TITLE
Trigger builds should depend on composites

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTestsPass.kt
@@ -18,11 +18,13 @@ package configurations
 
 import common.applyDefaultSettings
 import model.CIBuildModel
+import model.TestCoverage
 import projects.FunctionalTestProject
 
 class FunctionalTestsPass(model: CIBuildModel, functionalTestProject: FunctionalTestProject) : BaseGradleBuildType(init = {
-    id("${functionalTestProject.testConfig.asId(model)}_Trigger")
+    id("${functionalTestProject.testCoverage.asId(model)}_Trigger")
     name = functionalTestProject.name + " (Trigger)"
+    type = Type.COMPOSITE
 
     applyDefaultSettings()
 
@@ -33,4 +35,6 @@ class FunctionalTestsPass(model: CIBuildModel, functionalTestProject: Functional
     dependencies {
         snapshotDependencies(functionalTestProject.functionalTests)
     }
-})
+}) {
+    val testCoverage: TestCoverage = functionalTestProject.testCoverage
+}

--- a/.teamcity/src/main/kotlin/projects/FunctionalTestProject.kt
+++ b/.teamcity/src/main/kotlin/projects/FunctionalTestProject.kt
@@ -10,13 +10,13 @@ import model.TestCoverage
 class FunctionalTestProject(
     model: CIBuildModel,
     functionalTestBucketProvider: FunctionalTestBucketProvider,
-    val testConfig: TestCoverage,
+    val testCoverage: TestCoverage,
     stage: Stage
 ) : Project({
-    this.id(testConfig.asId(model))
-    this.name = testConfig.asName()
+    this.id(testCoverage.asId(model))
+    this.name = testCoverage.asName()
 }) {
-    val functionalTests: List<FunctionalTest> = functionalTestBucketProvider.createFunctionalTestsFor(stage, testConfig)
+    val functionalTests: List<FunctionalTest> = functionalTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
 
     init {
         functionalTests.forEach(this::buildType)


### PR DESCRIPTION
This allows to easier check out which tests fail, since you can check on the composite, and simplifies the dependencies a lot.