### PR TITLE
Fix for gradle-native issue #1084

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -262,6 +262,7 @@ public class InstallExecutable extends DefaultTask {
             copySpec.into(binaryDir);
             copySpec.from(executableFile);
             copySpec.from(libs);
+            copySpec.setFileMode(0755);
         });
     }
 }


### PR DESCRIPTION
Copy binary + library dependencies while explicitly setting file permission on executable files to 0755 (rwxr-x-rx).
Signed-off-by: Eivind Naess <eivnaes@yahoo.com>

<!--- The issue this PR addresses -->
Fixes gradle-native Issue #1084

### Context
Set the file permissions to 755 on executables (similar to the "install" utility with GNU autotools). 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
