### PR TITLE
Define scala source set with extension

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.ScalaSourceDirectorySet.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.ScalaSourceDirectorySet.xml
@@ -1,0 +1,23 @@
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                    <td>Default with <literal>scala</literal> plugin</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/plugins.xml
+++ b/subprojects/docs/src/docs/dsl/plugins.xml
@@ -13,7 +13,7 @@
         <extends targetClass="org.gradle.api.Project" id="publishing" extensionClass="org.gradle.api.publish.PublishingExtension"/>
     </plugin>
     <plugin id="scala" description="Scala Plugin">
-        <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.tasks.ScalaSourceSet"/>
+        <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.tasks.ScalaSourceDirectorySet"/>
     </plugin>
     <plugin id="antlr" description="Antlr Plugin">
         <extends targetClass="org.gradle.api.tasks.SourceSet" mixinClass="org.gradle.api.plugins.antlr.AntlrSourceDirectorySet"/>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -122,6 +122,7 @@ Gradle 7.1 defines source sets as an extension in the following plugins:
 
 - `groovy`
 - `antlr`
+- `scala`
 
  This means that the Kotlin DSL has auto-generated accessors and `withConvention` block can be omitted:
 

--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -194,7 +194,7 @@ The Scala plugin does not add any convention properties to the project.
 [[sec:scala_source_set_properties]]
 == Source set properties
 
-The Scala plugin adds the following convention properties to each source set in the project. You can use these properties in your build script as though they were properties of the source set object.
+The Scala plugin adds the following extensions to each source set in the project. You can use these  in your build script as though they were properties of the source set object.
 
 `scala` — link:{groovyDslPath}/org.gradle.api.file.SourceDirectorySet.html[SourceDirectorySet] (read-only)::
 The Scala source files of this source set. Contains all `.scala` and `.java` files found in the Scala source directories, and excludes all other types of files. _Default value:_ non-null.
@@ -207,7 +207,7 @@ _Default value:_ `[__projectDir__/src/__name__/scala]`.
 `allScala` — link:{javadocPath}/org/gradle/api/file/FileTree.html[FileTree] (read-only)::
 All Scala source files of this source set. Contains only the `.scala` files found in the Scala source directories. _Default value:_ non-null.
 
-These convention properties are provided by a convention object of type link:{groovyDslPath}/org.gradle.api.tasks.ScalaSourceSet.html[ScalaSourceSet].
+These extensions are backed by an object of type link:{groovyDslPath}/org.gradle.api.plugins.scala.ScalaSourceSet.html[ScalaSourceSet].
 
 The Scala plugin also modifies some source set properties:
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -171,6 +171,7 @@ The following source sets are contributed via an extension with a custom type:
 
 - `groovy`: link:{groovyDslPath}/org.gradle.api.tasks.GroovySourceDirectorySet.html[GroovySourceDirectorySet]
 - `antlr`: link:{groovyDslPath}/org.gradle.api.plugins.antlr.AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+- `scala`: link:{groovyDslPath}/org.gradle.api.tasks.ScalaSourceDirectorySet.html[ScalaSourceDirectorySet]
 
 The 'idiomatic' DSL declaration is backward compatible:
 
@@ -348,10 +349,12 @@ The following source set interfaces are now deprecated and scheduled for removal
 
 - link:{javadocPath}/org/gradle/api/tasks/GroovySourceSet.html[GroovySourceSet]
 - link:{javadocPath}/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+- link:{javadocPath}/org/gradle/api/tasks/ScalaSourceSet.html[ScalaSourceSet]
 
 Clients should configure the sources with their plugin-specific configuration:
 - `groovy`: link:{javadocPath}/org/gradle/api/tasks/GroovySourceDirectorySet.html[GroovySourceDirectorySet]
 - `antlr`: link:{javadocPath}/org/gradle/api/plugins/antlr/AntlrSourceDirectorySet.html[AntlrSourceDirectorySet]
+- `scala`: link:{javadocPath}/org/gradle/api/tasks/ScalaSourceDirectorySet.html[ScalaSourceDirectorySet]
 
 For example, here's how you configure the groovy sources from a plugin:
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceDirectorySet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceDirectorySet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks;
+
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.file.DefaultSourceDirectorySet;
+import org.gradle.api.tasks.ScalaSourceDirectorySet;
+
+public class DefaultScalaSourceDirectorySet extends DefaultSourceDirectorySet implements ScalaSourceDirectorySet {
+
+    public DefaultScalaSourceDirectorySet(SourceDirectorySet sourceDirectorySet) {
+        super(sourceDirectorySet);
+    }
+}

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/DefaultScalaSourceSet.java
@@ -19,39 +19,45 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.ScalaSourceDirectorySet;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
-import org.gradle.api.tasks.ScalaSourceSet;
 
 import static org.gradle.api.reflect.TypeOf.typeOf;
 import static org.gradle.util.internal.ConfigureUtil.configure;
 
