### PR TITLE
Prevent start script code execution in env vars using JAVA_TOOL_OPTIONS

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -311,7 +311,7 @@ installDist.destinationDir = buildDir
 
         File generatedLinuxStartScript = file("build/scripts/application")
         generatedLinuxStartScript.exists()
-        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 185)
+        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 188)
         assertLineSeparators(generatedLinuxStartScript, TextUtil.windowsLineSeparator, 1)
 
         file("build/scripts/application").exists()

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -68,7 +68,7 @@ class Main {
         if (OperatingSystem.current().windows) {
             builder.environment('APPLICATION_OPTS', '-DtestValue=value -DtestValue2="some value" -DtestValue3="some value"')
         } else {
-            builder.environment('APPLICATION_OPTS', '-DtestValue=value -DtestValue2=\'some value\' -DtestValue3=some\\ value')
+            builder.environment('APPLICATION_OPTS', '-DtestValue=value -DtestValue2=\'some value\' -DtestValue3=\'some value\'')
         }
 
         def result = builder.run()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.plugins
 
-import groovy.test.NotYetImplemented
+
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.internal.jvm.Jvm
@@ -699,7 +699,6 @@ rootProject.name = 'sample'
         executed(':compileJava', ':processResources', ':classes', ':jar', ':run')
     }
 
-    @NotYetImplemented
     @Issue("https://github.com/gradle/gradle-private/issues/3386")
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
     def "does not execute code in user-set environment variable"() {
@@ -720,10 +719,12 @@ rootProject.name = 'sample'
                 environment ${envVar}: '`\$(touch "${exploit.absolutePath}")`'
             }
         """
-        succeeds('execStartScript')
+        fails('execStartScript')
 
         then:
-        outputContains('Hello World!')
+        errorOutput.contains("Unrecognized option: `\$(touch")
+        errorOutput.contains("Execution failed for task ':execStartScript'")
+        //!errorOutput.contains("Picked up JAVA_TOOL_OPTIONS:")
         !exploit.exists()
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -725,6 +725,7 @@ rootProject.name = 'sample'
         errorOutput.contains("Unrecognized option: `\$(touch")
         errorOutput.contains("Execution failed for task ':execStartScript'")
         //!errorOutput.contains("Picked up JAVA_TOOL_OPTIONS:")
+        //!output.contains("Picked up JAVA_TOOL_OPTIONS:")
         !exploit.exists()
 
         where:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -702,7 +702,7 @@ rootProject.name = 'sample'
     @NotYetImplemented
     @Issue("https://github.com/gradle/gradle-private/issues/3386")
     @Requires(TestPrecondition.UNIX_DERIVATIVE)
-    def "does not execute code in environment variables"() {
+    def "does not execute code in user-set environment variable"() {
         when:
         succeeds('installDist')
 
@@ -717,7 +717,7 @@ rootProject.name = 'sample'
             task execStartScript(type: Exec) {
                 workingDir 'build/install/sample/bin'
                 commandLine './sample'
-                environment JAVA_OPTS: '`\$(touch "${exploit.absolutePath}")`'
+                environment ${envVar}: '`\$(touch "${exploit.absolutePath}")`'
             }
         """
         succeeds('execStartScript')
@@ -725,5 +725,8 @@ rootProject.name = 'sample'
         then:
         outputContains('Hello World!')
         !exploit.exists()
+
+        where:
+        envVar << ["JAVA_OPTS", "SAMPLE_OPTS"]
     }
 }

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -182,4 +182,7 @@ APP_ARGS=`save "\$@"`
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- \$DEFAULT_JVM_OPTS <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
 
-JAVA_TOOL_OPTIONS="\$JAVA_OPTS \$${optsEnvironmentVar}" exec "\$JAVACMD" "\$@"
+case "\${JAVA_OPTS}\${${optsEnvironmentVar}}" in
+    *\\ * ) JAVA_TOOL_OPTIONS="\$JAVA_OPTS \$${optsEnvironmentVar}" exec "\$JAVACMD" "\$@" ;;
+    * ) exec "\$JAVACMD" \$JAVA_OPTS \$${optsEnvironmentVar} "\$@" ;;
+esac

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -180,6 +180,6 @@ save () {
 APP_ARGS=`save "\$@"`
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
-eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
+eval set -- \$DEFAULT_JVM_OPTS <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
 
-exec "\$JAVACMD" "\$@"
+JAVA_TOOL_OPTIONS="\$JAVA_OPTS \$${optsEnvironmentVar}" exec "\$JAVACMD" "\$@"

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.unixLineSeparator).length == 185
+        destination.toString().split(TextUtil.unixLineSeparator).length == 188
     }
 
     def "defaultJvmOpts is expanded properly in unix script"() {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-private/issues/3386

Start scripts generated by the `application` plugin accept two environment variables from the user - `JAVA_OPTS` and `<APP_NAME>_OPTS` whose values get passed to the java process that runs the application jar.

Those variables can have argument lists, delimited by spaces:
```
APP_OPTS="-Dfoo=bar -Dfizz=buzz"
```
 and the arguments themselves might contain spaces that are either quoted or escaped:
```
APP_OPTS="-DtestValue=value -DtestValue2='some value'"
```
To support the latter case, the generated start scripts use `eval set -- $APP_OPTS` that correctly tokenizes the quoted arguments and in the above case sets the two separate positional arguments with values `-DtestValue=value`, `-DtestValue2=some value` respectively.
The problem with the above is that eval will also interpret and execute any code passed in that environment variable.

This change attempts to patch the possibility to inject and execute code this way by concatenating the `JAVA_OPTS` and `<APP_NAME>_OPTS` variables into [JAVA_TOOL_OPTIONS](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html) variable.
Because this causes all the arguments passed this way to be [logged to stderr](https://stackoverflow.com/questions/11683715/suppressing-the-picked-up-java-options-message), this workaround is applied only when the said environment variables contain spaces. Otherwise, they can be passed to the java command as-is, without having to go through eval.

This change keeps the start scripts POSIX compliant.