### PR TITLE
Replace task execution listener by simple tasks for code quality build scan data extraction

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.buildscan.tasks
+
+import com.gradle.scan.plugin.BuildScanExtension
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.specs.Specs
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import java.io.File
+
+
+abstract class AbstractExtractCodeQualityBuildScanData : DefaultTask() {
+
+    @get:Internal
+    internal
+    abstract val xmlOutputs: ConfigurableFileCollection
+
+    @get:Internal
+    internal
+    abstract val rootDir: DirectoryProperty
+
+    @get:Internal
+    internal
+    var buildScanExt: BuildScanExtension? = null
+
+    init {
+        outputs.upToDateWhen(Specs.SATISFIES_NONE)
+    }
+
+    @TaskAction
+    fun action() {
+        if (buildScanExt == null) return
+        val basePath = rootDir.get().asFile
+        xmlOutputs.files.filter { it.exists() }.forEach { xmlFile ->
+            extractIssuesFrom(xmlFile, basePath).forEach { issue ->
+                buildScanExt?.value(buildScanValueName, issue)
+            }
+        }
+    }
+
+    @get:Internal
+    protected
+    abstract val buildScanValueName: String
+
+    protected
+    abstract fun extractIssuesFrom(xmlFile: File, basePath: File): List<String>
+}
+
+
+abstract class ExtractCheckstyleBuildScanData : AbstractExtractCodeQualityBuildScanData() {
+
+    override val buildScanValueName: String = "Checkstyle Issue"
+
+    override fun extractIssuesFrom(xmlFile: File, basePath: File): List<String> {
+        val checkstyle = Jsoup.parse(xmlFile.readText(), "", Parser.xmlParser())
+        return checkstyle.getElementsByTag("file").flatMap { file ->
+            file.getElementsByTag("error").map { error ->
+                val filePath = File(file.attr("name")).relativeTo(basePath).path
+                "$filePath:${error.attr("line")}:${error.attr("column")} \u2192 ${error.attr("message")}"
+            }
+        }
+    }
+}
+
+
+abstract class ExtractCodeNarcBuildScanData : AbstractExtractCodeQualityBuildScanData() {
+
+    override val buildScanValueName: String = "CodeNarc Issue"
+
+    override fun extractIssuesFrom(xmlFile: File, basePath: File): List<String> {
+        val codenarc = Jsoup.parse(xmlFile.readText(), "", Parser.xmlParser())
+        return codenarc.getElementsByTag("Package").flatMap { codenarcPackage ->
+            codenarcPackage.getElementsByTag("File").flatMap { file ->
+                file.getElementsByTag("Violation").map { violation ->
+                    val filePath = File(file.attr("name")).relativeTo(basePath).path
+                    val message = violation.run {
+                        getElementsByTag("Message").first()
+                            ?: getElementsByTag("SourceLine").first()
+                    }
+                    "$filePath:${violation.attr("lineNumber")} \u2192 ${message.text()}"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
For compatibility with the configuration cache. Here's the reported problem that this PR fixes:

![image](https://user-images.githubusercontent.com/132773/121510801-50324700-c9e8-11eb-851f-e52830331be1.png)


This PR also makes the reported paths relative to the root directory instead of relative to each project directory. Here's a sample build scan https://ge.gradle.org/s/e4ln2awqyblxk/custom-values#L0

This is now using allprojects {} and should later be replaced by applying a plugin to all code-quality projects instead to comply with isolated projects constraints.
