### PR TITLE
Update abstract archive task tests to not use deprecated APIs

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTaskTest.groovy
@@ -28,7 +28,7 @@ abstract class AbstractArchiveTaskTest extends AbstractCopyTaskContractTest {
     }
 
     protected void checkConstructor() {
-        assert archiveTask.classifier == ''
+        assert archiveTask.archiveClassifier.get() == ''
     }
 
     @CompileStatic

--- a/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
+++ b/subprojects/ear/src/test/groovy/org/gradle/plugins/ear/EarPluginTest.groovy
@@ -84,7 +84,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
 
         then:
         task instanceof Ear
-        task.destinationDir == project.libsDirectory.get().asFile
+        task.destinationDirectory.get() == project.libsDirectory.get()
 
         when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
@@ -104,7 +104,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         then:
         task instanceof Ear
         task dependsOn(JavaPlugin.CLASSES_TASK_NAME)
-        task.destinationDir == project.libsDirectory.get().asFile
+        task.destinationDirectory.get() == project.libsDirectory.get()
 
         when:
         task = project.tasks[BasePlugin.ASSEMBLE_TASK_NAME]
@@ -141,7 +141,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDirectory.get().asFile
+        task.destinationDirectory.get() == project.libsDirectory.get()
     }
 
     def "works with java base plugin applied before ear plugin"() {
@@ -153,7 +153,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDirectory.get().asFile
+        task.destinationDirectory.get() == project.libsDirectory.get()
     }
 
     def "applies mappings to archive tasks for java project"() {
@@ -165,7 +165,7 @@ class EarPluginTest extends AbstractProjectBuilderSpec {
         def task = project.task(type: Ear, 'customEar')
 
         then:
-        task.destinationDir == project.libsDirectory.get().asFile
+        task.destinationDirectory.get() == project.libsDirectory.get()
         task dependsOn(hasItems(JavaPlugin.CLASSES_TASK_NAME))
     }
 


### PR DESCRIPTION
https://github.com/gradle/gradle/issues/15681