### PR TITLE
Report Groovy classpath inference errors at task execution time

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
@@ -69,7 +68,6 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "creates sample source using spock instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'spock', '--dsl', scriptDsl.id)
@@ -165,7 +163,6 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "creates sample source with package and spock and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-application', '--test-framework', 'spock', '--package', 'my.app', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.buildinit.plugins
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
@@ -67,7 +66,6 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "creates sample source using spock instead of junit with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'spock', '--dsl', scriptDsl.id)
@@ -163,7 +161,6 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "creates sample source with package and spock and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'spock', '--package', 'my.lib', '--dsl', scriptDsl.id)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGroovyIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheGroovyIntegrationTest.groovy
@@ -95,18 +95,10 @@ class ConfigurationCacheGroovyIntegrationTest extends AbstractConfigurationCache
         """
 
         when:
-        configurationCacheRunLenient "build"
+        configurationCacheRun "build"
 
         then:
         configurationCache.assertStateStored()
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Task `:compileGroovy` of type `org.gradle.api.tasks.compile.GroovyCompile`: value 'Groovy runtime classpath' failed to visit file collection",
-                "Task `:compileTestGroovy` of type `org.gradle.api.tasks.compile.GroovyCompile`: value 'Groovy runtime classpath' failed to visit file collection"
-            )
-            withTotalProblemsCount(2)
-            withProblemsWithStackTraceCount(2)
-        }
 
         when:
         configurationCacheRun "clean"
@@ -133,12 +125,6 @@ class ConfigurationCacheGroovyIntegrationTest extends AbstractConfigurationCache
 
         then:
         configurationCache.assertStateStored()
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Task `:compileGroovy` of type `org.gradle.api.tasks.compile.GroovyCompile`: value 'Groovy runtime classpath' failed to visit file collection"
-            )
-            withProblemsWithStackTraceCount(1)
-        }
 
         and:
         result.assertTaskExecuted(":compileGroovy")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
@@ -265,3 +265,28 @@ inline fun <T> ReadContext.decodePreservingIdentity(identities: ReadIdentities, 
         }
     }
 }
+
+
+internal
+suspend fun WriteContext.encodeBean(value: Any) {
+    val beanType = value.javaClass
+    withBeanTrace(beanType) {
+        writeClass(beanType)
+        beanStateWriterFor(beanType).run {
+            writeStateOf(value)
+        }
+    }
+}
+
+
+internal
+suspend fun ReadContext.decodeBean(): Any {
+    val beanType = readClass()
+    return withBeanTrace(beanType) {
+        beanStateReaderFor(beanType).run {
+            newBean(false).also {
+                readStateOf(it)
+            }
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/BeanSpecCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/BeanSpecCodec.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.decodeBean
+import org.gradle.configurationcache.serialization.encodeBean
+
+
+/**
+ * Forces the given [bean] to be encoded via the [BeanCodec] regardless of its type.
+ */
+internal
+class BeanSpec(val bean: Any)
+
+
+internal
+object BeanSpecCodec : Codec<BeanSpec> {
+
+    override suspend fun WriteContext.encode(value: BeanSpec) =
+        encodeBean(value.bean)
+
+    override suspend fun ReadContext.decode(): BeanSpec =
+        BeanSpec(decodeBean())
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -186,6 +186,8 @@ class Codecs(
         bind(unsupported<Externalizable>(NotYetImplementedJavaSerialization))
         bind(JavaObjectSerializationCodec())
 
+        bind(BeanSpecCodec)
+
         // This protects the BeanCodec against StackOverflowErrors but
         // we can still get them for the other codecs, for instance,
         // with deeply nested Lists, deeply nested Maps, etc.

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt
@@ -29,6 +29,7 @@ import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.FilteredFileCollection
 import org.gradle.api.internal.file.SubtractingFileCollection
+import org.gradle.api.internal.file.collections.FailingFileCollection
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.file.collections.MinimalFileSet
 import org.gradle.api.internal.file.collections.ProviderBackedFileCollection
@@ -86,6 +87,7 @@ class FileCollectionCodec(
                             is ProviderBackedFileCollectionSpec -> element.provider
                             is FileTree -> element
                             is ResolvedArtifactSet -> artifactSetConverter.asFileCollection(element)
+                            is BeanSpec -> element.bean
                             else -> throw IllegalArgumentException("Unexpected item $element in file collection contents")
                         }
                     }
@@ -140,6 +142,10 @@ class CollectingVisitor : FileCollectionStructureVisitor {
             }
             is FileTreeInternal -> {
                 elements.add(fileCollection)
+                false
+            }
+            is FailingFileCollection -> {
+                elements.add(BeanSpec(fileCollection))
                 false
             }
             else -> {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/jos/JavaObjectSerializationCodec.kt
@@ -26,7 +26,9 @@ import org.gradle.configurationcache.serialization.codecs.BrokenValue
 import org.gradle.configurationcache.serialization.codecs.Decoding
 import org.gradle.configurationcache.serialization.codecs.Encoding
 import org.gradle.configurationcache.serialization.codecs.EncodingProducer
+import org.gradle.configurationcache.serialization.decodeBean
 import org.gradle.configurationcache.serialization.decodePreservingIdentity
+import org.gradle.configurationcache.serialization.encodeBean
 import org.gradle.configurationcache.serialization.encodePreservingIdentityOf
 import org.gradle.configurationcache.serialization.logPropertyProblem
 import org.gradle.configurationcache.serialization.readEnum
@@ -295,37 +297,12 @@ fun StructuredMessage.Builder.failedJOS(value: Any) {
 
 
 private
-suspend fun WriteContext.encodeBean(value: Any) {
-    val beanType = value.javaClass
-    withBeanTrace(beanType) {
-        writeClass(beanType)
-        beanStateWriterFor(beanType).run {
-            writeStateOf(value)
-        }
-    }
-}
-
-
-private
 inline fun ReadContext.decodingBeanWithId(id: Int, decode: (Any, Class<*>, BeanStateReader) -> Unit): Any? {
     val beanType = readClass()
     return withBeanTrace(beanType) {
         val beanStateReader = beanStateReaderFor(beanType)
         beanStateReader.run { newBeanWithId(false, id) }.also { bean ->
             decode(bean, beanType, beanStateReader)
-        }
-    }
-}
-
-
-private
-suspend fun ReadContext.decodeBean(): Any {
-    val beanType = readClass()
-    return withBeanTrace(beanType) {
-        beanStateReaderFor(beanType).run {
-            newBean(false).also {
-                readStateOf(it)
-            }
         }
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FailingFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FailingFileCollection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file.collections;
+
+import org.gradle.api.file.FileCollection;
+
+/**
+ * A {@link FileCollection} implementation that throws a given exception when visited.
+ */
+public class FailingFileCollection extends LazilyInitializedFileCollection {
+
+    private final String displayName;
+    private final RuntimeException failure;
+
+    public FailingFileCollection(String displayName, RuntimeException failure) {
+        this.displayName = displayName;
+        this.failure = failure;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public FileCollection createDelegate() {
+        throw failure;
+    }
+}

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GroovyProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GroovyProjectIntegrationTest.groovy
@@ -16,11 +16,9 @@
 package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class GroovyProjectIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def handlesJavaSourceOnly() {
         given:
         buildFile << "apply plugin: 'groovy'"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -43,7 +43,6 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
 
     @ToBeFixedForConfigurationCache(bottomSpecs = [
         "BuildDashboardPluginIntegrationTest",
-        "GroovyPluginGoodBehaviourTest",
         "ScalaPluginGoodBehaviourTest",
         "AntlrPluginIntegrationTest",
         "PlayApplicationPluginGoodBehaviourIntegrationTest",
@@ -75,7 +74,6 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
 
     @ToBeFixedForConfigurationCache(bottomSpecs = [
         "BuildDashboardPluginIntegrationTest",
-        "GroovyPluginGoodBehaviourTest",
         "ScalaPluginGoodBehaviourTest",
         "AntlrPluginIntegrationTest",
         "PlayApplicationPluginGoodBehaviourIntegrationTest",

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -96,8 +96,8 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
         CompileOptions compileOptions = objectFactory.newInstance(CompileOptions.class);
         compileOptions.setIncremental(false);
         this.compileOptions = compileOptions;
-        this.astTransformationClasspath = objectFactory.fileCollection();
         this.javaLauncher = objectFactory.property(JavaLauncher.class);
+        this.astTransformationClasspath = objectFactory.fileCollection();
         if (!experimentalCompilationAvoidanceEnabled()) {
             this.astTransformationClasspath.from((Callable<FileCollection>) this::getClasspath);
         }
@@ -341,7 +341,7 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
             return javaLauncher.get().getMetadata().getLanguageVersion().toString();
         }
         final File customHome = getOptions().getForkOptions().getJavaHome();
-        if(customHome != null) {
+        if (customHome != null) {
             return getServices().get(JvmMetadataDetector.class).getMetadata(customHome).getLanguageVersion().getMajorVersion();
         }
         return JavaVersion.current().getMajorVersion();

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalCompilationIntegrationTest.groovy
@@ -20,7 +20,6 @@ package org.gradle.java.compile.incremental
 import groovy.test.NotYetImplemented
 import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends AbstractJavaGroovyIncrementalCompilationSupport {
@@ -86,13 +85,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         out
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects changed class in an upstream project"() {
         source api: ["class A {}", "class B {}"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -105,13 +97,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.recompiledClasses("ImplA")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects change to transitive superclass in an upstream project"() {
         settingsFile << """
             include 'app'
