### PR TITLE
Avoid evaluating providers when computing `orElse` task dependencies

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -244,6 +244,27 @@ class TaskDependencyInferenceIntegrationTest extends AbstractIntegrationSpec imp
         result.assertTasksExecuted(":b", ":c")
     }
 
+    def "dependency declared using orElse provider whose original value is missing and alternative value is missing task output file property doesn't imply dependency on task"() {
+        taskTypeWithOutputFileProperty()
+        buildFile << """
+            def taskA = tasks.create("a", FileProducer) {
+                // no output value
+            }
+            def taskB = tasks.create("b", FileProducer) {
+                // no output value
+            }
+            tasks.register("c") {
+                dependsOn taskA.output.orElse(taskB.output)
+            }
+        """
+
+        when:
+        run("c")
+
+        then:
+        result.assertTasksExecuted(":c")
+    }
+
     def "dependency declared using orElse provider whose original value is missing and alternative value is constant does not imply task dependency"() {
         taskTypeWithOutputFileProperty()
         buildFile << """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -20,7 +20,6 @@ package org.gradle.api.provider
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -725,7 +724,6 @@ project.extensions.create("some", SomeExtension)
         executedAndNotSkipped(":producer", ":consumer")
     }
 
-    @Ignore
     @Issue("https://github.com/gradle/gradle/issues/16775")
     def "orElse does not cause error when map-ing a task property"() {
         buildFile """
@@ -739,7 +737,7 @@ project.extensions.create("some", SomeExtension)
                     outputFile.write("some text")
                 }
             }
-            
+
             abstract class MyExt {
                 abstract DirectoryProperty getArtifactDir()
             }
