### PR TITLE
add new properties to allow wrapper to reuse the existing credentials

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -225,6 +225,15 @@ systemProp.gradle.wrapperUser=username
 systemProp.gradle.wrapperPassword=password
 ----
 
+[source,properties]
+.Specifying the wrapper credentials key to reuse the existing credentials defined by system properties: repoUsername and repoPassword, which property name could be re-defined by users
+----
+systemProp.repoUsername=username
+systemProp.repoPassword=password
+systemProp.gradle.wrapperUserKey=repoUsername
+systemProp.gradle.wrapperPasswordKey=repoPassword
+----
+
 Embedding credentials in the `distributionUrl` in the `gradle/wrapper/gradle-wrapper.properties` file also works. Please note that this file is to be committed into your source control system. Shared credentials embedded in `distributionUrl` should only be used in a controlled environment.
 
 [listing]

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
@@ -185,8 +185,10 @@ public class Download implements IDownload {
     }
 
     private String calculateUserInfo(URI uri) {
-        String username = systemProperties.get("gradle.wrapperUser");
-        String password = systemProperties.get("gradle.wrapperPassword");
+        String usernameKey = systemProperties.get("gradle.wrapperUserKey");
+        String passwordKey = systemProperties.get("gradle.wrapperPasswordKey");
+        String username = usernameKey != null ? systemProperties.get(usernameKey): systemProperties.get("gradle.wrapperUser");
+        String password = passwordKey != null ? systemProperties.get(passwordKey): systemProperties.get("gradle.wrapperPassword");
         if (username != null && password != null) {
             return username + ':' + password;
         }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #17223 

### Context
<!--- Why do you believe many users will benefit from this change? -->
It would allow user to only define credentials only once and avoid the duplication.
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