@@ -131,13 +116,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         app.recompiledClasses("C", "D")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects change to transitive dependency in an upstream project"() {
         settingsFile << """
             include 'app'
@@ -157,13 +135,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         app.recompiledClasses("C")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "distinguishes between api and implementation changes"() {
         settingsFile << """
             include 'app'
@@ -183,13 +154,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         app.recompiledClasses("D")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects deletions of transitive dependency in an upstream project"() {
         settingsFile << """
             include 'app'
@@ -214,13 +178,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         app.recompiledClasses("C")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "deletion of jar without dependents does not recompile any classes"() {
         source api: ["class A {}"], impl: ["class SomeImpl {}"]
         impl.snapshot { run language.compileTaskName }
@@ -234,13 +191,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "deletion of jar with dependents causes compilation failure"() {
         source api: ["class A {}"], impl: ["class ImplA extends A {}"]
         impl.snapshot { run language.compileTaskName }
@@ -253,13 +203,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects change to dependency and ensures class dependency info refreshed"() {
         source api: ["class A {}", "class B extends A {}"]
         source impl: ["class SomeImpl {}", "class ImplB extends B {}", "class ImplB2 extends ImplB {}"]
@@ -281,13 +224,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled() //because after earlier change to B, class A is no longer a dependency
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects deleted class in an upstream project and fails compilation"() {
         def b = source(api: ["class A {}", "class B {}"])
         source impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
@@ -301,13 +237,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "recompilation not necessary when upstream does not change any of the actual dependencies"() {
         source api: ["class A {}", "class B {}"], impl: ["class ImplA extends A {}"]
         impl.snapshot { run language.compileTaskName }
@@ -335,14 +264,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.recompiledClasses('Y')
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
-
     def "change in an upstream transitive class with non-private constant does not cause full rebuild"() {
         source api: ["class A { final static int x = 1; }", "class B extends A {}"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -355,13 +276,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.recompiledClasses('ImplB')
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "private constant in upstream project does not trigger full rebuild"() {
         source api: ["class A {}", "class B { private final static int x = 1; }"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -374,13 +288,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "addition of unused class in upstream project does not rebuild"() {
         source api: ["class A {}", "class B { private final static int x = 1; }"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -393,13 +300,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "removal of unused class in upstream project does not rebuild"() {
         source api: ["class A {}", "class B { private final static int x = 1; }"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         def c = source api: ["class C { }"]
@@ -413,13 +313,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "doesn't recompile if external dependency has ABI incompatible change but not on class we use"() {
         given:
         buildFile << """
