### PR TITLE
Remove unused assignment

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -117,7 +117,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
     void "doesn't allow selection of configuration is not consumable"() {
         def context = Mock(TaskDependencyResolveContext)
 
-        def conf = project.configurations.create('conf') {
+        project.configurations.create('conf') {
             canBeConsumed = false
         }
         def listener = Mock(ProjectAccessListener)


### PR DESCRIPTION
This is to test pre-tested commit by fixing tiny issues in Gradle codebase.