### PR TITLE
Enable some tests for non-embedded execution

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     integTestImplementation(project(":platform-jvm"))
     integTestImplementation(project(":test-kit"))
     integTestImplementation(project(":launcher"))
+    integTestImplementation(project(":cli"))
 
     integTestImplementation(libs.guava)
     integTestImplementation(libs.ant)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheIntegrationTest.groovy
@@ -35,17 +35,6 @@ abstract class AbstractConfigurationCacheIntegrationTest extends AbstractOptInFe
     static final String MAX_PROBLEMS_GRADLE_PROP = "${ConfigurationCacheMaxProblemsOption.PROPERTY_NAME}"
     static final String MAX_PROBLEMS_SYS_PROP = "-D$MAX_PROBLEMS_GRADLE_PROP"
 
-    def setup() {
-        // Verify that the previous test cleaned up state correctly
-        assert System.getProperty(ConfigurationCacheOption.PROPERTY_NAME) == null
-    }
-
-    @Override
-    def cleanup() {
-        // Verify that the test (or fixtures) has cleaned up state correctly
-        assert System.getProperty(ConfigurationCacheOption.PROPERTY_NAME) == null
-    }
-
     void buildKotlinFile(@Language(value = "kotlin") String script) {
         buildKotlinFile << script
     }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -16,15 +16,12 @@
 
 package org.gradle.configurationcache
 
-
 import org.gradle.integtests.resolve.transform.ArtifactTransformTestFixture
 import org.gradle.test.fixtures.server.http.HttpServer
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Issue
 
-@Ignore("https://github.com/gradle/gradle-private/issues/3396")
 class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ArtifactTransformTestFixture {
     @Rule
     HttpServer httpServer = new HttpServer()

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
@@ -20,7 +20,10 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
 
+// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
+@IgnoreIf({ GradleContextualExecuter.embedded })
 @Requires(TestPrecondition.NOT_WINDOWS)
 class ConfigurationCacheTestkitIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
     def "reports when a TestKit build runs with a Java agent and configuration caching enabled"() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
@@ -16,14 +16,15 @@
 
 package org.gradle.configurationcache
 
-
 import org.gradle.configurationcache.fixtures.SomeToolingModelBuildAction
 import org.gradle.configurationcache.fixtures.ToolingApiBackedGradleExecuter
 import org.gradle.configurationcache.fixtures.ToolingApiSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
-import spock.lang.Ignore
+import spock.lang.IgnoreIf
 
-@Ignore("https://github.com/gradle/gradle-private/issues/3395")
+// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
+@IgnoreIf({ GradleContextualExecuter.embedded })
 class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ToolingApiSpec {
     @Override
     GradleExecuter createExecuter() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/AbstractOptInFeatureIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/AbstractOptInFeatureIntegrationTest.groovy
@@ -29,7 +29,16 @@ abstract class AbstractOptInFeatureIntegrationTest extends AbstractIntegrationSp
     protected ConfigurationCacheProblemsFixture problems
 
     def setup() {
+        // Verify that the previous test cleaned up state correctly
+        assert System.getProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME) == null
+        assert System.getProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME) == null
         problems = new ConfigurationCacheProblemsFixture(executer, testDirectory)
+    }
+
+    def cleanup() {
+        // Verify that the test (or fixtures) has cleaned up state correctly
+        assert System.getProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME) == null
+        assert System.getProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME) == null
     }
 
     abstract void configurationCacheRun(String... tasks)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiBackedGradleExecuter.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiBackedGradleExecuter.groovy
@@ -73,6 +73,7 @@ class ToolingApiBackedGradleExecuter extends AbstractGradleExecuter {
         } finally {
             if (GradleContextualExecuter.embedded) {
                 System.clearProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME)
+                System.clearProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME)
             }
         }
     }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.configurationcache.inputs.undeclared
 
-import spock.lang.Ignore
-
-@Ignore("https://github.com/gradle/gradle-private/issues/3252")
 class UndeclaredBuildInputsDynamicGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     String getLocation() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest.groovy
@@ -16,9 +16,6 @@
 
 package org.gradle.configurationcache.inputs.undeclared
 
