### PR TITLE
Deprecate resolvable plugin configurations for consumption

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -229,20 +229,39 @@ They are replaced by the the properties of link:{groovyDslPath}/org.gradle.api.p
 [[plugin_configuration_consumption]]
 === Deprecated consumption of internal plugin configurations
 
-The following plugins each declare a configuration with the same name as the plugin:
+Some of the core Gradle plugins declare configurations that are used by the plugin itself and are not meant to be
+published or consumed by another subproject directly. Gradle did not explicitly prohobit this.
+Gradle 7.1 deprecates consumption of those configurations and this will become an error in Gradle 8.0.
 
-- `codenarc`
-- `pmd`
-- `checkstyle`
-- `antlr`
+The following plugin configurations have been deprecated for consumption:
 
-The `jacoco` plugin declares two configurations `jacocoAnt` and `jacocoAgent`.
+[cols="1,1"]
+|===
+| plugin | configurations deprecated for consumption
 
-Those configurations are used to declare dependencies for the respective tool's runtime classpath.
-They are not meant for consumption outside of the project applying the plugin, but Gradle did not explicitly
-prohibit this. Gradle 7.1 deprecates such consumption and it will become an error in Gradle 8.0.
+| `codenarc`
+| `codenarc`
 
-If your use case needs to consume the configurations of the above tools in another project, please create a separate consumable
+| `pmd`
+| `pmd`
+
+| `checkstyle`
+| `checkstyle`
+
+| `antlr`
+| `antlr`
+
+| `jacoco`
+| `jacocoAnt`, `jacocoAgent`
+
+| `scala`
+| `zinc`
+
+| `war`
+| `providedRuntime`
+|===
+
+If your use case needs to consume any of the above mentioned configurations in another project, please create a separate consumable
 configuration that extends from the internal ones. For example:
 ```
 plugins {

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -258,7 +258,7 @@ The following plugin configurations have been deprecated for consumption:
 | `zinc`
 
 | `war`
-| `providedRuntime`
+| `providedCompile`, `providedRuntime`
 |===
 
 If your use case needs to consume any of the above mentioned configurations in another project, please create a separate consumable

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
@@ -61,6 +61,7 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
         'jacoco'     | 'jacocoAnt'
         'scala'      | 'zinc'
         'war'        | 'providedRuntime'
+        'war'        | 'providedCompile'
     }
 
     def "plugin runtime configuration can be extended and consumed without deprecation"() {
@@ -117,6 +118,7 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
         'jacoco'     | 'jacocoAnt'
         'scala'      | 'zinc'
         'war'        | 'providedRuntime'
+        'war'        | 'providedCompile'
     }
 
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSpec {
 
@@ -29,6 +30,7 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
         """
     }
 
+    @ToBeFixedForConfigurationCache(iterationMatchers = ".*plugin: scala, configuration: zinc.*")
     def "plugin runtime configuration is deprecated for consumption"() {
         given:
         file("producer/build.gradle") << """

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/PluginConfigurationAttributesIntegrationTest.groovy
@@ -59,6 +59,8 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
         'antlr'      | 'antlr'
         'jacoco'     | 'jacocoAgent'
         'jacoco'     | 'jacocoAnt'
+        'scala'      | 'zinc'
+        'war'        | 'providedRuntime'
     }
 
     def "plugin runtime configuration can be extended and consumed without deprecation"() {
@@ -113,6 +115,8 @@ class PluginConfigurationAttributesIntegrationTest extends AbstractIntegrationSp
         'antlr'      | 'antlr'
         'jacoco'     | 'jacocoAgent'
         'jacoco'     | 'jacocoAnt'
+        'scala'      | 'zinc'
+        'war'        | 'providedRuntime'
     }
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.plugins.internal.DefaultWarPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
+import org.gradle.internal.deprecation.DeprecatableConfiguration;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -92,18 +93,21 @@ public class WarPlugin implements Plugin<Project> {
     }
 
     public void configureConfigurations(ConfigurationContainer configurationContainer) {
-        Configuration provideCompileConfiguration = configurationContainer.create(PROVIDED_COMPILE_CONFIGURATION_NAME).setVisible(false).
+        Configuration providedCompileConfiguration = configurationContainer.create(PROVIDED_COMPILE_CONFIGURATION_NAME).setVisible(false).
             setDescription("Additional compile classpath for libraries that should not be part of the WAR archive.");
-        Configuration provideRuntimeConfiguration = configurationContainer.create(PROVIDED_RUNTIME_CONFIGURATION_NAME).setVisible(false).
-            extendsFrom(provideCompileConfiguration).
+        Configuration providedRuntimeConfiguration = configurationContainer.create(PROVIDED_RUNTIME_CONFIGURATION_NAME).setVisible(false).
+            extendsFrom(providedCompileConfiguration).
             setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
-        configurationContainer.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(provideCompileConfiguration);
-        configurationContainer.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
-        configurationContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
-        configurationContainer.getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
-        configurationContainer.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
-        configurationContainer.getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
-        configurationContainer.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME).extendsFrom(provideRuntimeConfiguration);
+        ((DeprecatableConfiguration) providedRuntimeConfiguration).deprecateForConsumption(deprecation -> deprecation
+            .willBecomeAnErrorInGradle8()
+            .withUpgradeGuideSection(7, "plugin_configuration_consumption"));
+        configurationContainer.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(providedCompileConfiguration);
+        configurationContainer.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+        configurationContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+        configurationContainer.getByName(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+        configurationContainer.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+        configurationContainer.getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+        configurationContainer.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
     }
 
     private void configureComponent(Project project, PublishArtifact warArtifact) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -95,12 +95,13 @@ public class WarPlugin implements Plugin<Project> {
     public void configureConfigurations(ConfigurationContainer configurationContainer) {
         Configuration providedCompileConfiguration = configurationContainer.create(PROVIDED_COMPILE_CONFIGURATION_NAME).setVisible(false).
             setDescription("Additional compile classpath for libraries that should not be part of the WAR archive.");
+        deprecateForConsumption(providedCompileConfiguration);
+
         Configuration providedRuntimeConfiguration = configurationContainer.create(PROVIDED_RUNTIME_CONFIGURATION_NAME).setVisible(false).
             extendsFrom(providedCompileConfiguration).
             setDescription("Additional runtime classpath for libraries that should not be part of the WAR archive.");
-        ((DeprecatableConfiguration) providedRuntimeConfiguration).deprecateForConsumption(deprecation -> deprecation
-            .willBecomeAnErrorInGradle8()
-            .withUpgradeGuideSection(7, "plugin_configuration_consumption"));
+        deprecateForConsumption(providedRuntimeConfiguration);
+
         configurationContainer.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(providedCompileConfiguration);
         configurationContainer.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
         configurationContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
@@ -108,6 +109,12 @@ public class WarPlugin implements Plugin<Project> {
         configurationContainer.getByName(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
         configurationContainer.getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
         configurationContainer.getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME).extendsFrom(providedRuntimeConfiguration);
+    }
+
+    private static void deprecateForConsumption(Configuration configuration) {
+        ((DeprecatableConfiguration) configuration).deprecateForConsumption(deprecation -> deprecation
+            .willBecomeAnErrorInGradle8()
+            .withUpgradeGuideSection(7, "plugin_configuration_consumption"));
     }
 
     private void configureComponent(Project project, PublishArtifact warArtifact) {

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -54,6 +54,7 @@ import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.api.tasks.scala.ScalaDoc;
+import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.jvm.tasks.Jar;
 
 import javax.inject.Inject;
@@ -123,6 +124,9 @@ public class ScalaBasePlugin implements Plugin<Project> {
         Configuration zinc = project.getConfigurations().create(ZINC_CONFIGURATION_NAME);
         zinc.setVisible(false);
         zinc.setDescription("The Zinc incremental compiler to be used for this Scala project.");
+        ((DeprecatableConfiguration) zinc).deprecateForConsumption(deprecation -> deprecation
+            .willBecomeAnErrorInGradle8()
+            .withUpgradeGuideSection(7, "plugin_configuration_consumption"));
 
         zinc.getResolutionStrategy().eachDependency(rule -> {
             if (rule.getRequested().getGroup().equals("com.typesafe.zinc") && rule.getRequested().getName().equals("zinc")) {


### PR DESCRIPTION
Scala plugin's zinc configuration will be deprecated for consumption.
War plugin's providedRuntime configuration will be deprecated for consumption.

Those configurations are used to resolve dependencies and
were not meant to be published or directly consumed by
other subprojects.

https://github.com/gradle/gradle/issues/13736