### PR TITLE
Capture before execution state before validating

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -844,6 +844,30 @@ task someTask(type: SomeTask) {
         succeeds "foo"
     }
 
+    def "reports the input property which failed to evaluate"() {
+        buildFile("""
+            abstract class FailingTask extends DefaultTask {
+                @Input
+                abstract Property<String> getStringInput()
+
+                @TaskAction
+                void doStuff() {
+                    println("Hello world")
+                }
+            }
+
+            tasks.register("failingTask", FailingTask) {
+                stringInput.set(provider { throw new RuntimeException("BOOM") })
+            }
+        """)
+
+        when:
+        fails "failingTask"
+        then:
+        failureHasCause("Failed to calculate the value of task ':failingTask' property 'stringInput'.")
+        failureHasCause("BOOM")
+    }
+
     def "input and output properties are not evaluated too often"() {
         buildFile << """
             import org.gradle.api.services.BuildServiceParameters

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -866,6 +866,9 @@ task someTask(type: SomeTask) {
         then:
         failureHasCause("Failed to calculate the value of task ':failingTask' property 'stringInput'.")
         failureHasCause("BOOM")
+        if (GradleContextualExecuter.isConfigCache()) {
+            failureDescriptionContains("Configuration cache problems found in this build.")
+        }
     }
 
     def "input and output properties are not evaluated too often"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.properties;
 
 import groovy.lang.GString;
-import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.util.internal.DeferredUtil;
@@ -31,7 +30,7 @@ public class InputParameterUtils {
         try {
             return prepareInputParameterValue(inputProperty.getValue());
         } catch (Exception ex) {
-            throw new InvalidUserDataException(String.format("Error while evaluating property '%s' of %s", propertyName, task), ex);
+            throw new PropertyEvaluationException(task, propertyName, ex);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyEvaluationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyEvaluationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.properties;
+
+import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
+
+@Contextual
+public class PropertyEvaluationException extends GradleException {
+
+    public PropertyEvaluationException(Object work, String propertyName, Throwable cause) {
+        super(String.format("Error while evaluating property '%s' of %s", propertyName, work), cause);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -163,8 +163,8 @@ public class ExecutionGradleServices {
             new LoadExecutionStateStep<>(
             new MarkSnapshottingInputsStartedStep<>(
             new SkipEmptyWorkStep<>(
-            new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
             new CaptureStateBeforeExecutionStep(buildOperationExecutor, classLoaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
+            new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
             new ResolveCachingStateStep(buildCacheController, gradleEnterprisePluginManager.isPresent(),
             new MarkSnapshottingInputsFinishedStep<>(
             new ResolveChangesStep<>(changeDetector,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -159,8 +159,8 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         new AssignWorkspaceStep<>(
         new LoadExecutionStateStep<>(
         new SkipEmptyWorkStep<>(
-        new ValidateStep<>(virtualFileSystem, validationWarningReporter,
         new CaptureStateBeforeExecutionStep(buildOperationExecutor, classloaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
+        new ValidateStep<>(virtualFileSystem, validationWarningReporter,
         new ResolveCachingStateStep(buildCacheController, false,
         new ResolveChangesStep<>(changeDetector,
         new SkipUpToDateStep<>(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -166,7 +166,6 @@ import org.gradle.internal.execution.history.OverlappingOutputDetector;
 import org.gradle.internal.execution.history.changes.ExecutionStateChangeDetector;
 import org.gradle.internal.execution.impl.DefaultExecutionEngine;
 import org.gradle.internal.execution.steps.AssignWorkspaceStep;
-import org.gradle.internal.execution.steps.BeforeExecutionContext;
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep;
 import org.gradle.internal.execution.steps.CachingContext;
 import org.gradle.internal.execution.steps.CachingResult;
@@ -186,6 +185,7 @@ import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.UpToDateResult;
 import org.gradle.internal.execution.steps.ValidateStep;
+import org.gradle.internal.execution.steps.ValidationContext;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.RelativeFilePathResolver;
@@ -768,8 +768,8 @@ class DependencyManagementBuildScopeServices {
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadExecutionStateStep<>(
-            new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
             new CaptureStateBeforeExecutionStep(buildOperationExecutor, classLoaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
+            new ValidateStep<>(virtualFileSystem, validationWarningRecorder,
             new NoOpCachingStateStep(
             new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(
@@ -786,7 +786,7 @@ class DependencyManagementBuildScopeServices {
     }
 
 
-    private static class NoOpCachingStateStep implements Step<BeforeExecutionContext, CachingResult> {
+    private static class NoOpCachingStateStep implements Step<ValidationContext, CachingResult> {
         private final Step<? super CachingContext, ? extends UpToDateResult> delegate;
 
         public NoOpCachingStateStep(Step<? super CachingContext, ? extends UpToDateResult> delegate) {
@@ -794,7 +794,7 @@ class DependencyManagementBuildScopeServices {
         }
 
         @Override
-        public CachingResult execute(UnitOfWork work, BeforeExecutionContext context) {
+        public CachingResult execute(UnitOfWork work, ValidationContext context) {
             UpToDateResult result = delegate.execute(work, new CachingContext() {
                 @Override
                 public CachingState getCachingState() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -185,7 +185,7 @@ import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.UpToDateResult;
 import org.gradle.internal.execution.steps.ValidateStep;
-import org.gradle.internal.execution.steps.ValidationContext;
+import org.gradle.internal.execution.steps.ValidationFinishedContext;
 import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.RelativeFilePathResolver;
@@ -786,7 +786,7 @@ class DependencyManagementBuildScopeServices {
     }
 
 
-    private static class NoOpCachingStateStep implements Step<ValidationContext, CachingResult> {
+    private static class NoOpCachingStateStep implements Step<ValidationFinishedContext, CachingResult> {
         private final Step<? super CachingContext, ? extends UpToDateResult> delegate;
 
         public NoOpCachingStateStep(Step<? super CachingContext, ? extends UpToDateResult> delegate) {
@@ -794,7 +794,7 @@ class DependencyManagementBuildScopeServices {
         }
 
         @Override
-        public CachingResult execute(UnitOfWork work, ValidationContext context) {
+        public CachingResult execute(UnitOfWork work, ValidationFinishedContext context) {
             UpToDateResult result = delegate.execute(work, new CachingContext() {
                 @Override
                 public CachingState getCachingState() {

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -153,8 +153,8 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadExecutionStateStep<>(
-            new ValidateStep<>(virtualFileSystem, validationWarningReporter,
             new CaptureStateBeforeExecutionStep<>(buildOperationExecutor, classloaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector,
+            new ValidateStep<>(virtualFileSystem, validationWarningReporter,
             new ResolveCachingStateStep<>(buildCacheController, false,
             new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BeforeExecutionContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BeforeExecutionContext.java
@@ -20,7 +20,7 @@ import org.gradle.internal.execution.history.BeforeExecutionState;
 
 import java.util.Optional;
 
-public interface BeforeExecutionContext extends ValidationContext {
+public interface BeforeExecutionContext extends AfterPreviousExecutionContext {
     /**
      * Returns the execution state before execution.
      * Empty if execution state was not observed before execution.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingContext.java
@@ -18,7 +18,7 @@ package org.gradle.internal.execution.steps;
 
 import org.gradle.internal.execution.caching.CachingState;
 
-public interface CachingContext extends BeforeExecutionContext {
+public interface CachingContext extends ValidationContext {
     /**
      * The resolved state of caching for the work.
      */

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingContext.java
@@ -18,7 +18,7 @@ package org.gradle.internal.execution.steps;
 
 import org.gradle.internal.execution.caching.CachingState;
 
-public interface CachingContext extends ValidationContext {
+public interface CachingContext extends ValidationFinishedContext {
     /**
      * The resolved state of caching for the work.
      */

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Optional;
 
-public class CaptureStateBeforeExecutionStep extends BuildOperationStep<ValidationContext, CachingResult> {
+public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPreviousExecutionContext, CachingResult> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CaptureStateBeforeExecutionStep.class);
 
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
@@ -66,7 +66,7 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<Validati
     }
 
     @Override
-    public CachingResult execute(UnitOfWork work, ValidationContext context) {
+    public CachingResult execute(UnitOfWork work, AfterPreviousExecutionContext context) {
         Optional<BeforeExecutionState> beforeExecutionState = context.getHistory()
             .map(executionHistoryStore -> captureExecutionStateOp(work, context));
         return delegate.execute(work, new BeforeExecutionContext() {
@@ -117,11 +117,6 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<Validati
             @Override
             public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
                 return context.getAfterPreviousExecutionState();
-            }
-
-            @Override
-            public Optional<ValidationResult> getValidationProblems() {
-                return context.getValidationProblems();
             }
         });
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/InputChangesContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/InputChangesContext.java
@@ -20,7 +20,7 @@ import org.gradle.internal.execution.history.changes.InputChangesInternal;
 
 import java.util.Optional;
 
-public interface InputChangesContext extends ValidationContext {
+public interface InputChangesContext extends ValidationFinishedContext {
     Optional<InputChangesInternal> getInputChanges();
     boolean isIncrementalExecution();
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/InputChangesContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/InputChangesContext.java
@@ -20,7 +20,7 @@ import org.gradle.internal.execution.history.changes.InputChangesInternal;
 
 import java.util.Optional;
 
-public interface InputChangesContext extends BeforeExecutionContext {
+public interface InputChangesContext extends ValidationContext {
     Optional<InputChangesInternal> getInputChanges();
     boolean isIncrementalExecution();
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -46,7 +46,7 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.Optional;
 
-public class ResolveCachingStateStep implements Step<BeforeExecutionContext, CachingResult> {
+public class ResolveCachingStateStep implements Step<ValidationContext, CachingResult> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveCachingStateStep.class);
     private static final CachingDisabledReason BUILD_CACHE_DISABLED_REASON = new CachingDisabledReason(CachingDisabledReasonCategory.BUILD_CACHE_DISABLED, "Build cache is disabled");
     private static final CachingState BUILD_CACHE_DISABLED_STATE = CachingState.disabledWithoutInputs(BUILD_CACHE_DISABLED_REASON);
@@ -68,7 +68,7 @@ public class ResolveCachingStateStep implements Step<BeforeExecutionContext, Cac
     }
 
     @Override
-    public CachingResult execute(UnitOfWork work, BeforeExecutionContext context) {
+    public CachingResult execute(UnitOfWork work, ValidationContext context) {
         CachingState cachingState;
         if (!buildCache.isEnabled() && !buildScansEnabled) {
             cachingState = BUILD_CACHE_DISABLED_STATE;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -46,7 +46,7 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.Optional;
 
-public class ResolveCachingStateStep implements Step<ValidationContext, CachingResult> {
+public class ResolveCachingStateStep implements Step<ValidationFinishedContext, CachingResult> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveCachingStateStep.class);
     private static final CachingDisabledReason BUILD_CACHE_DISABLED_REASON = new CachingDisabledReason(CachingDisabledReasonCategory.BUILD_CACHE_DISABLED, "Build cache is disabled");
     private static final CachingState BUILD_CACHE_DISABLED_STATE = CachingState.disabledWithoutInputs(BUILD_CACHE_DISABLED_REASON);
@@ -68,7 +68,7 @@ public class ResolveCachingStateStep implements Step<ValidationContext, CachingR
     }
 
     @Override
-    public CachingResult execute(UnitOfWork work, ValidationContext context) {
+    public CachingResult execute(UnitOfWork work, ValidationFinishedContext context) {
         CachingState cachingState;
         if (!buildCache.isEnabled() && !buildScansEnabled) {
             cachingState = BUILD_CACHE_DISABLED_STATE;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -24,6 +24,7 @@ import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.reflect.validation.Severity;
@@ -47,7 +48,7 @@ import static java.util.stream.Collectors.toList;
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.convertToSingleLine;
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.renderMinimalInformationAbout;
 
-public class ValidateStep<R extends Result> implements Step<AfterPreviousExecutionContext, R> {
+public class ValidateStep<R extends Result> implements Step<BeforeExecutionContext, R> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidateStep.class);
     private static final String MAX_NB_OF_ERRORS = "org.gradle.internal.max.validation.errors";
 
@@ -66,7 +67,7 @@ public class ValidateStep<R extends Result> implements Step<AfterPreviousExecuti
     }
 
     @Override
-    public R execute(UnitOfWork work, AfterPreviousExecutionContext context) {
+    public R execute(UnitOfWork work, BeforeExecutionContext context) {
         WorkValidationContext validationContext = context.getValidationContext();
         work.validate(validationContext);
 
@@ -103,6 +104,11 @@ public class ValidateStep<R extends Result> implements Step<AfterPreviousExecuti
         }
 
         return delegate.execute(work, new ValidationContext() {
+            @Override
+            public Optional<BeforeExecutionState> getBeforeExecutionState() {
+                return context.getBeforeExecutionState();
+            }
+
             @Override
             public Optional<ValidationResult> getValidationProblems() {
                 return warnings.isEmpty()

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -54,12 +54,12 @@ public class ValidateStep<R extends Result> implements Step<BeforeExecutionConte
 
     private final VirtualFileSystem virtualFileSystem;
     private final ValidationWarningRecorder warningReporter;
-    private final Step<? super ValidationContext, ? extends R> delegate;
+    private final Step<? super ValidationFinishedContext, ? extends R> delegate;
 
     public ValidateStep(
         VirtualFileSystem virtualFileSystem,
         ValidationWarningRecorder warningReporter,
-        Step<? super ValidationContext, ? extends R> delegate
+        Step<? super ValidationFinishedContext, ? extends R> delegate
     ) {
         this.virtualFileSystem = virtualFileSystem;
         this.warningReporter = warningReporter;
@@ -103,7 +103,7 @@ public class ValidateStep<R extends Result> implements Step<BeforeExecutionConte
             virtualFileSystem.invalidateAll();
         }
 
-        return delegate.execute(work, new ValidationContext() {
+        return delegate.execute(work, new ValidationFinishedContext() {
             @Override
             public Optional<BeforeExecutionState> getBeforeExecutionState() {
                 return context.getBeforeExecutionState();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationContext.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableCollection;
 
 import java.util.Optional;
 
-public interface ValidationContext extends AfterPreviousExecutionContext {
+public interface ValidationContext extends BeforeExecutionContext {
     /**
      * Returns validation warnings or {@link Optional#empty()} if there were no validation problems.
      */

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationFinishedContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationFinishedContext.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableCollection;
 
 import java.util.Optional;
 
-public interface ValidationContext extends BeforeExecutionContext {
+public interface ValidationFinishedContext extends BeforeExecutionContext {
     /**
      * Returns validation warnings or {@link Optional#empty()} if there were no validation problems.
      */

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -46,8 +46,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
     def step = new CaptureStateBeforeExecutionStep(buildOperationExecutor, classloaderHierarchyHasher, outputSnapshotter, overlappingOutputDetector, delegate)
 
     @Override
-    protected ValidationContext createContext() {
-        Stub(ValidationContext) {
+    protected ValidationFinishedContext createContext() {
+        Stub(ValidationFinishedContext) {
             getInputProperties() >> ImmutableSortedMap.of()
             getInputFileProperties() >> ImmutableSortedMap.of()
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -34,7 +34,7 @@ import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 import static org.gradle.internal.execution.UnitOfWork.OverlappingOutputHandling.DETECT_OVERLAPS
 import static org.gradle.internal.execution.UnitOfWork.OverlappingOutputHandling.IGNORE_OVERLAPS
 
-class CaptureStateBeforeExecutionStepTest extends StepSpec<ValidationContext> {
+class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContext> {
 
     def classloaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def outputSnapshotter = Mock(OutputSnapshotter)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -21,14 +21,14 @@ import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 
-class ResolveCachingStateStepTest extends StepSpec<BeforeExecutionContext> {
+class ResolveCachingStateStepTest extends StepSpec<ValidationContext> {
 
     def buildCache = Mock(BuildCacheController)
     def step = new ResolveCachingStateStep(buildCache, true, delegate)
 
     @Override
-    protected BeforeExecutionContext createContext() {
-        Stub(BeforeExecutionContext)
+    protected ValidationContext createContext() {
+        Stub(ValidationContext)
     }
 
     def "build cache disabled reason is reported when build cache is disabled"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -21,14 +21,14 @@ import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 
-class ResolveCachingStateStepTest extends StepSpec<ValidationContext> {
+class ResolveCachingStateStepTest extends StepSpec<ValidationFinishedContext> {
 
     def buildCache = Mock(BuildCacheController)
     def step = new ResolveCachingStateStep(buildCache, true, delegate)
 
     @Override
-    protected ValidationContext createContext() {
-        Stub(ValidationContext)
+    protected ValidationFinishedContext createContext() {
+        Stub(ValidationFinishedContext)
     }
 
     def "build cache disabled reason is reported when build cache is disabled"() {
@@ -49,7 +49,7 @@ class ResolveCachingStateStepTest extends StepSpec<ValidationContext> {
         then:
         _ * buildCache.enabled >> false
         _ * context.beforeExecutionState >> Optional.empty()
-        _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationContext)
+        _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationFinishedContext)
         1 * delegate.execute(work, { CachingContext context ->
             context.cachingState.disabledReasons*.category == [CachingDisabledReasonCategory.VALIDATION_FAILURE]
             context.cachingState.disabledReasons*.message == ["Caching has been disabled to ensure correctness. Please consult deprecation warnings for more details."]

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
@@ -114,7 +114,7 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
         _ * context.rebuildReason >> Optional.empty()
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
-        _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationContext.ValidationResult)
+        _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationFinishedContext.ValidationResult)
         1 * beforeExecutionState.getInputFileProperties() >> ImmutableSortedMap.of()
         _ * context.afterPreviousExecutionState >> Optional.empty()
         0 * _

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -29,7 +29,7 @@ import static org.gradle.internal.reflect.validation.Severity.ERROR
 import static org.gradle.internal.reflect.validation.Severity.WARNING
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.convertToSingleLine
 
-class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implements ValidationMessageChecker {
+class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements ValidationMessageChecker {
     private final DocumentationRegistry documentationRegistry = new DocumentationRegistry()
 
     def warningReporter = Mock(ValidateStep.ValidationWarningRecorder)
@@ -38,9 +38,9 @@ class ValidateStepTest extends StepSpec<AfterPreviousExecutionContext> implement
     def delegateResult = Mock(Result)
 
     @Override
-    protected AfterPreviousExecutionContext createContext() {
+    protected BeforeExecutionContext createContext() {
         def validationContext = new DefaultWorkValidationContext(documentationRegistry)
-        return Stub(AfterPreviousExecutionContext) {
+        return Stub(BeforeExecutionContext) {
             getValidationContext() >> validationContext
         }
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -53,7 +53,7 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
         then:
         result == delegateResult
 
-        1 * delegate.execute(work, { ValidationContext context -> !context.validationProblems.present }) >> delegateResult
+        1 * delegate.execute(work, { ValidationFinishedContext context -> !context.validationProblems.present }) >> delegateResult
         _ * work.validate(_ as  WorkValidationContext) >> { validated = true }
 
         then:
@@ -140,7 +140,7 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
         1 * virtualFileSystem.invalidateAll()
 
         then:
-        1 * delegate.execute(work, { ValidationContext context -> context.validationProblems.get().warnings == [expectedWarning] })
+        1 * delegate.execute(work, { ValidationFinishedContext context -> context.validationProblems.get().warnings == [expectedWarning] })
         0 * _
     }
 


### PR DESCRIPTION
So we can use the state for validation as well.

As a preparation for deprecating the use a Lambdas as task actions.