### PR TITLE
Remove now unused "Won't fix" legend in CC docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -325,7 +325,6 @@ link:{gradle-issues}13473[[.red]#✖#]:: <<project_report_plugin.adoc#project_re
 [.green]#✓#:: Supported plugin
 [.yellow]#⚠#:: Partially supported plugin
 [.red]#✖#:: Unsupported plugin
-[.gray]#🚫#:: Won't fix
 
 [[config_cache:plugins:community]]
 === Community plugins


### PR DESCRIPTION
It was used for now removed deprecated core plugins such as the legacy publishing plugins.
