### PR TITLE
 Expose capability in resolved variant for artifact collection

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache.serialization.codecs
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.component.Artifact
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal
@@ -110,7 +111,7 @@ class CollectingArtifactVisitor : ArtifactVisitor {
         failures.add(failure)
     }
 
-    override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, artifact: ResolvableArtifact) {
+    override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, capabilities: MutableList<out Capability>, artifact: ResolvableArtifact) {
         elements.add(FixedFileArtifactSpec(artifact.id, variantAttributes, variantName, artifact.file))
     }
 
@@ -162,6 +163,7 @@ class FixedArtifactCollection(
                         DefaultResolvedArtifactResult(
                             element.id,
                             element.variantAttributes,
+                            emptyList(),
                             element.variantDisplayName,
                             Artifact::class.java,
                             element.file

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
@@ -88,7 +88,7 @@ class CalculateArtifactsCodec(
         override fun visit(visitor: ArtifactVisitor) {
             val displayName = Describables.of(ownerId)
             for (artifact in artifacts) {
-                visitor.visitArtifact(displayName, ImmutableAttributes.EMPTY, artifact)
+                visitor.visitArtifact(displayName, ImmutableAttributes.EMPTY, emptyList(), artifact)
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -109,9 +110,9 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
         void visitArtifacts(Collection<? extends PublishArtifact> artifacts);
 
         // This configuration as a variant. May not always be present
-        void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
+        void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts);
 
         // A child variant. May not always be present
-        void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
+        void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -88,11 +88,11 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         visitor.visitArtifacts(artifacts);
         PublishArtifactSet allArtifactSet = allArtifacts.getPublishArtifactSet();
         if (variants == null || variants.isEmpty() || !allArtifactSet.isEmpty()) {
-            visitor.visitOwnVariant(displayName, attributes.asImmutable(), allArtifactSet);
+            visitor.visitOwnVariant(displayName, attributes.asImmutable(), getCapabilities(), allArtifactSet);
         }
         if (variants != null) {
             for (DefaultVariant variant : variants.withType(DefaultVariant.class)) {
-                variant.visit(visitor);
+                variant.visit(visitor, getCapabilities());
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -35,6 +36,7 @@ import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.typeconversion.NotationParser;
 
+import java.util.Collection;
 import java.util.List;
 
 public class DefaultVariant implements ConfigurationVariantInternal {
@@ -68,8 +70,8 @@ public class DefaultVariant implements ConfigurationVariantInternal {
         return new LeafOutgoingVariant(getAsDescribable(), attributes, getArtifacts());
     }
 
-    public void visit(ConfigurationInternal.VariantVisitor visitor) {
-        visitor.visitChildVariant(name, getAsDescribable(), attributes.asImmutable(), getArtifacts());
+    public void visit(ConfigurationInternal.VariantVisitor visitor, Collection<? extends Capability> capabilities) {
+        visitor.visitChildVariant(name, getAsDescribable(), attributes.asImmutable(), capabilities, getArtifacts());
     }
 
     private DisplayName getAsDescribable() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ArtifactCollectingVisitor.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalDependencyFiles;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -27,6 +28,7 @@ import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.UncheckedException;
 
+import java.util.List;
 import java.util.Set;
 
 public class ArtifactCollectingVisitor implements ArtifactVisitor {
@@ -41,7 +43,7 @@ public class ArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
+    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
         this.artifacts.add(artifact.toPublicView());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfiguration.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.UnresolvedDependency;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DependencyGraphNodeResult;
 import org.gradle.api.internal.artifacts.ResolveArtifactsBuildOperationType;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
@@ -294,7 +295,7 @@ public class DefaultLenientConfiguration implements LenientConfiguration, Visite
         final Set<File> files = Sets.newLinkedHashSet();
 
         @Override
-        public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
+        public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
             try {
                 ResolvedArtifact resolvedArtifact = artifact.toPublicView();
                 files.add(resolvedArtifact.getFile());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.Artifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -28,6 +29,7 @@ import org.gradle.internal.DisplayName;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
@@ -41,11 +43,11 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
     }
 
     @Override
-    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
+    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
         try {
             if (seenArtifacts.add(artifact.getId())) {
                 File file = artifact.getFile();
-                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), variantAttributes, variantName, Artifact.class, file));
+                this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), variantAttributes, capabilities, variantName, Artifact.class, file));
             }
         } catch (Exception t) {
             failures.add(t);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -18,12 +18,14 @@ package org.gradle.api.internal.artifacts.ivyservice;
 
 import com.google.common.collect.Sets;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
@@ -31,7 +33,7 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
     private final Set<Throwable> failures = Sets.newLinkedHashSet();
 
     @Override
-    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
+    public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
         try {
             File file = artifact.getFile();
             this.files.add(file);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
@@ -57,13 +57,13 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
             }
 
             @Override
-            public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
-                metaData.addVariant(configuration.getName(), configuration.getName(), configurationIdentifier, displayName, attributes, artifacts);
+            public void visitOwnVariant(DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
+                metaData.addVariant(configuration.getName(), configuration.getName(), configurationIdentifier, displayName, attributes, ImmutableCapabilities.of(capabilities), artifacts);
             }
 
             @Override
-            public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts) {
-                metaData.addVariant(configuration.getName(), configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, artifacts);
+            public void visitChildVariant(String name, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends Capability> capabilities, Collection<? extends PublishArtifact> artifacts) {
+                metaData.addVariant(configuration.getName(), configuration.getName() + "-" + name, new NestedVariantIdentifier(configurationIdentifier, name), displayName, attributes, ImmutableCapabilities.of(capabilities), artifacts);
             }
         });
         return configurationMetadata;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactVisitor.java
@@ -17,9 +17,12 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.internal.DisplayName;
+
+import java.util.List;
 
 /**
  * A visitor over the contents of a {@link ResolvedArtifactSet}. A {@link ResolvedArtifactSet} may contain zero or more sets of files, each set containing zero or more artifacts.
@@ -35,10 +38,10 @@ public interface ArtifactVisitor {
     /**
      * Visits an artifact. Artifacts are resolved but not necessarily available unless {@link #requireArtifactFiles()} returns true.
      */
-    void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact);
+    void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact);
 
     /**
-     * Should the file for each artifacts be made available prior to calling {@link #visitArtifact(DisplayName, AttributeContainer, ResolvableArtifact)}?
+     * Should the file for each artifacts be made available prior to calling {@link #visitArtifact(DisplayName, AttributeContainer, List, ResolvableArtifact)}?
      *
      * Returns true here allows the collection to preemptively resolve the files in parallel.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -152,7 +152,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             identifier = null;
         }
 
-        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), variantAttributes, resolvedArtifacts.build());
+        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), variantAttributes, variant.getCapabilities(), resolvedArtifacts.build());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -97,7 +97,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     }
 
     public static ArtifactSet createForConfiguration(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ConfigurationMetadata configuration, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes, CalculatedValueContainerFactory calculatedValueContainerFactory) {
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), new ComponentConfigurationIdentifier(componentIdentifier, configuration.getName()), configuration.asDescribable(), configuration.getAttributes(), artifacts, ImmutableCapabilities.EMPTY);
+        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), new ComponentConfigurationIdentifier(componentIdentifier, configuration.getName()), configuration.asDescribable(), configuration.getAttributes(), artifacts, configuration.getCapabilities());
         ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, calculatedValueContainerFactory);
         return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -236,7 +236,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
         @Override
         public void visit(ArtifactVisitor visitor) {
-            visitor.visitArtifact(variantName, variantAttributes, artifact);
+            visitor.visitArtifact(variantName, variantAttributes, Collections.emptyList(), artifact);
             visitor.endVisitCollection(FileCollectionInternal.OTHER);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -63,6 +63,7 @@ import org.gradle.util.internal.CollectionUtils;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -190,7 +191,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
             if (resolveResult.getFailure() != null) {
                 artifacts.addArtifact(new DefaultUnresolvedArtifactResult(artifactMetaData.getId(), type, resolveResult.getFailure()));
             } else {
-                artifacts.addArtifact(ivyFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult())));
+                artifacts.addArtifact(ivyFactory.verifiedArtifact(new DefaultResolvedArtifactResult(artifactMetaData.getId(), ImmutableAttributes.EMPTY, Collections.emptyList(), Describables.of(component.getId().getDisplayName()), type, resolveResult.getResult())));
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -19,11 +19,12 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.Artifact;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
-import java.util.Collections;
+import java.util.List;
 
 public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     private final ComponentArtifactIdentifier identifier;
@@ -33,11 +34,12 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
 
     public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier,
                                          AttributeContainer variantAttributes,
+                                         List<? extends Capability> capabilities,
                                          DisplayName variantDisplayName,
                                          Class<? extends Artifact> type,
                                          File file) {
         this.identifier = identifier;
-        this.variant = new DefaultResolvedVariantResult(identifier.getComponentIdentifier(), variantDisplayName, variantAttributes, Collections.emptyList(), null);
+        this.variant = new DefaultResolvedVariantResult(identifier.getComponentIdentifier(), variantDisplayName, variantAttributes, capabilities, null);
         this.type = type;
         this.file = file;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.result;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
@@ -38,12 +39,12 @@ public class DefaultResolvedVariantResult implements ResolvedVariantResult {
     public DefaultResolvedVariantResult(ComponentIdentifier owner,
                                         DisplayName displayName,
                                         AttributeContainer attributes,
-                                        List<Capability> capabilities,
+                                        List<? extends Capability> capabilities,
                                         @Nullable ResolvedVariantResult externalVariant) {
         this.owner = owner;
         this.displayName = displayName;
         this.attributes = attributes;
-        this.capabilities = capabilities;
+        this.capabilities = ImmutableList.copyOf(capabilities);
         this.externalVariant = externalVariant;
         this.hashCode = computeHashCode();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedProjectArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedProjectArtifactSet.java
@@ -34,6 +34,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * An artifact set containing transformed project artifacts.
@@ -101,7 +102,7 @@ public class TransformedProjectArtifactSet implements ResolvedArtifactSet, FileC
             Try<TransformationSubject> transformedSubject = node.getTransformedSubject();
             if (transformedSubject.isSuccessful()) {
                 for (File file : transformedSubject.get().getFiles()) {
-                    visitor.visitArtifact(displayName, targetAttributes, node.getInputArtifact().transformedTo(file));
+                    visitor.visitArtifact(displayName, targetAttributes, Collections.emptyList(), node.getInputArtifact().transformedTo(file));
                 }
             } else {
                 Throwable failure = transformedSubject.getFailure().get();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BrokenArtifacts;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
@@ -34,6 +35,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Visitor {
@@ -54,7 +56,7 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
     public void visitArtifacts(ResolvedArtifactSet.Artifacts artifacts) {
         artifacts.visit(new ArtifactVisitor() {
             @Override
-            public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
+            public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, List<? extends Capability> capabilities, ResolvableArtifact artifact) {
                 TransformedArtifact transformedArtifact = new TransformedArtifact(variantName, target, artifact, transformationSteps);
                 result.add(transformedArtifact);
             }
@@ -214,7 +216,7 @@ public class TransformingAsyncArtifactListener implements ResolvedArtifactSet.Vi
                 subject -> {
                     for (File output : subject.getFiles()) {
                         ResolvableArtifact resolvedArtifact = artifact.transformedTo(output);
-                        visitor.visitArtifact(variantName, target, resolvedArtifact);
+                        visitor.visitArtifact(variantName, target, Collections.emptyList(), resolvedArtifact);
                     }
                 },
                 failure -> visitor.visitFailure(

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -144,6 +144,11 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
         return computedCapabilities;
     }
 
+    private CapabilitiesMetadata getRawCapabilities() {
+        // We need the raw capabilities when deriving a variant since we pass down the component metadata rules as well
+        return super.getCapabilities();
+    }
+
     @Override
     public boolean requiresMavenArtifactDiscovery() {
         // If artifacts are computed, we opt-out of artifact discovery
@@ -299,7 +304,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                     attributes == null ? DefaultConfigurationMetadata.super.getAttributes() : attributes,
                     lazyConfigDependencies(),
                     dependencyFilter,
-                    capabilities == null ? DefaultConfigurationMetadata.this.getCapabilities() : capabilities,
+                    capabilities == null ? DefaultConfigurationMetadata.this.getRawCapabilities() : capabilities,
                     DefaultConfigurationMetadata.super.requiresMavenArtifactDiscovery(),
                     isExternalVariant()
             );

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.capabilities.Capability;
 
+import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 
 public class ImmutableCapabilities implements CapabilitiesMetadata {
@@ -33,12 +35,12 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
         return of(capabilities.getCapabilities());
     }
 
-    public static ImmutableCapabilities of(List<? extends Capability> capabilities) {
-        if (capabilities.isEmpty()) {
+    public static ImmutableCapabilities of(@Nullable Collection<? extends Capability> capabilities) {
+        if (capabilities == null || capabilities.isEmpty()) {
             return EMPTY;
         }
         if (capabilities.size() == 1) {
-            Capability single = capabilities.get(0);
+            Capability single = capabilities.stream().findAny().get();
             if (single instanceof ShadowedCapability) {
                 return new ShadowedSingleImmutableCapabilities(single);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
@@ -47,7 +47,7 @@ public interface BuildableLocalComponentMetadata {
     /**
      * Adds a variant to this component, extending from the given configuration. Every configuration should include at least one variant.
      */
