### PR TITLE
Mark Provider types as ineligible for convention mapping

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -38,6 +38,14 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Deprecations
 
+[[convention_mapping]]
+==== Using convention mapping with properties with type Provider is deprecated
+Convention mapping is an internal feature that is been replaced by the <<lazy_configuration#lazy_configuration,Provider API>>.
+When mixing convention mapping with the Provider API, unexpected behavior can occur.
+Gradle emits a deprecation warning when a property in a task, extension or other domain object uses convention mapping with the Provider API.
+
+To fix this, the plugin that configures the convention mapping for the task, extension or domain object needs to be changed to use the Provider API only.
+
 [[jacoco_merge]]
 ==== JacocoMerge task type is deprecated
 

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -30,6 +30,8 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
     def "emits deprecation warning when convention mapping is used with Provider"() {
         buildFile << """
             abstract class MyTask extends DefaultTask {
+                @Inject abstract ProviderFactory getProviderFactory()
+                
                 @Internal abstract Property<String> getOther()
             
                 @Internal Provider<String> getFoo() {
@@ -42,7 +44,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
             tasks.register("mytask", MyTask) {
-                conventionMapping.map("foo", { project.provider { "foobar" } })
+                conventionMapping.map("foo", { providerFactory.provider { "foobar" } })
                 other.convention("other")
             }
         """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+// TODO: Also do this for FileCollection types eventually
+class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
+    private void expectDeprecationWarningForIneligibleTypes() {
+        executer.expectDocumentedDeprecationWarning("Using internal convention mapping with a Provider backed property. " +
+                "This will fail with an error in Gradle 8.0. " +
+                "Consult the upgrading guide for further information: " +
+                "https://docs.gradle.org/current/userguide/upgrading_version_7.html#TODO")
+    }
+
+    def "emits deprecation warning when convention mapping is used with Provider"() {
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @Internal abstract Property<String> getOther()
+            
+                @Internal Provider<String> getFoo() {
+                    return other;
+                }
+                
+                @TaskAction
+                void useIt() {
+                    assert foo.get() == "foobar"
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.provider { "foobar" } })
+                other.convention("other")
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("mytask")
+    }
+
+    def "emits deprecation warning when convention mapping is used with Property"() {
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @Internal abstract Property<String> getFoo()
+                
+                @TaskAction
+                void useIt() {
+                    // convention mapping for Property is already ignored
+                    assert foo.get() == "other"
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.objects.property(String).convention("foobar") })
+                foo.convention("other")
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("mytask")
+    }
+
+    def "emits deprecation warning when convention mapping is used with MapProperty"() {
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @Internal abstract MapProperty<String, String> getFoo()
+                
+                @TaskAction
+                void useIt() {
+                    // convention mapping for MapProperty is already ignored
+                    assert foo.get() == [other: "other"]
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.objects.mapProperty(String, String).convention([foobar: "foobar"]) })
+                foo.convention([other: "other"])
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("mytask")
+    }
+
+    def "emits deprecation warning when convention mapping is used with ListProperty"() {
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @Internal abstract ListProperty<String> getFoo()
+                
+                @TaskAction
+                void useIt() {
+                    // convention mapping for ListProperty is already ignored
+                    assert foo.get() == ["other"]
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.objects.listProperty(String).convention(["foobar"]) })
+                foo.convention(["other"])
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("mytask")
+    }
+
+    def "emits deprecation warning when convention mapping is used with Provider in a ConventionTask"() {
+        buildFile << """
+            abstract class MyTask extends org.gradle.api.internal.ConventionTask {
+                @Internal abstract Property<String> getFoo()
+                
+                @TaskAction
+                void useIt() {
+                    // convention mapping for Property is already ignored
+                    assert foo.get() == "other"
+                }
+            }
+            tasks.register("mytask", MyTask) {
+                conventionMapping.map("foo", { project.objects.property(String).convention("foobar") })
+                foo.convention("other")
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("mytask")
+    }
+
+    def "emits deprecation warning when convention mapping is used with Provider in domain object other than task"() {
+        buildFile << """
+            abstract class MyExtension {
+                abstract Property<String> getOther()
+            
+                Provider<String> getFoo() {
+                    return other
+                }
+            }
+
+            extensions.create("myext", MyExtension)
+            myext {
+                conventionMapping.map("foo", { project.provider { "foobar" } })
+                other.convention("other")
+            }
+        """
+        expectDeprecationWarningForIneligibleTypes()
+        expect:
+        succeeds("help")
+    }
+}

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProviderConventionMappingIntegrationTest.groovy
@@ -24,7 +24,7 @@ class ProviderConventionMappingIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDocumentedDeprecationWarning("Using internal convention mapping with a Provider backed property. " +
                 "This will fail with an error in Gradle 8.0. " +
                 "Consult the upgrading guide for further information: " +
-                "https://docs.gradle.org/current/userguide/upgrading_version_7.html#TODO")
+                "https://docs.gradle.org/current/userguide/upgrading_version_7.html#convention_mapping")
     }
 
     def "emits deprecation warning when convention mapping is used with Provider"() {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/ConventionMapping.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/ConventionMapping.java
@@ -31,6 +31,16 @@ public interface ConventionMapping {
 
     MappedProperty map(String propertyName, Callable<?> value);
 
+    /**
+     * Mark a property as ineligible for convention mapping.
+     */
+    void ineligible(String propertyName);
+
+    /**
+     * Mark a property as eligible for convention mapping.
+     */
+    void eligible(String propertyName);
+
     @Nullable
     <T> T getConventionValue(@Nullable T actualValue, String propertyName, boolean isExplicitValue);
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/ConventionMapping.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/ConventionMapping.java
@@ -36,11 +36,6 @@ public interface ConventionMapping {
      */
     void ineligible(String propertyName);
 
-    /**
-     * Mark a property as eligible for convention mapping.
-     */
-    void eligible(String propertyName);
-
     @Nullable
     <T> T getConventionValue(@Nullable T actualValue, String propertyName, boolean isExplicitValue);
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.Convention;
 import org.gradle.internal.Cast;
 import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,7 +50,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
     public ConventionAwareHelper(IConventionAware source, Convention convention) {
         this._source = source;
         this._convention = convention;
-        this._propertyNames = new HashSet<>();
+        this._propertyNames = JavaPropertyReflectionUtil.propertyNames(source);
         this._ineligiblePropertyNames = new HashSet<>();
     }
 
@@ -107,14 +108,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
 
     @Override
     public void ineligible(String propertyName) {
-        // Remove this once the deprecation above becomes an error
-        _propertyNames.add(propertyName);
         _ineligiblePropertyNames.add(propertyName);
-    }
-
-    @Override
-    public void eligible(String propertyName) {
-        _propertyNames.add(propertyName);
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -63,7 +63,7 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
         if (_ineligiblePropertyNames.contains(propertyName)) {
             DeprecationLogger.deprecateBehaviour("Using internal convention mapping with a Provider backed property.")
                     .willBecomeAnErrorInGradle8()
-                    .withUpgradeGuideSection(7, "TODO")
+                    .withUpgradeGuideSection(7, "convention_mapping")
                     .nagUser();
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -973,6 +973,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         private final List<PropertyMetadata> mutableProperties = new ArrayList<>();
         private final List<PropertyMetadata> readOnlyProperties = new ArrayList<>();
         private final List<PropertyMetadata> eagerAttachProperties = new ArrayList<>();
+        private final List<PropertyMetadata> allProperties = new ArrayList<>();
+
         private boolean hasFields;
 
         @Override
@@ -987,6 +989,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                 // If the getter is not final, then attach lazily in the getter
                 eagerAttachProperties.add(property);
             }
+            allProperties.add(property);
         }
 
         @Override
@@ -1029,6 +1032,9 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             for (PropertyMetadata property : eagerAttachProperties) {
                 boolean applyRole = isRoleType(property);
                 visitor.attachDuringConstruction(property, applyRole);
+            }
+            for (PropertyMetadata property : allProperties) {
+                visitor.trackProperty(property);
             }
         }
 
@@ -1360,6 +1366,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         void instantiatesNestedObjects();
 
         void attachDuringConstruction(PropertyMetadata property, boolean applyRole);
+
+        void trackProperty(PropertyMetadata property);
 
         ClassGenerationVisitor builder();
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.extensibility;
 
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.TestTask;
 import org.gradle.util.TestUtil;
@@ -50,9 +49,6 @@ public class ConventionAwareHelperTest {
     @Before public void setUp() {
         testTask = TestUtil.create(temporaryFolder).task(TestTask.class);
         conventionAware = new ConventionAwareHelper(testTask, new DefaultConvention(TestUtil.instantiatorFactory().decorateLenient()));
-        for (String name : JavaPropertyReflectionUtil.propertyNames(testTask)) {
-            conventionAware.eligible(name);
-        }
     }
 
     @Test

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ConventionAwareHelperTest.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.extensibility;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 import org.gradle.util.TestTask;
 import org.gradle.util.TestUtil;
@@ -49,6 +50,9 @@ public class ConventionAwareHelperTest {
     @Before public void setUp() {
         testTask = TestUtil.create(temporaryFolder).task(TestTask.class);
         conventionAware = new ConventionAwareHelper(testTask, new DefaultConvention(TestUtil.instantiatorFactory().decorateLenient()));
+        for (String name : JavaPropertyReflectionUtil.propertyNames(testTask)) {
+            conventionAware.eligible(name);
+        }
     }
 
     @Test

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -1465,6 +1465,16 @@ public class AsmBackedClassGeneratorTest {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public void ineligible(String propertyName) {
+
+        }
+
+        @Override
+        public void eligible(String propertyName) {
+
+        }
+
         public <T> T getConventionValue(T actualValue, String propertyName) {
             if (actualValue instanceof String) {
                 return (T) ("[" + actualValue + "]");

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AsmBackedClassGeneratorTest.java
@@ -1470,11 +1470,6 @@ public class AsmBackedClassGeneratorTest {
 
         }
 
-        @Override
-        public void eligible(String propertyName) {
-
-        }
-
         public <T> T getConventionValue(T actualValue, String propertyName) {
             if (actualValue instanceof String) {
                 return (T) ("[" + actualValue + "]");


### PR DESCRIPTION
- Convention mapping does not work for Property-based properties
- Convention mapping can work with Provider-based properties
- Currently, this will only emit a deprecation warning

Fixes #8404 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
