### PR TITLE
Improve documentation for building plugins with Kotlin 1.5

### DIFF
--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -402,7 +402,18 @@ tasks.register("myTask",
 
 Using Groovy closures works out of the box since they don't compile to lambdas in the bytecode.
 Same is true for Kotlin up to Kotlin 1.4.
-Starting with Kotlin 1.5, the Kotlin compiler is also using invoke-dynamic in the byte code for SAM wrappers in Kotlin source code, making it impossible for Gradle to uniquely identify the class at runtime.
-You need to pass `-Xsam-conversions=class` to the Kotlin compiler to switch back to the previous, supported behavior.
+
+Starting with Kotlin 1.5, the Kotlin compiler is using invoke-dynamic in the byte code for SAM wrappers in Kotlin source code.
+This makes it impossible for Gradle to uniquely identify implementations of SAM wrappers, like for example lambdas for task actions, at runtime.
+You need to set the `languageVersion` and `apiVersion` to 1.4 for the Kotlin compiler to switch back to the previous, supported behavior.
+
+```kotlin
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
+}
+```
 
 For the case where Gradle cannot track the implementation because it was loaded by a classloader unknown to Gradle, you can use Gradle's built-in ways to load the class.

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/NestedInputKotlinImplementationTrackingIntegrationTest.groovy
@@ -137,7 +137,7 @@ class NestedInputKotlinImplementationTrackingIntegrationTest extends AbstractPlu
         project2.file('build/tmp/myTask/output.txt').text == "hello"
     }
 
-    def "task action defined in Kotlin 1.5 can be tracked when using language versino 1.4"() {
+    def "task action defined in Kotlin 1.5 can be tracked when using language version 1.4"() {
         file("buildSrc/build.gradle.kts") << """
             plugins {
                 kotlin("jvm") version("1.5.10")


### PR DESCRIPTION
This improves the documentation for the deprecation message when Gradle encounters a lambda as a task action with regards to Kotlin 1.5.

Fixes https://github.com/gradle/gradle/issues/17086