### PR TITLE
Not run ReadyForNightlyTrigger build if dependencies fail

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -82,7 +82,12 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         if (!stage.runsIndependent && prevStage != null) {
             dependency(RelativeId(stageTriggerId(model, prevStage))) {
                 snapshot {
-                    onDependencyFailure = FailureAction.ADD_PROBLEM
+                    onDependencyFailure = if (stage.stageName == StageNames.READY_FOR_NIGHTLY) {
+                        // We have a "updateBranchStatus" task in Ready for Nightly Trigger
+                        FailureAction.FAIL_TO_START
+                    } else {
+                        FailureAction.ADD_PROBLEM
+                    }
                 }
             }
         }


### PR DESCRIPTION
We have a "updateBranchStatus" task in ReadyForNightlyTrigger build,
which pushes to green-master. We don't want it to run if dependencies
fail.
