### PR TITLE
Avoid leaking credentials in cross version tests

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.fixtures.CustomDaemonDirectory
 import org.gradle.testkit.runner.fixtures.CustomEnvironmentVariables
 import org.gradle.testkit.runner.fixtures.Debug
+import org.gradle.testkit.runner.fixtures.HideEnvVariableValuesInDaemonLog
 import org.gradle.testkit.runner.fixtures.InjectsPluginClasspath
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
@@ -72,6 +73,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
     public static final GradleVersion NO_SOURCE_TASK_OUTCOME_SUPPORT_VERSION = GradleVersion.version("3.4")
     public static final GradleVersion ENVIRONMENT_VARIABLES_SUPPORT_VERSION = GradleVersion.version("3.5")
     public static final GradleVersion INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION = GradleVersion.version("5.0")
+    public static final GradleVersion HIDE_ENV_VARIABLE_VALUE_IN_DAEMON_LOG_VERSION = GradleVersion.version("6.7")
 
     // Context set by multi run infrastructure
     public static GradleVersion gradleVersion
@@ -208,7 +210,8 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
             (CustomDaemonDirectory): CUSTOM_DAEMON_DIR_SUPPORT_VERSION,
             (WithNoSourceTaskOutcome): NO_SOURCE_TASK_OUTCOME_SUPPORT_VERSION,
             (CustomEnvironmentVariables): ENVIRONMENT_VARIABLES_SUPPORT_VERSION,
-            (InspectsGroupedOutput): INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION
+            (InspectsGroupedOutput): INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION,
+            (HideEnvVariableValuesInDaemonLog): HIDE_ENV_VARIABLE_VALUE_IN_DAEMON_LOG_VERSION
         ]
 
         private static final IntegrationTestBuildContext BUILD_CONTEXT = new IntegrationTestBuildContext()
@@ -423,6 +426,9 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
                     return false
                 }
                 if (testDetails.getAnnotation(InspectsGroupedOutput) && gradleVersion < INSPECTS_GROUPED_OUTPUT_SUPPORT_VERSION) {
+                    return false
+                }
+                if (testDetails.getAnnotation(HideEnvVariableValuesInDaemonLog) && gradleVersion < HIDE_ENV_VARIABLE_VALUE_IN_DAEMON_LOG_VERSION) {
                     return false
                 }
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerMechanicalFailureIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.launcher.daemon.client.DaemonDisappearedException
+import org.gradle.testkit.runner.fixtures.HideEnvVariableValuesInDaemonLog
 import org.gradle.testkit.runner.fixtures.InspectsBuildOutput
 import org.gradle.testkit.runner.fixtures.InspectsExecutedTasks
 import org.gradle.testkit.runner.fixtures.NoDebug
@@ -146,6 +147,7 @@ class GradleRunnerMechanicalFailureIntegrationTest extends BaseGradleRunnerInteg
     }
 
     @NoDebug
+    @HideEnvVariableValuesInDaemonLog
     def "daemon dies during build execution"() {
         given:
         buildFile << """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/HideEnvVariableValuesInDaemonLog.java
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/fixtures/HideEnvVariableValuesInDaemonLog.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the feature that hides env variable values in daemon log to avoid leaking credentials.
+ *
+ * @see {@link org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface HideEnvVariableValuesInDaemonLog {
+}


### PR DESCRIPTION
Previously, when running test-kit cross version tests targeting old versions,
env variables might be leaking because they don't have the protections we introduced in
Gradle 6.7. Now we stop testing them against old unprotected versions.
