### PR TITLE
Fix invalid attribute usage

### DIFF
--- a/subprojects/docs/src/docs/userguide/build-cache/caching_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/caching_java_projects.adoc
@@ -86,7 +86,7 @@ annotated link:{javadocPath}/org/gradle/process/CommandLineArgumentProvider.html
 include::sample[dir="snippets/buildCache/integration-tests/groovy",files="build.gradle[tags=distributionDirInput]"]
 include::sample[dir="snippets/buildCache/integration-tests/kotlin",files="build.gradle.kts[tags=distributionDirInput]"]
 ====
-<1> Create a class implementing `{api-reference}org/gradle/process/CommandLineArgumentProvider.html[CommandLineArgumentProvider]`.
+<1> Create a class implementing link:{javadocPath}/org/gradle/process/CommandLineArgumentProvider.html[`CommandLineArgumentProvider`].
 <2> Declare the inputs and outputs with the corresponding path sensitivity.
 <3> `asArguments` needs to return the JVM arguments passing the desired system properties to the test JVM.
 <4> Add an instance of the newly created class as JVM argument provider to the integration test task.

--- a/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/worker_api.adoc
@@ -118,7 +118,7 @@ include::{snippetsPath}/workerApi/md5NoIsolation/groovy/buildSrc/src/main/java/G
 <1> Do not implement the `getParameters()` method - Gradle will inject this at runtime.
 
 Now, you should change your custom task class to submit work to the
-{api-reference}org/gradle/workers/WorkerExecutor.html[WorkerExecutor] instead of doing the work itself.
+link:{javadocPath}/org/gradle/workers/WorkerExecutor.html[WorkerExecutor] instead of doing the work itself.
 
 .buildSrc/src/main/java/CreateMD5.java
 [source,java]
@@ -218,7 +218,7 @@ You may also want to configure custom settings for the new process.
 include::{snippetsPath}/workerApi/md5ProcessIsolation/groovy/buildSrc/src/main/java/CreateMD5.java[]
 ----
 <1> Change the isolation mode to `PROCESS`.
-<2> Set up the {api-reference}org/gradle/process/JavaForkOptions.html[JavaForkOptions] for the new process.
+<2> Set up the link:{javadocPath}/org/gradle/process/JavaForkOptions.html[JavaForkOptions] for the new process.
 
 Now, you should be able to run your task, and it will work as expected but using worker daemons instead:
 


### PR DESCRIPTION
{api-reference} was invalid and needed to be replaced with a link using
javadocPath