### PR TITLE
Disable deprecation warning check for GradleBuildSmokeTest

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTest.groovy
@@ -16,20 +16,14 @@
 
 package org.gradle.smoketests
 
-
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.util.GradleVersion
 
 class GradleBuildSmokeTest extends AbstractGradleceptionSmokeTest {
 
     def "can build Gradle distribution"() {
         when:
         result = runner(':distributions-full:binDistributionZip', ':distributions-full:binInstallation', '--stacktrace')
-            .expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. " +
-                "This is scheduled to be removed in Gradle 8.0. " +
-                "Please use the destinationDirectory property instead. " +
-                "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#compile_task_wiring",
-                "https://youtrack.jetbrains.com/issue/KT-46019")
+            .ignoreDeprecationWarnings()
             .build()
 
         then:


### PR DESCRIPTION
https://github.com/gradle/gradle-private/issues/3405