-    void addVariant(String configuration, String name, VariantResolveMetadata.Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> artifacts);
+    void addVariant(String configuration, String name, VariantResolveMetadata.Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, Collection<? extends PublishArtifact> artifacts);
 
     /**
      * Adds a configuration to this component.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -151,7 +151,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public void addVariant(String configuration, String name, VariantResolveMetadata.Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, Collection<? extends PublishArtifact> publishArtifacts) {
+    public void addVariant(String configuration, String name, VariantResolveMetadata.Identifier identifier, DisplayName displayName, ImmutableAttributes attributes, ImmutableCapabilities capabilities, Collection<? extends PublishArtifact> publishArtifacts) {
         ImmutableList<LocalComponentArtifactMetadata> artifacts;
         if (publishArtifacts.isEmpty()) {
             artifacts = ImmutableList.of();
@@ -162,7 +162,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
             }
             artifacts = builder.build();
         }
-        allVariants.put(configuration, new DefaultVariantMetadata(name, identifier, displayName, attributes, artifacts, null));
+        allVariants.put(configuration, new DefaultVariantMetadata(name, identifier, displayName, attributes, artifacts, capabilities));
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
@@ -33,6 +33,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 
 public class TestArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet.Artifacts {
     public static final String DEFAULT_TEST_VARIANT = "test variant";
@@ -70,7 +71,7 @@ public class TestArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet
     @Override
     public void visit(ArtifactVisitor visitor) {
         for (final ResolvedArtifact artifact : artifacts) {
-            visitor.visitArtifact(variantName, variant, new Adapter(artifact));
+            visitor.visitArtifact(variantName, variant, Collections.emptyList(), new Adapter(artifact));
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -470,7 +470,7 @@ class DefaultConfigurationSpec extends Specification {
                 files.each {
                     def artifact = Stub(ResolvableArtifact)
                     _ * artifact.file >> it
-                    visitor.visitArtifact(null, null, artifact)
+                    visitor.visitArtifact(null, null, [], artifact)
                 }
                 visitor.endVisitCollection(null)
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilderTest.groovy
@@ -45,8 +45,8 @@ class DefaultLocalComponentMetadataBuilderTest extends Specification {
         config1.name >> "config1"
         config1.collectVariants(_) >> { ConfigurationInternal.VariantVisitor visitor ->
             visitor.visitArtifacts(artifacts1)
-            visitor.visitChildVariant("child1", null, null, null)
-            visitor.visitChildVariant("child2", null, null, null)
+            visitor.visitChildVariant("child1", null, null, null, null)
+            visitor.visitChildVariant("child2", null, null, null, null)
         }
         config2.name >> "config2"
         config2.collectVariants(_) >> { ConfigurationInternal.VariantVisitor visitor ->
@@ -64,8 +64,8 @@ class DefaultLocalComponentMetadataBuilderTest extends Specification {
         1 * metaData.addConfiguration("config2", '', emptySet, emptySet, false, false, _, false, _, false, ImmutableCapabilities.EMPTY, _)
         1 * metaData.addDependenciesAndExcludesForConfiguration(config2, configurationMetadataBuilder)
         1 * metaData.addArtifacts("config1", artifacts1)
-        1 * metaData.addVariant("config1", "config1-child1", _, _, _, _)
-        1 * metaData.addVariant("config1", "config1-child2", _, _, _, _)
+        1 * metaData.addVariant("config1", "config1-child1", _, _, _, _, _)
+        1 * metaData.addVariant("config1", "config1-child2", _, _, _, _, _)
         1 * metaData.addArtifacts("config2", artifacts2)
         0 * metaData._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.Describables
 import org.gradle.internal.Try
+import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.model.CalculatedValue
@@ -76,7 +77,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> false
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact1)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER) // each artifact is treated as a separate collection, the entire variant could instead be treated as a collection
 
         then:
@@ -85,7 +86,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> false
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact2)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact2)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
 
@@ -98,7 +99,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> false
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact1)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
     }
@@ -127,7 +128,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> true
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact1)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER)
 
         then:
@@ -141,7 +142,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> true
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact2)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact2)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
 
@@ -159,7 +160,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
             artifacts.visit(artifactVisitor)
         }
         1 * artifactVisitor.requireArtifactFiles() >> true
-        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, artifact1)
+        1 * artifactVisitor.visitArtifact(variantDisplayName, variant, [], artifact1)
         1 * artifactVisitor.endVisitCollection(FileCollectionInternal.OTHER)
         0 * _
     }
@@ -209,7 +210,7 @@ class ArtifactBackedResolvedVariantTest extends Specification {
     }
 
     ResolvedVariant of(artifacts) {
-        return ArtifactBackedResolvedVariant.create(id, variantDisplayName, variant, artifacts)
+        return ArtifactBackedResolvedVariant.create(id, variantDisplayName, variant, ImmutableCapabilities.EMPTY, artifacts)
     }
 
     interface TestArtifact extends ResolvableArtifact, Buildable {}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSetTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.file.FileCollectionInternal
@@ -134,7 +135,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         1 * visitor.visitArtifacts(_) >> { ResolvedArtifactSet.Artifacts artifacts -> artifacts.visit(artifactVisitor) }
-        1 * artifactVisitor.visitArtifact(_, attrs1, { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+        1 * artifactVisitor.visitArtifact(_, attrs1, [], { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, List<? extends Capability> capabilities, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f1.name)
         }
@@ -142,7 +143,7 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
 
         then:
         1 * visitor.visitArtifacts(_) >> { ResolvedArtifactSet.Artifacts artifacts -> artifacts.visit(artifactVisitor) }
-        1 * artifactVisitor.visitArtifact(_, attrs2, { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+        1 * artifactVisitor.visitArtifact(_, attrs2, [], { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, List<? extends Capability> capabilities, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'
             assert artifact.id == new ComponentFileArtifactIdentifier(id, f2.name)
         }
@@ -172,11 +173,11 @@ class LocalFileDependencyBackedArtifactSetTest extends Specification {
         1 * files.files >> ([f1, f2] as Set)
         2 * selector.select(_, _) >> { ResolvedVariantSet variants, f -> variants.variants.first() }
         2 * visitor.visitArtifacts(_) >> { ResolvedArtifactSet.Artifacts artifacts -> artifacts.visit(artifactVisitor) }
-        1 * artifactVisitor.visitArtifact(_, attrs1, { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+        1 * artifactVisitor.visitArtifact(_, attrs1, [], { it.file == f1 }) >> { DisplayName displayName, AttributeContainer attrs, List<? extends Capability> capabilities, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'
             assert artifact.id == new OpaqueComponentArtifactIdentifier(f1)
         }
-        1 * artifactVisitor.visitArtifact(_, attrs2, { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, ResolvableArtifact artifact ->
+        1 * artifactVisitor.visitArtifact(_, attrs2, [], { it.file == f2 }) >> { DisplayName displayName, AttributeContainer attrs, List<? extends Capability> capabilities, ResolvableArtifact artifact ->
             assert displayName.displayName == 'local file'
             assert artifact.id == new OpaqueComponentArtifactIdentifier(f2)
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -56,7 +56,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
 
         then:
         artifacts.size() == 1
-        1 * artifacts.visit(_) >> { ArtifactVisitor visitor -> visitor.visitArtifact(null, null, artifact) }
+        1 * artifacts.visit(_) >> { ArtifactVisitor visitor -> visitor.visitArtifact(null, null, [], artifact) }
         0 * _
 
         when:
@@ -75,7 +75,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
 
         then:
         artifacts.size() == 1
-        1 * artifacts.visit(_) >> { ArtifactVisitor visitor -> visitor.visitArtifact(null, null, artifact) }
+        1 * artifacts.visit(_) >> { ArtifactVisitor visitor -> visitor.visitArtifact(null, null, [], artifact) }
         0 * _
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -226,8 +226,8 @@ class DefaultLocalComponentMetadataTest extends Specification {
         when:
         addConfiguration("conf1")
         addConfiguration("conf2", ["conf1"])
-        metadata.addVariant("conf1", "variant1", Stub(VariantResolveMetadata.Identifier), Stub(DisplayName), variant1Attrs, variant1Artifacts)
-        metadata.addVariant("conf2", "variant2", Stub(VariantResolveMetadata.Identifier), Stub(DisplayName), variant2Attrs, variant2Artifacts)
+        metadata.addVariant("conf1", "variant1", Stub(VariantResolveMetadata.Identifier), Stub(DisplayName), variant1Attrs, ImmutableCapabilities.EMPTY, variant1Artifacts)
+        metadata.addVariant("conf2", "variant2", Stub(VariantResolveMetadata.Identifier), Stub(DisplayName), variant2Attrs, ImmutableCapabilities.EMPTY, variant2Artifacts)
 
         then:
         def config1 = metadata.getConfiguration("conf1")


### PR DESCRIPTION
Previously that information was not wired in and would cause matching
variant information from artifact collection impossible.