### PR TITLE
Allow for HTTP Header credentials to be loaded from properties

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/AuthenticationSupported.java
@@ -114,6 +114,7 @@ public interface AuthenticationSupported {
      * <ul>
      * <li>{@link org.gradle.api.credentials.PasswordCredentials}</li>
      * <li>{@link org.gradle.api.credentials.AwsCredentials}</li>
+     * <li>{@link org.gradle.api.credentials.HttpHeaderCredentials}</li>
      * </ul>
      *
      * @throws IllegalArgumentException if {@code credentialsType} is not of a supported type

--- a/subprojects/core-api/src/main/java/org/gradle/api/credentials/HttpHeaderCredentials.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/credentials/HttpHeaderCredentials.java
@@ -21,6 +21,8 @@ import javax.annotation.Nullable;
 /**
  * Credentials that can be used to login to a protected server, e.g. a remote repository by using HTTP header.
  *
+ * The properties used for creating credentials from a property are <pre>repoAuthHeaderName</pre> and <pre>repoAuthHeaderValue</pre>, where <pre>repo</pre> is the name of the repository.
+ *
  * @since 4.10
  */
 public interface HttpHeaderCredentials extends Credentials {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
@@ -240,7 +240,7 @@ class CredentialsProviderIntegrationTest extends AbstractIntegrationSpec {
         credentialsType         | errorMessage
         'AwsCredentials'        | "The following Gradle properties are missing for 'test' credentials:\n  - testAccessKey\n  - testSecretKey"
         'PasswordCredentials'   | "The following Gradle properties are missing for 'test' credentials:\n  - testUsername\n  - testPassword"
-        'HttpHeaderCredentials' | "The following Gradle properties are missing for 'test' credentials:\n  - testName\n  - testValue"
+        'HttpHeaderCredentials' | "The following Gradle properties are missing for 'test' credentials:\n  - testAuthHeaderName\n  - testAuthHeaderValue"
     }
 
     @UnsupportedWithConfigurationCache(because = "test checks behavior with and without configuration cache")

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CredentialsProviderIntegrationTest.groovy
@@ -237,9 +237,10 @@ class CredentialsProviderIntegrationTest extends AbstractIntegrationSpec {
         }
 
         where:
-        credentialsType       | errorMessage
-        'AwsCredentials'      | "The following Gradle properties are missing for 'test' credentials:\n  - testAccessKey\n  - testSecretKey"
-        'PasswordCredentials' | "The following Gradle properties are missing for 'test' credentials:\n  - testUsername\n  - testPassword"
+        credentialsType         | errorMessage
+        'AwsCredentials'        | "The following Gradle properties are missing for 'test' credentials:\n  - testAccessKey\n  - testSecretKey"
+        'PasswordCredentials'   | "The following Gradle properties are missing for 'test' credentials:\n  - testUsername\n  - testPassword"
+        'HttpHeaderCredentials' | "The following Gradle properties are missing for 'test' credentials:\n  - testName\n  - testValue"
     }
 
     @UnsupportedWithConfigurationCache(because = "test checks behavior with and without configuration cache")

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
@@ -19,12 +19,14 @@ package org.gradle.api.internal.provider;
 import org.gradle.api.ProjectConfigurationException;
 import org.gradle.api.credentials.AwsCredentials;
 import org.gradle.api.credentials.Credentials;
+import org.gradle.api.credentials.HttpHeaderCredentials;
 import org.gradle.api.credentials.PasswordCredentials;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.internal.credentials.DefaultAwsCredentials;
+import org.gradle.internal.credentials.DefaultHttpHeaderCredentials;
 import org.gradle.internal.credentials.DefaultPasswordCredentials;
 import org.gradle.internal.logging.text.TreeFormatter;
 
@@ -42,6 +44,7 @@ public class CredentialsProviderFactory implements TaskExecutionGraphListener {
 
     private final Map<String, Provider<PasswordCredentials>> passwordProviders = new ConcurrentHashMap<>();
     private final Map<String, Provider<AwsCredentials>> awsProviders = new ConcurrentHashMap<>();
+    private final Map<String, Provider<HttpHeaderCredentials>> httpHeaderProviders = new ConcurrentHashMap<>();
 
     private final Set<String> missingProviderErrors = ConcurrentHashMap.newKeySet();
 
@@ -58,6 +61,9 @@ public class CredentialsProviderFactory implements TaskExecutionGraphListener {
         }
         if (AwsCredentials.class.isAssignableFrom(credentialsType)) {
             return (Provider<T>) awsProviders.computeIfAbsent(identity, id -> evaluateAtConfigurationTime(new AwsCredentialsProvider(id)));
+        }
+        if (HttpHeaderCredentials.class.isAssignableFrom(credentialsType)) {
+            return (Provider<T>) httpHeaderProviders.computeIfAbsent(identity, id -> evaluateAtConfigurationTime(new HttpHeaderCredentialsProvider(id)));
         }
 
         throw new IllegalArgumentException(String.format("Unsupported credentials type: %s", credentialsType));
@@ -151,6 +157,25 @@ public class CredentialsProviderFactory implements TaskExecutionGraphListener {
             credentials.setAccessKey(accessKey);
             credentials.setSecretKey(secretKey);
             credentials.setSessionToken(getOptionalProperty("SessionToken"));
+            return credentials;
+        }
+    }
+
+    private class HttpHeaderCredentialsProvider extends CredentialsProvider<HttpHeaderCredentials> {
+
+        HttpHeaderCredentialsProvider(String identity) {
+            super(identity);
+        }
+
+        @Override
+        public synchronized HttpHeaderCredentials call() {
+            String name = getRequiredProperty("Name");
+            String value = getRequiredProperty("Value");
+            assertRequiredValuesPresent();
+
+            HttpHeaderCredentials credentials = new DefaultHttpHeaderCredentials();
+            credentials.setName(name);
+            credentials.setValue(value);
             return credentials;
         }
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CredentialsProviderFactory.java
@@ -169,8 +169,8 @@ public class CredentialsProviderFactory implements TaskExecutionGraphListener {
 
         @Override
         public synchronized HttpHeaderCredentials call() {
-            String name = getRequiredProperty("Name");
-            String value = getRequiredProperty("Value");
+            String name = getRequiredProperty("AuthHeaderName");
+            String value = getRequiredProperty("AuthHeaderValue");
             assertRequiredValuesPresent();
 
             HttpHeaderCredentials credentials = new DefaultHttpHeaderCredentials();

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CredentialsProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CredentialsProviderFactoryTest.groovy
@@ -175,8 +175,8 @@ class CredentialsProviderFactoryTest extends Specification {
 
     def "evaluates name and value of header credentials provider"() {
         given:
-        providerFactory.gradleProperty('myServiceName') >> new DefaultProvider<>({ 'Private-Token' })
-        providerFactory.gradleProperty('myServiceValue') >> new DefaultProvider<>({ 'secret' })
+        providerFactory.gradleProperty('myServiceAuthHeaderName') >> new DefaultProvider<>({ 'Private-Token' })
+        providerFactory.gradleProperty('myServiceAuthHeaderValue') >> new DefaultProvider<>({ 'secret' })
         def provider = factory.provide(HttpHeaderCredentials, 'myService')
 
         when:

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CredentialsProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CredentialsProviderFactoryTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider
 
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.credentials.AwsCredentials
+import org.gradle.api.credentials.HttpHeaderCredentials
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.ProviderFactory
 import spock.lang.Specification
@@ -170,5 +171,20 @@ class CredentialsProviderFactoryTest extends Specification {
         def e = thrown(ProjectConfigurationException)
         e.message == 'Credentials required for this build could not be resolved.'
         e.causes.size() == 2
+    }
+
+    def "evaluates name and value of header credentials provider"() {
+        given:
+        providerFactory.gradleProperty('myServiceName') >> new DefaultProvider<>({ 'Private-Token' })
+        providerFactory.gradleProperty('myServiceValue') >> new DefaultProvider<>({ 'secret' })
+        def provider = factory.provide(HttpHeaderCredentials, 'myService')
+
+        when:
+        def credentials = provider.get()
+
+        then:
+        credentials instanceof HttpHeaderCredentials
+        credentials['name'] == 'Private-Token'
+        credentials['value'] == 'secret'
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #17369 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This is mostly for making the use of repositories protected via HTTP headers similar to that of basic authentication by allowing the name of the header and its value to be directly defined in properties (see my original comment in the [original issue](https://github.com/gradle/gradle/issues/17369)).

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
  - I am not sure of what kind of test could be done here. I have added the `HttpHeaderCredentials` to an existing integration test (`CredentialsProviderIntegrationTest.missing credentials error messages can be assembled in paarallel execution`) but I don't know what to do next.
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
  - Not sure of what to do here as #17378 will probably clash with what would be done here.
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
