### PR TITLE
Disable TC triggers for versioned settings branches which are not release or master

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -2,11 +2,14 @@ package common
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
-data class VersionedSettingsBranch(val branchName: String) {
+private
+val mainBranches = setOf("master", "release")
+
+data class VersionedSettingsBranch(val branchName: String, val enableTriggers: Boolean) {
 
     companion object {
-        val MASTER = VersionedSettingsBranch("master")
-        val EXPERIMENTAL = VersionedSettingsBranch("experimental")
+        val MASTER = VersionedSettingsBranch("master", true)
+        val EXPERIMENTAL = VersionedSettingsBranch("experimental", false)
 
         fun fromDslContext(): VersionedSettingsBranch {
             val branch = DslContext.getParameter("Branch")
@@ -14,7 +17,7 @@ data class VersionedSettingsBranch(val branchName: String) {
             if (branch.contains("placeholder-1")) {
                 return MASTER
             }
-            return VersionedSettingsBranch(branch.toLowerCase())
+            return VersionedSettingsBranch(branch.toLowerCase(), mainBranches.contains(branch.toLowerCase()))
         }
     }
 }

--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -2,22 +2,32 @@ package common
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 
-private
-val mainBranches = setOf("master", "release")
-
 data class VersionedSettingsBranch(val branchName: String, val enableTriggers: Boolean) {
 
     companion object {
-        val MASTER = VersionedSettingsBranch("master", true)
-        val EXPERIMENTAL = VersionedSettingsBranch("experimental", false)
+        private
+        const val MASTER_BRANCH = "master"
+        private
+        const val RELEASE_BRANCH = "release"
+        private
+        const val EXPERIMENTAL_BRANCH = "experimental"
+        private
+        val mainBranches = setOf(MASTER_BRANCH, RELEASE_BRANCH)
 
         fun fromDslContext(): VersionedSettingsBranch {
             val branch = DslContext.getParameter("Branch")
             // TeamCity uses a dummy name when first running the DSL
             if (branch.contains("placeholder-1")) {
-                return MASTER
+                return VersionedSettingsBranch(MASTER_BRANCH, true)
             }
             return VersionedSettingsBranch(branch.toLowerCase(), mainBranches.contains(branch.toLowerCase()))
         }
     }
+
+    val isMaster: Boolean
+        get() = branchName == MASTER_BRANCH
+    val isRelease: Boolean
+        get() = branchName == RELEASE_BRANCH
+    val isExperimental: Boolean
+        get() = branchName == EXPERIMENTAL_BRANCH
 }

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -1,5 +1,6 @@
 package configurations
 
+import common.VersionedSettingsBranch
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.gradleWrapper
@@ -32,12 +33,14 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         publishBuildStatusToGithub(model)
     }
 
+    val enableTriggers = VersionedSettingsBranch.fromDslContext().enableTriggers
     if (stage.trigger == Trigger.eachCommit) {
         triggers.vcs {
             quietPeriodMode = VcsTrigger.QuietPeriodMode.USE_CUSTOM
             quietPeriod = 90
             triggerRules = triggerExcludes
             branchFilter = branchFilter(model.branch)
+            enabled = enableTriggers
         }
     } else if (stage.trigger != Trigger.never) {
         triggers.schedule {
@@ -56,6 +59,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
             withPendingChangesOnly = true
             param("revisionRule", "lastFinished")
             branchFilter = branchFilter(model.branch)
+            enabled = enableTriggers
         }
     }
 

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -1,6 +1,5 @@
 package configurations
 
-import common.VersionedSettingsBranch
 import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.gradleWrapper
@@ -33,7 +32,7 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         publishBuildStatusToGithub(model)
     }
 
