### PR TITLE
Revert "Do not set a context class loader when creating thread."

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ThreadFactoryImpl.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ThreadFactoryImpl.java
@@ -40,7 +40,6 @@ public class ThreadFactoryImpl implements ThreadFactory {
         } else {
             thread.setName(displayName + " Thread " + count);
         }
-        thread.setContextClassLoader(null);
         return thread;
     }
 


### PR DESCRIPTION
Reverts gradle/gradle#17270