### PR TITLE
Fix BuildProgressCrossVersionSpec

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -285,7 +285,7 @@ public class DefaultGradleDistribution implements GradleDistribution {
 
     @Override
     public boolean isToolingApiHasExecutionPhaseBuildOperation() {
-        return isSameOrNewer("7.1");
+        return isSameOrNewer("7.1-rc-1");
     }
 
     @Override


### PR DESCRIPTION
The `7.1-rc.1` is not newer than `7.1` but it already contains
the feature.
