### PR TITLE
fix [#17252]: Add Linux Toolchain location for 64bit installations

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java
@@ -33,7 +33,7 @@ public class LinuxInstallationSupplier extends AutoDetectingInstallationSupplier
 
     @Inject
     public LinuxInstallationSupplier(ProviderFactory factory) {
-        this(factory, OperatingSystem.current(), "/usr/lib/jvm", "/usr/java");
+        this(factory, OperatingSystem.current(), "/usr/lib/jvm", "/usr/lib64/jvm", "/usr/java");
     }
 
     private LinuxInstallationSupplier(ProviderFactory factory, OperatingSystem os, String... roots) {


### PR DESCRIPTION
This fix adds the Linux toolchain location for 64bit installations.