-public class DefaultScalaSourceSet implements ScalaSourceSet, HasPublicType {
-    private final SourceDirectorySet scala;
+@Deprecated
+public class DefaultScalaSourceSet implements org.gradle.api.tasks.ScalaSourceSet, HasPublicType {
+    private final ScalaSourceDirectorySet scala;
     private final SourceDirectorySet allScala;
 
     public DefaultScalaSourceSet(String displayName, ObjectFactory objectFactory) {
-        scala = objectFactory.sourceDirectorySet("scala", displayName + " Scala source");
-        scala.getFilter().include("**/*.java", "**/*.scala");
+        scala = createScalaSourceDirectorySet("scala", displayName + " Scala source", objectFactory);
         allScala = objectFactory.sourceDirectorySet("allscala", displayName + " Scala source");
         allScala.getFilter().include("**/*.scala");
         allScala.source(scala);
     }
 
+    private static ScalaSourceDirectorySet createScalaSourceDirectorySet(String name, String displayName, ObjectFactory objectFactory) {
+        ScalaSourceDirectorySet scalaSourceDirectorySet = new DefaultScalaSourceDirectorySet(objectFactory.sourceDirectorySet(name, displayName));
+        scalaSourceDirectorySet.getFilter().include("**/*.java", "**/*.scala");
+        return scalaSourceDirectorySet;
+    }
+
     @Override
-    public SourceDirectorySet getScala() {
+    public ScalaSourceDirectorySet getScala() {
         return scala;
     }
 
     @Override
     @SuppressWarnings("rawtypes")
-    public ScalaSourceSet scala(Closure configureClosure) {
+    public org.gradle.api.tasks.ScalaSourceSet scala(Closure configureClosure) {
         configure(configureClosure, getScala());
         return this;
     }
 
     @Override
-    public ScalaSourceSet scala(Action<? super SourceDirectorySet> configureAction) {
+    public org.gradle.api.tasks.ScalaSourceSet scala(Action<? super SourceDirectorySet> configureAction) {
         configureAction.execute(getScala());
         return this;
     }
@@ -63,6 +69,6 @@ public class DefaultScalaSourceSet implements ScalaSourceSet, HasPublicType {
 
     @Override
     public TypeOf<?> getPublicType() {
-        return typeOf(ScalaSourceSet.class);
+        return typeOf(org.gradle.api.tasks.ScalaSourceSet.class);
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaPlugin.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.plugins.scala;
 
-import org.codehaus.groovy.runtime.InvokerHelper;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -29,6 +28,7 @@ import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.ScalaSourceDirectorySet;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.scala.ScalaDoc;
@@ -87,7 +87,7 @@ public class ScalaPlugin implements Plugin<Project> {
                         return files;
                     }
                 });
-                scalaDoc.setSource(InvokerHelper.invokeMethod(main, "getScala", null));
+                scalaDoc.setSource(main.getExtensions().getByType(ScalaSourceDirectorySet.class));
             }
         });
         project.getTasks().register(SCALA_DOC_TASK_NAME, ScalaDoc.class, new Action<ScalaDoc>() {

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceDirectorySet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceDirectorySet.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.file.SourceDirectorySet;
+
+/**
+ * A {@code ScalaSourceDirectorySet} defines the properties and methods added to a {@link org.gradle.api.tasks.SourceSet} by the {@code ScalaPlugin}.
+ *
+ * @since 7.1
+ */
+@Incubating
+public interface ScalaSourceDirectorySet extends SourceDirectorySet {
+}

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/ScalaSourceSet.java
@@ -20,9 +20,13 @@ import org.gradle.api.Action;
 import org.gradle.api.file.SourceDirectorySet;
 
 /**
- * A {@code ScalaSourceSetConvention} defines the properties and methods added to a {@link
+ * A {@code ScalaSourceSet} defines the properties and methods added to a {@link
  * org.gradle.api.tasks.SourceSet} by the {@code ScalaPlugin}.
+ *
+ * @deprecated Using conventions to contribute source sets is deprecated. You can configure the groovy sources via the {@code ScalaSourceDirectorySet} extension (e.g.
+ * {@code sourceSet.getExtensions().getByType(ScalaSourceDirectorySet.class).setSrcDirs(...)}). This interface is scheduled for removal in Gradle 8.0.
  */
+@Deprecated
 public interface ScalaSourceSet {
     /**
      * Returns the source to be compiled by the Scala compiler for this source set. This may contain both Java and Scala


### PR DESCRIPTION
This is a follow-up PR to #17149. Here, clean up the usages of conventions in the `scala` plugin. The conventions are unmodified as they will be deprecated in a separate step.