### PR TITLE
Enhance the Java version metadata available for toolchains

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
@@ -79,9 +79,11 @@ public class DefaultJvmMetadataDetector implements JvmMetadataDetector {
         } catch (IllegalArgumentException e) {
             return failure(javaHome, "Cannot parse version number: " + implementationVersion);
         }
+        String runtimeVersion = metadata.get(ProbedSystemProperty.RUNTIME_VERSION);
+        String jvmVersion = metadata.get(ProbedSystemProperty.VM_VERSION);
         String vendor = metadata.get(ProbedSystemProperty.VENDOR);
         String implementationName = metadata.get(ProbedSystemProperty.VM);
-        return JvmInstallationMetadata.from(javaHome, implementationVersion, vendor, implementationName);
+        return JvmInstallationMetadata.from(javaHome, implementationVersion, runtimeVersion, jvmVersion, vendor, implementationName);
     }
 
     private JvmInstallationMetadata getMetadataFromInstallation(File jdkPath) {

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -34,8 +34,8 @@ public interface JvmInstallationMetadata {
         JAVA_COMPILER, J9_VIRTUAL_MACHINE
     }
 
-    static DefaultJvmInstallationMetadata from(File javaHome, String implementationVersion, String vendor, String implementationName) {
-        return new DefaultJvmInstallationMetadata(javaHome, implementationVersion, vendor, implementationName);
+    static DefaultJvmInstallationMetadata from(File javaHome, String implementationVersion, String runtimeVersion, String jvmVersion, String vendor, String implementationName) {
+        return new DefaultJvmInstallationMetadata(javaHome, implementationVersion, runtimeVersion, jvmVersion, vendor, implementationName);
     }
 
     static JvmInstallationMetadata failure(File javaHome, String errorMessage) {
@@ -49,6 +49,10 @@ public interface JvmInstallationMetadata {
     JavaVersion getLanguageVersion();
 
     String getImplementationVersion();
+
+    String getRuntimeVersion();
+
+    String getJvmVersion();
 
     JvmVendor getVendor();
 
@@ -71,12 +75,16 @@ public interface JvmInstallationMetadata {
         private final String implementationName;
         private final Path javaHome;
         private final String implementationVersion;
+        private final String runtimeVersion;
+        private final String jvmVersion;
         private final Supplier<Set<JavaInstallationCapability>> capabilities = Suppliers.memoize(this::gatherCapabilities);
 
-        private DefaultJvmInstallationMetadata(File javaHome, String implementationVersion, String vendor, String implementationName) {
+        private DefaultJvmInstallationMetadata(File javaHome, String implementationVersion, String runtimeVersion, String jvmVersion, String vendor, String implementationName) {
             this.javaHome = javaHome.toPath();
             this.implementationVersion = implementationVersion;
             this.languageVersion = JavaVersion.toVersion(implementationVersion);
+            this.runtimeVersion = runtimeVersion;
+            this.jvmVersion = jvmVersion;
             this.vendor = vendor;
             this.implementationName = implementationName;
         }
@@ -89,6 +97,16 @@ public interface JvmInstallationMetadata {
         @Override
         public String getImplementationVersion() {
             return implementationVersion;
+        }
+
+        @Override
+        public String getRuntimeVersion() {
+            return runtimeVersion;
+        }
+
+        @Override
+        public String getJvmVersion() {
+            return jvmVersion;
         }
 
         @Override
@@ -182,6 +200,16 @@ public interface JvmInstallationMetadata {
 
         @Override
         public String getImplementationVersion() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getRuntimeVersion() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getJvmVersion() {
             throw unsupportedOperation();
         }
 

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/ProbedSystemProperty.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/ProbedSystemProperty.java
@@ -25,6 +25,7 @@ enum ProbedSystemProperty {
     VM("java.vm.name"),
     VM_VERSION("java.vm.version"),
     RUNTIME("java.runtime.name"),
+    RUNTIME_VERSION("java.runtime.version"),
     Z_ERROR("Internal"); // This line MUST be last!
 
     private final String key;

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
@@ -163,6 +163,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         assertIsUnsupported({ metadata.languageVersion })
         assertIsUnsupported({ metadata.vendor })
         assertIsUnsupported({ metadata.implementationVersion })
+        assertIsUnsupported({ metadata.runtimeVersion })
+        assertIsUnsupported({ metadata.jvmVersion })
 
         where:
         jdk                                   | systemProperties | exists | errorMessage
@@ -191,13 +193,14 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
-         'java.runtime.name': "Java(TM) SE Runtime Environment"
+         'java.runtime.name': "Java(TM) SE Runtime Environment",
+         'java.runtime.version': "bad luck"
         ]
     }
 
 
     private static Map<String, String> currentGradle() {
-        ['java.home', 'java.version', 'java.vendor', 'os.arch', 'java.vm.name', 'java.vm.version', 'java.runtime.name'].collectEntries { [it, System.getProperty(it)] }
+        ['java.home', 'java.version', 'java.vendor', 'os.arch', 'java.vm.name', 'java.vm.version', 'java.runtime.name', 'java.runtime.version'].collectEntries { [it, System.getProperty(it)] }
     }
 
     private static Map<String, String> openJdkJvm(String version) {
@@ -207,7 +210,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
-         'java.runtime.name': "Java(TM) SE Runtime Environment"
+         'java.runtime.name': "Java(TM) SE Runtime Environment",
+         'java.runtime.version': "1.${version}.0-b08"
         ]
     }
 
@@ -218,7 +222,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "${version}+7",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}+7"
         ]
     }
 
@@ -229,7 +234,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "Eclipse OpenJ9 VM",
          'java.vm.version': "openj9-0.21.0",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}+7"
         ]
     }
 
