### PR TITLE
Move breaking changes section to the top of 7.1 upgrade guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -36,81 +36,6 @@ Some plugins will break with this new version of Gradle, for example because the
 [[changes_7.1]]
 == Upgrading from 7.0 and earlier
 
-=== Deprecations
-
-[[convention_mapping]]
-==== Using convention mapping with properties with type Provider is deprecated
-Convention mapping is an internal feature that is been replaced by the <<lazy_configuration#lazy_configuration,Provider API>>.
-When mixing convention mapping with the Provider API, unexpected behavior can occur.
-Gradle emits a deprecation warning when a property in a task, extension or other domain object uses convention mapping with the Provider API.
-
-To fix this, the plugin that configures the convention mapping for the task, extension or domain object needs to be changed to use the Provider API only.
-
-[[jacoco_merge]]
-==== JacocoMerge task type is deprecated
-
-The `JacocoMerge` task was used for merging coverage reports from different subprojects into a single report.
-The same functionality is also available on the `JacocoReport` task.
-Because of the duplication, `JacocoMerge` is now deprecated and scheduled for removal in Gradle 8.0.
-
-[[configuring_custom_build_layout]]
-==== Setting custom build layout
-
-Command line options:
-
-* `-c`, `--settings-file` for specifying a custom settings file location
-* `-b`, `--build-file` for specifying a custom build file location
-
-have been deprecated.
-
-Setting custom build file using
-link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html#org.gradle.api.tasks.GradleBuild:buildFile[buildFile]
-property in link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html[GradleBuild] task has been deprecated.
-
-Please use the link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html#org.gradle.api.tasks.GradleBuild:dir[dir]
-property instead to specify the root of the nested build.
-Alternatively, consider using one of the recommended alternatives for
-link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html[GradleBuild] task as suggested in
-<<authoring_maintainable_build_scripts#sec:avoiding_use_of_gradlebuild, Avoid using the GradleBuild task type>> section.
-
-Setting custom build layout using
-link:{groovyDslPath}/org.gradle.StartParameter.html[StartParameter] methods
-link:{groovyDslPath}/org.gradle.StartParameter.html#setBuildFile-java.io.File-[setBuildFile(File)]
-and
-link:{groovyDslPath}/org.gradle.StartParameter.html#setSettingsFile-java.io.File-[setSettingsFile(File)]
-as well as the counterpart getters
-link:{groovyDslPath}/org.gradle.StartParameter.html#getBuildFile--[getBuildFile()]
-and
-link:{groovyDslPath}/org.gradle.StartParameter.html#getSettingsFile--[getSettingsFile()]
-have been deprecated.
-
-Please use standard locations for settings and build files:
-
-* settings file in the root of the build
-* build file in the root of each subproject
-
-For the use case where custom settings or build files are used to model different behavior (similar to Maven profiles),
-consider using <<build_environment#sec:gradle_system_properties, system properties>> with conditional logic.
-For example, given a piece of code in either settings or build file:
-```
-if (System.getProperty("profile") == "custom") {
-    println("custom profile")
-} else {
-    println("default profile")
-}
-```
-You can pass the `profile` system property to Gradle using `gradle -Dprofile=custom` to execute the code in the `custom` profile branch.
-
-[[dependency_substitutions_with]]
-=== Substitution.with replaced with Substitution.using
-
-<<resolution_rules#sec:dependency_substitution_rules, Dependency substitutions>> using `with` method have been deprecated
-and are replaced with `using` method that also allows chaining.
-For example, a dependency substitution rule `substitute(project(':a')).with(project(':b'))` should be replaced with
-`substitute(project(':a')).using(project(':b'))`.
-With chaining you can, for example, add a reason for a substitution like this:
-`substitute(project(':a')).using(project(':b')).because("a reason")`.
-
 === Potential breaking changes
 
 ==== Updates to default tool integration versions
