### PR TITLE
Add @gradle/ge-test-distribution to JVM testing subprojects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,9 @@ subprojects/snapshots/              @gradle/execution
 # Gradle Enterprise
 subprojects/enterprise/             @ldaley @marcphilipp
 
+# Testing
+subprojects/testing-junit-platform/ @gradle/ge-test-distribution
+subprojects/testing-jvm/            @gradle/ge-test-distribution
+
 # Release notes
 subprojects/docs/src/docs/release/notes.md @pioterj


### PR DESCRIPTION
In order to be notified of changes like 65775a520d884e366f0d27abf485234628590aa4 in the future, the @gradle/ge-test-distribution is added to the relevant subprojects.