### PR TITLE
Remove restriction on subgroups in version catalogs

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/catalog/parser/TomlCatalogFileParserTest.groovy
@@ -209,7 +209,7 @@ class TomlCatalogFileParserTest extends Specification implements VersionCatalogE
         hasDependency('groovy-templates') {
             withGAV("org.codehaus.groovy:groovy-templates:2.5.6")
         }
-        hasBundle('groovy', ['groovy-json', 'groovy', 'groovy-templates'])
+        hasBundle('groovy', ['groovy.json', 'groovy', 'groovy.templates'])
     }
 
     @VersionCatalogProblemTestFor([

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -491,7 +491,7 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.1"}
         run ':checkDeps'
 
         then:
-        outputContains "Duplicate entry for alias 'my-lib': dependency {group='org.gradle.test', name='lib', version='1.0'} is replaced with dependency {group='org.gradle.test', name='lib', version='1.1'}"
+        outputContains "Duplicate entry for alias 'my.lib': dependency {group='org.gradle.test', name='lib', version='1.0'} is replaced with dependency {group='org.gradle.test', name='lib', version='1.1'}"
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.gradle.test:lib:1.1')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1082,42 +1082,124 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         }
     }
 
-    def "reasonable error message if an alias clashes with a group of dependencies"() {
+    def "supports aliases which also have children"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
                     libs {
-                        alias("top").to("org:test:1.0") // would generate libs.top as a Provider<Dependency>
-                        alias("top.bottom").to("org:bottom:1.0") // would generate libs.top as a factory of dependencies
+                        alias("top").to("org:top:1.0")
+                        alias("top.bottom").to("org:bottom:1.0")
                     }
                 }
             }
         """
+        def top = mavenHttpRepo.module("org", "top", "1.0").publish()
+        def bottom = mavenHttpRepo.module("org", "bottom", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.top
+                implementation libs.top.bottom
+            }
+        """
 
         when:
-        fails ":help"
+        top.pom.expectGet()
+        bottom.pom.expectGet()
+        top.artifact.expectGet()
+        bottom.artifact.expectGet()
 
         then:
-        failure.assertHasCause "Cannot generate top level accessors because it contains both aliases and groups of the same name: [top]"
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:top:1.0')
+                module('org:bottom:1.0')
+            }
+        }
     }
 
-    def "reasonable error message if an alias clashes with a sub-group of dependencies"() {
+    def "supports aliases which also have children using intermediate leaves"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
                     libs {
-                        alias("top.middle").to("org:test:1.0") // would generate libs.top.middle as a Provider<Dependency>
-                        alias("top.middle.bottom").to("org:bottom:1.0") // would generate libs.top.middle as a factory of dependencies
+                        alias("top.middle").to("org:top:1.0")
+                        alias("top.middle.bottom").to("org:bottom:1.0")
                     }
                 }
             }
         """
+        def top = mavenHttpRepo.module("org", "top", "1.0").publish()
+        def bottom = mavenHttpRepo.module("org", "bottom", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.top.middle
+                implementation libs.top.middle.bottom
+            }
+        """
 
         when:
-        fails ":help"
+        top.pom.expectGet()
+        bottom.pom.expectGet()
+        top.artifact.expectGet()
+        bottom.artifact.expectGet()
 
         then:
-        failure.assertHasCause "Cannot generate accessors for top because it contains both aliases and groups of the same name: [middle]"
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:top:1.0')
+                module('org:bottom:1.0')
+            }
+        }
+    }
+
+    def "supports aliases which also have children using empty intermediate level"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        alias("top").to("org:top:1.0")
+                        alias("top.middle.bottom").to("org:bottom:1.0")
+                    }
+                }
+            }
+        """
+        def top = mavenHttpRepo.module("org", "top", "1.0").publish()
+        def bottom = mavenHttpRepo.module("org", "bottom", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.top
+                implementation libs.top.middle.bottom
+            }
+        """
+
+        when:
+        top.pom.expectGet()
+        bottom.pom.expectGet()
+        top.artifact.expectGet()
+        bottom.artifact.expectGet()
+
+        then:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:top:1.0')
+                module('org:bottom:1.0')
+            }
+        }
     }
 
     def "can access all version catalogs with optional API"() {
@@ -1264,26 +1346,94 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         }
     }
 