@@ -747,7 +745,7 @@ project.extensions.create("some", SomeExtension)
             abstract class Consumer extends DefaultTask {
                 @InputFiles
                 abstract ListProperty<String> getFileNames()
-                
+
                 @TaskAction
                 def action() {
                     println("files: " + fileNames.get())
@@ -757,12 +755,12 @@ project.extensions.create("some", SomeExtension)
             def producer = tasks.register("producer", Producer) {
                 output = layout.buildDirectory.dir("producer")
             }
-            
-            def myext = extensions.create("myext", MyExt)
-            myext.artifactDir = producer.flatMap { it.output }
-            
+
+            def myExt = extensions.create("myExt", MyExt)
+            myExt.artifactDir = producer.flatMap { it.output }
+
             tasks.register("consumer", Consumer) {
-               fileNames = myext.artifactDir.map {
+               fileNames = myExt.artifactDir.map {
                   it.asFileTree.collect { it.absolutePath }
                }.orElse([ "else" ])
             }
@@ -770,6 +768,7 @@ project.extensions.create("some", SomeExtension)
 
         when:
         run 'consumer'
+
         then:
         executedAndNotSkipped(":producer", ":consumer")
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -37,15 +37,7 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     public ValueProducer getProducer() {
-        ValueProducer producer = provider.getProducer();
-        if (producer.isProducesDifferentValueOverTime()) {
-            return producer;
-        }
-        if (provider.isPresent()) {
-            // isPresent() might have side-effects so we ask for the producer again
-            return provider.getProducer();
-        }
-        return ValueProducer.unknown();
+        return new OrElseValueProducer(provider, ValueProducer.unknown());
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseFixedValueProvider.java
@@ -37,7 +37,7 @@ class OrElseFixedValueProvider<T> extends AbstractProviderWithValue<T> {
 
     @Override
     public ValueProducer getProducer() {
-        return new OrElseValueProducer(provider, ValueProducer.unknown());
+        return new OrElseValueProducer(provider, null, ValueProducer.unknown());
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -35,10 +35,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ValueProducer getProducer() {
-        ExecutionTimeValue<? extends T> leftValue = left.calculateExecutionTimeValue();
-        return leftValue.isMissing()
-            ? right.getProducer()
-            : new OrElseValueProducer(left, right.getProducer());
+        return new OrElseValueProducer(left, right, right.getProducer());
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseProvider.java
@@ -16,11 +16,7 @@
 
 package org.gradle.api.internal.provider;
 
-import org.gradle.api.Action;
-import org.gradle.api.Task;
-
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 
 class OrElseProvider<T> extends AbstractMinimalProvider<T> {
     private final ProviderInternal<T> left;
@@ -42,7 +38,7 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
         ExecutionTimeValue<? extends T> leftValue = left.calculateExecutionTimeValue();
         return leftValue.isMissing()
             ? right.getProducer()
-            : new OrElseValueProducer();
+            : new OrElseValueProducer(left, right.getProducer());
     }
 
     @Override
@@ -72,45 +68,5 @@ class OrElseProvider<T> extends AbstractMinimalProvider<T> {
             return rightValue;
         }
         return leftValue.addPathsFrom(rightValue);
-    }
-
-    private class OrElseValueProducer implements ValueProducer {
-
-        final ValueProducer leftProducer = left.getProducer();
-        final ValueProducer rightProducer = right.getProducer();
-
-        @Override
-        public boolean isKnown() {
-            return leftProducer.isKnown()
-                || rightProducer.isKnown();
-        }
-
-        @Override
-        public boolean isProducesDifferentValueOverTime() {
-            return leftProducer.isProducesDifferentValueOverTime()
-                || rightProducer.isProducesDifferentValueOverTime();
-        }
-
-        @Override
-        public void visitProducerTasks(Action<? super Task> visitor) {
-            ArrayList<Task> leftTasks = producerTasksOf(leftProducer);
-            ArrayList<Task> rightTasks = producerTasksOf(rightProducer);
-            if (leftTasks.isEmpty() && rightTasks.isEmpty()) {
-                return;
-            }
-            // TODO: configuration cache: this condition needs to be evaluated at execution time
-            //  when `leftProducer.isProducesDifferentValueOverTime()`
-            ArrayList<Task> producerTasks = left.isPresent()
-                ? leftTasks
-                : rightTasks;
-            producerTasks.forEach(visitor::execute);
-        }
-
-        private ArrayList<Task> producerTasksOf(ValueProducer producer) {
-            ArrayList<Task> tasks = new ArrayList<>();
-            producer.visitProducerTasks(tasks::add);
-            return tasks;
-        }
-
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/OrElseValueProducer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+class OrElseValueProducer implements ValueSupplier.ValueProducer {
+
+    private final ProviderInternal<?> left;
+    private final ValueSupplier.ValueProducer leftProducer;
+    private final ValueSupplier.ValueProducer rightProducer;
+
+    public OrElseValueProducer(ProviderInternal<?> left, ValueSupplier.ValueProducer rightProducer) {
+        this.left = left;
+        this.leftProducer = left.getProducer();
+        this.rightProducer = rightProducer;
+    }
+
+    @Override
+    public boolean isKnown() {
+        return leftProducer.isKnown()
+            || rightProducer.isKnown();
+    }
+
+    @Override
+    public boolean isProducesDifferentValueOverTime() {
+        return leftProducer.isProducesDifferentValueOverTime()
+            || rightProducer.isProducesDifferentValueOverTime();
+    }
+
+    @Override
+    public void visitProducerTasks(Action<? super Task> visitor) {
+
+        List<Task> leftTasks = producerTasksOf(leftProducer);
+        List<Task> rightTasks = producerTasksOf(rightProducer);
+
+        if (rightTasks.isEmpty()) {
+            if (leftTasks.isEmpty()) {
+                return;
+            }
+            // We should only execute leftTasks if the left provider can ever produce a value
+            if (!isLeftMissing()) {
+                leftTasks.forEach(visitor::execute);
+            }
+            return;
+        }
+
+        if (leftTasks.isEmpty()) {
+            return;
+        }
+
+        // TODO: configuration cache: this condition needs to be evaluated at execution time
+        //  when `leftProducer.isProducesDifferentValueOverTime()`
+        List<Task> producerTasks = isLeftMissing()
+            ? rightTasks
+            : leftTasks;
+        producerTasks.forEach(visitor::execute);
+    }
+
+    private boolean isLeftMissing() {
+        return left.calculateExecutionTimeValue().isMissing();
+    }
+
+    private List<Task> producerTasksOf(ValueSupplier.ValueProducer producer) {
+        if (!producer.isKnown()) {
+            return emptyList();
+        }
+        ArrayList<Task> tasks = new ArrayList<>();
+        producer.visitProducerTasks(tasks::add);
+        return tasks;
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #16775