### PR TITLE
Add channel as input to performance test task

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -91,7 +91,8 @@ abstract class PerformanceTest extends DistributionTest {
     String checks
 
     @Nullable
-    @Internal
+    @Optional
+    @Input
     String channel
 
     /************** properties configured by PerformanceTestPlugin ***************/


### PR DESCRIPTION
Until we find a solution for reporting when the
cache hit comes from a different branch.