### PR TITLE
Report configuration cache problems during tooling model building when isolated projects is enabled

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/ExponentialBackoff.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/ExponentialBackoff.java
@@ -18,7 +18,6 @@ package org.gradle.internal.io;
 import org.gradle.internal.time.CountdownTimer;
 import org.gradle.internal.time.Time;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -59,20 +58,18 @@ public class ExponentialBackoff<S extends ExponentialBackoff.Signal> {
     }
 
     /**
-     * Retries the given query until it returns a non-null value.
+     * Retries the given query until it returns a 'sucessful' result.
      *
      * @param query which returns non-null value when successful.
      * @param <T> the result type.
-     *
      * @return the last value returned by the query.
      * @throws IOException thrown by the query.
      * @throws InterruptedException if interrupted while waiting.
      */
-    @Nullable
     public <T> T retryUntil(IOQuery<T> query) throws IOException, InterruptedException {
         int iteration = 0;
-        T result;
-        while ((result = query.run()) == null) {
+        IOQuery.Result<T> result;
+        while (!(result = query.run()).isSuccessful()) {
             if (timer.hasExpired()) {
                 break;
             }
@@ -81,7 +78,7 @@ public class ExponentialBackoff<S extends ExponentialBackoff.Signal> {
                 iteration = 0;
             }
         }
-        return result;
+        return result.getValue();
     }
 
     long backoffPeriodFor(int iteration) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/io/IOQuery.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/io/IOQuery.java
@@ -15,10 +15,54 @@
  */
 package org.gradle.internal.io;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 public interface IOQuery<T> {
-    @Nullable
-    T run() throws IOException, InterruptedException;
+    Result<T> run() throws IOException, InterruptedException;
+
+    abstract class Result<T> {
+        public abstract boolean isSuccessful();
+
+        public abstract T getValue();
+
+        /**
+         * Creates a result that indicates that the operation was successful and should not be repeated.
+         */
+        public static <T> Result<T> successful(final T value) {
+            if (value == null) {
+                throw new IllegalArgumentException();
+            }
+            return new Result<T>() {
+                @Override
+                public boolean isSuccessful() {
+                    return true;
+                }
+
+                @Override
+                public T getValue() {
+                    return value;
+                }
+            };
+        }
+
+        /**
+         * Creates a result that indicates that the operation was not successful and should be repeated.
+         */
+        public static <T> Result<T> notSuccessful(final T value) {
+            if (value == null) {
+                throw new IllegalArgumentException();
+            }
+            return new Result<T>() {
+                @Override
+                public boolean isSuccessful() {
+                    return false;
+                }
+
+                @Override
+                public T getValue() {
+                    return value;
+                }
+            };
+        }
+    }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheTestkitIntegrationTest.groovy
@@ -20,10 +20,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
-// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
-@IgnoreIf({ GradleContextualExecuter.embedded })
 @Requires(TestPrecondition.NOT_WINDOWS)
 class ConfigurationCacheTestkitIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
     def "reports when a TestKit build runs with a Java agent and configuration caching enabled"() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheToolingApiInvocationIntegrationTest.groovy
@@ -19,12 +19,8 @@ package org.gradle.configurationcache
 import org.gradle.configurationcache.fixtures.SomeToolingModelBuildAction
 import org.gradle.configurationcache.fixtures.ToolingApiBackedGradleExecuter
 import org.gradle.configurationcache.fixtures.ToolingApiSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
-import spock.lang.IgnoreIf
 
-// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
-@IgnoreIf({ GradleContextualExecuter.embedded })
 class ConfigurationCacheToolingApiInvocationIntegrationTest extends AbstractConfigurationCacheIntegrationTest implements ToolingApiSpec {
     @Override
     GradleExecuter createExecuter() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -65,6 +65,7 @@ trait ToolingApiSpec {
                     return modelName == "${SomeToolingModel.class.name}"
                 }
                 Object buildAll(String modelName, Project project) {
+                    println("creating model for \$project")
                     $content
                     return new MyModel("It works!")
                 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest.groovy
@@ -35,10 +35,7 @@ import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-import spock.lang.IgnoreIf
 
-// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
-@IgnoreIf({ GradleContextualExecuter.embedded })
 @Requires(TestPrecondition.NOT_WINDOWS)
 class UndeclaredBuildInputsTestKitInjectedJavaPluginIntegrationTest extends AbstractUndeclaredBuildInputsIntegrationTest implements JavaPluginImplementation {
     TestFile jar

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
@@ -18,12 +18,8 @@ package org.gradle.configurationcache.isolated
 
 import org.gradle.configurationcache.fixtures.ToolingApiBackedGradleExecuter
 import org.gradle.configurationcache.fixtures.ToolingApiSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
-import spock.lang.IgnoreIf
 
-// Currently, combining embedded execution and embedded tooling API build execution in the same process can cause a deadlock, when those builds use worker processes
-@IgnoreIf({ GradleContextualExecuter.embedded })
 class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements ToolingApiSpec {
     @Override
     GradleExecuter createExecuter() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -33,11 +33,11 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             }
         }
 
+        val isolatedProjects = startParameter.isolatedProjects.get()
         val modelParameters = if (createsModel) {
-            // When creating a model, disable certain features
-            BuildModelParameters(false, false, startParameter.isolatedProjects.get(), true)
+            // When creating a model, disable certain features - don't enable configure on demand and only enable configuration cache when isolated projects is enabled
+            BuildModelParameters(false, isolatedProjects, isolatedProjects, true)
         } else {
-            val isolatedProjects = startParameter.isolatedProjects.get()
             val configurationCache = startParameter.configurationCache.get() || isolatedProjects
             BuildModelParameters(startParameter.isConfigureOnDemand, configurationCache, isolatedProjects, false)
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/AbstractWorkerProcessIntegrationSpec.groovy
@@ -101,7 +101,6 @@ abstract class AbstractWorkerProcessIntegrationSpec extends Specification {
 
     def cleanup() {
         CurrentBuildOperationRef.instance().clear()
-        workerProcessClassPathProvider.close()
     }
 
     def cleanupSpec() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/LockTimeoutException.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/LockTimeoutException.java
@@ -21,41 +21,11 @@ import java.io.File;
  * Thrown on timeout acquiring a lock on a file.
  */
 public class LockTimeoutException extends RuntimeException {
-    private final String lockDisplayName;
-    private final String ownerPid;
-    private final String requestingPid;
-    private final String ownerOperation;
-    private final String requestingOperation;
     private final File lockFile;
 
-    public LockTimeoutException(String lockDisplayName, String ownerPid, String requestingPid, String ownerOperation, String requestingOperation, File lockFile) {
-        super(String.format("Timeout waiting to lock %s. It is currently in use by another Gradle instance.%nOwner PID: %s%nOur PID: %s%nOwner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, ownerPid, requestingPid, ownerOperation, requestingOperation, lockFile));
-        this.lockDisplayName = lockDisplayName;
-        this.ownerPid = ownerPid;
-        this.requestingPid = requestingPid;
-        this.ownerOperation = ownerOperation;
-        this.requestingOperation = requestingOperation;
+    public LockTimeoutException(String message, File lockFile) {
+        super(message);
         this.lockFile = lockFile;
-    }
-
-    public String getLockDisplayName() {
-        return lockDisplayName;
-    }
-
-    public String getOwnerPid() {
-        return ownerPid;
-    }
-
-    public String getRequestingPid() {
-        return requestingPid;
-    }
-
-    public String getOwnerOperation() {
-        return ownerOperation;
-    }
-
-    public String getRequestingOperation() {
-        return requestingOperation;
     }
 
     public File getLockFile() {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -25,6 +25,7 @@ import org.gradle.cache.InsufficientLockModeException;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.LockTimeoutException;
 import org.gradle.cache.internal.filelock.DefaultLockStateSerializer;
+import org.gradle.cache.internal.filelock.FileLockOutcome;
 import org.gradle.cache.internal.filelock.LockFileAccess;
 import org.gradle.cache.internal.filelock.LockInfo;
 import org.gradle.cache.internal.filelock.LockState;
@@ -44,7 +45,6 @@ import org.gradle.util.internal.GFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
@@ -247,17 +247,17 @@ public class DefaultFileLockManager implements FileLockManager {
                         try {
                             if (lock != null && !lock.isShared()) {
                                 // Discard information region
-                                java.nio.channels.FileLock info;
+                                FileLockOutcome lockOutcome;
                                 try {
-                                    info = lockInformationRegion(LockMode.Exclusive, newExponentialBackoff(shortTimeoutMs));
+                                    lockOutcome = lockInformationRegion(LockMode.Exclusive, newExponentialBackoff(shortTimeoutMs));
                                 } catch (InterruptedException e) {
                                     throw throwAsUncheckedException(e);
                                 }
-                                if (info != null) {
+                                if (lockOutcome.isLockWasAcquired()) {
                                     try {
                                         lockFileAccess.clearLockInfo();
                                     } finally {
-                                        info.release();
+                                        lockOutcome.getFileLock().release();
                                     }
                                 }
                             }
@@ -299,12 +299,13 @@ public class DefaultFileLockManager implements FileLockManager {
             LOGGER.debug("Waiting to acquire {} lock on {}.", lockMode.toString().toLowerCase(), displayName);
 
             // Lock the state region, with the requested mode
-            java.nio.channels.FileLock stateRegionLock = lockStateRegion(lockMode);
-            if (stateRegionLock == null) {
+            FileLockOutcome lockOutcome = lockStateRegion(lockMode);
+            if (!lockOutcome.isLockWasAcquired()) {
                 LockInfo lockInfo = readInformationRegion(newExponentialBackoff(shortTimeoutMs));
-                throw new LockTimeoutException(displayName, lockInfo.pid, metaDataProvider.getProcessIdentifier(), lockInfo.operation, operationDisplayName, lockFile);
+                throw timeoutException(displayName, operationDisplayName, lockFile, metaDataProvider.getProcessIdentifier(), lockOutcome, lockInfo);
             }
 
+            java.nio.channels.FileLock stateRegionLock = lockOutcome.getFileLock();
             try {
                 LockState lockState;
                 if (!stateRegionLock.isShared()) {
@@ -314,15 +315,15 @@ public class DefaultFileLockManager implements FileLockManager {
                     lockState = lockFileAccess.ensureLockState();
 
                     // Acquire an exclusive lock on the information region and write our details there
-                    java.nio.channels.FileLock informationRegionLock = lockInformationRegion(LockMode.Exclusive, newExponentialBackoff(shortTimeoutMs));
-                    if (informationRegionLock == null) {
+                    FileLockOutcome informationRegionLockOutcome = lockInformationRegion(LockMode.Exclusive, newExponentialBackoff(shortTimeoutMs));
+                    if (!informationRegionLockOutcome.isLockWasAcquired()) {
                         throw new IllegalStateException(String.format("Unable to lock the information region for %s", displayName));
                     }
                     // check that the length of the reserved region is enough for storing our content
                     try {
                         lockFileAccess.writeLockInfo(port, lockId, metaDataProvider.getProcessIdentifier(), operationDisplayName);
                     } finally {
-                        informationRegionLock.release();
+                        informationRegionLockOutcome.getFileLock().release();
                     }
                 } else {
                     // Just read the state region
@@ -337,34 +338,43 @@ public class DefaultFileLockManager implements FileLockManager {
             }
         }
 
+        private LockTimeoutException timeoutException(String lockDisplayName, String thisOperation, File lockFile, String thisProcessPid, FileLockOutcome fileLockOutcome, LockInfo lockInfo) {
+            if (fileLockOutcome == FileLockOutcome.LOCKED_BY_THIS_PROCESS) {
+                String message = String.format("Timeout waiting to lock %s. It is currently in use by another Gradle instance.%nOwner PID: %s%nOur PID: %s%nOwner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.pid, thisProcessPid, lockInfo.operation, thisOperation, lockFile);
+                return new LockTimeoutException(message, lockFile);
+            } else {
+                String message = String.format("Timeout waiting to lock %s. It is currently in use by this Gradle process.Owner Operation: %s%nOur operation: %s%nLock file: %s", lockDisplayName, lockInfo.operation, thisOperation, lockFile);
+                return new LockTimeoutException(message, lockFile);
+            }
+        }
+
         private LockInfo readInformationRegion(ExponentialBackoff<AwaitableFileLockReleasedSignal> backoff) throws IOException, InterruptedException {
             // Can't acquire lock, get details of owner to include in the error message
             LockInfo out = new LockInfo();
-            java.nio.channels.FileLock informationRegionLock = lockInformationRegion(LockMode.Shared, backoff);
-            if (informationRegionLock == null) {
+            FileLockOutcome lockOutcome = lockInformationRegion(LockMode.Shared, backoff);
+            if (!lockOutcome.isLockWasAcquired()) {
                 LOGGER.debug("Could not lock information region for {}. Ignoring.", displayName);
             } else {
                 try {
                     out = lockFileAccess.readLockInfo();
                 } finally {
-                    informationRegionLock.release();
+                    lockOutcome.getFileLock().release();
                 }
             }
             return out;
         }
 
-        @Nullable
-        private java.nio.channels.FileLock lockStateRegion(final LockMode lockMode) throws IOException, InterruptedException {
+        private FileLockOutcome lockStateRegion(final LockMode lockMode) throws IOException, InterruptedException {
             final ExponentialBackoff<AwaitableFileLockReleasedSignal> backoff = newExponentialBackoff(lockTimeoutMs);
-            return backoff.retryUntil(new IOQuery<java.nio.channels.FileLock>() {
+            return backoff.retryUntil(new IOQuery<FileLockOutcome>() {
                 private long lastPingTime;
                 private int lastLockHolderPort;
 
                 @Override
-                public java.nio.channels.FileLock run() throws IOException, InterruptedException {
-                    java.nio.channels.FileLock fileLock = lockFileAccess.tryLockState(lockMode == LockMode.Shared);
-                    if (fileLock != null) {
-                        return fileLock;
+                public IOQuery.Result<FileLockOutcome> run() throws IOException, InterruptedException {
+                    FileLockOutcome lockOutcome = lockFileAccess.tryLockState(lockMode == LockMode.Shared);
+                    if (lockOutcome.isLockWasAcquired()) {
+                        return IOQuery.Result.successful(lockOutcome);
                     }
                     if (port != -1) { //we don't like the assumption about the port very much
                         LockInfo lockInfo = readInformationRegion(backoff);
@@ -382,14 +392,20 @@ public class DefaultFileLockManager implements FileLockManager {
                             LOGGER.debug("The file lock for {} is held by a different Gradle process. I was unable to read on which port the owner listens for lock access requests.", displayName);
                         }
                     }
-                    return null;
+                    return IOQuery.Result.notSuccessful(lockOutcome);
                 }
             });
         }
 
-        @Nullable
-        private java.nio.channels.FileLock lockInformationRegion(final LockMode lockMode, ExponentialBackoff<AwaitableFileLockReleasedSignal> backoff) throws IOException, InterruptedException {
-            return backoff.retryUntil(() -> lockFileAccess.tryLockInfo(lockMode == LockMode.Shared));
+        private FileLockOutcome lockInformationRegion(final LockMode lockMode, ExponentialBackoff<AwaitableFileLockReleasedSignal> backoff) throws IOException, InterruptedException {
+            return backoff.retryUntil(() -> {
+                FileLockOutcome lockOutcome = lockFileAccess.tryLockInfo(lockMode == LockMode.Shared);
+                if (lockOutcome.isLockWasAcquired()) {
+                    return IOQuery.Result.successful(lockOutcome);
+                } else {
+                    return IOQuery.Result.notSuccessful(lockOutcome);
+                }
+            });
         }
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/FileLockOutcome.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/FileLockOutcome.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.filelock;
+
+import java.nio.channels.FileLock;
+
+public abstract class FileLockOutcome {
+    public static final FileLockOutcome LOCKED_BY_ANOTHER_PROCESS = new FileLockOutcome() {
+    };
+    public static final FileLockOutcome LOCKED_BY_THIS_PROCESS = new FileLockOutcome() {
+    };
+
+    public boolean isLockWasAcquired() {
+        return false;
+    }
+
+    public FileLock getFileLock() {
+        throw new IllegalStateException("Lock was not acquired");
+    }
+
+    static FileLockOutcome acquired(FileLock fileLock) {
+        return new FileLockOutcome() {
+            @Override
+            public boolean isLockWasAcquired() {
+                return true;
+            }
+
+            @Override
+            public FileLock getFileLock() {
+                return fileLock;
+            }
+        };
+    }
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockFileAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockFileAccess.java
@@ -15,12 +15,10 @@
  */
 package org.gradle.cache.internal.filelock;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.channels.FileLock;
 
 public class LockFileAccess {
 
@@ -75,13 +73,11 @@ public class LockFileAccess {
         lockInfoAccess.clearLockInfo(lockFileAccess);
     }
 
-    @Nullable
-    public FileLock tryLockInfo(boolean shared) throws IOException {
+    public FileLockOutcome tryLockInfo(boolean shared) throws IOException {
         return lockInfoAccess.tryLock(lockFileAccess, shared);
     }
 
-    @Nullable
-    public FileLock tryLockState(boolean shared) throws IOException {
+    public FileLockOutcome tryLockState(boolean shared) throws IOException {
         return lockStateAccess.tryLock(lockFileAccess, shared);
     }
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockStateAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/filelock/LockStateAccess.java
@@ -86,11 +86,16 @@ public class LockStateAccess {
         }
     }
 
-    public FileLock tryLock(RandomAccessFile lockFileAccess, boolean shared) throws IOException {
+    public FileLockOutcome tryLock(RandomAccessFile lockFileAccess, boolean shared) throws IOException {
         try {
-            return lockFileAccess.getChannel().tryLock(REGION_START, stateRegionSize, shared);
+            FileLock fileLock = lockFileAccess.getChannel().tryLock(REGION_START, stateRegionSize, shared);
+            if (fileLock == null) {
+                return FileLockOutcome.LOCKED_BY_ANOTHER_PROCESS;
+            } else {
+                return FileLockOutcome.acquired(fileLock);
+            }
         } catch (OverlappingFileLockException e) {
-            return null;
+            return FileLockOutcome.LOCKED_BY_THIS_PROCESS;
         }
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerProcessClassPathProviderTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/WorkerProcessClassPathProviderTest.groovy
@@ -48,8 +48,10 @@ class WorkerProcessClassPathProviderTest extends Specification {
         then:
         1 * cacheRepository.cache('workerMain') >> cacheBuilder
         1 * cacheBuilder.withInitializer(!null) >> { args -> initializer = args[0]; return cacheBuilder }
+        1 * cacheBuilder.withLockOptions(_) >> cacheBuilder
         1 * cacheBuilder.open() >> { initializer.execute(cache); return cache }
         _ * cache.getBaseDir() >> cacheDir
+        1 * cache.close()
         0 * cache._
         classpath.asFiles == [jarFile]
         jarFile.file
@@ -66,9 +68,11 @@ class WorkerProcessClassPathProviderTest extends Specification {
 
         then:
         1 * cacheRepository.cache('workerMain') >> cacheBuilder
+        1 * cacheBuilder.withLockOptions(_) >> cacheBuilder
         1 * cacheBuilder.withInitializer(!null) >> cacheBuilder
         1 * cacheBuilder.open() >> cache
         _ * cache.getBaseDir() >> cacheDir
+        1 * cache.close()
         0 * cache._
         classpath.asFiles == [jarFile]
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Also fixes some issues that were affecting configuration cache tests that use the tooling API or testkit.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
