### PR TITLE
Enable the test distribution runner only when requested

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -273,7 +273,10 @@ fun removeTeamcityTempProperty() {
     }
 }
 
-fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name)
+fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
+
+val isExperimentalTestFilteringEnabled
+    get() = System.getProperty("gradle.internal.testselection.enabled").toBoolean()
 
 val Project.maxParallelForks: Int
     get() = if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") {


### PR DESCRIPTION
We should use the test distribution runner only when test selection or test distribution with remote agents is used. This way, we still dogfood Gradle's built-in test runner.