### PR TITLE
Do not nest the 'calculate task graph' build operations of child builds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -131,6 +131,90 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         "rootProject.name='someLib'" | "buildB"  | "someLib"      | "configured root project name"
     }
 
+    def "generates build lifecycle operations for multiple included builds"() {
+        given:
+        def buildC = multiProjectBuild("buildC", ["someLib"]) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                }
+            """
+        }
+        includedBuilds << buildC
+        dependency "org.test:buildB:1.0"
+        dependency "org.test:buildC:1.0"
+        dependency buildB, "org.test:buildC:1.0"
+
+        when:
+        execute(buildA, ":jar", [])
+
+        then:
+        executed ":buildB:jar", ":buildC:jar"
+
+        and:
+        def root = operations.root(RunBuildBuildOperationType)
+
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 3
+        taskGraphOps[0].displayName == "Calculate task graph"
+        taskGraphOps[0].details.buildPath == ":"
+        taskGraphOps[0].parentId == root.id
+        taskGraphOps[1].displayName == "Calculate task graph (:buildC)"
+        taskGraphOps[1].details.buildPath == ":buildC"
+        taskGraphOps[1].parentId == taskGraphOps[0].id
+        taskGraphOps[2].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[2].details.buildPath == ":buildB"
+        taskGraphOps[2].parentId == taskGraphOps[0].id
+    }
+
+    def "generates build lifecycle operations for multiple included builds used as buildscript dependencies"() {
+        given:
+        def buildC = multiProjectBuild("buildC", ["someLib"]) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java'
+                }
+            """
+        }
+        includedBuilds << buildC
+        buildA.buildFile.text = """
+            buildscript {
+                dependencies {
+                    classpath 'org.test:buildB:1.0'
+                    classpath 'org.test:buildC:1.0'
+                }
+            }
+        """ + buildA.buildFile.text
+        dependency buildB, "org.test:buildC:1.0"
+
+        when:
+        execute(buildA, ":jar", [])
+
+        then:
+        executed ":buildB:jar", ":buildC:jar"
+
+        and:
+        def root = operations.root(RunBuildBuildOperationType)
+
+        def applyRootProjectBuildScript = operations.first(Pattern.compile("Apply build file 'build.gradle' to root project 'buildA'"))
+
+        // The task graph for buildC is calculated multiple times, once for buildscript dependency and again for the dependency from buildB
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 4
+        taskGraphOps[0].displayName == "Calculate task graph (:buildC)"
+        taskGraphOps[0].details.buildPath == ":buildC"
+        taskGraphOps[0].parentId == applyRootProjectBuildScript.id
+        taskGraphOps[1].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[1].details.buildPath == ":buildB"
+        taskGraphOps[1].parentId == applyRootProjectBuildScript.id
+        taskGraphOps[2].displayName == "Calculate task graph (:buildC)"
+        taskGraphOps[2].details.buildPath == ":buildC"
+        taskGraphOps[2].parentId == applyRootProjectBuildScript.id
+        taskGraphOps[3].displayName == "Calculate task graph"
+        taskGraphOps[3].details.buildPath == ":"
+        taskGraphOps[3].parentId == root.id
+    }
+
     def "generates build lifecycle operations for included build used as buildscript and production dependency"() {
         given:
         buildA.buildFile.text = """

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
@@ -46,7 +46,11 @@ public class DefaultTaskExecutionPreparer implements TaskExecutionPreparer {
         TaskExecutionGraphInternal taskGraph = gradle.getTaskGraph();
         taskGraph.populate();
 
-        includedBuildControllers.populateTaskGraphs();
+        if (gradle.isRootBuild()) {
+            // Force the population of other task graphs to happen as part of the build operation for populating
+            // the root build task graph. Should get rid of this nesting instead
+            includedBuildControllers.populateTaskGraphs();
+        }
 
         if (buildModelParameters.isConfigureOnDemand() && gradle.isRootBuild()) {
             new ProjectsEvaluatedNotifier(buildOperationExecutor).notify(gradle);


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

This is a regression in 7.1 and can break build scans in certain cases where multiple included builds are present in the tree.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
