### PR TITLE
Bump instrumented jars cache version

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultClasspathTransformerCacheFactory.java
@@ -44,6 +44,7 @@ public class DefaultClasspathTransformerCacheFactory implements ClasspathTransfo
         .incrementedIn("3.2-rc-1")
         .incrementedIn("3.5-rc-1")
         .changedTo(8, "6.5-rc-1")
+        .incrementedIn("7.1")
         .build();
     @VisibleForTesting
     static final String CACHE_NAME = "jars";


### PR DESCRIPTION
Since `InstrumentingClasspathFileTransformer` was changed to use the cross version file locking protocol in 466cfcc8d0cf965d53a63a9415551362f3a15f16.