### PR TITLE
Dependency verification usability improvements

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1461,7 +1461,7 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
 2 artifacts failed verification:
   - foo-1.0.jar (org:foo:1.0) from repository maven
   - foo-1.0.pom (org:foo:1.0) from repository maven
-This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums."""
+This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums. Key servers are disabled, this can indicate that you need to update the local keyring with the missing keys."""
     }
 
     private static void tamperWithFile(File file) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -322,6 +322,14 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         keyrings.size() == 2
         keyrings.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
         keyrings.find { it.publicKey.keyID == keyring.publicKey.keyID }
+
+        and: "also generates an ascii armored keyring file"
+        def exportedKeyRingAscii = file("gradle/verification-keyring.keys")
+        exportedKeyRingAscii.exists()
+        def keyringsAscii = SecuritySupport.loadKeyRingFile(exportedKeyRingAscii)
+        keyringsAscii.size() == 2
+        keyringsAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+        keyringsAscii.find { it.publicKey.keyID == keyring.publicKey.keyID }
     }
 
     @UnsupportedWithConfigurationCache

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -171,7 +171,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
                     Collection<RepositoryAwareVerificationFailure> value = entry.getValue();
                     return value.stream().noneMatch(wrapper -> wrapper.getFailure().isFatal());
                 });
-                VerificationReport report = reportWriter.generateReport(displayName, failures);
+                VerificationReport report = reportWriter.generateReport(displayName, failures, verifier.getConfiguration().isUseKeyServers());
                 String errorMessage = buildConsoleErrorMessage(report);
                 if (verificationMode == DependencyVerificationMode.LENIENT) {
                     LOGGER.error(errorMessage);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -97,7 +97,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
         } catch (InvalidUserDataException e) {
             throw new InvalidUserDataException("Unable to read dependency verification metadata from " + verificationsFile, e.getCause());
         }
-        this.signatureVerificationService = signatureVerificationServiceFactory.create(keyRingsFile, keyServers());
+        this.signatureVerificationService = signatureVerificationServiceFactory.create(keyRingsFile, keyServers(), verifier.getConfiguration().isUseKeyServers());
     }
 
     private List<URI> keyServers() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/AbstractTextDependencyVerificationReportRenderer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/AbstractTextDependencyVerificationReportRenderer.java
@@ -43,6 +43,9 @@ abstract class AbstractTextDependencyVerificationReportRenderer implements Depen
                 sb.append("signatures and ");
             }
             sb.append("checksums.");
+            if (highLevelErrors.hasFailedSignatures() && highLevelErrors.isKeyServersDisabled()) {
+                sb.append(" Key servers are disabled, this can indicate that you need to update the local keyring with the missing keys.");
+            }
             legend(sb.toString());
         }
         if (highLevelErrors.canSuggestWriteMetadata()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/DependencyVerificationReportWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/DependencyVerificationReportWriter.java
@@ -83,12 +83,13 @@ public class DependencyVerificationReportWriter {
     }
 
     public VerificationReport generateReport(String displayName,
-                                             Multimap<ModuleComponentArtifactIdentifier, RepositoryAwareVerificationFailure> failuresByArtifact) {
+                                             Multimap<ModuleComponentArtifactIdentifier, RepositoryAwareVerificationFailure> failuresByArtifact,
+                                             boolean useKeyServers) {
         assertInitialized();
         // We need at least one fatal failure: if it's only "warnings" we don't care
         // but of there's a fatal failure AND a warning we want to show both
-        doRender(displayName, failuresByArtifact, summaryRenderer);
-        doRender(displayName, failuresByArtifact, htmlRenderer);
+        doRender(displayName, failuresByArtifact, summaryRenderer, useKeyServers);
+        doRender(displayName, failuresByArtifact, htmlRenderer, useKeyServers);
         File htmlReport = htmlRenderer.writeReport();
         return new VerificationReport(summaryRenderer.render(), htmlReport);
     }
@@ -100,8 +101,14 @@ public class DependencyVerificationReportWriter {
         }
     }
 
