### PR TITLE
Fix dependency verification downloading bogus files during IDE sync

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1395,22 +1395,26 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
                         .forModule("org", "foo", "1.0")
                         .withArtifacts(JvmLibrary, SourcesArtifact, JavadocArtifact)
                         .execute()
+                        .components
+                        .each {
+                            // trigger file access for verification to happen
+                            it.getArtifacts(SourcesArtifact)*.file
+                            it.getArtifacts(JavadocArtifact)*.file
+                        }
                 }
             }
         """
 
         when:
         module.pom.expectGet()
-        module.artifact.expectGet()
         module.getArtifact(type:'pom.asc').expectGet()
-        module.getArtifact(type:'jar.asc').expectGet()
         module.getArtifact(classifier:'sources').expectHead()
         module.getArtifact(classifier:'sources').expectGet()
         module.getArtifact(classifier:'sources', type:'jar.asc').expectGet()
         module.getArtifact(classifier:'javadoc').expectHead()
         module.getArtifact(classifier:'javadoc').expectGet()
         module.getArtifact(classifier:'javadoc', type:'jar.asc').expectGet()
-        run ":artifactQuery", ":classes"
+        run ":artifactQuery"
 
         then:
         noExceptionThrown()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1368,6 +1368,54 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
         terse << [true, false]
     }
 
+    def "dependency verification should work correctly with artifact queries"() {
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+            verifySignatures()
+            addTrustedKey("org:foo:1.0", validPublicKeyHexString, "pom", "pom")
+            addTrustedKey("org:foo:1.0", validPublicKeyHexString, "jar", "jar")
+            addTrustedKeyByFileName("org:foo:1.0", "foo-1.0-javadoc.jar", validPublicKeyHexString)
+            addTrustedKeyByFileName("org:foo:1.0", "foo-1.0-sources.jar", validPublicKeyHexString)
+        }
+
+        terseConsoleOutput(false)
+        javaLibrary()
+        def module = mavenHttpRepo.module("org", "foo", "1.0")
+            .withSourceAndJavadoc()
+            .publish()
+
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+
+            tasks.register("artifactQuery") {
+                doLast {
+                    dependencies.createArtifactResolutionQuery()
+                        .forModule("org", "foo", "1.0")
+                        .withArtifacts(JvmLibrary, SourcesArtifact, JavadocArtifact)
+                        .execute()
+                }
+            }
+        """
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+        module.getArtifact(type:'pom.asc').expectGet()
+        module.getArtifact(type:'jar.asc').expectGet()
+        module.getArtifact(classifier:'sources').expectHead()
+        module.getArtifact(classifier:'sources').expectGet()
+        module.getArtifact(classifier:'sources', type:'jar.asc').expectGet()
+        module.getArtifact(classifier:'javadoc').expectHead()
+        module.getArtifact(classifier:'javadoc').expectGet()
+        module.getArtifact(classifier:'javadoc', type:'jar.asc').expectGet()
+        run ":artifactQuery", ":classes"
+
+        then:
+        noExceptionThrown()
+    }
+
     private static void tamperWithFile(File file) {
         file.bytes = [0, 1, 2, 3] + file.readBytes().toList() as byte[]
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
@@ -52,11 +52,15 @@ public class DefaultModuleComponentArtifactIdentifier implements ModuleComponent
 
     @Override
     public ModuleComponentArtifactIdentifier getSignatureArtifactId() {
+        String extension = name.getExtension();
+        if (extension == null) {
+            extension = name.getType();
+        }
         return new DefaultModuleComponentArtifactIdentifier(
             componentIdentifier,
             name.getName(),
             "asc",
-            name.getType() + ".asc",
+            extension + ".asc",
             name.getClassifier()
         );
     }


### PR DESCRIPTION
## Context

This pull request fixes the dependency verification mechanism downloading non-existent signature files on remote repositories during IDE sync. The reason was a malformed artifact identifier.

Fixes #16956