### PR TITLE
Use placeholders for java.lang.StackTraceElement

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -98,6 +98,11 @@ public abstract class AvailableJavaHomes {
     }
 
     @Nullable
+    public static Jvm getJdk11() {
+        return getJdk(JavaVersion.VERSION_11);
+    }
+
+    @Nullable
     public static Jvm getJdk(final JavaVersion version) {
         return Iterables.getFirst(getAvailableJdks(version), null);
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/ExceptionPlaceholder.java
@@ -60,7 +60,7 @@ class ExceptionPlaceholder implements Serializable {
     private final boolean assertionError;
     private final List<ExceptionPlaceholder> causes;
     private final List<ExceptionPlaceholder> suppressed;
-    private StackTraceElement[] stackTrace;
+    private List<StackTraceElementPlaceholder> stackTrace;
     private Throwable toStringRuntimeExec;
     private Throwable getMessageExec;
 
@@ -71,11 +71,11 @@ class ExceptionPlaceholder implements Serializable {
         contextual = throwable.getClass().getAnnotation(Contextual.class) != null;
         assertionError = throwable instanceof AssertionError;
         try {
-            stackTrace = throwable.getStackTrace() == null ? new StackTraceElement[0] : throwable.getStackTrace();
+            stackTrace = throwable.getStackTrace() == null ? Collections.<StackTraceElementPlaceholder>emptyList() : convertStackTrace(throwable.getStackTrace());
         } catch (Throwable ignored) {
 // TODO:ADAM - switch the logging back on. Need to make sending messages from daemon to client async wrt log event generation
 //                LOGGER.debug("Ignoring failure to extract throwable stack trace.", ignored);
-            stackTrace = new StackTraceElement[0];
+            stackTrace = Collections.emptyList();
         }
 
         try {
@@ -141,6 +141,22 @@ class ExceptionPlaceholder implements Serializable {
         this.causes = convertToExceptionPlaceholderList(causes, objectOutputStreamCreator, dejaVu);
         this.suppressed = convertToExceptionPlaceholderList(suppressed, objectOutputStreamCreator, dejaVu);
 
+    }
+
+    private List<StackTraceElementPlaceholder> convertStackTrace(StackTraceElement[] stackTrace) {
+        List<StackTraceElementPlaceholder> placeholders = new ArrayList<StackTraceElementPlaceholder>(stackTrace.length);
+        for (StackTraceElement stackTraceElement : stackTrace) {
+            placeholders.add(new StackTraceElementPlaceholder(stackTraceElement));
+        }
+        return placeholders;
+    }
+
+    private StackTraceElement[] convertStackTrace(List<StackTraceElementPlaceholder> placeholders) {
+        StackTraceElement[] stackTrace = new StackTraceElement[placeholders.size()];
+        for (int i = 0; i < placeholders.size(); i++) {
+            stackTrace[i] = placeholders.get(i).toStackTraceElement();
+        }
+        return stackTrace;
     }
 
     @SuppressWarnings("Since15")
@@ -215,7 +231,7 @@ class ExceptionPlaceholder implements Serializable {
                 if (!causes.isEmpty()) {
                     reconstructed.initCause(causes.get(0));
                 }
-                reconstructed.setStackTrace(stackTrace);
+                reconstructed.setStackTrace(convertStackTrace(stackTrace));
                 registerSuppressedExceptions(suppressed, reconstructed);
                 return reconstructed;
             }
@@ -242,7 +258,7 @@ class ExceptionPlaceholder implements Serializable {
         } else {
             placeholder = new DefaultMultiCauseException(message, causes);
         }
-        placeholder.setStackTrace(stackTrace);
+        placeholder.setStackTrace(convertStackTrace(stackTrace));
         registerSuppressedExceptions(suppressed, placeholder);
         return placeholder;
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/StackTraceElementPlaceholder.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/StackTraceElementPlaceholder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.serialize;
+
+import org.gradle.api.JavaVersion;
+
+import java.io.Serializable;
+
+public class StackTraceElementPlaceholder implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String classLoaderName;
+    private final String moduleName;
+    private final String moduleVersion;
+    private final String declaringClass;
+    private final String methodName;
+    private final String fileName;
+    private final int lineNumber;
+
+    public StackTraceElementPlaceholder(StackTraceElement ste) {
+        if (JavaVersion.current().isJava9Compatible()) {
+            classLoaderName = ste.getClassLoaderName();
+            moduleName = ste.getModuleName();
+            moduleVersion = ste.getModuleVersion();
+        } else {
+            classLoaderName = null;
+            moduleName = null;
+            moduleVersion = null;
+        }
+        declaringClass = ste.getClassName();
+        methodName = ste.getMethodName();
+        fileName = ste.getFileName();
+        lineNumber = ste.getLineNumber();
+    }
+
+    public StackTraceElement toStackTraceElement() {
+        if (JavaVersion.current().isJava9Compatible()) {
+            return new StackTraceElement(classLoaderName, moduleName, moduleVersion, declaringClass, methodName, fileName, lineNumber);
+        } else {
+            return new StackTraceElement(declaringClass, methodName, fileName, lineNumber);
+        }
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r72/JavaVersionCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r72/JavaVersionCrossVersionTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.gradle.integtests.tooling.r72
+
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.GradleConnectionException
+import org.gradle.tooling.ProjectConnection
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.IgnoreIf
+import spock.lang.Issue
+import spock.util.Exceptions
+
+@Issue('https://github.com/gradle/gradle/issues/9339')
+@TargetGradleVersion(">=7.2")
+@ToolingApiVersion("current")
+class JavaVersionCrossVersionTest extends ToolingApiSpecification {
+
+    def setup() {
+        buildFile << """
+            task myTask {
+                doLast {
+                    throw new RuntimeException("Boom")
+                }
+            }
+        """
+    }
+
+    @Requires(TestPrecondition.JDK11_OR_LATER)
+    @IgnoreIf({ AvailableJavaHomes.jdk8 == null })
+    def "can deserialize failures with post-jigsaw client and pre-jigsaw daemon"() {
+        projectDir.file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk8.javaHome.absolutePath)
+
+        when:
+        toolingApi.withConnection { ProjectConnection connection ->
+            connection.newBuild().forTasks('myTask').run()
+        }
+
+        then:
+        GradleConnectionException e = thrown()
+        def rootCause = Exceptions.getRootCause(e)
+        rootCause instanceof RuntimeException
+        rootCause.message == "Boom"
+        rootCause.stackTrace.find {
+            it.fileName.endsWith("build.gradle") && it.lineNumber == 4
+        }
+    }
+
+    @Requires(TestPrecondition.JDK8_OR_EARLIER)
+    @IgnoreIf({ AvailableJavaHomes.jdk11 == null })
+    def "can deserialize failures with pre-jigsaw client and post-jigsaw daemon"() {
+        projectDir.file("gradle.properties").writeProperties("org.gradle.java.home": AvailableJavaHomes.jdk11.javaHome.absolutePath)
+
+        when:
+        toolingApi.withConnection { ProjectConnection connection ->
+            connection.newBuild().forTasks('myTask').run()
+        }
+
+        then:
+        GradleConnectionException e = thrown()
+        def rootCause = Exceptions.getRootCause(e)
+        rootCause instanceof RuntimeException
+        rootCause.message == "Boom"
+        rootCause.stackTrace.find {
+            it.fileName.endsWith("build.gradle") && it.lineNumber == 4
+        }
+    }
+}


### PR DESCRIPTION
This class has different fields in different Java versions, so we can't use it for
serialization. Instead we now use a placeholder class and reconstruct the stack trace
elements upon deserialization.

Fixes #13957
Fixes #9339

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
