### PR TITLE
Add some leniency around time-sensitive test

### DIFF
--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -51,13 +51,14 @@ class ExecuteStepTest extends StepSpec<InputChangesContext> {
 
         then:
         result.executionResult.get().outcome == expectedOutcome
-        result.duration.toMillis() >= 3
+        // Check
+        result.duration.toMillis() >= 100
 
         _ * context.inputChanges >> Optional.empty()
         _ * work.execute({ UnitOfWork.ExecutionRequest executionRequest ->
             executionRequest.workspace == workspace && !executionRequest.inputChanges.present && executionRequest.previouslyProducedOutputs.get() == previousOutputs
         }) >> {
-            sleep 3
+            sleep 200
             Stub(UnitOfWork.WorkOutput) {
                 getDidWork() >> workResult
             }
@@ -78,13 +79,13 @@ class ExecuteStepTest extends StepSpec<InputChangesContext> {
         then:
         !result.executionResult.successful
         result.executionResult.failure.get() == failure
-        result.duration.toMillis() >= 3
+        result.duration.toMillis() >= 100
 
         _ * context.inputChanges >> Optional.empty()
         _ * work.execute({ UnitOfWork.ExecutionRequest executionRequest ->
             executionRequest.workspace == workspace && !executionRequest.inputChanges.present && executionRequest.previouslyProducedOutputs.get() == previousOutputs
         }) >> {
-            sleep 3
+            sleep 200
             throw failure
         }
         0 * _


### PR DESCRIPTION
Fix flaky test.

```text
  Condition not satisfied:
  
  result.duration.toMillis() >= 3
  |      |        |          |
  |      PT0.002S 2          false
  <org.gradle.internal.execution.steps.ExecuteStep$ResultImpl@9b15c0c duration=PT0.002S executionResultTry=Successful(org.gradle.internal.execution.steps.ExecuteStep$ExecutionResultImpl@22d918c0)>
  Condition not satisfied:
  result.duration.toMillis() >= 3
  |      |        |          |
  |      PT0.002S 2          false
  <org.gradle.internal.execution.steps.ExecuteStep$ResultImpl@9b15c0c duration=PT0.002S executionResultTry=Successful(org.gradle.internal.execution.steps.ExecuteStep$ExecutionResultImpl@22d918c0)>
    at org.gradle.internal.execution.steps.ExecuteStepTest.result #workResult yields outcome #expectedOutcome (incremental false)(ExecuteStepTest.groovy:54)
```

https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_Quick_2_Trigger/44094035?buildTab=tests&expandedTest=build%3A%28id%3A44094024%29%2Cid%3A10692