### PR TITLE
Use kill instead of kill -9 to allow daemon exit gracefully

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -19,6 +19,9 @@ package common
 private const val killAllGradleProcessesUnixLike = """
 free -m
 ps aux | egrep 'Gradle(Daemon|Worker)'
+ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill
+sleep 10
+ps aux | egrep 'Gradle(Daemon|Worker)'
 ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}' | xargs kill -9
 free -m
 ps aux | egrep 'Gradle(Daemon|Worker)' | awk '{print ${'$'}2}'


### PR DESCRIPTION
Closes https://github.com/gradle/gradle/issues/17345

We found the force killing script might break subsequent builds on
the same machine, let's use `kill`-`sleep`-`kill -9` instead.
