### PR TITLE
Make Configuration.copy() work when project dependency constraint is present

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,14 +27,14 @@ import spock.lang.Specification
 class DefaultProjectDependencyConstraintTest extends Specification {
 
     @Issue("https://github.com/gradle/gradle/issues/17179")
-    def "can copy project dependency constraint" () {
+    def "can copy project dependency constraint"() {
         setup:
         DefaultProjectDependencyConstraint constraint = createProjectDependencyConstraint()
         constraint.force = true
         constraint.reason = "reason"
 
         when:
-        DefaultProjectDependencyConstraint constraintCopy = constraint.copy()
+        def constraintCopy = constraint.copy()
 
         then:
         constraintCopy.group == constraint.group
@@ -48,19 +48,18 @@ class DefaultProjectDependencyConstraintTest extends Specification {
     }
 
     private DefaultProjectDependencyConstraint createProjectDependencyConstraint() {
-        def projectDummy = Mock(ProjectInternal) {
+        def project = Mock(ProjectInternal) {
             getGroup() >> "org.example"
             getVersion() >> "0.0.1"
         }
-        def depFactory = new DefaultProjectDependencyFactory(
+        def dependencyFactory = new DefaultProjectDependencyFactory(
             Mock(ProjectAccessListener),
             TestUtil.instantiatorFactory().decorateLenient(),
             true,
             new CapabilityNotationParserFactory(false).create(),
             AttributeTestUtil.attributesFactory()
         )
-
-        def projectDependency = depFactory.create(projectDummy, "mockConfiguration")
+        def projectDependency = dependencyFactory.create(project, "mockConfiguration")
         new DefaultProjectDependencyConstraint(projectDependency)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -47,6 +47,23 @@ class DefaultProjectDependencyConstraintTest extends Specification {
         constraintCopy.force == constraint.force
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/17179")
+    def "modifying mutable properties on the copy does not affect the original"() {
+        setup:
+        DefaultProjectDependencyConstraint constraint = createProjectDependencyConstraint()
+        constraint.force = false
+        constraint.reason = 'reason1'
+        DefaultProjectDependencyConstraint constraintCopy = constraint.copy()
+
+        when:
+        constraintCopy.force = true
+        constraintCopy.reason = 'reason2'
+
+        then:
+        constraint.force == false
+        constraint.reason == 'reason1'
+    }
+
     private DefaultProjectDependencyConstraint createProjectDependencyConstraint() {
         def project = Mock(ProjectInternal) {
             getGroup() >> "org.example"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraintTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies
+
+import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.initialization.ProjectAccessListener
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Issue
+import spock.lang.Specification
+
+class DefaultProjectDependencyConstraintTest extends Specification {
+
+    @Issue("https://github.com/gradle/gradle/issues/17179")
+    def "can copy project dependency constraint" () {
+        setup:
+        DefaultProjectDependencyConstraint constraint = createProjectDependencyConstraint()
+        constraint.force = true
+        constraint.reason = "reason"
+
+        when:
+        DefaultProjectDependencyConstraint constraintCopy = constraint.copy()
+
+        then:
+        constraintCopy.group == constraint.group
+        constraintCopy.name == constraint.name
+        constraintCopy.version == constraint.version
+        constraintCopy.versionConstraint == constraint.versionConstraint
+        constraintCopy.versionConstraint.preferredVersion == constraint.versionConstraint.preferredVersion
+        constraintCopy.versionConstraint.rejectedVersions == constraint.versionConstraint.rejectedVersions
+        constraintCopy.reason == constraint.reason
+        constraintCopy.force == constraint.force
+    }
+
+    private DefaultProjectDependencyConstraint createProjectDependencyConstraint() {
+        def projectDummy = Mock(ProjectInternal) {
+            getGroup() >> "org.example"
+            getVersion() >> "0.0.1"
+        }
+        def depFactory = new DefaultProjectDependencyFactory(
+            Mock(ProjectAccessListener),
+            TestUtil.instantiatorFactory().decorateLenient(),
+            true,
+            new CapabilityNotationParserFactory(false).create(),
+            AttributeTestUtil.attributesFactory()
+        )
+
+        def projectDependency = depFactory.create(projectDummy, "mockConfiguration")
+        new DefaultProjectDependencyConstraint(projectDependency)
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformEcosystemIntegrationTest.groovy
@@ -74,4 +74,26 @@ class JavaPlatformEcosystemIntegrationTest extends AbstractHttpDependencyResolut
             }
         }
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/17179")
+    def "Configuration.copy() should work when platform declares project dependency constraints"() {
+        setup:
+        buildFile << """
+            plugins {
+              id 'java-platform'
+            }
+
+            dependencies {
+                constraints {
+                    api(project(":lib")) { because "platform alignment" }
+                }
+            }
+
+            configurations.api.copy()
+        """
+        settingsFile << "include 'lib'"
+
+        expect:
+        succeeds ":help"
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -68,6 +68,7 @@ import org.gradle.api.internal.artifacts.ExcludeRuleNotationConverter;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.ResolverResults;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedFileCollectionVisitor;
@@ -1139,7 +1140,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         }
         DomainObjectSet<DependencyConstraint> copiedDependencyConstraints = copiedConfiguration.getDependencyConstraints();
         for (DependencyConstraint dependencyConstraint : dependencyConstraints) {
-            copiedDependencyConstraints.add(((DefaultDependencyConstraint) dependencyConstraint).copy());
+            copiedDependencyConstraints.add(((DependencyConstraintInternal) dependencyConstraint).copy());
         }
         return copiedConfiguration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -159,6 +159,7 @@ public class DefaultDependencyConstraint implements DependencyConstraintInternal
         this.reason = reason;
     }
 
+    @Override
     public DependencyConstraint copy() {
         DefaultDependencyConstraint constraint = new DefaultDependencyConstraint(moduleIdentifier, versionConstraint);
         constraint.reason = reason;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -122,6 +122,9 @@ public class DefaultProjectDependencyConstraint implements DependencyConstraintI
 
     @Override
     public DependencyConstraint copy() {
-        return new DefaultProjectDependencyConstraint(projectDependency.copy());
+        DefaultProjectDependencyConstraint result = new DefaultProjectDependencyConstraint(projectDependency.copy());
+        result.force = force;
+        result.reason = reason;
+        return result;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -119,4 +119,9 @@ public class DefaultProjectDependencyConstraint implements DependencyConstraintI
     public boolean isForce() {
         return force;
     }
+
+    @Override
+    public DependencyConstraint copy() {
+        return new DefaultProjectDependencyConstraint(projectDependency.copy());
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyConstraintInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyConstraintInternal.java
@@ -20,4 +20,5 @@ import org.gradle.api.artifacts.DependencyConstraint;
 public interface DependencyConstraintInternal extends DependencyConstraint {
     void setForce(boolean force);
     boolean isForce();
+    DependencyConstraint copy();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -32,8 +32,8 @@ import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
-import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.internal.catalog.DependencyBundleValueSource;
+import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -116,6 +116,11 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
 
         @Override
         public ModuleIdentifier getModule() {
+            throw shouldNotBeCalled();
+        }
+
+        @Override
+        public DependencyConstraint copy() {
             throw shouldNotBeCalled();
         }
     };


### PR DESCRIPTION
Fixes #17179