### PR TITLE
Do not set a context class loader when creating thread.

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ThreadFactoryImpl.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ThreadFactoryImpl.java
@@ -40,6 +40,7 @@ public class ThreadFactoryImpl implements ThreadFactory {
         } else {
             thread.setName(displayName + " Thread " + count);
         }
+        thread.setContextClassLoader(null);
         return thread;
     }
 


### PR DESCRIPTION
When creating a thread, the current context class loader (if any) will
be used to set the initial context class loader for the thread.

In Gradle's case, the initial class loader is the VisitableClassLoader
instance for the current build.

Because thread usages will always set/reset the context class loader
before/after any work actions, the initial context class loader
will be kept forever during the lifetime of the daemon.

Issue #16797

Signed-off-by: Jerome Dochez <jedo@google.com>

Backport of #17270