### PR TITLE
Remove channel as input from performance tests

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -91,8 +91,7 @@ abstract class PerformanceTest extends DistributionTest {
     String checks
 
     @Nullable
-    @Optional
-    @Input
+    @Internal
     String channel
 
     /************** properties configured by PerformanceTestPlugin ***************/
@@ -318,6 +317,7 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.regression.checks", checks)
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.channel", channel)
             addSystemPropertyIfExist(result, "org.gradle.performance.debugArtifactsDirectory", getDebugArtifactsDirectory())
+            addSystemPropertyIfExist(result, "gradleBuildBranch", branchName)
 
             if (profiler.isPresent() && profiler.get() != "none") {
                 addSystemPropertyIfExist(result, "org.gradle.performance.profiler", profiler.get())

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -210,7 +210,8 @@ abstract class PerformanceTest extends DistributionTest {
         this.scenarios = scenarios
     }
 
-    @Internal
+    @Optional
+    @Input
     @Option(option = "baselines", description = "A comma or semicolon separated list of Gradle versions to be used as baselines for comparing.")
     Property<String> getBaselines() {
         return baselines

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -416,7 +416,6 @@ class PerformanceTestExtension(
             val identityExtension = project.the<ModuleIdentityExtension>()
             val gradleBuildBranch = identityExtension.gradleBuildBranch.get()
             branchName = gradleBuildBranch
-            systemProperty("gradleBuildBranch", gradleBuildBranch)
             commitId.set(identityExtension.gradleBuildCommitId)
 
             reportGeneratorClass.set("org.gradle.performance.results.report.DefaultReportGenerator")


### PR DESCRIPTION
So we can get build cache hits between different pre-tested commit branches.