### PR TITLE
Expose the java-platform plugin's component and extension name as constants

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -50,6 +50,9 @@ import java.util.Set;
  * @see <a href="https://docs.gradle.org/current/userguide/java_platform_plugin.html">Java Platform plugin reference</a>
  */
 public class JavaPlatformPlugin implements Plugin<Project> {
+    public static final String COMPONENT_NAME = "javaPlatform";
+    public static final String EXTENSION_NAME = "javaPlatform";
+
     // Buckets of dependencies
     public static final String API_CONFIGURATION_NAME = "api";
     public static final String RUNTIME_CONFIGURATION_NAME = "runtime";
@@ -111,7 +114,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     }
 
     private void createSoftwareComponent(Project project, Configuration apiElements, Configuration runtimeElements) {
-        AdhocComponentWithVariants component = softwareComponentFactory.adhoc("javaPlatform");
+        AdhocComponentWithVariants component = softwareComponentFactory.adhoc(COMPONENT_NAME);
         project.getComponents().add(component);
         component.addVariantsFromConfiguration(apiElements, new JavaConfigurationVariantMapping("compile", false));
         component.addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", false));
@@ -170,7 +173,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     }
 
     private void configureExtension(Project project) {
-        final DefaultJavaPlatformExtension platformExtension = (DefaultJavaPlatformExtension) project.getExtensions().create(JavaPlatformExtension.class, "javaPlatform", DefaultJavaPlatformExtension.class);
+        final DefaultJavaPlatformExtension platformExtension = (DefaultJavaPlatformExtension) project.getExtensions().create(JavaPlatformExtension.class, EXTENSION_NAME, DefaultJavaPlatformExtension.class);
         project.afterEvaluate(project1 -> {
             if (!platformExtension.isAllowDependencies()) {
                 checkNoDependencies(project1);


### PR DESCRIPTION
### Context
A simple change to expose the java-platform plugin's software component name ("javaPlatform") and extension name ("javaPlatform") as constants allowing plugins (and/or build-scripts) to use them, as has been done with many other plugin/task/etc names already.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