@@ -240,7 +246,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64\r",
          'java.vm.name': "OpenJDK 64-Bit Server VM\r",
          'java.vm.version': "${version}+7\r",
-         'java.runtime.name': "OpenJDK Runtime Environment\r"
+         'java.runtime.name': "OpenJDK Runtime Environment\r",
+         'java.runtime.version': "${version}+7\r"
         ]
     }
 
@@ -251,7 +258,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "Java HotSpot(TM) 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
-         'java.runtime.name': "Java(TM) SE Runtime Environment"
+         'java.runtime.name': "Java(TM) SE Runtime Environment",
+         'java.runtime.version': "1.${version}.0-b08"
         ]
     }
 
@@ -262,7 +270,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "IBM J9 VM",
          'java.vm.version': "2.4",
-         'java.runtime.name': "Java(TM) SE Runtime Environment"
+         'java.runtime.name': "Java(TM) SE Runtime Environment",
+         'java.runtime.version': "1.${version}.0-b08"
         ]
     }
 
@@ -273,7 +282,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.66-b17",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "1.${version}.0_66-b08"
         ]
     }
 
@@ -284,7 +294,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "ia64",
          'java.vm.name': "Java HotSpot(TM) 64-Bit Server VM",
          'java.vm.version': "25.66-b17",
-         'java.runtime.name': "Java(TM) SE Runtime Environment"
+         'java.runtime.name': "Java(TM) SE Runtime Environment",
+         'java.runtime.version': "1.${version}.0_66-b08"
         ]
     }
 
@@ -295,7 +306,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "13.0.2+8-sapmachine",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}.0.2-b08"
         ]
     }
 
@@ -306,7 +318,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "11.0.8+10-LTS",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}.0.8+10-LTS"
         ]
     }
 
@@ -317,7 +330,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "${version}+36",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}+36"
         ]
     }
 
@@ -328,7 +342,8 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit GraalVM CE 19.3.5",
          'java.vm.version': "25.282-b07-jvmci-19.3-b21",