-    public void doRender(String displayName, Multimap<ModuleComponentArtifactIdentifier, RepositoryAwareVerificationFailure> failuresByArtifact, DependencyVerificationReportRenderer renderer) {
+    public void doRender(String displayName,
+                         Multimap<ModuleComponentArtifactIdentifier, RepositoryAwareVerificationFailure> failuresByArtifact,
+                         DependencyVerificationReportRenderer renderer,
+                         boolean useKeyServers) {
         ReportState reportState = new ReportState();
+        if (!useKeyServers) {
+            reportState.keyServersAreDisabled();
+        }
         renderer.startNewSection(displayName);
         renderer.startArtifactErrors(() -> {
             // Sorting entries so that error messages are always displayed in a reproducible order

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/ReportState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/ReportState.java
@@ -25,6 +25,7 @@ class ReportState implements VerificationHighLevelErrors {
     private boolean hasMissing;
     private boolean failedSignatures;
     private boolean hasUntrustedKeys;
+    private boolean keyServersDisabled;
 
     public void maybeCompromised() {
         maybeCompromised = true;
@@ -40,6 +41,10 @@ class ReportState implements VerificationHighLevelErrors {
 
     public void hasUntrustedKeys() {
         hasUntrustedKeys = true;
+    }
+
+    public void keyServersAreDisabled() {
+        keyServersDisabled = true;
     }
 
     @Override
@@ -64,5 +69,10 @@ class ReportState implements VerificationHighLevelErrors {
 
     public void addAffectedFile(String file) {
         affectedFiles.add(file);
+    }
+
+    @Override
+    public boolean isKeyServersDisabled() {
+        return keyServersDisabled;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/VerificationHighLevelErrors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/report/VerificationHighLevelErrors.java
@@ -26,4 +26,6 @@ interface VerificationHighLevelErrors {
     boolean canSuggestWriteMetadata();
 
     Set<String> getAffectedFiles();
+
+    boolean isKeyServersDisabled();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -171,8 +171,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         ensureOutputDirCreated();
         maybeReadExistingFile();
         // when we generate the verification file, we intentionally ignore if the "use key servers" flag is false
-        // because otherwise it forces the user to disable the flag in the XML file, generate, then switch it back
-        // to false
+        // because otherwise it forces the user to remove the option in the XML file, generate, then switch it back.
         boolean offline = gradle.getStartParameter().isOffline();
         SignatureVerificationService signatureVerificationService = signatureVerificationServiceFactory.create(
             keyringsFile,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -172,7 +172,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         maybeReadExistingFile();
         SignatureVerificationService signatureVerificationService = signatureVerificationServiceFactory.create(
             keyringsFile,
-            DefaultKeyServers.getOrDefaults(verificationsBuilder.getKeyServers())
+            DefaultKeyServers.getOrDefaults(verificationsBuilder.getKeyServers()),
+            verificationsBuilder.isUseKeyServers()
         );
         try {
             validateChecksums();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -534,7 +534,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
                 }
             }
             // Then write the ascii armored keyring
-            try (ArmoredOutputStream out = new ArmoredOutputStream(new FileOutputStream(ascii, true))) {
+            try (FileOutputStream fos = new FileOutputStream(ascii, true);
+                 ArmoredOutputStream out = new ArmoredOutputStream(fos)) {
                 keyRing.encode(out, true);
             }
             hasKey = true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationXmlTags.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationXmlTags.java
@@ -21,6 +21,7 @@ abstract class DependencyVerificationXmlTags {
     static final String COMPONENT = "component";
     static final String COMPONENTS = "components";
     static final String CONFIG = "configuration";
+    static final String ENABLED = "enabled";
     static final String FILE = "file";
     static final String GROUP = "group";
     static final String ID = "id";

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -48,6 +48,7 @@ import static org.gradle.api.internal.artifacts.verification.serializer.Dependen
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENT;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENTS;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.CONFIG;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ENABLED;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.FILE;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.GROUP;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ID;
@@ -180,6 +181,10 @@ public class DependencyVerificationsXmlReader {
                 case KEY_SERVERS:
                     assertInConfiguration(KEY_SERVERS);
                     inKeyServers = true;
+                    String enabled = getNullableAttribute(attributes, ENABLED);
+                    if (enabled != null) {
+                        builder.setUseKeyServers(Boolean.parseBoolean(enabled));
+                    }
                     break;
                 case KEY_SERVER:
                     assertContext(inKeyServers, KEY_SERVER, KEY_SERVERS);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriter.java
@@ -41,6 +41,7 @@ import static org.gradle.api.internal.artifacts.verification.serializer.Dependen
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENT;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.COMPONENTS;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.CONFIG;
+import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.ENABLED;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.TRUSTING;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.FILE;
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.GROUP;
@@ -86,7 +87,7 @@ public class DependencyVerificationsXmlWriter {
         writer.startElement(VERIFICATION_METADATA);
         writeAttribute("xmlns", "https://schema.gradle.org/dependency-verification");
         writeAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-        writeAttribute("xsi:schemaLocation", "https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.0.xsd");
+        writeAttribute("xsi:schemaLocation", "https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.1.xsd");
         writeConfiguration(verifier.getConfiguration());
         writeVerifications(verifier.getVerificationMetadata());
         writer.endElement();
@@ -203,8 +204,11 @@ public class DependencyVerificationsXmlWriter {
 
     private void writeKeyServers(DependencyVerificationConfiguration configuration) throws IOException {
         List<URI> keyServers = configuration.getKeyServers();
-        if (!keyServers.isEmpty()) {
+        if (!keyServers.isEmpty() || !configuration.isUseKeyServers()) {
             writer.startElement(KEY_SERVERS);
+            if (!configuration.isUseKeyServers()) {
+                writer.attribute(ENABLED, "false");
+            }
             for (URI keyServer : keyServers) {
                 writer.startElement(KEY_SERVER);
                 writeAttribute(URI, keyServer.toASCIIString());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
@@ -87,6 +87,9 @@ public class DefaultSignatureVerificationServiceFactory implements SignatureVeri
         });
         PublicKeyDownloadService keyDownloadService = new PublicKeyDownloadService(ImmutableList.copyOf(keyServers), connector);
         PublicKeyService keyService = new CrossBuildCachingKeyService(cacheRepository, decoratorFactory, buildOperationExecutor, keyDownloadService, timeProvider, refreshKeys);
+        if (!keyringsFile.exists()) {
+            keyringsFile = SecuritySupport.asciiArmoredFileFor(keyringsFile);
+        }
         if (keyringsFile.exists()) {
             KeyringFilePublicKeyService keyringFilePublicKeyService = new KeyringFilePublicKeyService(keyringsFile);
             keyService = PublicKeyServiceChain.of(keyringFilePublicKeyService, keyService);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/SignatureVerificationServiceFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/SignatureVerificationServiceFactory.java
@@ -20,5 +20,5 @@ import java.net.URI;
 import java.util.List;
 
 public interface SignatureVerificationServiceFactory {
-    SignatureVerificationService create(File keyringsFile, List<URI> keyServers);
+    SignatureVerificationService create(File keyringsFile, List<URI> keyServers, boolean useKeyServers);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerificationConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerificationConfiguration.java
@@ -30,14 +30,22 @@ public class DependencyVerificationConfiguration {
     private final boolean verifyMetadata;
     private final boolean verifySignatures;
     private final List<TrustedArtifact> trustedArtifacts;
+    private final boolean useKeyServers;
     private final List<URI> keyServers;
     private final Set<IgnoredKey> ignoredKeys;
     private final List<TrustedKey> trustedKeys;
 
-    public DependencyVerificationConfiguration(boolean verifyMetadata, boolean verifySignatures, List<TrustedArtifact> trustedArtifacts, List<URI> keyServers, Set<IgnoredKey> ignoredKeys, List<TrustedKey> trustedKeys) {
+    public DependencyVerificationConfiguration(boolean verifyMetadata,
+                                               boolean verifySignatures,
+                                               List<TrustedArtifact> trustedArtifacts,
+                                               boolean useKeyServers,
+                                               List<URI> keyServers,
+                                               Set<IgnoredKey> ignoredKeys,
+                                               List<TrustedKey> trustedKeys) {
         this.verifyMetadata = verifyMetadata;
         this.verifySignatures = verifySignatures;
         this.trustedArtifacts = ImmutableList.copyOf(trustedArtifacts);
+        this.useKeyServers = useKeyServers;
         this.keyServers = keyServers;
         this.ignoredKeys = ignoredKeys;
         this.trustedKeys = trustedKeys;
@@ -65,6 +73,10 @@ public class DependencyVerificationConfiguration {
 
     public List<TrustedKey> getTrustedKeys() {
         return trustedKeys;
+    }
+
+    public boolean isUseKeyServers() {
+        return useKeyServers;
     }
 
     public abstract static class TrustCoordinates {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
@@ -52,6 +52,7 @@ public class DependencyVerifierBuilder {
     private final Set<IgnoredKey> ignoredKeys = Sets.newLinkedHashSet();
     private boolean isVerifyMetadata = true;
     private boolean isVerifySignatures = false;
+    private boolean useKeyServers = true;
 
     public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
         ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
@@ -87,6 +88,14 @@ public class DependencyVerifierBuilder {
         isVerifySignatures = verifySignatures;
     }
 
+    public boolean isUseKeyServers() {
+        return useKeyServers;
+    }
+
+    public void setUseKeyServers(boolean useKeyServers) {
+        this.useKeyServers = useKeyServers;
+    }
+
     public List<URI> getKeyServers() {
         return keyServers;
     }
@@ -118,7 +127,7 @@ public class DependencyVerifierBuilder {
             .stream()
             .sorted(Map.Entry.comparingByKey(MODULE_COMPONENT_IDENTIFIER_COMPARATOR))
             .forEachOrdered(entry -> builder.put(entry.getKey(), entry.getValue().build()));
-        return new DependencyVerifier(builder.build(), new DependencyVerificationConfiguration(isVerifyMetadata, isVerifySignatures, trustedArtifacts, ImmutableList.copyOf(keyServers), ImmutableSet.copyOf(ignoredKeys), ImmutableList.copyOf(trustedKeys)));
+        return new DependencyVerifier(builder.build(), new DependencyVerificationConfiguration(isVerifyMetadata, isVerifySignatures, trustedArtifacts, useKeyServers, ImmutableList.copyOf(keyServers), ImmutableSet.copyOf(ignoredKeys), ImmutableList.copyOf(trustedKeys)));
     }
 
     public List<DependencyVerificationConfiguration.TrustedArtifact> getTrustedArtifacts() {

--- a/subprojects/dependency-management/src/main/resources/org/gradle/schema/dependency-verification-1.1.xsd
+++ b/subprojects/dependency-management/src/main/resources/org/gradle/schema/dependency-verification-1.1.xsd
@@ -1,0 +1,155 @@
+<!--
+  ~ Copyright 2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<xs:schema
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="https://schema.gradle.org/dependency-verification">
+    <xs:complexType name="coordinatesType">
+        <xs:attribute type="xs:string" name="group"/>
+        <xs:attribute type="xs:string" name="name"/>
+        <xs:attribute type="xs:string" name="version"/>
+        <xs:attribute type="xs:boolean" name="regex"/>
+        <xs:attribute type="xs:string" name="file"/>
+    </xs:complexType>
+    <xs:complexType name="trustType">
+        <xs:simpleContent>
+            <xs:extension base="coordinatesType"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="trusted-artifactsType">
+        <xs:sequence>
+            <xs:element type="trustType" name="trust" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ignored-keyType">
+        <xs:attribute type="xs:string" name="id" use="required"/>
+        <xs:attribute type="xs:string" name="reason"/>
+    </xs:complexType>
+    <xs:complexType name="ignored-keysType">
+        <xs:sequence>
+            <xs:element type="ignored-keyType" name="ignored-key"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="trusted-keyType" mixed="true">
+        <xs:sequence>
+            <xs:element type="trustingType" name="trusting" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="id" use="required"/>
+        <xs:attribute type="xs:string" name="group"/>
+        <xs:attribute type="xs:string" name="name"/>
+        <xs:attribute type="xs:string" name="version"/>
+        <xs:attribute type="xs:string" name="file"/>
+        <xs:attribute type="xs:string" name="regex"/>
+    </xs:complexType>
+    <xs:complexType name="trustingType">
+        <xs:simpleContent>
+            <xs:extension base="coordinatesType"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="trusted-keysType">
+        <xs:sequence>
+            <xs:element type="trusted-keyType" name="trusted-key" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="key-serversType">
+        <xs:sequence>
+            <xs:element type="key-serverType" name="key-server" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="enabled"/>
+    </xs:complexType>
+    <xs:complexType name="key-serverType">
+        <xs:attribute type="xs:string" name="uri"/>
+    </xs:complexType>
+    <xs:complexType name="configurationType">
+        <xs:sequence>
+            <xs:element type="xs:boolean" name="verify-metadata"/>
+            <xs:element type="xs:boolean" name="verify-signatures"/>
+            <xs:element type="trusted-artifactsType" name="trusted-artifacts"/>
+            <xs:element type="ignored-keysType" name="ignored-keys"/>
+            <xs:element type="trusted-keysType" name="trusted-keys"/>
+            <xs:element type="key-serversType" name="key-servers"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="md5Type" mixed="true">
+        <xs:sequence>
+            <xs:element type="also-trustType" name="also-trust" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+        <xs:attribute type="xs:string" name="origin"/>
+    </xs:complexType>
+    <xs:complexType name="sha1Type" mixed="true">
+        <xs:sequence>
+            <xs:element type="also-trustType" name="also-trust" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+        <xs:attribute type="xs:string" name="origin"/>
+    </xs:complexType>
+    <xs:complexType name="sha256Type" mixed="true">
+        <xs:sequence>
+            <xs:element type="also-trustType" name="also-trust" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+        <xs:attribute type="xs:string" name="origin"/>
+    </xs:complexType>
+    <xs:complexType name="sha512Type" mixed="true">
+        <xs:sequence>
+            <xs:element type="also-trustType" name="also-trust" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="value" use="required"/>
+        <xs:attribute type="xs:string" name="origin"/>
+    </xs:complexType>
+    <xs:complexType name="pgpType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute type="xs:string" name="value" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="artifactType">
+        <xs:choice maxOccurs="unbounded" minOccurs="0">
+            <xs:element type="ignored-keysType" name="ignored-keys"/>
+            <xs:element type="pgpType" name="pgp"/>
+            <xs:element type="md5Type" name="md5"/>
+            <xs:element type="sha1Type" name="sha1"/>
+            <xs:element type="sha256Type" name="sha256"/>
+            <xs:element type="sha512Type" name="sha512"/>
+        </xs:choice>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="componentType">
+        <xs:sequence>
+            <xs:element type="artifactType" name="artifact" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="group" use="required"/>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:string" name="version" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="also-trustType">
+        <xs:attribute type="xs:string" name="value"/>
+    </xs:complexType>
+    <xs:complexType name="componentsType">
+        <xs:sequence>
+            <xs:element type="componentType" name="component" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="verification-metadataType">
+        <xs:sequence>
+            <xs:element type="configurationType" name="configuration"/>
+            <xs:element type="componentsType" name="components"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="verification-metadata" type="verification-metadataType"/>
+</xs:schema>

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReaderTest.groovy
@@ -40,7 +40,7 @@ class DependencyVerificationsXmlReaderTest extends Specification {
         parse """<?xml version="1.0" encoding="UTF-8"?>
 <verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.0.xsd">
+      xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.1.xsd">
 </verification-metadata>
 """
         then:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
@@ -61,7 +61,7 @@ class DependencyVerificationsXmlWriterTest extends Specification {
     }
 
     private boolean hasNamespaceDeclaration() {
-        rawContents.contains('<verification-metadata xmlns="https://schema.gradle.org/dependency-verification" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.0.xsd"')
+        rawContents.contains('<verification-metadata xmlns="https://schema.gradle.org/dependency-verification" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.1.xsd"')
     }
 
     def "can declare key servers"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierTest.groovy
@@ -32,7 +32,7 @@ import spock.lang.Subject
 
 class DependencyVerifierTest extends Specification {
     @Subject
-    DependencyVerifier verifier = new DependencyVerifier([:], new DependencyVerificationConfiguration(true, true, [], [], [] as Set, []))
+    DependencyVerifier verifier = new DependencyVerifier([:], new DependencyVerificationConfiguration(true, true, [], true, [], [] as Set, []))
 
     ChecksumService checksumService = Mock(ChecksumService)
     PublicKeyService publicKeyService = Mock(PublicKeyService)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
@@ -224,6 +224,10 @@ class DependencyVerificationFixture {
     static class Builder {
         private final DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
 
+        void disableKeyServers() {
+            builder.useKeyServers = false
+        }
+
         void noMetadataVerification() {
             builder.verifyMetadata = false
         }

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -585,6 +585,31 @@ This situation is common as explained for <<sec:trusting-several-checksums,this 
 
 In addition, Gradle will try to group keys automatically and generate the `trusted-keys` block which reduced the configuration file size as much as possible.
 
+[[sec:local-keyring-only]]
+== Forcing use of local keyrings only
+
+The local keyring files (`.gpg` or `.keys`) can be used to avoid reaching out to key servers whenever a key is required to verify an artifact.
+However, it may be that the local keyring doesn't contain a key, in which case Gradle would use the key servers to fetch the missing key.
+If the local keyring file isn't regularly updated, using <<sec:local-keyring,key export>>, then it may be that your CI builds, for example, would reach out to key servers too often (especially if you use disposable containers for builds).
+
+To avoid this, Gradle offers the ability to disallow use of key servers altogether: only the local keyring file would be used, and if a key is missing from this file, the build will fail.
+
+To enable this mode, you need to disable key servers in the configuration file:
+
+[source,xml]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+   <configuration>
+      <key-servers enabled="false"/>
+      ...
+   </configuration>
+   ...
+</verification-metadata>
+----
+
+NOTE: If you are asking Gradle to <<sec:bootstrapping-verification,generate a verification metadata file>> and that an existing verification metadata file sets `enabled` to `false`, then this flag will be ignored, so that potentially missing keys are downloaded.
+
 [[sec:troubleshooting-verification]]
 == Troubleshooting dependency verification
 

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -486,9 +486,16 @@ However, if the signature cannot be verified with at least one other key, Gradle
 Gradle automatically downloads the required keys but this operation can be quite slow and requires everyone to download the keys.
 To avoid this, Gradle offers the ability to use a local keyring file containing the required public keys.
 
-If the `gradle/verification-keyring.gpg` file is present, Gradle will search for keys there in priority.
+Gradle supports 2 different file formats for keyrings: a binary format (`.gpg` file) and a plain text format (`.keys`).
 
-You can generate this file using GPG, for example issuing the following commands (syntax may depend on the tool you use):
+There are pros and cons for each of the formats: the binary format is more compact and can be updated directly via GPG commands, but is completely opaque (binary).
+On the opposite, the plain text format is human readable, can be easily updated by hand and makes it easier to do code reviews thanks to readable diffs.
+
+If the `gradle/verification-keyring.gpg` or `gradle/verification-keyring.keys` file is present, Gradle will search for keys there in priority.
+
+Note that the plain text file will be ignored if there's already a `.gpg` file (the binary version takes precedence).
+
+You can generate the binary version using GPG, for example issuing the following commands (syntax may depend on the tool you use):
 
 [source,bash]
 ----
@@ -506,8 +513,28 @@ gpg: Total number processed: 1
 gpg:               imported: 1
 ----
 
-Or, alternatively, you can _ask Gradle to export all keys it used for verification of this build to the keyring_ during bootstrapping:
+The plain text version, on the other hand, can be updated manually.
+The file must be formatted with the `US-ASCII` encoding and consists of a list of keys in ASCII armored format.
 
+In the example above, you could amend an existing KEYS file by issuing the following commands:
+
+[source,bash]
+----
+$ gpg --no-default-keyring --keyring /tmp/keyring.gpg --recv-keys 379ce192d401ab61
+
+gpg: keybox '/tmp/keyring.gpg' created
+gpg: key 379CE192D401AB61: public key "Bintray (by JFrog) <****>" imported
+gpg: Total number processed: 1
+gpg:               imported: 1
+
+# First let's add a header so that we can recognize the added key
+$ gpg --keyring /tmp/keyring.gpg --list-sigs 379CE192D401AB61 > gradle/verification-keyring.keys
+
+# Then write its ASCII armored version
+$ gpg --keyring /tmp/keyring.gpg --export --armor 379CE192D401AB61 > gradle/verification-keyring.keys
+----
+
+Or, alternatively, you can _ask Gradle to export all keys it used for verification of this build to the keyring_ during bootstrapping:
 
 ----
 ./gradlew --write-verification-metadata pgp,sha256 --export-keys
@@ -515,8 +542,11 @@ Or, alternatively, you can _ask Gradle to export all keys it used for verificati
 
 [NOTE]
 ====
+This command will generate *both* the binary version and the ASCII armored file.
+You should only pick one for your project.
+
 It's a good idea to commit this file to VCS (as long as you trust your VCS).
-If you use git, make sure to make it treat this file as binary, by adding this to your `.gitattributes` file:
+If you use git and use the binary version, make sure to make it treat this file as binary, by adding this to your `.gitattributes` file:
 
 ----
 *.gpg           binary

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/gradle/verification-metadata.xml
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/groovy/gradle/verification-metadata.xml
@@ -16,7 +16,7 @@
   -->
 <verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.0.xsd">
+                       xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.1.xsd">
     <configuration>
         <verify-metadata>false</verify-metadata>
         <verify-signatures>true</verify-signatures>

--- a/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/gradle/verification-metadata.xml
+++ b/subprojects/docs/src/snippets/dependencyManagement/dependencyVerification-disablingVerification/kotlin/gradle/verification-metadata.xml
@@ -16,7 +16,7 @@
   -->
 <verification-metadata xmlns="https://schema.gradle.org/dependency-verification"
                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.0.xsd">
+                       xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/verification-1.1.xsd">
     <configuration>
         <verify-metadata>false</verify-metadata>
         <verify-signatures>true</verify-signatures>

--- a/subprojects/security/src/main/java/org/gradle/security/internal/EmptyPublicKeyService.java
+++ b/subprojects/security/src/main/java/org/gradle/security/internal/EmptyPublicKeyService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.security.internal;
+
+import java.io.IOException;
+
+public class EmptyPublicKeyService implements PublicKeyService {
+    private final static EmptyPublicKeyService EMPTY = new EmptyPublicKeyService();
+
+    private EmptyPublicKeyService() {
+
+    }
+
+    public static EmptyPublicKeyService getInstance() {
+        return EMPTY;
+    }
+
+    @Override
+    public void findByLongId(long keyId, PublicKeyResultBuilder builder) {
+
+    }
+
+    @Override
+    public void findByFingerprint(byte[] fingerprint, PublicKeyResultBuilder builder) {
+
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
+++ b/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.security.internal;
 
+import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPObjectFactory;
@@ -44,6 +45,7 @@ public class SecuritySupport {
     private static final Logger LOGGER = Logging.getLogger(SecuritySupport.class);
 
     private static final int BUFFER = 4096;
+    public static final String KEYS_FILE_EXT = ".keys";
 
     static {
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
@@ -103,7 +105,7 @@ public class SecuritySupport {
     public static List<PGPPublicKeyRing> loadKeyRingFile(File keyringFile) throws IOException {
         List<PGPPublicKeyRing> existingRings = new ArrayList<>();
         // load existing keys from keyring before
-        try (InputStream ins = new BufferedInputStream(new FileInputStream(keyringFile))) {
+        try (InputStream ins = new BufferedInputStream(createInputStreamFor(keyringFile))) {
             PGPObjectFactory objectFactory = new JcaPGPObjectFactory(
                 PGPUtil.getDecoderStream(ins));
             try {
@@ -117,5 +119,18 @@ public class SecuritySupport {
             }
         }
         return existingRings;
+    }
+
+    private static InputStream createInputStreamFor(File keyringFile) throws IOException {
+        InputStream stream = new FileInputStream(keyringFile);
+        if (keyringFile.getName().endsWith(KEYS_FILE_EXT)) {
+            return new ArmoredInputStream(stream);
+        }
+        return stream;
+    }
+
+    public static File asciiArmoredFileFor(File keyringsFile) {
+        String baseName = keyringsFile.getName().substring(0, keyringsFile.getName().toLowerCase().lastIndexOf(".gpg"));
+        return new File(keyringsFile.getParentFile(), baseName + KEYS_FILE_EXT);
     }
 }

--- a/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
+++ b/subprojects/security/src/main/java/org/gradle/security/internal/SecuritySupport.java
@@ -105,9 +105,8 @@ public class SecuritySupport {
     public static List<PGPPublicKeyRing> loadKeyRingFile(File keyringFile) throws IOException {
         List<PGPPublicKeyRing> existingRings = new ArrayList<>();
         // load existing keys from keyring before
-        try (InputStream ins = new BufferedInputStream(createInputStreamFor(keyringFile))) {
-            PGPObjectFactory objectFactory = new JcaPGPObjectFactory(
-                PGPUtil.getDecoderStream(ins));
+        try (InputStream ins = PGPUtil.getDecoderStream(createInputStreamFor(keyringFile))) {
+            PGPObjectFactory objectFactory = new JcaPGPObjectFactory(ins);
             try {
                 for (Object o : objectFactory) {
                     if (o instanceof PGPPublicKeyRing) {

--- a/subprojects/security/src/testFixtures/groovy/org/gradle/security/fixtures/SimpleKeyRing.groovy
+++ b/subprojects/security/src/testFixtures/groovy/org/gradle/security/fixtures/SimpleKeyRing.groovy
@@ -43,11 +43,12 @@ class SimpleKeyRing {
 
     void writePublicKeyRingTo(File file) {
         def asciiArmored = file.name.endsWith(".keys")
-        def stream = asciiArmored ? new ArmoredOutputStream(file.newOutputStream()) : file.newOutputStream()
-        stream.withCloseable { out ->
-            new PGPPublicKeyRingCollection(
-                [new PGPPublicKeyRing([publicKey])]
-            ).encode(stream)
+        file.newOutputStream().withCloseable {stream ->
+            (asciiArmored ? new ArmoredOutputStream(stream) : stream).withCloseable { out ->
+                new PGPPublicKeyRingCollection(
+                    [new PGPPublicKeyRing([publicKey])]
+                ).encode(out)
+            }
         }
     }
 

--- a/subprojects/security/src/testFixtures/groovy/org/gradle/security/fixtures/SimpleKeyRing.groovy
+++ b/subprojects/security/src/testFixtures/groovy/org/gradle/security/fixtures/SimpleKeyRing.groovy
@@ -42,10 +42,12 @@ class SimpleKeyRing {
     final String password
 
     void writePublicKeyRingTo(File file) {
-        file.withOutputStream { out ->
+        def asciiArmored = file.name.endsWith(".keys")
+        def stream = asciiArmored ? new ArmoredOutputStream(file.newOutputStream()) : file.newOutputStream()
+        stream.withCloseable { out ->
             new PGPPublicKeyRingCollection(
                 [new PGPPublicKeyRing([publicKey])]
-            ).encode(out)
+            ).encode(stream)
         }
     }
 


### PR DESCRIPTION
### Context

This pull request improves the usability of dependency verification. The first improvement is to support plain text keyrings. The format is similar to what is usually found on public repositories (here's an example [on Apache](https://dist.apache.org/repos/dist/release/groovy/KEYS)). It makes code reviews easier by avoiding to rely on a binary file for keys.

The second improvement is to support completely ignoring key servers. Therefore, if a key isn't found in the local keyring, the build would fail immediately, and wouldn't try to fetch the key in a public key server. This can be useful when we want to make sure that the keys file is in sync with what is required to build the project, without needing external resources.

