### PR TITLE
Don't hide Kotlin compiler configuration when Java 9+ is used

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -41,7 +41,26 @@ public class JpmsConfiguration {
         "--add-opens", "java.base/java.lang=ALL-UNNAMED" // required by ClassLoaderUtils
     ));
 
-    public static final List<String> GRADLE_DAEMON_JPMS_ARGS;
+    private static final List<String> GRADLE_DAEMON_JPMS_ARGS;
+
+    public static final List<String> gradleDaemonJpmsArgs(List<String> existingJvmArgs) {
+        List<String> result = new ArrayList<String>(GRADLE_DAEMON_JPMS_ARGS);
+
+        // Workaround until external kotlin-dsl plugins support JDK16 properly
+        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
+        String kotlinCompilerOptions = null;
+        for (String jvmArg : existingJvmArgs) {
+            if (jvmArg.startsWith("-Dkotlin.daemon.jvm.options=")) {
+                kotlinCompilerOptions = jvmArg.substring(28);
+            }
+        }
+        if (kotlinCompilerOptions == null) {
+            result.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
+        } else {
+            result.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit " + kotlinCompilerOptions);
+        }
+        return result;
+    }
 
     static {
         List<String> gradleDaemonJvmArgs = new ArrayList<String>();
@@ -54,10 +73,6 @@ public class JpmsConfiguration {
             "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED" // serialized from org.gradle.internal.file.StatStatistics$Collector
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
-
-        // Workaround until external kotlin-dsl plugins support JDK16 properly
-        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
-        gradleDaemonJvmArgs.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
 
         GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(gradleDaemonJvmArgs);
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -41,23 +41,19 @@ public class JpmsConfiguration {
         "--add-opens", "java.base/java.lang=ALL-UNNAMED" // required by ClassLoaderUtils
     ));
 
-    private static final List<String> GRADLE_DAEMON_JPMS_ARGS;
+    public static final List<String> GRADLE_DAEMON_JPMS_ARGS;
 
     public static final List<String> gradleDaemonJpmsArgs(List<String> existingJvmArgs) {
         List<String> result = new ArrayList<String>(GRADLE_DAEMON_JPMS_ARGS);
 
-        // Workaround until external kotlin-dsl plugins support JDK16 properly
-        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
         String kotlinCompilerOptions = null;
         for (String jvmArg : existingJvmArgs) {
             if (jvmArg.startsWith("-Dkotlin.daemon.jvm.options=")) {
                 kotlinCompilerOptions = jvmArg.substring(28);
             }
         }
-        if (kotlinCompilerOptions == null) {
-            result.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
-        } else {
-            result.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit " + kotlinCompilerOptions);
+        if (kotlinCompilerOptions != null) {
+            result.add(result.size() - 1, "-Dkotlin.daemon.jvm.options=--illegal-access=permit " + kotlinCompilerOptions);
         }
         return result;
     }
@@ -73,6 +69,10 @@ public class JpmsConfiguration {
             "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED" // serialized from org.gradle.internal.file.StatStatistics$Collector
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
+
+        // Workaround until external kotlin-dsl plugins support JDK16 properly
+        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
+        gradleDaemonJvmArgs.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
 
         GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(gradleDaemonJvmArgs);
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -36,7 +36,6 @@ import org.gradle.util.GradleVersion;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -129,7 +128,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         List<String> buildJvmOptions = super.getImplicitBuildJvmArgs();
         final Jvm current = Jvm.current();
         if (getJavaHome().equals(current.getJavaHome()) && JavaVersion.current().isJava9Compatible() && !isUseDaemon()) {
-            buildJvmOptions.addAll(JpmsConfiguration.gradleDaemonJpmsArgs(Collections.emptyList()));
+            buildJvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
         }
         return buildJvmOptions;
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/NoDaemonGradleExecuter.java
@@ -36,6 +36,7 @@ import org.gradle.util.GradleVersion;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -128,7 +129,7 @@ public class NoDaemonGradleExecuter extends AbstractGradleExecuter {
         List<String> buildJvmOptions = super.getImplicitBuildJvmArgs();
         final Jvm current = Jvm.current();
         if (getJavaHome().equals(current.getJavaHome()) && JavaVersion.current().isJava9Compatible() && !isUseDaemon()) {
-            buildJvmOptions.addAll(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
+            buildJvmOptions.addAll(JpmsConfiguration.gradleDaemonJpmsArgs(Collections.emptyList()));
         }
         return buildJvmOptions;
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -126,7 +126,7 @@ public class DaemonParameters {
     public void applyDefaultsFor(JavaVersion javaVersion) {
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
             jvmOptions.jvmArgs(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
-            jvmOptions.jvmArgs(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
+            jvmOptions.jvmArgs(JpmsConfiguration.gradleDaemonJpmsArgs(jvmOptions.getAllJvmArgs()));
         }
         if (hasJvmArgs) {
             return;


### PR DESCRIPTION
Fixes #17075 