### PR TITLE
Let config cache support circular `writeReplace` methods

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -203,13 +203,8 @@ class JavaObjectSerializationCodec : EncodingProducer, Decoding {
         override suspend fun WriteContext.encode(value: Any) {
             encodePreservingIdentityOf(value) {
                 val replacement = writeReplace.invoke(value)
-                if (replacement === value) {
-                    writeEnum(Format.ReadResolve)
-                    encodeBean(value)
-                } else {
-                    writeEnum(Format.WriteReplace)
-                    write(replacement)
-                }
+                writeEnum(Format.ReadResolve)
+                encodeBean(replacement)
             }
         }
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -129,10 +129,6 @@ class JavaObjectSerializationCodec : EncodingProducer, Decoding {
                         }
                     }
                 }
-                Format.WriteReplace -> {
-                    readResolve(readNonNull())
-                        .also { putIdentity(id, it) }
-                }
                 Format.ReadResolve -> {
                     readResolve(decodeBean())
                         .also { putIdentity(id, it) }
@@ -221,7 +217,6 @@ class JavaObjectSerializationCodec : EncodingProducer, Decoding {
 
     private
     enum class Format {
-        WriteReplace,
         ReadResolve,
         WriteObject,
         ReadObject,

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/JavaObjectSerializationCodecTest.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache.serialization.codecs
 
+import com.google.common.reflect.TypeToken
 import com.nhaarman.mockitokotlin2.mock
 import org.gradle.api.Project
 import org.gradle.configurationcache.extensions.uncheckedCast
@@ -268,6 +269,21 @@ class JavaObjectSerializationCodecTest : AbstractUserTypeCodecTest() {
                 "it allows writeReplace to initialize the object",
                 first.value,
                 equalTo("42")
+            )
+        }
+    }
+
+    @Test
+    fun `can handle circular writeReplace`() {
+        verifyRoundtripOf({ pairOf(TypeToken.of(String::class.java)) }) { (first, second) ->
+            assertThat(
+                "it preserves identity",
+                first,
+                sameInstance(second)
+            )
+            assertThat(
+                first,
+                equalTo(TypeToken.of(String::class.java))
             )
         }
     }


### PR DESCRIPTION
A `writeReplace` implementation is free to return a new object of the same type (or a derived type) like `TypeToken` does.