### PR TITLE
Allow custom implementations of PublishArtifact

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/PublishArtifactInternal.java
@@ -19,4 +19,12 @@ import org.gradle.api.artifacts.PublishArtifact;
 
 public interface PublishArtifactInternal extends PublishArtifact {
     boolean shouldBePublished();
+
+    static boolean shouldBePublished(PublishArtifact artifact) {
+        if (artifact instanceof PublishArtifactInternal) {
+            return ((PublishArtifactInternal) artifact).shouldBePublished();
+        }
+        // This can happen for custom publish artifacts
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/publish/DecoratingPublishArtifact.java
@@ -102,10 +102,6 @@ public class DecoratingPublishArtifact extends AbstractPublishArtifact implement
 
     @Override
     public boolean shouldBePublished() {
-        if (publishArtifact instanceof PublishArtifactInternal) {
-            return ((PublishArtifactInternal) publishArtifact).shouldBePublished();
-        }
-        // This can happen for custom publish artifacts
-        return true;
+        return PublishArtifactInternal.shouldBePublished(publishArtifact);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/LazyPublishArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/LazyPublishArtifact.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
 import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact;
@@ -89,7 +88,7 @@ public class LazyPublishArtifact implements PublishArtifactInternal {
         return new Date();
     }
 
-    private PublishArtifact getDelegate() {
+    private PublishArtifactInternal getDelegate() {
         if (delegate == null) {
             Object value = provider.get();
             if (value instanceof FileSystemLocation) {
@@ -127,6 +126,6 @@ public class LazyPublishArtifact implements PublishArtifactInternal {
 
     @Override
     public boolean shouldBePublished() {
-        return ((PublishArtifactInternal) getDelegate()).shouldBePublished();
+        return getDelegate().shouldBePublished();
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/AbstractIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/AbstractIvyArtifact.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.ivy.internal.artifact;
 import com.google.common.base.Strings;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
@@ -114,7 +113,7 @@ public abstract class AbstractIvyArtifact implements IvyArtifact, PublicationArt
         return allBuildDependencies;
     }
 
-    protected abstract TaskDependencyInternal getDefaultBuildDependencies();
+    protected abstract TaskDependency getDefaultBuildDependencies();
 
     @Override
     public String toString() {
@@ -124,7 +123,7 @@ public abstract class AbstractIvyArtifact implements IvyArtifact, PublicationArt
     private class CompositeTaskDependency extends AbstractTaskDependency {
         @Override
         public void visitDependencies(TaskDependencyResolveContext context) {
-            getDefaultBuildDependencies().visitDependencies(context);
+            context.add(getDefaultBuildDependencies());
             additionalBuildDependencies.visitDependencies(context);
         }
     }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/ArchiveTaskBasedIvyArtifact.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
 import java.io.File;
@@ -61,7 +62,7 @@ public class ArchiveTaskBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
+    protected TaskDependency getDefaultBuildDependencies() {
         return buildDependencies;
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DerivedIvyArtifact.java
@@ -16,9 +16,9 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
+import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
@@ -59,8 +59,8 @@ public class DerivedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return (TaskDependencyInternal) original.getBuildDependencies();
+    protected TaskDependency getDefaultBuildDependencies() {
+        return original.getBuildDependencies();
     }
 
     @Override

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/FileBasedIvyArtifact.java
@@ -19,6 +19,7 @@ package org.gradle.api.publish.ivy.internal.artifact;
 import com.google.common.io.Files;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
@@ -59,7 +60,7 @@ public class FileBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
+    protected TaskDependency getDefaultBuildDependencies() {
         return TaskDependencyInternal.EMPTY;
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/PublishArtifactBasedIvyArtifact.java
@@ -16,17 +16,18 @@
 
 package org.gradle.api.publish.ivy.internal.artifact;
 
+import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
 public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
-    private final PublishArtifactInternal artifact;
+    private final PublishArtifact artifact;
     private final IvyPublicationIdentity identity;
 
-    public PublishArtifactBasedIvyArtifact(PublishArtifactInternal artifact, IvyPublicationIdentity identity) {
+    public PublishArtifactBasedIvyArtifact(PublishArtifact artifact, IvyPublicationIdentity identity) {
         this.artifact = artifact;
         this.identity = identity;
     }
@@ -57,8 +58,8 @@ public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return (TaskDependencyInternal) artifact.getBuildDependencies();
+    protected TaskDependency getDefaultBuildDependencies() {
+        return artifact.getBuildDependencies();
     }
 
     @Override
@@ -68,6 +69,6 @@ public class PublishArtifactBasedIvyArtifact extends AbstractIvyArtifact {
 
     @Override
     public boolean shouldBePublished() {
-        return artifact.shouldBePublished();
+        return PublishArtifactInternal.shouldBePublished(artifact);
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 
 import java.io.File;
@@ -70,7 +71,7 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
+    protected TaskDependency getDefaultBuildDependencies() {
         return buildDependencies;
     }
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.publish.ivy.internal.artifact
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
-import org.gradle.api.internal.artifacts.PublishArtifactInternal
+import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.publish.ivy.IvyArtifact
@@ -34,7 +34,7 @@ public class IvyArtifactNotationParserFactoryTest extends AbstractProjectBuilder
     def fileNotationParser = Mock(NotationParser)
     def task = Mock(Task)
     def taskDependency = new DefaultTaskDependency(null, ImmutableSet.of(task))
-    def publishArtifact = Stub(PublishArtifactInternal) {
+    def publishArtifact = Stub(PublishArtifact) {
         getName() >> 'name'
         getExtension() >> 'extension'
         getType() >> 'type'

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/plugins/NativeBasePluginTest.groovy
@@ -17,12 +17,12 @@
 package org.gradle.language.plugins
 
 import org.gradle.api.Task
+import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.component.PublishableComponent
 import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
@@ -412,7 +412,7 @@ class NativeBasePluginTest extends Specification {
 
     def "adds Maven publications for component with main publication"() {
         def usage1 = Stub(UsageContext)
-        def artifact1 = Stub(PublishArtifactInternal)
+        def artifact1 = Stub(PublishArtifact)
         artifact1.getFile() >> projectDir.file("artifact1")
         usage1.artifacts >> [artifact1]
         def variant1 = Stub(PublishableVariant)
@@ -421,7 +421,7 @@ class NativeBasePluginTest extends Specification {
         variant1.getCoordinates() >> new DefaultModuleVersionIdentifier("my.group", "test_app_debug", "1.2")
 
         def usage2 = Stub(UsageContext)
-        def artifact2 = Stub(PublishArtifactInternal)
+        def artifact2 = Stub(PublishArtifact)
         artifact2.getFile() >> projectDir.file("artifact1")
         usage2.artifacts >> [artifact2]
         def variant2 = Stub(PublishableVariant)

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/AbstractMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/AbstractMavenArtifact.java
@@ -19,7 +19,6 @@ package org.gradle.api.publish.maven.internal.artifact;
 import com.google.common.base.Strings;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.publish.internal.PublicationArtifactInternal;
 import org.gradle.api.publish.maven.MavenArtifact;
@@ -75,7 +74,7 @@ public abstract class AbstractMavenArtifact implements MavenArtifact, Publicatio
         return allBuildDependencies;
     }
 
-    protected abstract TaskDependencyInternal getDefaultBuildDependencies();
+    protected abstract TaskDependency getDefaultBuildDependencies();
 
     @Override
     public final String toString() {
@@ -86,7 +85,7 @@ public abstract class AbstractMavenArtifact implements MavenArtifact, Publicatio
 
         @Override
         public void visitDependencies(TaskDependencyResolveContext context) {
-            getDefaultBuildDependencies().visitDependencies(context);
+            context.add(getDefaultBuildDependencies());
             additionalBuildDependencies.visitDependencies(context);
         }
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/PublishArtifactBasedMavenArtifact.java
@@ -18,15 +18,15 @@ package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.PublishArtifactInternal;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
+import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
 
 public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
-    private final PublishArtifactInternal publishArtifact;
+    private final PublishArtifact publishArtifact;
 
     public PublishArtifactBasedMavenArtifact(PublishArtifact publishArtifact) {
-        this.publishArtifact = (PublishArtifactInternal) publishArtifact;
+        this.publishArtifact = publishArtifact;
     }
 
     @Override
@@ -45,12 +45,12 @@ public class PublishArtifactBasedMavenArtifact extends AbstractMavenArtifact {
     }
 
     @Override
-    protected TaskDependencyInternal getDefaultBuildDependencies() {
-        return (TaskDependencyInternal) publishArtifact.getBuildDependencies();
+    protected TaskDependency getDefaultBuildDependencies() {
+        return publishArtifact.getBuildDependencies();
     }
 
     @Override
     public boolean shouldBePublished() {
-        return publishArtifact.shouldBePublished();
+        return PublishArtifactInternal.shouldBePublished(publishArtifact);
     }
 }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
@@ -19,10 +19,10 @@ package org.gradle.api.publish.maven.internal.artifact
 
 import com.google.common.collect.ImmutableSet
 import org.gradle.api.Task
+import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.internal.TaskOutputsInternal
-import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.tasks.DefaultTaskDependency
@@ -42,7 +42,7 @@ class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuilderSpec 
     def dependencies = ImmutableSet.of(task)
     def taskDependency = new DefaultTaskDependency(null, dependencies)
     def fileNotationParser = Mock(NotationParser)
-    def publishArtifact = Stub(PublishArtifactInternal) {
+    def publishArtifact = Stub(PublishArtifact) {
         getExtension() >> 'extension'
         getClassifier() >> 'classifier'
         getFile() >> new File('foo')

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -24,13 +24,13 @@ import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
-import org.gradle.api.internal.artifacts.PublishArtifactInternal
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -183,7 +183,7 @@ class DefaultMavenPublicationTest extends Specification {
     def "artifacts are taken from added component"() {
         given:
         def publication = createPublication()
-        def artifact = Mock(PublishArtifactInternal)
+        def artifact = Mock(PublishArtifact)
         artifact.file >> artifactFile
         artifact.classifier >> ""
         artifact.extension >> "jar"
@@ -215,11 +215,11 @@ class DefaultMavenPublicationTest extends Specification {
     def "multiple usages of a component can provide the same artifact"() {
         given:
         def publication = createPublication()
-        def artifact1 = Mock(PublishArtifactInternal)
+        def artifact1 = Mock(PublishArtifact)
         artifact1.file >> artifactFile
         artifact1.classifier >> ""
         artifact1.extension >> "jar"
-        def artifact2 = Mock(PublishArtifactInternal)
+        def artifact2 = Mock(PublishArtifact)
         artifact2.file >> artifactFile
         artifact2.classifier >> ""
         artifact2.extension >> "jar"

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/metadata/ModuleMetadataSpecBuilder.java
@@ -183,8 +183,7 @@ class ModuleMetadataSpecBuilder {
     }
 
     private boolean shouldNotBePublished(PublishArtifact artifact) {
-        return artifact instanceof PublishArtifactInternal
-            && !((PublishArtifactInternal) artifact).shouldBePublished();
+        return !PublishArtifactInternal.shouldBePublished(artifact);
     }
 
     private ModuleMetadataSpec.AvailableAt availableAt(ModuleVersionIdentifier coordinates, ModuleVersionIdentifier targetCoordinates) {


### PR DESCRIPTION
These used to work in the past and we don't want to break them
now unless we have a very compelling reason to.

<!--- The issue this PR addresses -->
Fixes #17273 
