### PR TITLE
Prefer parseInt(String), etc., to valueOf(String)

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/ActionsTest.groovy
@@ -51,7 +51,7 @@ class ActionsTest extends Specification {
         when:
         transformBefore(action, new Transformer<Integer, String>() {
             Integer transform(String original) {
-                Integer.valueOf(original, 10) * 2
+                Integer.parseInt(original, 10) * 2
             }
 
         }).execute("1")

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/IntegerBuildOption.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/IntegerBuildOption.java
@@ -36,7 +36,7 @@ public abstract class IntegerBuildOption<T> extends AbstractBuildOption<T, Comma
     public void applyFromProperty(Map<String, String> properties, T settings) {
         String value = properties.get(gradleProperty);
         if (value != null) {
-            applyTo(Integer.valueOf(value), settings, Origin.forGradleProperty(gradleProperty));
+            applyTo(Integer.parseInt(value), settings, Origin.forGradleProperty(gradleProperty));
         }
     }
 
@@ -52,7 +52,7 @@ public abstract class IntegerBuildOption<T> extends AbstractBuildOption<T, Comma
         for (CommandLineOptionConfiguration config : commandLineOptionConfigurations) {
             if (options.hasOption(config.getLongOption())) {
                 String value = options.option(config.getLongOption()).getValue();
-                applyTo(Integer.valueOf(value), settings, Origin.forCommandLine(config.getLongOption()));
+                applyTo(Integer.parseInt(value), settings, Origin.forCommandLine(config.getLongOption()));
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java
@@ -57,14 +57,14 @@ public class DefaultFileAccessTimeJournal implements FileAccessTimeJournal, Stop
         inceptionTimestamp = loadOrPersistInceptionTimestamp();
     }
 
-    private Long loadOrPersistInceptionTimestamp() {
+    private long loadOrPersistInceptionTimestamp() {
         return cache.useCache(() -> {
             File propertiesFile = new File(cache.getBaseDir(), FILE_ACCESS_PROPERTIES_FILE_NAME);
             if (propertiesFile.exists()) {
                 Properties properties = GUtil.loadProperties(propertiesFile);
                 String inceptionTimestamp = properties.getProperty(INCEPTION_TIMESTAMP_KEY);
                 if (inceptionTimestamp != null) {
-                    return Long.valueOf(inceptionTimestamp);
+                    return Long.parseLong(inceptionTimestamp);
                 }
             }
             long inceptionTimestamp = System.currentTimeMillis();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -137,7 +137,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
             attributes.attribute(Category.CATEGORY_ATTRIBUTE, instantiator.named(Category.class, Category.LIBRARY));
             attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, instantiator.named(LibraryElements.class, LibraryElements.JAR));
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, instantiator.named(Bundling.class, Bundling.EXTERNAL));
-            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
+            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()));
             attributes.attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, instantiator.named(GradlePluginApiVersion.class, GradleVersion.current().getVersion()));
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/TypedNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/TypedNotationConverterTest.groovy
@@ -43,7 +43,7 @@ public class TypedNotationConverterTest extends Specification {
         }
 
         Integer parseType(String notation) {
-            return Integer.valueOf(notation);
+            return Integer.parseInt(notation);
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -480,7 +480,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
             System.out.println("I'm the daemon")
             System.out.close()
             System.err.close()
-            int napTime = (args.length == 0) ? 10000L : Integer.valueOf(args[0])
+            int napTime = (args.length == 0) ? 10000L : Integer.parseInt(args[0])
             Thread.sleep(napTime)
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -50,7 +50,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
                         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'jar'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -107,7 +107,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                         attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, 'jar'))
                         attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('test:lib:1.0')
                     outgoing.capability('test:lib-fixtures:1.0')

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -276,7 +276,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
                         break;
                     case "initialize-in-order":
 
