### PR TITLE
destinationDir defaults to project.distsDirectory

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
@@ -66,11 +66,11 @@
             </tr>
             <tr>
                 <td>destinationDir</td>
-                <td><literal>project.distsDir</literal></td>
+                <td><literal>project.distsDirectory</literal></td>
             </tr>
             <tr>
                 <td>destinationDirectory</td>
-                <td><literal>project.distsDir</literal></td>
+                <td><literal>project.distsDirectory</literal></td>
             </tr>
             <tr>
                 <td>preserveFileTimestamps</td>


### PR DESCRIPTION
instead of project.distsDir, which does not exists

Signed-off-by: James Shaw <js102@zepler.net>

<!--- The issue this PR addresses -->
Fixes #1086

### Context
Corrects a mistake in the documentation

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