-         'java.runtime.name': "OpenJDK Runtime Environment"
+         'java.runtime.name': "OpenJDK Runtime Environment",
+         'java.runtime.version': "${version}-b08"
         ]
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
@@ -40,14 +40,24 @@ public interface JavaInstallationMetadata {
     JavaLanguageVersion getLanguageVersion();
 
     /**
-     * Returns the full Java version of the JVM, as specified in its {@code java.version} property.
+     * Returns the full Java version (including the build number) of the JVM, as specified in its {@code java.runtime.version} property.
      *
      * @return the full Java version of the JVM
      * @since 7.1
      */
     @Internal
     @Incubating
-    String getJavaVersion();
+    String getJavaRuntimeVersion();
+
+    /**
+     * Returns the version of the JVM, as specified in its {@code java.vm.version} property.
+     *
+     * @return the version of the JVM
+     * @since 7.1
+     */
+    @Internal
+    @Incubating
+    String getJvmVersion();
 
     /**
      * Returns a human-readable string for the vendor of the JVM.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -80,8 +80,13 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
 
     @Internal
     @Override
-    public String getJavaVersion() {
-        return metadata.getImplementationVersion();
+    public String getJavaRuntimeVersion() {
+        return metadata.getRuntimeVersion();
+    }
+
+    @Override
+    public String getJvmVersion() {
+        return metadata.getJvmVersion();
     }
 
     @Internal

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/task/ToolchainReportRenderer.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/task/ToolchainReportRenderer.java
@@ -34,7 +34,7 @@ public class ToolchainReportRenderer extends TextReportRenderer {
         StyledTextOutput output = getTextOutput();
         JvmInstallationMetadata metadata = toolchain.metadata;
         String displayName = metadata.getDisplayName();
-        output.withStyle(Identifier).println(" + " + displayName + " " + metadata.getImplementationVersion());
+        output.withStyle(Identifier).println(" + " + displayName + " " + metadata.getRuntimeVersion());
         printAttribute("Location", metadata.getJavaHome().toString());
         printAttribute("Language Version", metadata.getLanguageVersion().getMajorVersion());
         printAttribute("Vendor", metadata.getVendor().getDisplayName());

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
@@ -26,7 +26,7 @@ class JavaToolchainTest extends Specification {
     def "java version is reported as specified in metadata"() {
         given:
         def javaHome = new File("/jvm/$implementationVersion").absoluteFile
-        def metadata = JvmInstallationMetadata.from(javaHome, implementationVersion, "vendor", "implName")
+        def metadata = JvmInstallationMetadata.from(javaHome, implementationVersion, runtimeVersion, jvmVersion, "vendor", "implName")
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
 
@@ -37,13 +37,14 @@ class JavaToolchainTest extends Specification {
             getImplementation() >> JvmImplementation.VENDOR_SPECIFIC.toString()
         })
         then:
-        javaToolchain.javaVersion == implementationVersion
         javaToolchain.languageVersion.asInt() == languageVersion
+        javaToolchain.javaRuntimeVersion == runtimeVersion
+        javaToolchain.jvmVersion == jvmVersion
 
         where:
-        implementationVersion | languageVersion
-        "1.8.0_292"           | 8
-        "11.0.11"             | 11
-        "16"                  | 16
+        implementationVersion | runtimeVersion  | jvmVersion   | languageVersion
+        "1.8.0_292"           | "1.8.0_292-b10" | "25.292-b10" | 8
+        "11.0.11"             | "11.0.9+11"     | "11.0.9+11"  | 11
+        "16"                  | "16+36"         | "16+36"      | 16
     }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
@@ -54,11 +54,11 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         given:
         task.installationRegistry.listInstallations() >>
             [jdk14, jdk15, jdk9, jdk8, jdk82].collect {new InstallationLocation(it, "TestSource")}
-        detector.getMetadata(jdk14) >> metadata("14")
-        detector.getMetadata(jdk15) >> metadata("15-ea")
-        detector.getMetadata(jdk9) >> metadata("9")
-        detector.getMetadata(jdk8) >> metadata("1.8.0_202")
-        detector.getMetadata(jdk82) >> metadata("1.8.0_404")
+        detector.getMetadata(jdk14) >> metadata("14", "+2")
+        detector.getMetadata(jdk15) >> metadata("15-ea", "+2")
+        detector.getMetadata(jdk9) >> metadata("9", "+2")
+        detector.getMetadata(jdk8) >> metadata("1.8.0_202", "-b01")
+        detector.getMetadata(jdk82) >> metadata("1.8.0_404", "-b01")
 
         when:
         task.showToolchains()
@@ -69,35 +69,35 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
      | Auto-detection:     {description}Enabled{normal}
      | Auto-download:      {description}Enabled{normal}
 
-{identifier} + AdoptOpenJDK JRE 1.8.0_202{normal}
+{identifier} + AdoptOpenJDK JRE 1.8.0_202-b01{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}8{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
      | Is JDK:             {description}false{normal}
      | Detected by:        {description}TestSource{normal}
 
-{identifier} + AdoptOpenJDK JRE 1.8.0_404{normal}
+{identifier} + AdoptOpenJDK JRE 1.8.0_404-b01{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}8{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
      | Is JDK:             {description}false{normal}
      | Detected by:        {description}TestSource{normal}
 
-{identifier} + AdoptOpenJDK JRE 9{normal}
+{identifier} + AdoptOpenJDK JRE 9+2{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}9{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
      | Is JDK:             {description}false{normal}
      | Detected by:        {description}TestSource{normal}
 
-{identifier} + AdoptOpenJDK JRE 14{normal}
+{identifier} + AdoptOpenJDK JRE 14+2{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}14{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
      | Is JDK:             {description}false{normal}
      | Detected by:        {description}TestSource{normal}
 
-{identifier} + AdoptOpenJDK JRE 15-ea{normal}
+{identifier} + AdoptOpenJDK JRE 15-ea+2{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}15{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
@@ -115,7 +115,7 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
         given:
         task.installationRegistry.listInstallations() >>
             [jdk14, invalid, noSuchDirectory].collect {new InstallationLocation(it, "TestSource")}
-        detector.getMetadata(jdk14) >> metadata("14")
+        detector.getMetadata(jdk14) >> metadata("14", "+1")
         detector.getMetadata(invalid) >> newInvalidMetadata()
         detector.getMetadata(noSuchDirectory) >> newInvalidMetadata()
 
@@ -128,7 +128,7 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
      | Auto-detection:     {description}Enabled{normal}
      | Auto-download:      {description}Enabled{normal}
 
-{identifier} + AdoptOpenJDK JRE 14{normal}
+{identifier} + AdoptOpenJDK JRE 14+1{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}14{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
@@ -188,8 +188,10 @@ class ShowToolchainsTaskTest extends AbstractProjectBuilderSpec {
 """
     }
 
-    JvmInstallationMetadata metadata(String implVersion) {
-        return JvmInstallationMetadata.from(new File("path"), implVersion, "adoptopenjdk", "")
+    JvmInstallationMetadata metadata(String implVersion, String build) {
+        def runtimeVersion = implVersion + build
+        def jvmVersion = runtimeVersion + "-vm"
+        return JvmInstallationMetadata.from(new File("path"), implVersion, runtimeVersion, jvmVersion, "adoptopenjdk", "")
     }
 
     JvmInstallationMetadata newInvalidMetadata() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
@@ -38,12 +38,14 @@ class ToolchainReportRendererTest extends Specification {
         def metadata = JvmInstallationMetadata.from(
             new File("path"),
             "1.8.0",
+            "1.8.0-b01",
+            "25.292-b01",
             "vendorName",
             "")
         installation.source >> "SourceSupplier"
 
         expect:
-        assertOutput(metadata, """{identifier} + vendorName JRE 1.8.0{normal}
+        assertOutput(metadata, """{identifier} + vendorName JRE 1.8.0-b01{normal}
      | Location:           {description}path{normal}
      | Language Version:   {description}8{normal}
      | Vendor:             {description}vendorName{normal}
@@ -59,6 +61,8 @@ class ToolchainReportRendererTest extends Specification {
         def metadata = JvmInstallationMetadata.from(
             javaHome,
             "1.8.0",
+            "1.8.0-b01",
+            "25.292-b01",
             "adoptopenjdk",
             "")
         installation.source >> "SourceSupplier"
@@ -70,7 +74,7 @@ class ToolchainReportRendererTest extends Specification {
         }
 
         expect:
-        assertOutput(metadata, """{identifier} + AdoptOpenJDK 1.8.0{normal}
+        assertOutput(metadata, """{identifier} + AdoptOpenJDK 1.8.0-b01{normal}
      | Location:           {description}$javaHome{normal}
      | Language Version:   {description}8{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}


### PR DESCRIPTION
The `java.version` property might not be unique enough to identify
a toolchain. It is replaced with `java.runtime.version` which includes
a build number (it is useful for EA releases). The `java.vm.version` is
also made available so it is possible to report usages of non-Hotspot
VMs like J9 or GraalVM.

Fixes #17085

I've tried to remove JvmInstallationMetadata.implementationVersion altogether but it seems that there is a place where JvmInstallationMetadata.implementationVersion is used and cannot be easily replaced with runtimeVersion: https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/internal/jvm/Jvm.java#L294
This codepath is only used in integration tests and I suspect that it can be removed because Java 5 is no longer supported, but I'd prefer to submit another PR to deal with deletion. This PR is to make public API right before 7.1 branch point.