### PR TITLE
Remove channel as input to performance tests

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -91,7 +91,8 @@ abstract class PerformanceTest extends DistributionTest {
     String checks
 
     @Nullable
-    @Internal
+    @Optional
+    @Input
     String channel
 
     /************** properties configured by PerformanceTestPlugin ***************/

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -91,8 +91,7 @@ abstract class PerformanceTest extends DistributionTest {
     String checks
 
     @Nullable
-    @Optional
-    @Input
+    @Internal
     String channel
 
     /************** properties configured by PerformanceTestPlugin ***************/

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractWritableResultsStore.groovy
@@ -18,6 +18,7 @@ package org.gradle.performance.results
 
 import com.google.common.collect.ImmutableMap
 import groovy.transform.CompileStatic
+import org.jetbrains.annotations.NotNull
 
 import java.sql.Timestamp
 import java.time.LocalDateTime
@@ -59,6 +60,11 @@ abstract class AbstractWritableResultsStore<T extends PerformanceTestResult> imp
         join testExecution on testExecution.id = last.lastId
         order by last.testClass, last.testId, last.testProject, last.os
     """
+
+    @NotNull
+    static String teamcityBuildIdQueryFor(List<String> teamcityBuildIds) {
+        return teamcityBuildIds.isEmpty() ? '' : " or teamcitybuildid in (${String.join(',', Collections.nCopies(teamcityBuildIds.size(), '?'))})"
+    }
 
     @Override
     public Map<PerformanceExperimentOnOs, Long> getEstimatedExperimentDurationsInMillis() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AllResultsStore.java
@@ -39,8 +39,8 @@ public class AllResultsStore implements ResultsStore, Closeable {
     }
 
     @Override
-    public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
-        return store.getTestResults(experiment, mostRecentN, maxDaysOld, channel);
+    public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel, List<String> teamcityBuildIds) {
+        return store.getTestResults(experiment, mostRecentN, maxDaysOld, channel, teamcityBuildIds);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CompositeResultsStore.java
@@ -45,8 +45,8 @@ public class CompositeResultsStore implements ResultsStore {
     }
 
     @Override
-    public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
-        return getStoreForTest(experiment).getTestResults(experiment, mostRecentN, maxDaysOld, channel);
+    public PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel, List<String> teamcityBuildIds) {
+        return getStoreForTest(experiment).getTestResults(experiment, mostRecentN, maxDaysOld, channel, teamcityBuildIds);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/NoResultsStore.groovy
@@ -39,7 +39,7 @@ class NoResultsStore<T extends PerformanceTestResult> implements WritableResults
     }
 
     @Override
-    PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel) {
+    PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel, List<String> teamcityBuildIds) {
         new EmptyPerformanceTestHistory(experiment)
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStore.java
@@ -33,8 +33,10 @@ public interface ResultsStore extends Closeable {
 
     /**
      * Returns the n most recent instances of the given test which are younger than the max age.
+     *
+     * This returns all the executions which are either from the channel or in the list of provided teamcity build ids.
      */
-    PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel);
+    PerformanceTestHistory getTestResults(PerformanceExperiment experiment, int mostRecentN, int maxDaysOld, String channel, List<String> teamcityBuildIds);
 
     /**
      * Returns the estimated duration for each experiment in milliseconds.

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractReportGenerator.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.gradle.performance.results.report.PerformanceFlakinessDataProvider.EmptyPerformanceFlakinessDataProvider;
 
@@ -68,12 +69,15 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
 
     protected void generateReport(ResultsStore store, PerformanceFlakinessDataProvider flakinessDataProvider, PerformanceExecutionDataProvider executionDataProvider, File outputDirectory, String projectName) throws IOException {
         renderIndexPage(flakinessDataProvider, executionDataProvider, new File(outputDirectory, "index.html"));
+        List<String> includedBuildIds = executionDataProvider.getScenarioExecutionData().stream()
+            .map(ScenarioBuildResultData::getTeamCityBuildId)
+            .collect(Collectors.toList());
 
         executionDataProvider.getScenarioExecutionData().stream()
             .map(ScenarioBuildResultData::getPerformanceExperiment)
             .distinct()
             .forEach(experiment -> {
-                PerformanceTestHistory testResults = store.getTestResults(experiment, 500, 90, ResultsStoreHelper.determineChannel());
+                PerformanceTestHistory testResults = store.getTestResults(experiment, 500, 90, ResultsStoreHelper.determineChannel(), includedBuildIds);
                 renderScenarioPage(projectName, outputDirectory, testResults);
             });
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
@@ -67,11 +67,12 @@ public class DefaultPerformanceExecutionDataProvider extends PerformanceExecutio
     private ScenarioBuildResultData queryAndSortExecutionData(List<ScenarioBuildResultData> scenarios) {
         ScenarioBuildResultData mergedScenario = mergeScenarioWithSameName(scenarios);
 
-        PerformanceTestHistory history = resultsStore.getTestResults(scenarios.get(0).getPerformanceExperiment(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel());
+        List<String> teamcityBuildIds = scenarios.stream().map(ScenarioBuildResultData::getTeamCityBuildId).collect(toList());
+        PerformanceTestHistory history = resultsStore.getTestResults(scenarios.get(0).getPerformanceExperiment(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel(), teamcityBuildIds);
         List<? extends PerformanceTestExecution> recentExecutions = history.getExecutions();
 
         scenarios.forEach(scenario -> setExecutions(scenario, singletonList(scenario.getTeamCityBuildId()), recentExecutions));
-        setExecutions(mergedScenario,  scenarios.stream().map(ScenarioBuildResultData::getTeamCityBuildId).collect(toList()), recentExecutions);
+        setExecutions(mergedScenario, teamcityBuildIds, recentExecutions);
 
         mergedScenario.setCrossBuild(history instanceof CrossBuildPerformanceTestHistory);
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/FlakinessDetectionPerformanceExecutionDataProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.results.report;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.performance.results.PerformanceTestExecution;
 import org.gradle.performance.results.PerformanceTestHistory;
 import org.gradle.performance.results.ResultsStore;
@@ -58,7 +59,7 @@ class FlakinessDetectionPerformanceExecutionDataProvider extends PerformanceExec
     }
 
     private ScenarioBuildResultData queryExecutionData(ScenarioBuildResultData scenario) {
-        PerformanceTestHistory history = resultsStore.getTestResults(scenario.getPerformanceExperiment(), MOST_RECENT_EXECUTIONS, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel());
+        PerformanceTestHistory history = resultsStore.getTestResults(scenario.getPerformanceExperiment(), MOST_RECENT_EXECUTIONS, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel(), ImmutableList.of());
         List<? extends PerformanceTestExecution> executionsOfSameCommit = history.getExecutions().stream().filter(execution -> execution.getVcsCommits().contains(commitId)).collect(toList());
         List<? extends PerformanceTestExecution> currentExecutions = executionsOfSameCommit.isEmpty()
             ? history.getExecutions().stream().limit(3).collect(toList())

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossBuildResultsStoreTest.groovy
@@ -437,7 +437,7 @@ class CrossBuildResultsStoreTest extends ResultSpecification {
         history.results*.startTime == [currentTime - 1000, currentTime - 2000, currentTime - 3000]
 
         when:
-        history = readStore.getTestResults(experiment1, 2, Integer.MAX_VALUE, channel)
+        history = readStore.getTestResults(experiment1, 2, Integer.MAX_VALUE, channel, [])
 
         then:
         history.results*.startTime == [currentTime - 1000, currentTime - 2000]

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/CrossVersionResultsStoreTest.groovy
@@ -223,7 +223,7 @@ class CrossVersionResultsStoreTest extends ResultSpecification {
         results.resultsOldestFirst*.versionUnderTest == ["1.7-rc-1", "1.7-rc-2", "1.7-rc-3"]
 
         when:
-        results = readStore.getTestResults(experiment1, 2, Integer.MAX_VALUE, channel)
+        results = readStore.getTestResults(experiment1, 2, Integer.MAX_VALUE, channel, [])
 
         then:
         results.results.size() == 2


### PR DESCRIPTION
This allows caching between different pre-tested commit changes. The problem we had was that we didn't pick up cached results from other channels. Now we do, by also including all the teamcity build ids in the query for the previous test results.