### PR TITLE
Note that Project.relativePath may throw IllegalArgumentException

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -709,6 +709,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      *
      * @param path The path to convert to a relative path.
      * @return The relative path. Never returns null.
+     * @throws IllegalArgumentException If the given path cannot be relativized against the project directory.
      */
     String relativePath(Object path);
 


### PR DESCRIPTION
This exception is typically thrown on Windows when project dir and the
given path reside on different disks (e.g. C:\ and D:\).

<!--- The issue this PR addresses -->
Fixes #17227 