-import spock.lang.Ignore
-
-@Ignore("https://github.com/gradle/gradle-private/issues/3252")
 class UndeclaredBuildInputsStaticGroovyBuildSrcIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements GroovyPluginImplementation {
     @Override
     String getLocation() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
@@ -35,7 +35,10 @@ import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
+import spock.lang.IgnoreIf
 
+// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
+@IgnoreIf({ GradleContextualExecuter.embedded })
 @Requires(TestPrecondition.NOT_WINDOWS)
 class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
     TestFile jar

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIsolatedProjectsIntegrationTest.groovy
@@ -18,8 +18,10 @@ package org.gradle.configurationcache.isolated
 
 import org.gradle.configurationcache.fixtures.AbstractOptInFeatureIntegrationTest
 
+import static org.gradle.initialization.StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME
+
 abstract class AbstractIsolatedProjectsIntegrationTest extends AbstractOptInFeatureIntegrationTest {
-    public static final String ENABLE_CLI = "-Dorg.gradle.unsafe.isolated-projects=true"
+    public static final String ENABLE_CLI = "-D${PROPERTY_NAME}=true"
 
     @Override
     void configurationCacheRun(String... tasks) {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
@@ -18,8 +18,12 @@ package org.gradle.configurationcache.isolated
 
 import org.gradle.configurationcache.fixtures.ToolingApiBackedGradleExecuter
 import org.gradle.configurationcache.fixtures.ToolingApiSpec
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
+import spock.lang.IgnoreIf
 
+// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
+@IgnoreIf({ GradleContextualExecuter.embedded })
 class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements ToolingApiSpec {
     @Override
     GradleExecuter createExecuter() {

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -484,8 +484,10 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
     }
 
     public static class IsolatedProjectsOption extends BooleanBuildOption<StartParameterInternal> {
+        public static final String PROPERTY_NAME = "org.gradle.unsafe.isolated-projects";
+
         public IsolatedProjectsOption() {
-            super("org.gradle.unsafe.isolated-projects");
+            super(PROPERTY_NAME);
         }
 
         @Override
@@ -495,7 +497,6 @@ public class StartParameterBuildOptions extends BuildOptionSet<StartParameterInt
     }
 
     public static class ConfigurationCacheProblemsOption extends EnumBuildOption<ConfigurationCacheProblemsOption.Value, StartParameterInternal> {
-
         public static final String PROPERTY_NAME = "org.gradle.unsafe.configuration-cache-problems";
         public static final String LONG_OPTION = "configuration-cache-problems";
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionFactory.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/ConnectionFactory.java
@@ -38,7 +38,7 @@ public class ConnectionFactory {
     }
 
     public ProjectConnection create(Distribution distribution, ConnectionParameters parameters, ProjectConnectionCloseListener listener) {
-        ConsumerActionExecutor lazyConnection = new LazyConsumerActionExecutor(distribution, toolingImplementationLoader, loggingProvider, executorFactory, parameters);
+        ConsumerActionExecutor lazyConnection = new LazyConsumerActionExecutor(distribution, toolingImplementationLoader, loggingProvider, parameters);
         ConsumerActionExecutor cancellableConnection = new CancellableConsumerActionExecutor(lazyConnection);
         ConsumerActionExecutor progressLoggingConnection = new ProgressLoggingConsumerActionExecutor(cancellableConnection, loggingProvider);
         ConsumerActionExecutor rethrowingErrorsConnection = new RethrowingErrorsConsumerActionExecutor(progressLoggingConnection);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutor.java
@@ -18,7 +18,6 @@ package org.gradle.tooling.internal.consumer.connection;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.UncheckedException;
-import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.tooling.internal.consumer.ConnectionParameters;
 import org.gradle.tooling.internal.consumer.DefaultCancellationTokenSource;
@@ -55,7 +54,7 @@ public class LazyConsumerActionExecutor implements ConsumerActionExecutor {
     private final ConnectionParameters connectionParameters;
     private BuildCancellationToken cancellationToken;
 
-    public LazyConsumerActionExecutor(Distribution distribution, ToolingImplementationLoader implementationLoader, LoggingProvider loggingProvider, ExecutorFactory executorFactory, ConnectionParameters connectionParameters) {
+    public LazyConsumerActionExecutor(Distribution distribution, ToolingImplementationLoader implementationLoader, LoggingProvider loggingProvider, ConnectionParameters connectionParameters) {
         this.distribution = distribution;
         this.implementationLoader = implementationLoader;
         this.loggingProvider = loggingProvider;

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.tooling.internal.consumer.connection
 
 import org.gradle.initialization.BuildCancellationToken
-import org.gradle.internal.concurrent.ExecutorFactory
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.tooling.internal.consumer.ConnectionParameters
 import org.gradle.tooling.internal.consumer.Distribution
@@ -39,8 +38,7 @@ class LazyConsumerActionExecutorTest extends Specification {
     final FailsafeBuildProgressListenerAdapter buildProgressListener = Mock()
     final BuildCancellationToken cancellationToken = Mock()
 
-    final ExecutorFactory executorFactory = Mock()
-    final LazyConsumerActionExecutor connection = new LazyConsumerActionExecutor(distribution, implementationLoader, loggingProvider, executorFactory, connectionParams)
+    final LazyConsumerActionExecutor connection = new LazyConsumerActionExecutor(distribution, implementationLoader, loggingProvider, connectionParams)
 
     def createsConnectionOnDemandToBuildModel() {
         when:


### PR DESCRIPTION

### Context

Enable some tests that were disabled due to flakiness, but keep them disabled for embedded execution due to a potential deadlock combining embedded execution and embedded tooling API builds in the same JVM (a situation which only happens in the Gradle test suite, rather than in real builds).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
