### PR TITLE
Provide java.version in java toolchains' metadata

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.jvm.toolchain;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.file.Directory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
@@ -37,6 +38,16 @@ public interface JavaInstallationMetadata {
      */
     @Input
     JavaLanguageVersion getLanguageVersion();
+
+    /**
+     * Returns the full Java version of the JVM, as specified in its {@code java.version} property.
+     *
+     * @return the full Java version of the JVM
+     * @since 7.1
+     */
+    @Internal
+    @Incubating
+    String getJavaVersion();
 
     /**
      * Returns a human-readable string for the vendor of the JVM.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -79,6 +79,12 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     }
 
     @Internal
+    @Override
+    public String getJavaVersion() {
+        return metadata.getImplementationVersion();
+    }
+
+    @Internal
     public VersionNumber getToolVersion() {
         return implementationVersion;
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.jvm.toolchain.internal
+
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmImplementation
+import spock.lang.Specification
+
+class JavaToolchainTest extends Specification {
+    def "java version is reported as specified in metadata"() {
+        given:
+        def javaHome = new File("/jvm/$implementationVersion").absoluteFile
+        def metadata = JvmInstallationMetadata.from(javaHome, implementationVersion, "vendor", "implName")
+        def compilerFactory = Mock(JavaCompilerFactory)
+        def toolFactory = Mock(ToolchainToolFactory)
+
+        when:
+        def javaToolchain = new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), Mock(JavaToolchainInput) {
+            getLanguageVersion() >> JavaLanguageVersion.of(languageVersion)
+            getVendor() >> DefaultJvmVendorSpec.any().toString()
+            getImplementation() >> JvmImplementation.VENDOR_SPECIFIC.toString()
+        })
+        then:
+        javaToolchain.javaVersion == implementationVersion
+        javaToolchain.languageVersion.asInt() == languageVersion
+
+        where:
+        implementationVersion | languageVersion
+        "1.8.0_292"           | 8
+        "11.0.11"             | 11
+        "16"                  | 16
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #17085 
