### PR TITLE
Restore previous outputs after task execution failure

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/FailingIncrementalTasksIntegrationTest.groovy
@@ -49,7 +49,7 @@ class FailingIncrementalTasksIntegrationTest extends AbstractIntegrationSpec {
         fails "foo", "--info"
         then:
         failureHasCause "Boo!"
-        output.contains "Task has failed previously."
+        output.contains "out.txt has changed"
         //this exposes an issue we used to have with in-memory cache.
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -50,7 +50,7 @@ import org.gradle.internal.execution.steps.BuildCacheStep;
 import org.gradle.internal.execution.steps.CancelExecutionStep;
 import org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep;
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep;
-import org.gradle.internal.execution.steps.CreateOutputsStep;
+import org.gradle.internal.execution.steps.MkDirsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
 import org.gradle.internal.execution.steps.IdentifyStep;
 import org.gradle.internal.execution.steps.IdentityCacheStep;
@@ -174,7 +174,7 @@ public class ExecutionGradleServices {
             new BuildCacheStep(buildCacheController, buildCacheCommandFactory, deleter, outputChangeListener,
             new BroadcastChangingOutputsStep<>(outputChangeListener,
             new CaptureStateAfterExecutionStep<>(buildOperationExecutor, buildInvocationScopeId.getId(), outputSnapshotter,
-            new CreateOutputsStep<>(
+            new MkDirsStep<>(
             new TimeoutStep<>(timeoutHandler, currentBuildOperationRef,
             new CancelExecutionStep<>(cancellationToken,
             new ResolveInputChangesStep<>(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -44,7 +44,7 @@ import org.gradle.internal.execution.DefaultOutputSnapshotter
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinterRegistry
 import org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OverlappingOutputDetector
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
@@ -105,7 +105,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         getInputFileProperties() >> ImmutableSortedSet.of()
         getOutputFileProperties() >> ImmutableSortedSet.of()
     }
-    def previousState = Stub(AfterPreviousExecutionState) {
+    def previousState = Stub(AfterExecutionState) {
         getInputProperties() >> ImmutableSortedMap.of()
         getInputFileProperties() >> ImmutableSortedMap.of()
         getOutputFilesProducedByWork() >> ImmutableSortedMap.of()
@@ -204,7 +204,8 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         executionContext.getTaskProperties() >> taskProperties
         executionContext.getValidationContext() >> validationContext
         executionContext.getValidationAction() >> { { historyMaintained, c -> } as TaskExecutionContext.ValidationAction }
-        executionHistoryStore.load("task") >> Optional.of(previousState)
+        executionHistoryStore.loadLastState("task") >> Optional.of(previousState)
+        executionHistoryStore.loadLastSuccessfulState("task") >> Optional.of(previousState)
         taskProperties.getOutputFileProperties() >> ImmutableSortedSet.of()
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -159,7 +159,7 @@ import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OverlappingOutputDetector;
@@ -171,7 +171,7 @@ import org.gradle.internal.execution.steps.CachingContext;
 import org.gradle.internal.execution.steps.CachingResult;
 import org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep;
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep;
-import org.gradle.internal.execution.steps.CreateOutputsStep;
+import org.gradle.internal.execution.steps.MkDirsStep;
 import org.gradle.internal.execution.steps.ExecuteStep;
 import org.gradle.internal.execution.steps.IdentifyStep;
 import org.gradle.internal.execution.steps.IdentityCacheStep;
@@ -776,7 +776,7 @@ class DependencyManagementBuildScopeServices {
             new BroadcastChangingOutputsStep<>(outputChangeListener,
             new StoreExecutionStateStep<>(
             new CaptureStateAfterExecutionStep<>(buildOperationExecutor, fixedUniqueId, outputSnapshotter,
-            new CreateOutputsStep<>(
+            new MkDirsStep<>(
             new TimeoutStep<>(timeoutHandler, currentBuildOperationRef,
             new ResolveInputChangesStep<>(
             new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
@@ -837,7 +837,12 @@ class DependencyManagementBuildScopeServices {
                 }
 
                 @Override
-                public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+                public Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState() {
+                    return context.getAfterLastSuccessfulExecutionState();
+                }
+
+                @Override
+                public Optional<AfterExecutionState> getAfterPreviousExecutionState() {
                     return context.getAfterPreviousExecutionState();
                 }
 

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -41,7 +41,7 @@ import org.gradle.internal.execution.steps.AssignWorkspaceStep
 import org.gradle.internal.execution.steps.BroadcastChangingOutputsStep
 import org.gradle.internal.execution.steps.CaptureStateAfterExecutionStep
 import org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep
-import org.gradle.internal.execution.steps.CreateOutputsStep
+import org.gradle.internal.execution.steps.MkDirsStep
 import org.gradle.internal.execution.steps.ExecuteStep
 import org.gradle.internal.execution.steps.IdentifyStep
 import org.gradle.internal.execution.steps.IdentityCacheStep
@@ -162,7 +162,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
             new StoreExecutionStateStep<>(
             new BroadcastChangingOutputsStep<>(outputChangeListener,
             new CaptureStateAfterExecutionStep<>(buildOperationExecutor, buildInvocationScopeId.getId(), outputSnapshotter,
-            new CreateOutputsStep<>(
+            new MkDirsStep<>(
             new ResolveInputChangesStep<>(
             new RemovePreviousOutputsStep<>(deleter, outputChangeListener,
             new ExecuteStep<>(buildOperationExecutor
@@ -264,7 +264,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
 
         when:
         buildInvocationScopeId = new BuildInvocationScopeId(UniqueId.generate())
-        result = outOfDate(builder.build(), "Task has failed previously.")
+        result = outOfDate(builder.build(), "No history is available.")
 
         then:
         result.executionResult.get().outcome == EXECUTED_NON_INCREMENTALLY

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/AfterExecutionState.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/AfterExecutionState.java
@@ -17,24 +17,25 @@
 package org.gradle.internal.execution.history;
 
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
+import javax.annotation.Nullable;
+
 /**
- * A execution state after the previous execution has finished.
+ * The state after an execution of a work item.
  */
-public interface AfterPreviousExecutionState extends ExecutionState {
+public interface AfterExecutionState extends ExecutionState {
 
     /**
      * The ID and execution time of origin of the execution's outputs.
      */
     OriginMetadata getOriginMetadata();
 
-    /**
-     * Whether or not the execution was successful.
-     */
-    boolean isSuccessful();
+    @Nullable
+    BuildCacheKey getCacheKey();
 
     @Override
     ImmutableSortedMap<String, FileCollectionFingerprint> getInputFileProperties();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/BeforeExecutionState.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/BeforeExecutionState.java
@@ -35,7 +35,7 @@ public interface BeforeExecutionState extends ExecutionState {
      *
      * This includes snapshots for the whole output {@link org.gradle.api.file.FileCollection}.
      *
-     * @see AfterPreviousExecutionState#getOutputFilesProducedByWork()
+     * @see AfterExecutionState#getOutputFilesProducedByWork()
      * @see SnapshotResult#getOutputFilesProduceByWork()
      */
     ImmutableSortedMap<String, FileSystemSnapshot> getOutputFileLocationSnapshots();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryStore.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/ExecutionHistoryStore.java
@@ -18,25 +18,31 @@ package org.gradle.internal.execution.history;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 public interface ExecutionHistoryStore {
-    Optional<AfterPreviousExecutionState> load(String key);
+    Optional<AfterExecutionState> loadLastSuccessfulState(String key);
 
-    void store(String key,
-               OriginMetadata originMetadata,
-               ImplementationSnapshot implementation,
-               ImmutableList<ImplementationSnapshot> additionalImplementations,
-               ImmutableSortedMap<String, ValueSnapshot> inputProperties,
-               ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileProperties,
-               ImmutableSortedMap<String, FileSystemSnapshot> outputFileProperties,
-               boolean successful);
+    Optional<AfterExecutionState> loadLastState(String key);
 
+    void store(
+        boolean success,
+        String key,
+        OriginMetadata originMetadata,
+        @Nullable BuildCacheKey cacheKey,
+        ImplementationSnapshot implementation,
+        ImmutableList<ImplementationSnapshot> additionalImplementations,
+        ImmutableSortedMap<String, ValueSnapshot> inputProperties,
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileProperties,
+        ImmutableSortedMap<String, FileSystemSnapshot> outputFileProperties
+    );
     void remove(String key);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChangeDetector.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChangeDetector.java
@@ -17,14 +17,14 @@
 package org.gradle.internal.execution.history.changes;
 
 import org.gradle.api.Describable;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 
 public interface ExecutionStateChangeDetector {
     int MAX_OUT_OF_DATE_MESSAGES = 3;
 
     ExecutionStateChanges detectChanges(
-        AfterPreviousExecutionState lastExecution,
+        AfterExecutionState lastExecution,
         BeforeExecutionState thisExecution,
         Describable executable,
         IncrementalInputProperties incrementalInputProperties

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ExecutionStateChanges.java
@@ -18,6 +18,8 @@ package org.gradle.internal.execution.history.changes;
 
 import com.google.common.collect.ImmutableList;
 
+import java.util.Optional;
+
 /**
  * Represents the complete changes in execution state
  */
@@ -29,6 +31,10 @@ public interface ExecutionStateChanges {
     ImmutableList<String> getAllChangeMessages();
 
     InputChangesInternal createInputChanges();
+
+    default Optional<String> getOutputFileChangeMessage() {
+        return Optional.empty();
+    }
 
     /**
      * Turn these changes into ones forcing a rebuild with the given reason.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultAfterExecutionState.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultAfterExecutionState.java
@@ -18,31 +18,35 @@ package org.gradle.internal.execution.history.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 
-public class DefaultAfterPreviousExecutionState extends AbstractExecutionState<FileCollectionFingerprint> implements AfterPreviousExecutionState {
+import javax.annotation.Nullable;
+
+public class DefaultAfterExecutionState extends AbstractExecutionState<FileCollectionFingerprint> implements AfterExecutionState {
+    private final BuildCacheKey cacheKey;
     private final ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork;
     private final OriginMetadata originMetadata;
-    private final boolean successful;
 
-    public DefaultAfterPreviousExecutionState(
+    public DefaultAfterExecutionState(
         OriginMetadata originMetadata,
+        @Nullable
+        BuildCacheKey cacheKey,
         ImplementationSnapshot implementation,
         ImmutableList<ImplementationSnapshot> additionalImplementations,
         ImmutableSortedMap<String, ValueSnapshot> inputProperties,
         ImmutableSortedMap<String, FileCollectionFingerprint> inputFileProperties,
-        ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork,
-        boolean successful
+        ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork
     ) {
         super(implementation, additionalImplementations, inputProperties, inputFileProperties);
+        this.cacheKey = cacheKey;
         this.outputFilesProducedByWork = outputFilesProducedByWork;
         this.originMetadata = originMetadata;
-        this.successful = successful;
     }
 
     @Override
@@ -56,7 +60,7 @@ public class DefaultAfterPreviousExecutionState extends AbstractExecutionState<F
     }
 
     @Override
-    public boolean isSuccessful() {
-        return successful;
+    public BuildCacheKey getCacheKey() {
+        return cacheKey;
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BeforeExecutionContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BeforeExecutionContext.java
@@ -20,7 +20,7 @@ import org.gradle.internal.execution.history.BeforeExecutionState;
 
 import java.util.Optional;
 
-public interface BeforeExecutionContext extends AfterPreviousExecutionContext {
+public interface BeforeExecutionContext extends ExecutionHistoryContext {
     /**
      * Returns the execution state before execution.
      * Empty if execution state was not observed before execution.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
@@ -17,12 +17,13 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.Try;
 import org.gradle.internal.execution.ExecutionResult;
 import org.gradle.internal.execution.OutputSnapshotter;
 import org.gradle.internal.execution.UnitOfWork;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -85,6 +86,11 @@ public class CaptureStateAfterExecutionStep<C extends BeforeExecutionContext> ex
             public boolean isReused() {
                 return false;
             }
+
+            @Override
+            public BuildCacheKey getCacheKey() {
+                return null;
+            }
         };
     }
 
@@ -97,7 +103,7 @@ public class CaptureStateAfterExecutionStep<C extends BeforeExecutionContext> ex
 
         if (hasDetectedOverlappingOutputs) {
             ImmutableSortedMap<String, FileSystemSnapshot> previousExecutionOutputSnapshots = context.getAfterPreviousExecutionState()
-                .map(AfterPreviousExecutionState::getOutputFilesProducedByWork)
+                .map(AfterExecutionState::getOutputFilesProducedByWork)
                 .orElse(ImmutableSortedMap.of());
 
             ImmutableSortedMap<String, FileSystemSnapshot> unfilteredOutputSnapshotsBeforeExecution = context.getBeforeExecutionState()

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CurrentSnapshotResult.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CurrentSnapshotResult.java
@@ -17,8 +17,11 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
+
+import javax.annotation.Nullable;
 
 public interface CurrentSnapshotResult extends SnapshotResult {
     /**
@@ -35,6 +38,9 @@ public interface CurrentSnapshotResult extends SnapshotResult {
      * or to another build if the work was reused.
      */
     OriginMetadata getOriginMetadata();
+
+    @Nullable
+    BuildCacheKey getCacheKey();
 
     /**
      * Did we reuse the output from some previous execution?

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -21,7 +21,7 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.ExecutionOutcome;
 import org.gradle.internal.execution.ExecutionResult;
 import org.gradle.internal.execution.UnitOfWork;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -77,7 +77,7 @@ public class ExecuteStep<C extends InputChangesContext> implements Step<C, Resul
                 @Override
                 public Optional<ImmutableSortedMap<String, FileSystemSnapshot>> getPreviouslyProducedOutputs() {
                     return context.getAfterPreviousExecutionState()
-                        .map(AfterPreviousExecutionState::getOutputFilesProducedByWork);
+                        .map(AfterExecutionState::getOutputFilesProducedByWork);
                 }
             };
             UnitOfWork.WorkOutput workOutput = work.execute(executionRequest);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecutionHistoryContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecutionHistoryContext.java
@@ -16,14 +16,20 @@
 
 package org.gradle.internal.execution.steps;
 
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 
 import java.util.Optional;
 
-public interface AfterPreviousExecutionContext extends WorkspaceContext {
+public interface ExecutionHistoryContext extends WorkspaceContext {
     /**
      * Returns the execution state after the previous execution if available.
      * Empty when execution history is not available.
      */
-    Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState();
+    Optional<AfterExecutionState> getAfterPreviousExecutionState();
+
+    /**
+     * Returns the execution state after the last successful execution if available.
+     * Empty when execution history is not available.
+     */
+    Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState();
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/MkDirsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/MkDirsStep.java
@@ -26,12 +26,12 @@ import java.io.File;
 
 import static org.gradle.util.internal.GFileUtils.mkdirs;
 
-public class CreateOutputsStep<C extends WorkspaceContext, R extends Result> implements Step<C, R> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CreateOutputsStep.class);
+public class MkDirsStep<C extends WorkspaceContext, R extends Result> implements Step<C, R> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MkDirsStep.class);
 
     private final Step<? super C, ? extends R> delegate;
 
-    public CreateOutputsStep(Step<? super C, ? extends R> delegate) {
+    public MkDirsStep(Step<? super C, ? extends R> delegate) {
         this.delegate = delegate;
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveCachingStateStep.java
@@ -31,7 +31,7 @@ import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.caching.CachingStateBuilder;
 import org.gradle.internal.execution.caching.impl.DefaultCachingStateBuilder;
 import org.gradle.internal.execution.caching.impl.LoggingCachingStateBuilder;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OverlappingOutputs;
@@ -130,8 +130,13 @@ public class ResolveCachingStateStep implements Step<ValidationFinishedContext, 
             }
 
             @Override
-            public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+            public Optional<AfterExecutionState> getAfterPreviousExecutionState() {
                 return context.getAfterPreviousExecutionState();
+            }
+
+            @Override
+            public Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState() {
+                return context.getAfterLastSuccessfulExecutionState();
             }
 
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveChangesStep.java
@@ -25,7 +25,7 @@ import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.FileValueSupplier;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.InputVisitor;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.changes.DefaultIncrementalInputProperties;
@@ -67,7 +67,7 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
             )
             .orElseGet(() ->
                 beforeExecutionState
-                    .map(beforeExecution -> context.getAfterPreviousExecutionState()
+                    .map(beforeExecution -> context.getAfterLastSuccessfulExecutionState()
                         .map(afterPreviousExecution -> context.getValidationProblems()
                             .map(__ -> rebuildChanges(work, beforeExecution, VALIDATION_FAILED))
                             .orElseGet(() ->
@@ -129,8 +129,13 @@ public class ResolveChangesStep<R extends Result> implements Step<CachingContext
             }
 
             @Override
-            public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+            public Optional<AfterExecutionState> getAfterPreviousExecutionState() {
                 return context.getAfterPreviousExecutionState();
+            }
+
+            @Override
+            public Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState() {
+                return context.getAfterLastSuccessfulExecutionState();
             }
 
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.steps;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges;
@@ -94,8 +94,13 @@ public class ResolveInputChangesStep<C extends IncrementalChangesContext> implem
             }
 
             @Override
-            public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+            public Optional<AfterExecutionState> getAfterPreviousExecutionState() {
                 return context.getAfterPreviousExecutionState();
+            }
+
+            @Override
+            public Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState() {
+                return context.getAfterLastSuccessfulExecutionState();
             }
 
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
@@ -24,12 +24,12 @@ import org.gradle.internal.execution.ExecutionOutcome;
 import org.gradle.internal.execution.ExecutionResult;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.caching.CachingState;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import java.util.Optional;
 
-public class SkipEmptyWorkStep<C extends AfterPreviousExecutionContext> implements Step<C, CachingResult> {
+public class SkipEmptyWorkStep<C extends ExecutionHistoryContext> implements Step<C, CachingResult> {
     private final Step<? super C, ? extends CachingResult> delegate;
 
     public SkipEmptyWorkStep(Step<? super C, ? extends CachingResult> delegate) {
@@ -39,7 +39,7 @@ public class SkipEmptyWorkStep<C extends AfterPreviousExecutionContext> implemen
     @Override
     public CachingResult execute(UnitOfWork work, C context) {
         ImmutableSortedMap<String, FileSystemSnapshot> outputFilesAfterPreviousExecution = context.getAfterPreviousExecutionState()
-            .map(AfterPreviousExecutionState::getOutputFilesProducedByWork)
+            .map(AfterExecutionState::getOutputFilesProducedByWork)
             .orElse(ImmutableSortedMap.of());
         UnitOfWork.Identity identity = context.getIdentity();
         return work.skipIfInputsEmpty(outputFilesAfterPreviousExecution)

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipUpToDateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipUpToDateStep.java
@@ -24,7 +24,7 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.ExecutionOutcome;
 import org.gradle.internal.execution.ExecutionResult;
 import org.gradle.internal.execution.UnitOfWork;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +56,7 @@ public class SkipUpToDateStep<C extends IncrementalChangesContext> implements St
                     LOGGER.info("Skipping {} as it is up-to-date.", work.getDisplayName());
                 }
                 @SuppressWarnings("OptionalGetWithoutIsPresent")
-                AfterPreviousExecutionState afterPreviousExecutionState = context.getAfterPreviousExecutionState().get();
+                AfterExecutionState afterExecutionState = context.getAfterPreviousExecutionState().get();
                 return new UpToDateResult() {
                     @Override
                     public ImmutableList<String> getExecutionReasons() {
@@ -65,12 +65,12 @@ public class SkipUpToDateStep<C extends IncrementalChangesContext> implements St
 
                     @Override
                     public ImmutableSortedMap<String, FileSystemSnapshot> getOutputFilesProduceByWork() {
-                        return afterPreviousExecutionState.getOutputFilesProducedByWork();
+                        return afterExecutionState.getOutputFilesProducedByWork();
                     }
 
                     @Override
                     public Optional<OriginMetadata> getReusedOutputOriginMetadata() {
-                        return Optional.of(afterPreviousExecutionState.getOriginMetadata());
+                        return Optional.of(afterExecutionState.getOriginMetadata());
                     }
 
                     @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.WorkValidationException;
-import org.gradle.internal.execution.history.AfterPreviousExecutionState;
+import org.gradle.internal.execution.history.AfterExecutionState;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
@@ -117,8 +117,13 @@ public class ValidateStep<R extends Result> implements Step<BeforeExecutionConte
             }
 
             @Override
-            public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+            public Optional<AfterExecutionState> getAfterPreviousExecutionState() {
                 return context.getAfterPreviousExecutionState();
+            }
+
+            @Override
+            public Optional<AfterExecutionState> getAfterLastSuccessfulExecutionState() {
+                return context.getAfterLastSuccessfulExecutionState();
             }
 
             @Override

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.execution.OutputSnapshotter
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.fingerprint.InputFingerprinter
 import org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OverlappingOutputDetector
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
@@ -150,18 +150,22 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
     }
 
     def "detects overlapping outputs when instructed"() {
-        def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
+        def afterPreviousExecutionState = Mock(AfterExecutionState)
         def afterPreviousOutputSnapshot = Mock(FileSystemSnapshot)
         def afterPreviousOutputSnapshots = ImmutableSortedMap.of("outputDir", afterPreviousOutputSnapshot)
+        def afterLastSuccessExecutionState = Mock(AfterExecutionState)
         def beforeExecutionOutputSnapshot = Mock(FileSystemSnapshot)
         def beforeExecutionOutputSnapshots = ImmutableSortedMap.of("outputDir", beforeExecutionOutputSnapshot)
 
         when:
         step.execute(work, context)
+
         then:
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
-        1 * afterPreviousExecutionState.inputProperties >> ImmutableSortedMap.of()
         1 * afterPreviousExecutionState.outputFilesProducedByWork >> afterPreviousOutputSnapshots
+
+        _ * context.afterLastSuccessfulExecutionState >> Optional.of(afterLastSuccessExecutionState)
+        1 * afterLastSuccessExecutionState.inputProperties >> ImmutableSortedMap.of()
         _ * outputSnapshotter.snapshotOutputs(work, _) >> beforeExecutionOutputSnapshots
 
         _ * work.overlappingOutputHandling >> DETECT_OVERLAPS

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.steps
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.execution.ExecutionOutcome
 import org.gradle.internal.execution.UnitOfWork
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.changes.InputChangesInternal
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Unroll
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 class ExecuteStepTest extends StepSpec<InputChangesContext> {
     def workspace = Mock(File)
     def previousOutputs = ImmutableSortedMap.of()
-    def afterPreviousExecutionState = Stub(AfterPreviousExecutionState) {
+    def afterPreviousExecutionState = Stub(AfterExecutionState) {
         getOutputFilesProducedByWork() >> previousOutputs
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/MkDirsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/MkDirsStepTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.file.TreeType
 
-class CreateOutputsStepTest extends StepSpec<WorkspaceContext> {
-    def step = new CreateOutputsStep<>(delegate)
+class MkDirsStepTest extends StepSpec<WorkspaceContext> {
+    def step = new MkDirsStep<>(delegate)
 
     @Override
     protected WorkspaceContext createContext() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableSortedMap
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.execution.UnitOfWork.OutputVisitor
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.BeforeExecutionState
 import org.gradle.internal.execution.history.OverlappingOutputs
 import org.gradle.internal.file.TreeType
@@ -31,7 +31,7 @@ import org.junit.Rule
 class RemovePreviousOutputsStepTest extends StepSpec<InputChangesContext> implements SnasphotterFixture {
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
-    def afterPreviousExecution = Mock(AfterPreviousExecutionState)
+    def afterPreviousExecution = Mock(AfterExecutionState)
     def beforeExecutionState = Mock(BeforeExecutionState)
     def delegateResult = Mock(Result)
     def outputChangeListener = Mock(OutputChangeListener)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveChangesStepTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.steps
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.execution.UnitOfWork
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.BeforeExecutionState
 import org.gradle.internal.execution.history.changes.ExecutionStateChangeDetector
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges
@@ -97,7 +97,7 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
     }
 
     def "doesn't provide input file changes when work fails validation"() {
-        def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
+        def afterPreviousExecutionState = Mock(AfterExecutionState)
         when:
         def result = step.execute(work, context)
 
@@ -113,15 +113,15 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
         }
         _ * context.rebuildReason >> Optional.empty()
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
-        _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
+        _ * context.afterLastSuccessfulExecutionState >> Optional.of(afterPreviousExecutionState)
         _ * context.validationProblems >> Optional.of({ ImmutableList.of("Validation problem") } as ValidationFinishedContext.ValidationResult)
         1 * beforeExecutionState.getInputFileProperties() >> ImmutableSortedMap.of()
-        _ * context.afterPreviousExecutionState >> Optional.empty()
+        _ * context.afterLastSuccessfulExecutionState >> Optional.empty()
         0 * _
     }
 
     def "provides input file changes when history is available"() {
-        def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
+        def afterPreviousExecutionState = Mock(AfterExecutionState)
         def changes = Mock(ExecutionStateChanges)
 
         when:
@@ -136,7 +136,7 @@ class ResolveChangesStepTest extends StepSpec<CachingContext> {
         }
         _ * context.rebuildReason >> Optional.empty()
         _ * context.beforeExecutionState >> Optional.of(beforeExecutionState)
-        _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
+        _ * context.afterLastSuccessfulExecutionState >> Optional.of(afterPreviousExecutionState)
         _ * work.inputChangeTrackingStrategy >> UnitOfWork.InputChangeTrackingStrategy.NONE
         1 * changeDetector.detectChanges(afterPreviousExecutionState, beforeExecutionState, work, _) >> changes
         0 * _

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
@@ -18,22 +18,22 @@ package org.gradle.internal.execution.steps
 
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.execution.ExecutionOutcome
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import spock.lang.Unroll
 
-class SkipEmptyWorkStepTest extends StepSpec<AfterPreviousExecutionContext> {
+class SkipEmptyWorkStepTest extends StepSpec<ExecutionHistoryContext> {
     def step = new SkipEmptyWorkStep<>(delegate)
-    def afterPreviousExecutionState = Mock(AfterPreviousExecutionState)
+    def afterPreviousExecutionState = Mock(AfterExecutionState)
 
     def delegateResult = Mock(CachingResult)
     def outputSnapshots = ImmutableSortedMap.<String, FileSystemSnapshot>of()
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
     @Override
-    protected AfterPreviousExecutionContext createContext() {
-        Stub(AfterPreviousExecutionContext)
+    protected ExecutionHistoryContext createContext() {
+        Stub(ExecutionHistoryContext)
     }
 
     def setup() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.Try
 import org.gradle.internal.execution.ExecutionOutcome
 import org.gradle.internal.execution.ExecutionResult
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
+import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges
 import org.gradle.internal.snapshot.FileSystemSnapshot
 
@@ -44,7 +44,7 @@ class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
 
         _ * context.changes >> Optional.of(changes)
         1 * changes.allChangeMessages >> ImmutableList.of()
-        _ * context.afterPreviousExecutionState >> Optional.of(Mock(AfterPreviousExecutionState))
+        _ * context.afterPreviousExecutionState >> Optional.of(Mock(AfterExecutionState))
         0 * _
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CacheProjectIntegrationTest.groovy
@@ -58,7 +58,7 @@ class CacheProjectIntegrationTest extends AbstractIntegrationTest {
         userHomeDir = executer.gradleUserHomeDir
         buildFile = projectDir.file('build.gradle')
 
-        artifactsCache = projectDir.file(".gradle/$version/executionHistory/executionHistory.bin")
+        artifactsCache = projectDir.file(".gradle/$version/executionHistory/lastExecution.bin")
 
         repo = new MavenHttpRepository(server, mavenRepo)
 


### PR DESCRIPTION
This allows incremental tasks to continue incrementally even if one or many previous builds failed.
This is achieved by remembering the last successful build along with its cache key and restoring
that build's outputs from the build cache before running the incremental action. If the output can't
be restored (e.g. it's no longer in the cache), we fall back to full execution as we did before.

<!--- The issue this PR addresses -->
Fixes #13766
Fixes https://github.com/gradle/gradle-native/issues/320
Fixes #14133
Fixes #13601

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
