### PR TITLE
Add Gradle build smoke test that would fail on deprecations

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTest.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+
+class GradleBuildSmokeTest extends AbstractGradleceptionSmokeTest {
+
+    def "can build Gradle distribution"() {
+        when:
+        result = runner(':distributions-full:binDistributionZip', ':distributions-full:binInstallation', '--stacktrace')
+            .expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. " +
+                "This is scheduled to be removed in Gradle 8.0. " +
+                "Please use the destinationDirectory property instead. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#compile_task_wiring",
+                "https://youtrack.jetbrains.com/issue/KT-46019")
+            .build()
+
+        then:
+        result.task(":distributions-full:binDistributionZip").outcome == TaskOutcome.SUCCESS
+        result.task(":distributions-full:binInstallation").outcome == TaskOutcome.SUCCESS
+    }
+}
+
+
+


### PR DESCRIPTION
This traverses only a small path in our build logic catching any deprecations
only in that path.
To really catch all possible deprecations in our own build logic we should
run nearly the whole pipeline using newly built Gradle distribution and exercise
as much of the build logic as possible. This might not be feasible.
