### PR TITLE
Re-use version selector parser to check for dynamic version when publishing

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -31,11 +31,11 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
             return maybeCreateRangeSelector(selectorString);
         }
 
-        if (selectorString.endsWith("+")) {
+        if (isSubVersion(selectorString)) {
             return new SubVersionSelector(selectorString);
         }
 
-        if (selectorString.startsWith("latest.")) {
+        if (isLatestVersion(selectorString)) {
             return new LatestVersionSelector(selectorString);
         }
 
@@ -68,4 +68,11 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
         return new InverseVersionSelector(selector);
     }
 
+    public static boolean isSubVersion(String selectorString) {
+        return selectorString.endsWith("+");
+    }
+
+    public static boolean isLatestVersion(String selectorString) {
+        return selectorString.startsWith("latest.");
+    }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -65,11 +65,15 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+        javaLibrary(mavenRepo.module("org.test", "baz", "1.0+10")).withModuleMetadata().publish()
+        javaLibrary(mavenRepo.module("org.test", "qux", "1.0-latest")).withModuleMetadata().publish()
 
         createBuildScripts("""
             dependencies {
                 api "org.test:foo:1.0"
                 implementation "org.test:bar:1.0"
+                implementation "org.test:baz:1.0+10"
+                implementation "org.test:qux:1.0-latest"
             }
             publishing {
                 publications {
@@ -84,13 +88,14 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         run "publish"
 
         then:
+        outputDoesNotContain(DefaultMavenPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
         javaLibrary.assertApiDependencies("org.test:foo:1.0")
-        javaLibrary.assertRuntimeDependencies("org.test:bar:1.0")
+        javaLibrary.assertRuntimeDependencies("org.test:bar:1.0", "org.test:baz:1.0+10", "org.test:qux:1.0-latest")
 
         and:
         resolveArtifacts(javaLibrary) {
-            expectFiles "bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            expectFiles "bar-1.0.jar", "baz-1.0+10.jar", "qux-1.0-latest.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
@@ -105,7 +110,7 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            expectFiles "bar-1.0.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            expectFiles "bar-1.0.jar", "baz-1.0+10.jar", "qux-1.0-latest.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
     }
 
@@ -503,7 +508,7 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
         }
 
         where:
-        version << ['1.+', 'latest.milestone']
+        version << ['1.+', 'latest.milestone', '+']
     }
 
     def "can publish java-library with attached artifacts"() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -46,6 +46,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MavenVersionUtils;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -386,10 +387,10 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         if (version == null) {
             return false;
         }
-        if (version.contains("+")) {
+        if (DefaultVersionSelectorScheme.isSubVersion(version)) {
             return true;
         }
-        if (version.contains("latest")) {
+        if (DefaultVersionSelectorScheme.isLatestVersion(version)) {
             return !MavenVersionSelectorScheme.isSubstituableLatest(version);
         }
         return false;


### PR DESCRIPTION
Prior ad hoc check was mistakenly considering some versions dynamic
while they actually weren't. Reusing the code from the version selector
parser fixes it and adds some future-proofing there.

Note that we cannot check for VersionSelector.isDynamic because:
 - VersionSelector instance is not readily avaliable there
 - some dynamic versions are supported

Fixes #16555

