### PR TITLE
Fix doc which uses wrong property to disable a violation rule

### DIFF
--- a/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/jacoco-quickstart/kotlin/build.gradle.kts
@@ -60,7 +60,7 @@ tasks.jacocoTestCoverageVerification {
         }
 
         rule {
-            enabled = false
+            isEnabled = false
             element = "CLASS"
             includes = listOf("org.gradle.*")
 


### PR DESCRIPTION
The code sample in the documentation regarding the violation rules ("https://docs.gradle.org/current/userguide/jacoco_plugin.html#sec:jacoco_report_violation_rules") is wrong.
The property "enabled" is part of the task and will disable/enable the task itself. If "enabled=false", the task will be "SKIPPED".
Instead "isEnabled" should be used as a property, to enable/disable the rule.
