### PR TITLE
Use extension to configure antlr source sets

### DIFF
--- a/subprojects/antlr/build.gradle.kts
+++ b/subprojects/antlr/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":plugins"))
     implementation(project(":workers"))
     implementation(project(":files"))
+    implementation(project(":file-collections"))
 
     implementation(libs.slf4jApi)
     implementation(libs.groovy)

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrPlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.plugins.antlr.internal.AntlrSourceVirtualDirectoryImpl;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 
@@ -48,6 +47,7 @@ public class AntlrPlugin implements Plugin<Project> {
         this.objectFactory = objectFactory;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaLibraryPlugin.class);
@@ -74,10 +74,13 @@ public class AntlrPlugin implements Plugin<Project> {
                     public void execute(final SourceSet sourceSet) {
                         // for each source set we will:
                         // 1) Add a new 'antlr' virtual directory mapping
-                        final AntlrSourceVirtualDirectoryImpl antlrDirectoryDelegate
-                                = new AntlrSourceVirtualDirectoryImpl(((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
+
+
+                        org.gradle.api.plugins.antlr.internal.AntlrSourceVirtualDirectoryImpl antlrDirectoryDelegate
+                                = new org.gradle.api.plugins.antlr.internal.AntlrSourceVirtualDirectoryImpl(((DefaultSourceSet) sourceSet).getDisplayName(), objectFactory);
                         new DslObject(sourceSet).getConvention().getPlugins().put(
                                 AntlrSourceVirtualDirectory.NAME, antlrDirectoryDelegate);
+                        sourceSet.getExtensions().add(AntlrSourceDirectorySet.class, AntlrSourceVirtualDirectory.NAME, antlrDirectoryDelegate.getAntlr());
                         final String srcDir = "src/"+ sourceSet.getName() +"/antlr";
                         antlrDirectoryDelegate.getAntlr().srcDir(srcDir);
                         sourceSet.getAllSource().source(antlrDirectoryDelegate.getAntlr());

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.antlr;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.file.SourceDirectorySet;
+
+/**
+ *
+ * Contract for a Gradle extension that acts as a handler for what I call a virtual directory mapping,
+ * injecting a virtual directory named 'antlr' into the project's various {@link org.gradle.api.tasks.SourceSet source
+ * sets}.
+ *
+ * @since 7.1
+ */
+@Incubating
+public interface AntlrSourceDirectorySet extends SourceDirectorySet {
+}

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrSourceVirtualDirectory.java
@@ -24,7 +24,11 @@ import org.gradle.api.file.SourceDirectorySet;
  * Contract for a Gradle "convention object" that acts as a handler for what I call a virtual directory mapping,
  * injecting a virtual directory named 'antlr' into the project's various {@link org.gradle.api.tasks.SourceSet source
  * sets}.
+ *
+ * @deprecated Using conventions to contribute source sets is deprecated. You can configure the antlr sources via the {@code AntlrSourceDirectorySet} extension (e.g.
+ * {@code sourceSet.getExtensions().getByType(AntlrSourceDirectorySet.class).setSrcDirs(...)}). This interface is scheduled for removal in Gradle 8.0.
  */
+@Deprecated
 public interface AntlrSourceVirtualDirectory {
     String NAME = "antlr";
 

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSourceVirtualDirectoryImpl.java
@@ -19,7 +19,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory;
+import org.gradle.api.plugins.antlr.AntlrSourceDirectorySet;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.util.internal.ConfigureUtil;
@@ -29,35 +29,42 @@ import static org.gradle.api.reflect.TypeOf.typeOf;
 /**
  * The implementation of the {@link org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory} contract.
  */
-public class AntlrSourceVirtualDirectoryImpl implements AntlrSourceVirtualDirectory, HasPublicType {
-    private final SourceDirectorySet antlr;
+@Deprecated
+public class AntlrSourceVirtualDirectoryImpl implements org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory, HasPublicType {
+
+    private final AntlrSourceDirectorySet antlr;
 
     public AntlrSourceVirtualDirectoryImpl(String parentDisplayName, ObjectFactory objectFactory) {
-        antlr = objectFactory.sourceDirectorySet(parentDisplayName + ".antlr", parentDisplayName + " Antlr source");
-        antlr.getFilter().include("**/*.g");
-        antlr.getFilter().include("**/*.g4");
+        antlr = createAntlrSourceDirectorySet(parentDisplayName + ".antlr", parentDisplayName + " Antlr source", objectFactory);
+    }
+
+    private static AntlrSourceDirectorySet createAntlrSourceDirectorySet(String name, String displayName, ObjectFactory objectFactory) {
+        AntlrSourceDirectorySet antlrSourceSet = new DefaultAntlrSourceDirectorySet(objectFactory.sourceDirectorySet(name, displayName));
+        antlrSourceSet.getFilter().include("**/*.g");
+        antlrSourceSet.getFilter().include("**/*.g4");
+        return antlrSourceSet;
     }
 
     @Override
-    public SourceDirectorySet getAntlr() {
+    public AntlrSourceDirectorySet getAntlr() {
         return antlr;
     }
 
     @Override
     @SuppressWarnings("rawtypes")
-    public AntlrSourceVirtualDirectory antlr(Closure configureClosure) {
+    public org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory antlr(Closure configureClosure) {
         ConfigureUtil.configure(configureClosure, getAntlr());
         return this;
     }
 
     @Override
-    public AntlrSourceVirtualDirectory antlr(Action<? super SourceDirectorySet> configureAction) {
+    public org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory antlr(Action<? super SourceDirectorySet> configureAction) {
         configureAction.execute(getAntlr());
         return this;
     }
 
     @Override
     public TypeOf<?> getPublicType() {
-        return typeOf(AntlrSourceVirtualDirectory.class);
+        return typeOf(org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory.class);
     }
 }

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/DefaultAntlrSourceDirectorySet.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/DefaultAntlrSourceDirectorySet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.antlr.internal;
+
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.file.DefaultSourceDirectorySet;
+import org.gradle.api.plugins.antlr.AntlrSourceDirectorySet;
+
+public class DefaultAntlrSourceDirectorySet extends DefaultSourceDirectorySet implements AntlrSourceDirectorySet {
+
+    public DefaultAntlrSourceDirectorySet(SourceDirectorySet sourceDirectorySet) {
+        super(sourceDirectorySet);
+    }
+}

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.antlr.AntlrSourceDirectorySet.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.antlr.AntlrSourceDirectorySet.xml
@@ -1,0 +1,23 @@
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default with <literal>antlr</literal> plugin</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/plugins.xml
+++ b/subprojects/docs/src/docs/dsl/plugins.xml
@@ -16,7 +16,7 @@
         <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.tasks.ScalaSourceSet"/>
     </plugin>
     <plugin id="antlr" description="Antlr Plugin">
-        <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.plugins.antlr.AntlrSourceVirtualDirectory"/>
+        <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.plugins.antlr.AntlrSourceDirectorySet"/>
     </plugin>
     <plugin id="war" description="War Plugin">
         <extends targetClass="org.gradle.api.Project" mixinClass="org.gradle.api.plugins.WarPluginConvention"/>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -102,9 +102,9 @@ class JavaAgentCommandLineArgumentProvider implements CommandLineArgumentProvide
 }
 ```
 
-### Easier Groovy source set configuration in the Kotlin DSL
+### Easier source set configuration in the Kotlin DSL
 
-When using the Kotlin DSL, a special construct was required when configuring `groovy` source locations:
+When using the Kotlin DSL, a special construct was required when configuring source locations. For example, here's how you could configure `groovy` sources:
 
 ```kotlin
 sourceSets {
@@ -118,7 +118,12 @@ sourceSets {
 }
 ```
 
-Gradle 7.1 defines the `groovy` source set as an extension when applying the Groovy plugin. This means that the Kotlin DSL has auto-generated accessors and `withConvention` block can be omitted:
+Gradle 7.1 defines source sets as an extension in the following plugins:
+
+- `groovy`
+- `antlr`
+
+ This means that the Kotlin DSL has auto-generated accessors and `withConvention` block can be omitted:
 
 ```kotlin
 sourceSets {

--- a/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/antlr_plugin.adoc
@@ -88,13 +88,21 @@ include::sample[dir="snippets/antlr/useAntlrPlugin/kotlin",files="build.gradle.k
 
 If no dependency is declared, `antlr:antlr:2.7.7` will be used as the default. To use a different ANTLR version add the appropriate dependency to the `antlr` dependency configuration as above.
 
+[[sec:antlr_extensions]]
+== Contributed extension
+
+`antlr` — link:{groovyDslPath}/org.gradle.api.plugins.antlr.AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]::
+The ANTLR grammar files of this source set. Contains all `.g` or `.g4` files found in the ANTLR source directories, and excludes all other types of files. _Default value is non-null._
+
 [[sec:antlr_convention_properties]]
-== Convention properties
+== Convention properties (deprecated)
 
 The ANTLR plugin adds one convention property.
 
 `antlr` — link:{groovyDslPath}/org.gradle.api.file.SourceDirectorySet.html[SourceDirectorySet]::
 The ANTLR grammar files of this source set. Contains all `.g` or `.g4` files found in the ANTLR source directories, and excludes all other types of files. _Default value is non-null._
+
+This convention property is *deprecated* and superseded by the extension described above.
 
 [[sec:antlr_source_set_properties]]
 == Source set properties

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -165,8 +165,13 @@ The last set of classes have no external or internal usages and therefore were d
 - `DeferredUtil`
 - `ChangeListener`
 
-==== The return type of the `groovy { }` block has changed
-The `groovy` source set is now defined via extension. This extension is backed by the link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceDirectorySet.html[GroovySourceDirectorySet] interface.
+==== The return type of source set extensions have changed
+
+The following source sets are contributed via an extension with a custom type:
+
+- `groovy`: link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceDirectorySet.html[GroovySourceDirectorySet]
+- `antlr`: link:{groovyDslPath}/org.gradle.api.plugins.antlr.AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+
 The 'idiomatic' DSL declaration is backward compatible:
 
 ```groovy
@@ -179,8 +184,7 @@ sourceSets {
 }
 ```
 
-However, the return type of the groovy block has changed from link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceSet.html[GroovySourceSet] to
-link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceDirectorySet.html[GroovySourceDirectorySet]. This means that the following snippet no longer works in Gradle 7.1:
+However, the return type of the groovy block has changed to the extension type. This means that the following snippet no longer works in Gradle 7.1:
 
 ```groovy
  sourceSets {
@@ -190,7 +194,7 @@ link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceDirectorySet.html[GroovySo
          }
      }
  }
- ```
+```
 
 [[java_exec_properties]]
 ==== Properties deprecated in JavaExec task
@@ -323,7 +327,7 @@ configurations {
 }
 ```
 
-[[ear_convention_deprecation]]
+[[project_report_convention_deprecation]]
 === Deprecated `project-report` plugin conventions
 
 link:{groovyDslPath}/org.gradle.api.plugins.ProjectReportsPluginConvention.html[ProjectReportsPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the project report tasks directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(...).configureEach(...)] can be used to configure each task of the same type (`HtmlDependencyReportTask` for example).
@@ -338,10 +342,19 @@ link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConv
 
 link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `Ear`.
 
-[[groovy_source_set_deprecation]]
-=== Deprecated `GroovySourceSet` interface
-link:{javadocPath}/org/gradle/api/tasks/GroovySourceSet.html[GroovySourceSet] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure `groovy` sources configuration via the
-the link:{javadocPath}/org/gradle/api/tasks/GroovySourceDirectorySet.html[new extension] defined on the source set object:
+[[custom_source_set_deprecation]]
+=== Deprecated custom source set interfaces
+The following source set interfaces are now deprecated and scheduled for removal in Gradle 8.0:
+
+- link:{javadocPath}/org/gradle/api/tasks/GroovySourceSet.html[GroovySourceSet]
+- link:{javadocPath}/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+
+Clients should configure the sources with their plugin-specific configuration:
+- `groovy`: link:{javadocPath}/org/gradle/api/tasks/GroovySourceDirectorySet.html[GroovySourceDirectorySet]
+- `antlr`: link:{javadocPath}/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+
+For example, here's how you configure the groovy sources from a plugin:
+
 ```java
 GroovySourceDirectorySet groovySources = sourceSet.getExtensions().getByType(GroovySourceDirectorySet.class);
 groovySources.setSrcDirs(Arrays.asList("sources/groovy"));


### PR DESCRIPTION
This is a follow-up PR to #17149. Here, clean up the usages of conventions in the `antlr` plugin. The conventions are unmodified as they will be deprecated in a separate step.