@@ -201,6 +126,82 @@ However, the return type of the groovy block has changed to the extension type. 
  }
 ```
 
+
+=== Deprecations
+
+[[convention_mapping]]
+==== Using convention mapping with properties with type Provider is deprecated
+Convention mapping is an internal feature that is been replaced by the <<lazy_configuration#lazy_configuration,Provider API>>.
+When mixing convention mapping with the Provider API, unexpected behavior can occur.
+Gradle emits a deprecation warning when a property in a task, extension or other domain object uses convention mapping with the Provider API.
+
+To fix this, the plugin that configures the convention mapping for the task, extension or domain object needs to be changed to use the Provider API only.
+
+[[jacoco_merge]]
+==== JacocoMerge task type is deprecated
+
+The `JacocoMerge` task was used for merging coverage reports from different subprojects into a single report.
+The same functionality is also available on the `JacocoReport` task.
+Because of the duplication, `JacocoMerge` is now deprecated and scheduled for removal in Gradle 8.0.
+
+[[configuring_custom_build_layout]]
+==== Setting custom build layout
+
+Command line options:
+
+* `-c`, `--settings-file` for specifying a custom settings file location
+* `-b`, `--build-file` for specifying a custom build file location
+
+have been deprecated.
+
+Setting custom build file using
+link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html#org.gradle.api.tasks.GradleBuild:buildFile[buildFile]
+property in link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html[GradleBuild] task has been deprecated.
+
+Please use the link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html#org.gradle.api.tasks.GradleBuild:dir[dir]
+property instead to specify the root of the nested build.
+Alternatively, consider using one of the recommended alternatives for
+link:{groovyDslPath}/org.gradle.api.tasks.GradleBuild.html[GradleBuild] task as suggested in
+<<authoring_maintainable_build_scripts#sec:avoiding_use_of_gradlebuild, Avoid using the GradleBuild task type>> section.
+
+Setting custom build layout using
+link:{groovyDslPath}/org.gradle.StartParameter.html[StartParameter] methods
+link:{groovyDslPath}/org.gradle.StartParameter.html#setBuildFile-java.io.File-[setBuildFile(File)]
+and
+link:{groovyDslPath}/org.gradle.StartParameter.html#setSettingsFile-java.io.File-[setSettingsFile(File)]
+as well as the counterpart getters
+link:{groovyDslPath}/org.gradle.StartParameter.html#getBuildFile--[getBuildFile()]
+and
+link:{groovyDslPath}/org.gradle.StartParameter.html#getSettingsFile--[getSettingsFile()]
+have been deprecated.
+
+Please use standard locations for settings and build files:
+
+* settings file in the root of the build
+* build file in the root of each subproject
+
+For the use case where custom settings or build files are used to model different behavior (similar to Maven profiles),
+consider using <<build_environment#sec:gradle_system_properties, system properties>> with conditional logic.
+For example, given a piece of code in either settings or build file:
+```
+if (System.getProperty("profile") == "custom") {
+    println("custom profile")
+} else {
+    println("default profile")
+}
+```
+You can pass the `profile` system property to Gradle using `gradle -Dprofile=custom` to execute the code in the `custom` profile branch.
+
+[[dependency_substitutions_with]]
+==== Substitution.with replaced with Substitution.using
+
+<<resolution_rules#sec:dependency_substitution_rules, Dependency substitutions>> using `with` method have been deprecated
+and are replaced with `using` method that also allows chaining.
+For example, a dependency substitution rule `substitute(project(':a')).with(project(':b'))` should be replaced with
+`substitute(project(':a')).using(project(':b'))`.
+With chaining you can, for example, add a reason for a substitution like this:
+`substitute(project(':a')).using(project(':b')).because("a reason")`.
+
 [[java_exec_properties]]
 ==== Properties deprecated in JavaExec task
 
@@ -209,7 +210,7 @@ in link:{groovyDslPath}/org.gradle.api.tasks.JavaExec.html[JavaExec] task have b
 Use the link:{groovyDslPath}/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:mainClass[mainClass] property instead.
 
 [[compile_task_wiring]]
-=== Deprecated properties in `compile` task
+==== Deprecated properties in `compile` task
 
 * The link:{groovyDslPath}/org.gradle.api.tasks.compile.JavaCompile.html#org.gradle.api.tasks.compile.JavaCompile:destinationDir[JavaCompile.destinationDir]
 property has been deprecated.
@@ -225,7 +226,7 @@ Use the link:{groovyDslPath}/org.gradle.api.tasks.scala.ScalaCompile.html#org.gr
 property instead.
 
 [[deprecated_flat_project_structure]]
-=== Deprecated flat project structure
+==== Deprecated flat project structure
 
 There are several disadvantages of using a flat project structure. One example being that Gradle link:https://github.com/gradle/gradle/issues/13891[file-system watching cannot be efficiently used].
 Because of this, Gradle 7.1 deprecates all layouts that define subprojects outside of a root project directory.
@@ -234,7 +235,7 @@ To make this change more visible for plugin author, Gradle 7.1 also deprecates t
 link:{groovyDslPath}/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:includeFlat(java.lang.String&#91;&#93;)[Settings.includeFlat()] method.
 
 [[upload_task_deprecation]]
-=== Deprecated `Upload` task
+==== Deprecated `Upload` task
 
 Gradle used to have two ways of publishing artifacts.
 Now, the situation has been cleared and all build should use the `maven-publish` plugin.
@@ -255,7 +256,7 @@ Plugin authors migrate to extensions if they replicate the changes we've done in
 - Migrate custom source sets: link:https://github.com/gradle/gradle/pull/17149/files#diff-e159587e2f9aec398fa795b1d8b344f1593cb631e15e04893d31cdc9465f9781[gradle/gradle#17149].
 
 [[base_convention_deprecation]]
-=== Deprecated `base` plugin conventions
+==== Deprecated `base` plugin conventions
 
 The convention properties contributed by the `base` plugin have been deprecated and scheduled for removal in Gradle 8.0.
 The conventions are replaced by the the `base { }` configuration block backed by link:{groovyDslPath}/org.gradle.api.plugins.BasePluginExtension.html[BasePluginExtension].
@@ -272,19 +273,19 @@ base {
 ```
 
 [[application_convention_deprecation]]
