### PR TITLE
Fix non-determenism when selecting the latest Java 8 toolchain

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -48,7 +48,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
         this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
-        this.implementationVersion = VersionNumber.parse(metadata.getImplementationVersion());
+        this.implementationVersion = VersionNumber.withPatchNumber().parse(metadata.getImplementationVersion());
         this.metadata = metadata;
         this.input = input;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
@@ -18,6 +18,7 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.internal.jvm.inspection.JvmVendor;
 
+import java.io.File;
 import java.util.Comparator;
 
 public class JavaToolchainComparator implements Comparator<JavaToolchain> {
@@ -28,6 +29,10 @@ public class JavaToolchainComparator implements Comparator<JavaToolchain> {
             .comparing(JavaToolchain::isJdk)
             .thenComparing(this::extractVendor, Comparator.reverseOrder())
             .thenComparing(JavaToolchain::getToolVersion)
+            // It is possible for different JDK builds to have exact same version. The input order
+            // may change so the installation path breaks ties to keep sorted output consistent
+            // between runs.
+            .thenComparing(this::extractInstallationPathAsFile)
             .reversed()
             .compare(o1, o2);
     }
@@ -36,4 +41,7 @@ public class JavaToolchainComparator implements Comparator<JavaToolchain> {
         return toolchain.getMetadata().getVendor().getKnownVendor();
     }
 
+    private File extractInstallationPathAsFile(JavaToolchain javaToolchain) {
+        return javaToolchain.getInstallationPath().getAsFile();
+    }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.jvm.toolchain.internal
 
-import groovy.test.NotYetImplemented
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.file.TestFiles
@@ -86,7 +85,6 @@ class JavaToolchainQueryServiceTest extends Specification {
         JavaLanguageVersion.of(14)  | "/path/14.0.2+12"
     }
 
-    @NotYetImplemented
     def "uses most recent version of multiple matches if version has a legacy format"() {
         // See https://github.com/gradle/gradle/issues/17195
         given:

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.jvm.toolchain.JvmImplementation
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.install.internal.JavaToolchainProvisioningService
 import org.gradle.util.TestUtil
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -85,8 +86,8 @@ class JavaToolchainQueryServiceTest extends Specification {
         JavaLanguageVersion.of(14)  | "/path/14.0.2+12"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/17195")
     def "uses most recent version of multiple matches if version has a legacy format"() {
-        // See https://github.com/gradle/gradle/issues/17195
         given:
         def registry = createDeterministicInstallationRegistry(["1.8.0_282", "1.8.0_292"])
         def toolchainFactory = newToolchainFactory()


### PR DESCRIPTION
This test fails now because VersionCode cannot parse older version
format (it falls back to 0.0.0) so the first appropriate toolchain wins.
A mock JavaInstallationRegistry is used to ensure the determenistic
order in which toolchains are enumerated so the test doesn't flake.

~~This is a test case for #17195, but it doesn't fix the issue :(~~