### PR TITLE
Clarify file system watching enabling

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -69,7 +69,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
             ? WatchLogging.DEBUG
             : WatchLogging.NORMAL;
 
-        LOGGER.info("Watching the file system is {}", watchFileSystemMode.getDescription());
+        LOGGER.info("Watching the file system is configured to be {}", watchFileSystemMode.getDescription());
         if (watchFileSystemMode.isEnabled()) {
             dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
         }
@@ -78,6 +78,7 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
         }
 
         boolean actuallyWatching = virtualFileSystem.afterBuildStarted(watchFileSystemMode, verboseVfsLogging, debugWatchLogging, buildOperationRunner);
+        LOGGER.info("File system watching is {}", actuallyWatching ? "active" : "inactive");
         //noinspection Convert2Lambda
         eventEmitter.emitNowForCurrent(new FileSystemWatchingSettingsFinalizedProgressDetails() {
             @Override


### PR DESCRIPTION
- Better phrasing for INFO log on whether FSW is enabled by the user,
- Additional INFO log to reflect whether we successfully activated FSW or not,
- Tests for the current confusing behavior where FSW can be disabled from an init script in the Gradle user home, but not one passed via `--init-script`.
