### PR TITLE
fix: improve detection of msys2/mingw in startup and wrapper scripts

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -19,6 +19,7 @@ We would like to thank the following community members for their contributions t
 [Anuraag Agrawal](https://github.com/anuraaga),
 [Florian Schmitt](https://github.com/florianschmitt),
 [Evgeny Mandrikov](https://github.com/Godin),
+[Ievgenii Shepeliuk](https://github.com/eshepelyuk),
 [Sverre Moe](https://github.com/DJViking).
 
 ## Upgrade Instructions

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -72,7 +72,7 @@ case "`uname`" in
   Darwin* )
     darwin=true
     ;;
-  MINGW* )
+  MSYS* | MINGW* )
     msys=true
     ;;
   NONSTOP* )


### PR DESCRIPTION
### Context

While running Gradle on Windows under Msys2 / MinGW  bash shell - the special path handling is required.
Gradle startup and Gradle wrapper bash scripts are using command `uname` to detect environment.

Recently `msys2` shell started to produce different output for `uname` command, e.g. 
```
$ uname
MSYS_NT-10.0-19042
```

This completely breaks Gradle usage, since startup and wrapper scripts are producing following error.

```
$ ./gradlew --version
Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain
```

As far as I see - this bug affects all the versions of Gradle, personally tested on : 6.6.x, 6.8.x, 7.0.x.
Unfortunately I can't provide the date when exactly Msys2 introduced this new behavior, 2-3 months ago it worked fine. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~ **Unable to find Msys2/MinGW specific tests**
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~ **Unable to find Msys2/MinGW specific tests**
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~ **no public changes**
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
