### PR TITLE
Mark daemons unavailable if the response the client gets back is nonsense

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonConnector.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonConnector.java
@@ -43,6 +43,17 @@ public interface DaemonConnector {
     DaemonClientConnection maybeConnect(ExplainingSpec<DaemonContext> constraint);
 
     /**
+     * Mark the daemon as unavailable if the client cannot communicate with the daemon.
+     *
+     * This is not intended to be used for all communication errors, only the most grave.
+     * For example, if the daemon is communicating in some way, but its responses
+     * are empty or do not appear to be daemon messages.
+     *
+     * @param daemon the daemon that could not be communicated with
+     */
+    void markDaemonAsUnavailable(DaemonConnectDetails daemon);
+
+    /**
      * Connects to a daemon that matches the given constraint, starting one if required.
      *
      * @return A connection to a matching daemon. Never returns null.


### PR DESCRIPTION

This scenario blocks all new builds:
1. Daemon starts with port 12345
2. Daemon is killed without shutting down cleanly (kill -9 $PID)
3. A non-daemon process starts and listens on port 12345

The Gradle client will see an entry for an idle daemon and the
port will appear to be valid. If the non-daemon process just
immediately closes the connection, the Gradle client will fail
and retry 100 times.

Unfortunately, we'll keep retrying the exact same daemon because
it otherwise appears good (idle + port is connectable).

This change makes it so if we receive no response from the daemon,
we mark the daemon as unavailable and retry again. This will usually
mean that a new daemon is started or we try the next available daemon.

<!--- The issue this PR addresses -->
Fixes the underlying reason for https://github.com/gradle/gradle/issues/17345
