### PR TITLE
Update to GE & TD Gradle plugins to latest RC versions

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -14,7 +14,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 dependencies {
     constraints {
         // Gradle Plugins
-        api("com.gradle:gradle-enterprise-gradle-plugin:3.6.1")
+        api("com.gradle:gradle-enterprise-gradle-plugin:3.6.2-rc-1")
         api("com.gradle.enterprise:test-distribution-gradle-plugin:2.1-rc-2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.18.1-hotfix")
         api("com.gradle.publish:plugin-publish-plugin:0.14.0")

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.6.1")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.1-rc-1") // Sync with `settings.gradle.kts`
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.1-rc-2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.18.1-hotfix")
         api("com.gradle.publish:plugin-publish-plugin:0.14.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     id("gradlebuild.internal.testfiltering")
-    id("com.gradle.enterprise.test-distribution").version("2.1-rc-1") // Sync with `build-logic/build-platform/buildSrc.gradle.kts`
+    id("com.gradle.enterprise.test-distribution").version("2.1-rc-2") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("com.gradle.internal.test-selection").version("0.5.3-rc-1")
 }
 


### PR DESCRIPTION
This PR upgrades
* the test-distribution Gradle plugin to the latest RC version 2.1-rc-2
* the GE Gradle plugin to the latest RC version 3.6.2-rc-1