-    val enableTriggers = VersionedSettingsBranch.fromDslContext().enableTriggers
+    val enableTriggers = model.branch.enableTriggers
     if (stage.trigger == Trigger.eachCommit) {
         triggers.vcs {
             quietPeriodMode = VcsTrigger.QuietPeriodMode.USE_CUSTOM

--- a/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
+++ b/.teamcity/src/main/kotlin/projects/GradleBuildToolRootProject.kt
@@ -20,8 +20,8 @@ class GradleBuildToolRootProject(branch: VersionedSettingsBranch) : Project({
     val gradleBuildBucketProvider = StatisticBasedFunctionalTestBucketProvider(model, File("./test-class-data.json"))
     subProject(CheckProject(model, gradleBuildBucketProvider))
 
-    if (model.branch != VersionedSettingsBranch.EXPERIMENTAL) {
-        subProject(PromotionProject(model.branch))    
+    if (!model.branch.isExperimental) {
+        subProject(PromotionProject(model.branch))
     }
     subProject(UtilProject)
     subProject(UtilPerformanceProject)

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -16,7 +16,7 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     buildType(PublishBranchSnapshotFromQuickFeedback)
     buildType(PublishMilestone(branch))
 
-    if (branch == VersionedSettingsBranch.MASTER) {
+    if (branch.isMaster) {
         buildType(StartReleaseCycle)
         buildType(StartReleaseCycleTest)
     } else {

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
@@ -59,8 +59,8 @@ abstract class PublishGradleDistribution(
     }
 }
 
-fun VersionedSettingsBranch.promoteNightlyTaskName(): String = when (this) {
-    VersionedSettingsBranch.MASTER -> "promoteNightly"
-    VersionedSettingsBranch("release") -> "promoteReleaseNightly"
+fun VersionedSettingsBranch.promoteNightlyTaskName(): String = when {
+    isMaster -> "promoteNightly"
+    isRelease -> "promoteReleaseNightly"
     else -> "promotePatchReleaseNightly"
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
@@ -61,5 +61,6 @@ abstract class PublishGradleDistribution(
 
 fun VersionedSettingsBranch.promoteNightlyTaskName(): String = when (this) {
     VersionedSettingsBranch.MASTER -> "promoteNightly"
-    else -> "promoteReleaseNightly"
+    VersionedSettingsBranch("release") -> "promoteReleaseNightly"
+    else -> "promotePatchReleaseNightly"
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -38,15 +38,15 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
                 }
                 triggerBuild = always()
                 withPendingChangesOnly = false
-                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
+                enabled = branch.enableTriggers
             }
         }
     }
 }
 
 // Avoid two jobs running at the same time and causing troubles
-private fun VersionedSettingsBranch.triggeredHour() = when (this.branchName) {
-    "master" -> 0
-    "release" -> 1
+private fun VersionedSettingsBranch.triggeredHour() = when {
+    isMaster -> 0
+    isRelease -> 1
     else -> null
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -36,6 +36,7 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
                 }
                 triggerBuild = always()
                 withPendingChangesOnly = false
+                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
             }
         }
     }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -31,8 +31,10 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
 
         triggers {
             schedule {
-                schedulingPolicy = daily {
-                    this.hour = branch.triggeredHour()
+                branch.triggeredHour()?.apply {
+                    schedulingPolicy = daily {
+                        this.hour = this@apply
+                    }
                 }
                 triggerBuild = always()
                 withPendingChangesOnly = false
@@ -46,5 +48,5 @@ class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDis
 private fun VersionedSettingsBranch.triggeredHour() = when (this.branchName) {
     "master" -> 0
     "release" -> 1
-    else -> 0
+    else -> null
 }

--- a/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/promotion/SanityCheck.kt
@@ -1,6 +1,7 @@
 package promotion
 
 import common.Os
+import common.VersionedSettingsBranch
 import common.gradleWrapper
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -27,6 +28,7 @@ object SanityCheck : BuildType({
     triggers {
         vcs {
             branchFilter = ""
+            enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
         }
     }
 

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -37,10 +37,11 @@ object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotio
             }
         }
 
+        val enableTriggers = VersionedSettingsBranch.fromDslContext().enableTriggers
         triggers {
             vcs {
                 branchFilter = "+:master"
-                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
+                enabled = enableTriggers
             }
             schedule {
                 schedulingPolicy = daily {
@@ -49,7 +50,7 @@ object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotio
                 branchFilter = "+:master"
                 triggerBuild = always()
                 withPendingChangesOnly = false
-                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
+                enabled = enableTriggers
             }
         }
     }

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -16,6 +16,7 @@
 
 package promotion
 
+import common.VersionedSettingsBranch
 import common.gradleWrapper
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
@@ -39,6 +40,7 @@ object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotio
         triggers {
             vcs {
                 branchFilter = "+:master"
+                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
             }
             schedule {
                 schedulingPolicy = daily {
@@ -47,6 +49,7 @@ object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotio
                 branchFilter = "+:master"
                 triggerBuild = always()
                 withPendingChangesOnly = false
+                enabled = VersionedSettingsBranch.fromDslContext().enableTriggers
             }
         }
     }

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -1,6 +1,5 @@
-import common.VersionedSettingsBranch
-import model.JsonBasedGradleSubprojectProvider
 import common.Os
+import common.VersionedSettingsBranch
 import configurations.BaseGradleBuildType
 import configurations.applyDefaults
 import configurations.applyTestDefaults
@@ -13,6 +12,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
+import model.JsonBasedGradleSubprojectProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,7 +48,7 @@ class ApplyDefaultConfigurationTest {
     private
     val buildModel = CIBuildModel(
         projectId = "Gradle_Check",
-        branch = VersionedSettingsBranch.MASTER,
+        branch = VersionedSettingsBranch("master", true),
         buildScanTags = listOf("Check"),
         subprojects = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     )

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -4,6 +4,8 @@ import common.Os
 import common.VersionedSettingsBranch
 import configurations.FunctionalTest
 import configurations.StagePasses
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
@@ -28,9 +30,14 @@ import projects.StageProject
 import java.io.File
 
 class CIConfigIntegrationTests {
+    init {
+        // Set the project id here, so we can use methods on the DslContext
+        DslContext.projectId = AbsoluteId("Gradle_Master")
+    }
+
     private val subprojectProvider = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     private val model = CIBuildModel(
-        projectId = "Gradle_Check",
+        projectId = "Check",
         branch = VersionedSettingsBranch.MASTER,
         buildScanTags = listOf("Check"),
         subprojects = subprojectProvider
@@ -50,7 +57,7 @@ class CIConfigIntegrationTests {
     @Test
     fun macBuildsHasEmptyRepoMirrorUrlsParam() {
         val rootProject = CheckProject(model, gradleBuildBucketProvider)
-        val readyForRelease = rootProject.searchSubproject("Gradle_Check_Stage_ReadyforRelease")
+        val readyForRelease = rootProject.searchSubproject("Gradle_Master_Check_Stage_ReadyforRelease")
         val macBuilds = readyForRelease.subProjects.filter { it.name.contains("Macos") }.flatMap { (it as FunctionalTestProject).functionalTests }
         assertTrue(macBuilds.isNotEmpty())
         assertTrue(macBuilds.all { it.params.findRawParam("env.REPO_MIRROR_URLS")!!.value == "" })
@@ -192,7 +199,7 @@ class CIConfigIntegrationTests {
         }
     }
 
-    private fun toTriggerId(id: String) = "Gradle_Check_Stage_${id}_Trigger"
+    private fun toTriggerId(id: String) = "Gradle_Master_Check_Stage_${id}_Trigger"
     private fun subProjectFolderList(): List<File> {
         val subProjectFolders = File("../subprojects").listFiles()!!.filter { it.isDirectory }
         assertFalse(subProjectFolders.isEmpty())
@@ -294,13 +301,13 @@ class CIConfigIntegrationTests {
         val testCoverage = TestCoverage(1, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmVersion.java11, JvmVendor.oracle)
         val shortenedId = testCoverage.asConfigurationId(model, "veryLongSubprojectNameLongerThanEverythingWeHave")
         assertTrue(shortenedId.length < 80)
-        assertEquals("Gradle_Check_QckFdbckCrssVrsn_1_vryLngSbprjctNmLngrThnEvrythngWHv", shortenedId)
+        assertEquals("Check_QckFdbckCrssVrsn_1_vryLngSbprjctNmLngrThnEvrythngWHv", shortenedId)
 
-        assertEquals("Gradle_Check_QuickFeedbackCrossVersion_1_iIntegT", testCoverage.asConfigurationId(model, "internalIntegTesting"))
+        assertEquals("Check_QuickFeedbackCrossVersion_1_iIntegT", testCoverage.asConfigurationId(model, "internalIntegTesting"))
 
-        assertEquals("Gradle_Check_QuickFeedbackCrossVersion_1_buildCache", testCoverage.asConfigurationId(model, "buildCache"))
+        assertEquals("Check_QuickFeedbackCrossVersion_1_buildCache", testCoverage.asConfigurationId(model, "buildCache"))
 
-        assertEquals("Gradle_Check_QuickFeedbackCrossVersion_1_0", testCoverage.asConfigurationId(model))
+        assertEquals("Check_QuickFeedbackCrossVersion_1_0", testCoverage.asConfigurationId(model))
     }
 
     @Test

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -33,12 +33,13 @@ class CIConfigIntegrationTests {
     init {
         // Set the project id here, so we can use methods on the DslContext
         DslContext.projectId = AbsoluteId("Gradle_Master")
+        DslContext.addParameters("Branch" to "master")
     }
 
     private val subprojectProvider = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     private val model = CIBuildModel(
         projectId = "Check",
-        branch = VersionedSettingsBranch.MASTER,
+        branch = VersionedSettingsBranch.fromDslContext(),
         buildScanTags = listOf("Check"),
         subprojects = subprojectProvider
     )

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import common.VersionedSettingsBranch
-import configurations.PerformanceTest
-import model.JsonBasedGradleSubprojectProvider
-import model.PerformanceTestCoverage
 import common.JvmVendor
 import common.JvmVersion
 import common.Os
+import common.VersionedSettingsBranch
 import configurations.BaseGradleBuildType
+import configurations.PerformanceTest
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
+import model.JsonBasedGradleSubprojectProvider
+import model.PerformanceTestCoverage
 import model.PerformanceTestType
 import model.SpecificBuild
 import model.Stage
@@ -39,7 +39,7 @@ class PerformanceTestBuildTypeTest {
     private
     val buildModel = CIBuildModel(
         projectId = "Gradle_Check",
-        branch = VersionedSettingsBranch.MASTER,
+        branch = VersionedSettingsBranch("master", true),
         buildScanTags = listOf("Check"),
         subprojects = JsonBasedGradleSubprojectProvider(File("../.teamcity/subprojects.json"))
     )


### PR DESCRIPTION
For branches apart from `master` and `release`, we don't want any triggers to fire. This should prevent problems when we are trying out something, for example on the `experimental` branch.

I also cherry-picked the changes from the `release6x` branch, causing the promotion build to run `promotePatchReleaseNightly` when not on the `release` or `master` branches.