-=== Deprecated `ApplicationPluginConvention`
+==== Deprecated `ApplicationPluginConvention`
 
 link:{javadocPath}/org/gradle/api/plugins/ApplicationPluginConvention.html[ApplicationPluginConvention] was already listed as deprecated in the <<application_plugin.adoc#application_convention_properties, documentation>.
 Now, it is officially annotated as deprecated and scheduled for removal in Gradle 8.0.
 
 [[java_convention_deprecation]]
-=== Deprecated `java` plugin conventions
+==== Deprecated `java` plugin conventions
 
 The convention properties contributed by the `java` plugin have been deprecated and scheduled for removal in Gradle 8.0.
 They are replaced by the the properties of link:{groovyDslPath}/org.gradle.api.plugins.JavaPluginExtension.html[JavaPluginExtension] which can we configured in the `java {}` block.
 
 [[plugin_configuration_consumption]]
-=== Deprecated consumption of internal plugin configurations
+==== Deprecated consumption of internal plugin configurations
 
 Some of the core Gradle plugins declare configurations that are used by the plugin itself and are not meant to be
 published or consumed by another subproject directly. Gradle did not explicitly prohobit this.
@@ -346,22 +347,22 @@ configurations {
 ```
 
 [[project_report_convention_deprecation]]
-=== Deprecated `project-report` plugin conventions
+==== Deprecated `project-report` plugin conventions
 
 link:{groovyDslPath}/org.gradle.api.plugins.ProjectReportsPluginConvention.html[ProjectReportsPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the project report tasks directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(...).configureEach(...)] can be used to configure each task of the same type (`HtmlDependencyReportTask` for example).
 
 [[war_convention_deprecation]]
-=== Deprecated `war` plugin conventions
+==== Deprecated `war` plugin conventions
 
 link:{javadocPath}/org/gradle/api/plugins/WarPluginConvention.html[WarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `war` task  directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `War`.
 
 [[ear_convention_deprecation]]
-=== Deprecated `ear` plugin conventions
+==== Deprecated `ear` plugin conventions
 
 link:{javadocPath}/org/gradle/plugins/ear/EarPluginConvention.html[EarPluginConvention] is now deprecated and scheduled for removal in Gradle 8.0. Clients should configure the `ear` task directly. Also, link:{javadocPath}/org/gradle/api/DomainObjectCollection.html#withType-java.lang.Class-[tasks.withType(War.class).configureEach(...)] can be used to configure each task of type `Ear`.
 
 [[custom_source_set_deprecation]]
-=== Deprecated custom source set interfaces
+==== Deprecated custom source set interfaces
 The following source set interfaces are now deprecated and scheduled for removal in Gradle 8.0:
 
 - link:{javadocPath}/org/gradle/api/tasks/GroovySourceSet.html[GroovySourceSet]


### PR DESCRIPTION
So that it is not mixed in between deprecations and consistent
with the previous version upgrade guides.