-    def "reasonable error message if a version is both a leaf and a node"() {
+    def "supports versions which also have children"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
                     libs {
                         version("my", "1.0")
-                        version("my.nested", "1.1")
+                        version("my.bottom", "1.1")
                     }
                 }
             }
         """
 
+        buildFile """
+            tasks.register("dumpVersions") {
+                doLast {
+                    println "First: \${libs.versions.my.asProvider().get()}"
+                    println "Second: \${libs.versions.my.bottom.get()}"
+                }
+            }
+        """
+
         when:
-        fails 'help'
+        succeeds 'dumpVersions'
 
         then:
-        failureDescriptionContains "Cannot generate accessors for versions because it contains both aliases and groups of the same name: [my]"
+        outputContains """First: 1.0
+Second: 1.1"""
     }
 
-    def "reasonable error message if a bundle is both a leaf and a node"() {
+    def "supports versions which also have children using intermediate leaves"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        version("my.middle", "1.0")
+                        version("my.middle.bottom", "1.1")
+                    }
+                }
+            }
+        """
+
+        buildFile """
+            tasks.register("dumpVersions") {
+                doLast {
+                    println "First: \${libs.versions.my.middle.asProvider().get()}"
+                    println "Second: \${libs.versions.my.middle.bottom.get()}"
+                }
+            }
+        """
+
+        when:
+        succeeds 'dumpVersions'
+
+        then:
+        outputContains """First: 1.0
+Second: 1.1"""
+    }
+
+    def "supports versions which also have children using empty intermediate level"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        version("my", "1.0")
+                        version("my.middle.bottom", "1.1")
+                    }
+                }
+            }
+        """
+
+        buildFile """
+            tasks.register("dumpVersions") {
+                doLast {
+                    println "First: \${libs.versions.my.asProvider().get()}"
+                    println "Second: \${libs.versions.my.middle.bottom.get()}"
+                }
+            }
+        """
+
+        when:
+        succeeds 'dumpVersions'
+
+        then:
+        outputContains """First: 1.0
+Second: 1.1"""
+    }
+
+    def "supports bundles which also have children"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
@@ -1297,11 +1447,119 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             }
         """
 
