### PR TITLE
Fully support substituting an enforced dependency through a project

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -75,12 +76,20 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
-        return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) delegate.withTarget(target));
+        DependencyMetadata dependencyMetadata = delegate.withTarget(target);
+        if (dependencyMetadata instanceof DefaultProjectDependencyMetadata) {
+            return ((DefaultProjectDependencyMetadata) dependencyMetadata).forced();
+        }
+        return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) dependencyMetadata);
     }
 
     @Override
     public DependencyMetadata withTargetAndArtifacts(ComponentSelector target, List<IvyArtifactName> artifacts) {
-        return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) delegate.withTargetAndArtifacts(target, artifacts));
+        DependencyMetadata dependencyMetadata = delegate.withTargetAndArtifacts(target, artifacts);
+        if (dependencyMetadata instanceof DefaultProjectDependencyMetadata) {
+            return ((DefaultProjectDependencyMetadata) dependencyMetadata).forced();
+        }
+        return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) dependencyMetadata);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -25,13 +25,14 @@ import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class DefaultProjectDependencyMetadata implements DependencyMetadata {
+public class DefaultProjectDependencyMetadata implements ForcingDependencyMetadata {
     private final ProjectComponentSelector selector;
     private final DependencyMetadata delegate;
     private final boolean isTransitive;
@@ -108,4 +109,19 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
         return delegate.withReason(reason);
     }
 
+    @Override
+    public boolean isForce() {
+        if (delegate instanceof ForcingDependencyMetadata) {
+            return ((ForcingDependencyMetadata) delegate).isForce();
+        }
+        return false;
+    }
+
+    @Override
+    public ForcingDependencyMetadata forced() {
+        if (delegate instanceof ForcingDependencyMetadata) {
+            return ((ForcingDependencyMetadata) delegate).forced();
+        }
+        return this;
+    }
 }


### PR DESCRIPTION
This caused an exception before, if the enforce platform was sourced from a BOM (pom.xml).

Fixes #10808