@@ -443,13 +336,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects changed classes when upstream project was built in isolation"() {
         source api: ["class A {}", "class B {}"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -463,13 +349,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.recompiledClasses("ImplA")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects class changes in subsequent runs ensuring the jar snapshots are refreshed"() {
         source api: ["class A {}", "class B {}"], impl: ["class ImplA extends A {}", "class ImplB extends B {}"]
         impl.snapshot { run language.compileTaskName }
@@ -504,13 +383,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "handles multiple compile tasks in the same project"() {
         settingsFile << "\n include 'other'" //add an extra project
         source impl: ["class ImplA extends A {}"], api: ["class A {}"], other: ["class Other {}"]
@@ -703,13 +575,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "change to class referenced by an annotation recompiles annotated types"() {
         source api: [
             """
@@ -743,13 +608,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
     }
 
     @Unroll
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "change to class referenced by an array value in an annotation recompiles annotated types"() {
         source api: [
             """
@@ -783,13 +641,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
     }
 
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "detects that changed class still has the same constants so no recompile is necessary"() {
         source api: ["class A { public static final int FOO = 123;}"],
             impl: ["class B { void foo() { int x = 123; }}"]
@@ -803,13 +654,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
         impl.noneRecompiled()
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "does not recompile on non-abi change across projects"() {
         source api: ["class A { }"],
             impl: ["class B { A a; }", "class C { B b; }"]
@@ -826,13 +670,6 @@ abstract class AbstractCrossTaskIncrementalCompilationIntegrationTest extends Ab
     // This test checks the current behavior, not necessarily the desired one.
     // If all classes are compiled by the same compile task, we do not know if a
     // change is an abi change or not. Hence, an abi change is always assumed.
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     def "does recompile on non-abi changes inside one project"() {
         source impl: ["class A { }", "class B { A a; }", "class C { B b; }"]
         impl.snapshot { run language.compileTaskName }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalGroovyCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalGroovyCompilationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.java.compile.incremental
 
 import org.gradle.integtests.fixtures.CompiledLanguage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 abstract class AbstractCrossTaskIncrementalGroovyCompilationIntegrationTest extends AbstractCrossTaskIncrementalCompilationIntegrationTest {
@@ -79,13 +78,6 @@ abstract class AbstractCrossTaskIncrementalGroovyCompilationIntegrationTest exte
         impl.recompiledClasses("OnClass", "OnMethod", "OnParameter", "OnField", "InMethodBody", "X")
     }
 
-    @ToBeFixedForConfigurationCache(
-        bottomSpecs = [
-            "CrossTaskIncrementalGroovyCompilationUsingClassDirectoryIntegrationTest",
-            "CrossTaskIncrementalGroovyCompilationUsingJarIntegrationTest"
-        ],
-        because = "gradle/configuration-cache#270"
-    )
     // This is a constant test that is not incremental for Groovy
     def "does full recompilation in case a constant is computed from another constant"() {
         source api: ["class A { public static final int FOO = 10; }"], impl: ['class B { public static final int BAR = 2 + A.FOO; }', 'class C { }']

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/GroovyBasePluginIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.groovy
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Issue
 
 class GroovyBasePluginIntegrationTest extends AbstractIntegrationSpec {
@@ -86,7 +85,6 @@ task verify {
         succeeds("verify")
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "not specifying a groovy runtime produces decent error message"() {
         given:
         buildFile << """

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JvmPluginsHelper.java
@@ -20,6 +20,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
@@ -57,13 +58,14 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.internal.Cast;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
-import org.gradle.util.internal.TextUtil;
 
 import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
+
+import static org.gradle.util.internal.TextUtil.camelToKebabCase;
 
 /**
  * Helpers for Jvm plugins. They are in a separate class so that they don't leak
@@ -79,17 +81,19 @@ public class JvmPluginsHelper {
      * @return the created API configuration
      */
     public static Configuration addApiToSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
-        Configuration apiConfiguration = configurations.maybeCreate(sourceSet.getApiConfigurationName());
-        apiConfiguration.setVisible(false);
-        apiConfiguration.setDescription("API dependencies for " + sourceSet + ".");
-        apiConfiguration.setCanBeResolved(false);
-        apiConfiguration.setCanBeConsumed(false);
+        Configuration apiConfiguration = maybeCreateInvisibleConfig(
+            configurations,
+            sourceSet.getApiConfigurationName(),
+            "API dependencies for " + sourceSet + ".",
+            false
+        );
 
-        Configuration compileOnlyApiConfiguration = configurations.maybeCreate(sourceSet.getCompileOnlyApiConfigurationName());
-        compileOnlyApiConfiguration.setVisible(false);
-        compileOnlyApiConfiguration.setDescription("Compile only API dependencies for " + sourceSet + ".");
-        compileOnlyApiConfiguration.setCanBeConsumed(false);
-        compileOnlyApiConfiguration.setCanBeResolved(false);
+        Configuration compileOnlyApiConfiguration = maybeCreateInvisibleConfig(
+            configurations,
+            sourceSet.getCompileOnlyApiConfigurationName(),
+            "Compile only API dependencies for " + sourceSet + ".",
+            false
+        );
 
         Configuration apiElementsConfiguration = configurations.getByName(sourceSet.getApiElementsConfigurationName());
         apiElementsConfiguration.extendsFrom(apiConfiguration, compileOnlyApiConfiguration);
@@ -128,6 +132,7 @@ public class JvmPluginsHelper {
     /***
      * For compatibility with https://plugins.gradle.org/plugin/io.freefair.aspectj
      */
+    @SuppressWarnings("unused")
     public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target, Provider<? extends AbstractCompile> compileTask, Provider<CompileOptions> options) {
         TaskProvider<? extends AbstractCompile> taskProvider = Cast.uncheckedCast(compileTask);
         configureOutputDirectoryForSourceSet(sourceSet, sourceDirectorySet, target, taskProvider, options, AbstractCompile::getDestinationDirectory);
@@ -156,24 +161,37 @@ public class JvmPluginsHelper {
                 javadoc.setGroup(JavaBasePlugin.DOCUMENTATION_GROUP);
                 javadoc.setClasspath(sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
                 javadoc.setSource(sourceSet.getAllJava());
-                javadoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension.getDocsDir().dir(javadocTaskName).get().getAsFile());
                 if (javaPluginExtension != null) {
+                    javadoc.getConventionMapping().map("destinationDir", () -> javaPluginExtension.getDocsDir().dir(javadocTaskName).get().getAsFile());
                     javadoc.getModularity().getInferModulePath().convention(javaPluginExtension.getModularity().getInferModulePath());
                 }
             });
         }
     }
 
-    public static void configureDocumentationVariantWithArtifact(String variantName, @Nullable String featureName, String docsType, List<Capability> capabilities, String jarTaskName, Object artifactSource, @Nullable AdhocComponentWithVariants component, ConfigurationContainer configurations, TaskContainer tasks, ObjectFactory objectFactory) {
-        Configuration variant = configurations.maybeCreate(variantName);
-        variant.setVisible(false);
-        variant.setDescription(docsType + " elements for " + (featureName == null ? "main" : featureName) + ".");
-        variant.setCanBeResolved(false);
-        variant.setCanBeConsumed(true);
-        variant.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        variant.getAttributes().attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.DOCUMENTATION));
-        variant.getAttributes().attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
-        variant.getAttributes().attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objectFactory.named(DocsType.class, docsType));
+    public static void configureDocumentationVariantWithArtifact(
+        String variantName,
+        @Nullable String featureName,
+        String docsType,
+        List<Capability> capabilities,
+        String jarTaskName,
+        Object artifactSource,
+        @Nullable AdhocComponentWithVariants component,
+        ConfigurationContainer configurations,
+        TaskContainer tasks,
+        ObjectFactory objectFactory
+    ) {
+        Configuration variant = maybeCreateInvisibleConfig(
+            configurations,
+            variantName,
+            docsType + " elements for " + (featureName == null ? "main" : featureName) + ".",
+            true
+        );
+        AttributeContainer attributes = variant.getAttributes();
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        attributes.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.DOCUMENTATION));
+        attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
+        attributes.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objectFactory.named(DocsType.class, docsType));
         capabilities.forEach(variant.getOutgoing()::capability);
 
         if (!tasks.getNames().contains(jarTaskName)) {
@@ -181,7 +199,7 @@ public class JvmPluginsHelper {
                 jar.setDescription("Assembles a jar archive containing the " + (featureName == null ? "main " + docsType + "." : (docsType + " of the '" + featureName + "' feature.")));
                 jar.setGroup(BasePlugin.BUILD_GROUP);
                 jar.from(artifactSource);
-                jar.getArchiveClassifier().set(TextUtil.camelToKebabCase(featureName == null ? docsType : (featureName + "-" + docsType)));
+                jar.getArchiveClassifier().set(camelToKebabCase(featureName == null ? docsType : (featureName + "-" + docsType)));
             });
             if (tasks.getNames().contains(LifecycleBasePlugin.ASSEMBLE_TASK_NAME)) {
                 tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME).configure(task -> task.dependsOn(jarTask));
@@ -192,6 +210,20 @@ public class JvmPluginsHelper {
         if (component != null) {
             component.addVariantsFromConfiguration(variant, new JavaConfigurationVariantMapping("runtime", true));
         }
+    }
+
+    private static Configuration maybeCreateInvisibleConfig(
+        ConfigurationContainer container,
+        String name,
+        String description,
+        boolean canBeConsumed
+    ) {
+        Configuration configuration = container.maybeCreate(name);
+        configuration.setVisible(false);
+        configuration.setDescription(description);
+        configuration.setCanBeResolved(false);
+        configuration.setCanBeConsumed(canBeConsumed);
+        return configuration;
     }
 
     @Nullable

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -114,7 +114,10 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
 
     @Override
     public <T> void configureAsRuntimeClasspath(HasConfigurableAttributes<T> configuration) {
-        configureAttributes(configuration, details -> details.library().runtimeUsage().asJar().withExternalDependencies().preferStandardJVM());
+        configureAttributes(
+            configuration,
+            details -> details.library().runtimeUsage().asJar().withExternalDependencies().preferStandardJVM()
+        );
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
@@ -18,6 +18,7 @@ package org.gradle.api.tasks;
 import com.google.common.collect.Iterables;
 import org.gradle.api.Buildable;
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.FileCollection;
@@ -76,8 +77,8 @@ public class GroovyRuntime {
 
     private final ProjectInternal project;
 
-    public GroovyRuntime(ProjectInternal project) {
-        this.project = project;
+    public GroovyRuntime(Project project) {
+        this.project = (ProjectInternal) project;
     }
 
     /**

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testkit.runner.enduser
 
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
@@ -45,7 +44,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "can capture user input if standard input was provided"() {
         when:
         file("src/test/groovy/Test.groovy") << functionalTest(true, true)
@@ -56,7 +54,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
         new JUnitXmlTestExecutionResult(projectDir).totalNumberOfTestClassesExecuted > 0
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "cannot capture user input if standard in was not provided"() {
         when:
         file("src/test/groovy/Test.groovy") << functionalTest(false, null)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -18,7 +18,6 @@
 package org.gradle.testkit.runner.enduser
 
 import org.gradle.integtests.fixtures.Sample
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.testing.internal.util.RetryUtil
@@ -64,7 +63,6 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     }
 
     @UsesSample("testKit/spockQuickstart")
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def spockQuickstart() {
         expect:
         executer.inDirectory(sample.dir.file('groovy'))
@@ -96,7 +94,6 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     @Requires([ONLINE, JDK11_OR_EARLIER])
     // Uses Gradle 5.0 which does not support Java versions >11
     @UsesSample("testKit/gradleVersion")
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def gradleVersion() {
         expect:
         RetryUtil.retry { //This test is also affected by gradle/gradle#1111 on Windows

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.testing.junit
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 import spock.lang.Issue
 
@@ -94,7 +93,6 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def 'can run spock with @Unroll'() {
         given:
         writeSpockDependencies()
@@ -123,7 +121,6 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     }
 
     @Issue('https://github.com/gradle/gradle/issues/4358')
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def 'can run spock test with same method name in super class and base class'() {
         given:
         writeSpockDependencies()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2FilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2FilteringIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing.spock
 
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class Spock2FilteringIntegrationTest extends Spock2IntegrationSpec {
 
@@ -61,7 +60,6 @@ class Spock2FilteringIntegrationTest extends Spock2IntegrationSpec {
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "can filter tests"() {
         when:
         succeeds("test", "--tests", "SubClass.$testMethod")
@@ -77,7 +75,6 @@ class Spock2FilteringIntegrationTest extends Spock2IntegrationSpec {
         testMethod << ["sub test", "super test", "super super test"]
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "can filter unrolled tests"() {
         when:
         succeeds("test", "--tests", "SubClass.$testMethod")
@@ -94,7 +91,6 @@ class Spock2FilteringIntegrationTest extends Spock2IntegrationSpec {
         testMethod << ["sub unrolled test", "super unrolled test", "super super unrolled test"]
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "can filter unrolled tests with parameter name in test header"() {
         when:
         succeeds("test", "--tests", "SubClass.$testMethod param=#param")
@@ -111,7 +107,6 @@ class Spock2FilteringIntegrationTest extends Spock2IntegrationSpec {
         testMethod << ["sub unrolled test", "super unrolled test", "super super unrolled test"]
     }
 
-    @ToBeFixedForConfigurationCache(because = "gradle/configuration-cache#270")
     def "can not filter specific iterations of unrolled tests"() {
         when:
         fails("test", "--tests", "SubClass.$testMethod")


### PR DESCRIPTION
And not at configuration cache store time so disabled/sourceless Groovy tasks
can still appear in the task graph.