+        def lib1 = mavenHttpRepo.module("org", "lib1", "1.0").publish()
+        def lib2 = mavenHttpRepo.module("org", "lib2", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.bundles.my
+                implementation libs.bundles.my.other
+            }
+        """
+
         when:
-        fails 'help'
+        lib1.pom.expectGet()
+        lib2.pom.expectGet()
+        lib1.artifact.expectGet()
+        lib2.artifact.expectGet()
 
         then:
-        failureDescriptionContains "Cannot generate accessors for bundles because it contains both aliases and groups of the same name: [my]"
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:lib1:1.0')
+                module('org:lib2:1.0')
+            }
+        }
+    }
+
+    def "supports bundles which also have children using intermediate leaves"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        alias("lib1").to("org:lib1:1.0")
+                        alias("lib2").to("org:lib2:1.0")
+                        bundle("my.middle", ["lib1", "lib2"])
+                        bundle("my.middle.other", ["lib1", "lib2"])
+                    }
+                }
+            }
+        """
+
+        def lib1 = mavenHttpRepo.module("org", "lib1", "1.0").publish()
+        def lib2 = mavenHttpRepo.module("org", "lib2", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.bundles.my.middle
+                implementation libs.bundles.my.middle.other
+            }
+        """
+
+        when:
+        lib1.pom.expectGet()
+        lib2.pom.expectGet()
+        lib1.artifact.expectGet()
+        lib2.artifact.expectGet()
+
+        then:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:lib1:1.0')
+                module('org:lib2:1.0')
+            }
+        }
+    }
+
+    def "supports bundles which also have children using empty intermediate leaves"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        alias("lib1").to("org:lib1:1.0")
+                        alias("lib2").to("org:lib2:1.0")
+                        bundle("my", ["lib1", "lib2"])
+                        bundle("my.middle.other", ["lib1", "lib2"])
+                    }
+                }
+            }
+        """
+
+        def lib1 = mavenHttpRepo.module("org", "lib1", "1.0").publish()
+        def lib2 = mavenHttpRepo.module("org", "lib2", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation libs.bundles.my
+                implementation libs.bundles.my.middle.other
+            }
+        """
+
+        when:
+        lib1.pom.expectGet()
+        lib2.pom.expectGet()
+        lib1.artifact.expectGet()
+        lib2.artifact.expectGet()
+
+        then:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:lib1:1.0')
+                module('org:lib2:1.0')
+            }
+        }
     }
 
     @VersionCatalogProblemTestFor(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -46,6 +46,7 @@ import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependencyVariant;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.catalog.DependencyBundleValueSource;
+import org.gradle.api.internal.catalog.ExternalModuleDependencyFactory;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -172,6 +173,9 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
                 .withDslReference(Configuration.class, "extendsFrom(org.gradle.api.artifacts.Configuration[])")
                 .nagUser();
             return doAddConfiguration(configuration, (Configuration) dependencyNotation);
+        }
+        if (dependencyNotation instanceof ExternalModuleDependencyFactory.ProviderConvertible<?>) {
+            return doAddProvider(configuration, ((ExternalModuleDependencyFactory.ProviderConvertible<?>) dependencyNotation).asProvider(), configureClosure);
         }
         if (dependencyNotation instanceof Provider<?>) {
             return doAddProvider(configuration, (Provider<?>) dependencyNotation, configureClosure);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AliasNormalizer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AliasNormalizer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.catalog;
+
+import javax.annotation.Nullable;
+import java.util.regex.Pattern;
+
+abstract class AliasNormalizer {
+    private final static Pattern SEPARATOR = Pattern.compile("[_.-]");
+
+    @Nullable
+    static String normalize(@Nullable String name) {
+        if (name == null) {
+            return null;
+        }
+        return SEPARATOR.matcher(name).replaceAll(".");
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalog.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalog.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.internal.catalog.AliasNormalizer.normalize;
+
 public class DefaultVersionCatalog implements Serializable {
     private final String name;
     private final String description;
@@ -65,7 +67,7 @@ public class DefaultVersionCatalog implements Serializable {
     }
 
     public DependencyModel getDependencyData(String alias) {
-        return aliasToDependency.get(alias);
+        return aliasToDependency.get(normalize(alias));
     }
 
     public List<String> getVersionAliases() {
@@ -76,11 +78,11 @@ public class DefaultVersionCatalog implements Serializable {
     }
 
     public BundleModel getBundle(String name) {
-        return bundles.get(name);
+        return bundles.get(normalize(name));
     }
 
     public VersionModel getVersion(String name) {
-        return versions.get(name);
+        return versions.get(normalize(name));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
@@ -15,7 +15,22 @@
  */
 package org.gradle.api.internal.catalog;
 
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.provider.Provider;
 
 public interface ExternalModuleDependencyFactory extends VersionCatalog {
+    interface ProviderConvertible<T> {
+        Provider<T> asProvider();
+    }
+
+    interface DependencyNotationSupplier extends ProviderConvertible<MinimalExternalModuleDependency> {
+    }
+
+    interface VersionNotationSupplier extends ProviderConvertible<String> {
+    }
+
+    interface BundleNotationSupplier extends ProviderConvertible<ExternalModuleDependencyBundle> {
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -172,7 +172,7 @@ class LibrariesSourceGeneratorTest extends Specification implements VersionCatal
         ex = thrown()
         verify(ex.message, """Cannot generate dependency accessors:
 ${nameClash { noIntro().inConflict('groovy.json', 'groovyJson').getterName('getGroovyJson') }}
