### PR TITLE
Use commit id for from cache detection

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/reporter/PerformanceReporter.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/reporter/PerformanceReporter.groovy
@@ -50,7 +50,8 @@ class PerformanceReporter {
         String branchName,
         String commitId,
         FileCollection classpath,
-        String projectName
+        String projectName,
+        boolean debugReportGeneration
     ) {
         fileOperations.delete {
            it.delete(reportDir)
@@ -63,6 +64,7 @@ class PerformanceReporter {
                 spec.args(reportDir.path, projectName)
                 spec.args(resultJsons*.path)
                 spec.systemProperties(databaseParameters)
+                spec.debug = debugReportGeneration
                 spec.systemProperty("org.gradle.performance.execution.channel", channel)
                 spec.systemProperty("org.gradle.performance.execution.branch", branchName)
 

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -170,7 +170,8 @@ abstract class PerformanceTest extends DistributionTest {
                 branchName,
                 commitId.get(),
                 classpath,
-                projectName.get()
+                projectName.get(),
+                false
             )
         }
     }

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
@@ -81,11 +81,19 @@ abstract class PerformanceTestReport : DefaultTask() {
     @get:Input
     abstract val projectName: Property<String>
 
+    @get:Option(option = "debug-jvm", description = "Debug the JVM started for report generation.")
+    @get:Input
+    abstract val debugReportGeneration: Property<Boolean>
+
     @get:Inject
     abstract val fileOperations: FileSystemOperations
 
     @get:Inject
     abstract val execOperations: ExecOperations
+
+    init {
+        outputs.doNotCacheIf("Debug enabled") { debugReportGeneration.get() }
+    }
 
     @TaskAction
     fun generateReport() {
@@ -99,7 +107,8 @@ abstract class PerformanceTestReport : DefaultTask() {
             branchName.get(),
             commitId.get(),
             classpath,
-            projectName.get()
+            projectName.get(),
+            debugReportGeneration.getOrElse(false)
         )
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -36,6 +36,13 @@ class ScenarioBuildResultData {
     String testFailure
     String status
     boolean crossBuild
+
+    /**
+     * The commit id of the current build which is generating the report.
+     *
+     * Set after loading from the JSON/DB so we can determine if an execution is from cache or not.
+     */
+    String currentCommitId
     List<ExecutionData> currentBuildExecutions = []
     List<ExecutionData> recentExecutions = []
 
@@ -71,7 +78,11 @@ class ScenarioBuildResultData {
     }
 
     boolean isFromCache() {
-        return status == STATUS_SUCCESS && currentBuildExecutions.empty
+        // Current approximation: If the current executions are for a different commit id,
+        // then the build result is from the cache.
+        // It could be that the performance test did re-run on the same commit with a cache hit and we won't detect that here.
+        // For now, this should be good enough.
+        return status == STATUS_SUCCESS && !(currentBuildExecutions*.commitId.contains(currentCommitId))
     }
 
     double getDifferenceSortKey() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/DefaultPerformanceExecutionDataProvider.java
@@ -66,6 +66,7 @@ public class DefaultPerformanceExecutionDataProvider extends PerformanceExecutio
 
     private ScenarioBuildResultData queryAndSortExecutionData(List<ScenarioBuildResultData> scenarios) {
         ScenarioBuildResultData mergedScenario = mergeScenarioWithSameName(scenarios);
+        mergedScenario.setCurrentCommitId(commitId);
 
         List<String> teamcityBuildIds = scenarios.stream().map(ScenarioBuildResultData::getTeamCityBuildId).collect(toList());
         PerformanceTestHistory history = resultsStore.getTestResults(scenarios.get(0).getPerformanceExperiment(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel(), teamcityBuildIds);


### PR DESCRIPTION
in performance tests. The current detection based on the teamcity build id doesn't work, since we load the teamcity build id from the jsons, which also come from the cache.