-                        initializeInOrder = Boolean.valueOf(child.text());
+                        initializeInOrder = Boolean.parseBoolean(child.text());
 
                         break;
                     case "description":

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/AbstractClasspathEntry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/AbstractClasspathEntry.java
@@ -56,9 +56,9 @@ public abstract class AbstractClasspathEntry implements ClasspathEntry {
         if (value == null) {
             return false;
         } else if (value instanceof Boolean) {
-            return ((Boolean) value).booleanValue();
+            return (Boolean) value;
         } else {
-            return Boolean.valueOf((String) value);
+            return Boolean.parseBoolean((String) value);
         }
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -153,7 +153,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
             }
 
             task customTask(type: CustomTask) {
-                int numOutputs = Integer.valueOf(
+                int numOutputs = Integer.parseInt(
                     providers.gradleProperty('numOutputs').forUseAtConfigurationTime().get()
                 )
                 outputFiles = (0..(numOutputs-1)).collect { lazyProperty("output\$it") }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractBuildExperimentRunner.java
@@ -150,7 +150,7 @@ public abstract class AbstractBuildExperimentRunner implements BuildExperimentRu
     protected static Integer invocationsForExperiment(BuildExperimentSpec experiment) {
         String overriddenInvocationCount = getExperimentOverride("runs");
         if (overriddenInvocationCount != null) {
-            return Integer.valueOf(overriddenInvocationCount);
+            return Integer.parseInt(overriddenInvocationCount);
         }
         if (experiment.getInvocationCount() != null) {
             return experiment.getInvocationCount();

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/AbstractTestDirectoryProvider.java
@@ -41,7 +41,7 @@ abstract class AbstractTestDirectoryProvider implements TestRule, TestDirectoryP
 
     private static final Random RANDOM = new Random();
     private static final int ALL_DIGITS_AND_LETTERS_RADIX = 36;
-    private static final int MAX_RANDOM_PART_VALUE = Integer.valueOf("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX);
+    private static final int MAX_RANDOM_PART_VALUE = Integer.parseInt("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX);
     private static final Pattern WINDOWS_RESERVED_NAMES = Pattern.compile("(con)|(prn)|(aux)|(nul)|(com\\d)|(lpt\\d)", Pattern.CASE_INSENSITIVE);
 
     private String prefix;

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishIssuesIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishIssuesIntegTest.groovy
@@ -78,7 +78,7 @@ public class IvyPublishIssuesIntegTest extends AbstractIvyPublishIntegTest {
             version = "1.0"
 
             jar {
-                enabled = Boolean.valueOf(project.getProperty("jarEnabled"))
+                enabled = Boolean.parseBoolean(project.getProperty("jarEnabled"))
             }
 
             publishing {
@@ -131,7 +131,7 @@ public class IvyPublishIssuesIntegTest extends AbstractIvyPublishIntegTest {
             }
 
             javadocJar {
-                enabled = Boolean.valueOf(project.getProperty("javadocEnabled"))
+                enabled = Boolean.parseBoolean(project.getProperty("javadocEnabled"))
             }
 
             publishing {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -342,7 +342,7 @@ public class JacocoTaskExtension {
             if (value != null
                 && !((value instanceof Collection) && ((Collection) value).isEmpty())
                 && !((value instanceof String) && (StringUtils.isEmpty((String) value)))
-                && !((value instanceof Integer) && (value == Integer.valueOf(0)))) {
+                && !((value instanceof Integer) && ((Integer) value == 0))) {
                 if (anyArgs) {
                     builder.append(',');
                 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/SourceDistributionProvider.kt
@@ -152,7 +152,7 @@ class SourceDistributionResolver(val project: Project) : SourceDistributionProvi
 
     private
     fun previous(versionDigit: String) =
-        Integer.valueOf(versionDigit) - 1
+        Integer.parseInt(versionDigit) - 1
 
     private
     val resolver by lazy { projectInternal.newDetachedResolver() }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonStartupCommunication.java
@@ -79,7 +79,7 @@ public class DaemonStartupCommunication {
             Decoder decoder = new InputStreamBackedDecoder(inputStream);
             String pidString = decoder.readNullableString();
             String uid = decoder.readString();
-            Long pid = pidString == null ? null : Long.valueOf(pidString);
+            Long pid = pidString == null ? null : Long.parseLong(pidString);
             Address address = new MultiChoiceAddressSerializer().read(decoder);
             File daemonLog = new File(decoder.readString());
             return new DaemonStartupInfo(uid, address, new DaemonDiagnostics(daemonLog, pid));

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -74,7 +74,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         @Override
         public void applyTo(String value, DaemonParameters settings, Origin origin) {
             try {
-                settings.setIdleTimeout(Integer.valueOf(value));
+                settings.setIdleTimeout(Integer.parseInt(value));
             } catch (NumberFormatException e) {
                 origin.handleInvalidValue(value, "the value should be an int");
             }
@@ -91,7 +91,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         @Override
         public void applyTo(String value, DaemonParameters settings, Origin origin) {
             try {
-                settings.setPeriodicCheckInterval(Integer.valueOf(value));
+                settings.setPeriodicCheckInterval(Integer.parseInt(value));
             } catch (NumberFormatException e) {
                 origin.handleInvalidValue(value, "the value should be an int");
             }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishIssuesIntegTest.groovy
@@ -271,7 +271,7 @@ subprojects {
             version = "1.0"
 
             jar {
-                enabled = Boolean.valueOf(project.getProperty("jarEnabled"))
+                enabled = Boolean.parseBoolean(project.getProperty("jarEnabled"))
             }
 
             publishing {
@@ -325,7 +325,7 @@ subprojects {
             }
 
             javadocJar {
-                enabled = Boolean.valueOf(project.getProperty("javadocEnabled"))
+                enabled = Boolean.parseBoolean(project.getProperty("javadocEnabled"))
             }
 
             publishing {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
@@ -43,7 +43,7 @@ public class CoercingStringValueSnapshot extends StringValueSnapshot {
             return type.cast(instantiator.named(type.asSubclass(Named.class), getValue()));
         }
         if (Integer.class.equals(type)) {
-            return type.cast(Integer.valueOf(getValue()));
+            return type.cast(Integer.parseInt(getValue()));
         }
         return null;
     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/NativePlatformBackedProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/NativePlatformBackedProcessEnvironment.java
@@ -48,7 +48,7 @@ public class NativePlatformBackedProcessEnvironment extends AbstractProcessEnvir
 
     @Override
     public Long getPid() {
-        return Long.valueOf(process.getProcessId());
+        return (long) process.getProcessId();
     }
 
     @Override

--- a/subprojects/performance/src/templates/workerApiProject/buildSrc/src/main/java/com/example/worker/WorkerPlugin.java
+++ b/subprojects/performance/src/templates/workerApiProject/buildSrc/src/main/java/com/example/worker/WorkerPlugin.java
@@ -45,7 +45,7 @@ public class WorkerPlugin implements Plugin<Project> {
             @Override
             public void execute(WorkerTask workerTask) {
                 Object maybeOutputSize = project.findProperty("outputSize");
-                int outputSize = Integer.valueOf(maybeOutputSize == null ? "1" : maybeOutputSize.toString());
+                int outputSize = Integer.parseInt(maybeOutputSize == null ? "1" : maybeOutputSize.toString());
                 workerTask.setOutputSize(outputSize);
             }
         });

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -175,7 +175,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         def toolFactory = Mock(ToolchainToolFactory)
         def toolchainFactory = new JavaToolchainFactory(Mock(JvmMetadataDetector), compilerFactory, toolFactory, TestFiles.fileFactory()) {
             Optional<JavaToolchain> newInstance(File javaHome, JavaToolchainInput input) {
-                def vendor = vendors[Integer.valueOf(javaHome.name.substring(2))]
+                def vendor = vendors[Integer.parseInt(javaHome.name.substring(2))]
                 def metadata = newMetadata(new File("/path/8"), vendor)
                 return Optional.of(new JavaToolchain(metadata, compilerFactory, toolFactory, TestFiles.fileFactory(), input))
             }

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/GpgCmdFixture.groovy
@@ -27,7 +27,7 @@ import java.util.regex.Pattern
 class GpgCmdFixture {
     private static final Random RANDOM = new Random()
     private static final int ALL_DIGITS_AND_LETTERS_RADIX = 36
-    private static final int MAX_RANDOM_PART_VALUE = Integer.valueOf("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX)
+    private static final int MAX_RANDOM_PART_VALUE = Integer.parseInt("zzzzz", ALL_DIGITS_AND_LETTERS_RADIX)
     private static final Pattern GPG_VERSION_REGEX = Pattern.compile(/(?s).*gpg \(GnuPG\) (\d).\d+.\d+.*/)
 
     static String createRandomPrefix() {

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningPublicationsIntegrationSpec.groovy
@@ -644,7 +644,7 @@ class SigningPublicationsIntegrationSpec extends SigningIntegrationSpec {
             if (sign == 'skip') {
                 tasks.withType(Sign)*.onlyIf { false }
             } else {
-                tasks.withType(Sign)*.enabled = Boolean.valueOf(sign)
+                tasks.withType(Sign)*.enabled = Boolean.parseBoolean(sign)
             }
 
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -347,7 +347,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             public class TestCase {
                 @Test
                 public void test() {
-                    assertTrue(Double.valueOf(System.getProperty("java.specification.version")) >= 1.8);
+                    assertTrue(Double.parseDouble(System.getProperty("java.specification.version")) >= 1.8);
                 }
             }
         """

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIntegrationTest/executesTestsInCorrectEnvironment/src/test/java/org/gradle/OkTest.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIntegrationTest/executesTestsInCorrectEnvironment/src/test/java/org/gradle/OkTest.java
@@ -32,7 +32,7 @@ public class OkTest {
         // check classloader and classpath
         assertSame(ClassLoader.getSystemClassLoader(), getClass().getClassLoader());
         assertSame(getClass().getClassLoader(), Thread.currentThread().getContextClassLoader());
-        boolean isJava9 = Boolean.valueOf(System.getProperty("isJava9"));
+        boolean isJava9 = Boolean.parseBoolean(System.getProperty("isJava9"));
         String classPathString = System.getProperty("java.class.path");
         String expectedClassPathString = System.getProperty("expectedClassPath");
         if (isJava9) {

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -51,7 +51,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
                 classpath = sourceSets.main.runtimeClasspath
                 mainClass = "ToolingApiCompatibilityClient"
                 javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(Integer.valueOf(project.findProperty("clientJdk")))
+                    languageVersion = JavaLanguageVersion.of(Integer.parseInt(project.findProperty("clientJdk")))
                 }
                 enableAssertions = true
                 $jvmArgs
@@ -63,7 +63,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
                 classpath = sourceSets.main.runtimeClasspath
                 mainClass = "ToolingApiCompatibilityClient"
                 javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(Integer.valueOf(project.findProperty("clientJdk")))
+                    languageVersion = JavaLanguageVersion.of(Integer.parseInt(project.findProperty("clientJdk")))
                 }
                 enableAssertions = true
                 $jvmArgs


### PR DESCRIPTION
Since Java supports autoboxing (and auto-unboxing), parseInt(String),
etc., can do everything valueOf(String) can, while avoiding warnings about
redundant boxing (i.e. boxing followed by immediate unboxing) for
simple assignments and function calls.

Changes was made by:
  - `$ for i in Boolean Byte Short Character Long Float Double; do git grep -Plz "\W$i\.valueOf" | xargs -r0 sed -i "s/$i\.valueOf/$i.parse$i/g"; done`
  - `$ git grep -Plz '\WInteger\.valueOf' | xargs -r0 sed -i 's/Integer\.valueOf/Integer\.parseInt/g'`

  - `$ git checkout subprojects/{code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/PmdPluginIncrementalAnalysisIntegrationTest.groovy,code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy,ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/DefaultResourceFilter.java,model-core/src/integTest/groovy/org/gradle/model/managed/ScalarTypesInManagedModelIntegrationTest.groovy,model-core/src/main/java/org/gradle/model/internal/manage/schema/ModelProperty.java,model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy,persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java,configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyRead.groovy}`

- Rewrite
subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileAccessTimeJournal.java

- Rewrite
subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/AbstractClasspathEntry.java

- Rewrite
subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java

- Rewrite
subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/NativePlatformBackedProcessEnvironment.java

Signed-off-by: Daniel Le <greenrecyclebin@gmail.com>

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