-${nameClash { noIntro().inConflict('tada.one', 'tadaOne', 'tada_one').getterName('getTadaOne') }}
+${nameClash { noIntro().inConflict('tada.one', 'tadaOne').getterName('getTadaOne') }}
 """)
     }
 
@@ -211,7 +211,7 @@ ${nameClash { noIntro().inConflict('tada.one', 'tadaOne', 'tada_one').getterName
         then:
         ex = thrown()
         verify(ex.message, """Cannot generate dependency accessors:
-${nameClash { noIntro().kind('bundles').inConflict('other.cool', 'otherCool', 'other_cool').getterName('getOtherCoolBundle') }}
+${nameClash { noIntro().kind('bundles').inConflict('other.cool', 'otherCool').getterName('getOtherCoolBundle') }}
 ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getterName('getOneCoolBundle') }}
 """)
     }
@@ -344,6 +344,7 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         }
 
         void hasDependencyAlias(String name, String methodName = "get${toJavaName(name)}", String javadoc = null) {
+            name = AliasNormalizer.normalize(name)
             def lookup = "public Provider<MinimalExternalModuleDependency> $methodName() { return create(\"$name\"); }"
             def result = Lookup.find(lines, lookup)
             assert result.match
@@ -353,6 +354,7 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         }
 
         void hasBundle(String name, String methodName = "get${toJavaName(name)}Bundle", String javadoc = null) {
+            name = AliasNormalizer.normalize(name)
             def lookup = "public Provider<ExternalModuleDependencyBundle> $methodName() { return createBundle(\"$name\"); }"
             def result = Lookup.find(lines, lookup)
             assert result.match
@@ -362,6 +364,7 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         }
 
         void hasVersion(String name, String methodName = "get${toJavaName(name)}Version", String javadoc = null) {
+            name = AliasNormalizer.normalize(name)
             def lookup = "public Provider<String> $methodName() { return getVersion(\"$name\"); }"
             def result = Lookup.find(lines, lookup)
             assert result.match

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -22,6 +22,13 @@ For Java, Groovy, Kotlin and Android compatibility, see the [full compatibility 
 
 <!-- 
 
+<a name="VERSION-CATALOG-IMPROVEMENTS"></a>
+### Version catalog improvements
+
+In previous Gradle releases, it wasn't possible to declare a [version catalog](userguide/platforms.html#sub:version-catalog) where an alias would also contain sub-aliases.
+For example, it wasn't possible to declare both an alias `jackson` and `jackson.xml`, you would have had to create aliases `jackson.core` and `jackson.xml`.
+This limitation is now lifted.
+
 ================== TEMPLATE ==============================
 
 <a name="FILL-IN-KEY-AREA"></a>

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -76,6 +76,9 @@ We would generate the following type-safe accessors:
 
 In case you want to avoid the generation of a subgroup accessor, we recommend to rely on case to differentiate.
 For example the aliases `groovyCore`, `groovyJson` and `groovyXml` would be mapped to the `libs.groovyCore`, `libs.groovyJson` and `libs.groovyXml` accessors respectively.
+
+When declaring aliases, it's worth noting that any of the `-`, `_` and `.` characters can be used as separators, but the generated catalog will have all normalized to `.`:
+for example `foo-bar` as an alias is converted to `foo.bar` automatically.
 ====
 
 [[sec:common-version-numbers]]

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -74,9 +74,6 @@ We would generate the following type-safe accessors:
 - `libs.groovy.json`
 - `libs.androidx.awesome.lib`
 
-It is illegal to have an alias to a dependency which happens to also belong to a nested group.
-For example `commons` and `commons-core` is illegal.
-
 In case you want to avoid the generation of a subgroup accessor, we recommend to rely on case to differentiate.
 For example the aliases `groovyCore`, `groovyJson` and `groovyXml` would be mapped to the `libs.groovyCore`, `libs.groovyJson` and `libs.groovyXml` accessors respectively.
 ====


### PR DESCRIPTION
This PR removes the restriction that you cannot have an alias which is both an accessor for a dependency (or version or bundle) and a subaccessor for other dependencies. This is now allowed:

```
implementation libs.top
implementation libs.top.bottom
```

Fixes #17170
