### PR TITLE
Remove no longer needed JPMS workaround for Kotlin compiler daemon

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -55,10 +55,6 @@ public class JpmsConfiguration {
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
 
-        // Workaround until external kotlin-dsl plugins support JDK16 properly
-        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
-        gradleDaemonJvmArgs.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
-
         GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(gradleDaemonJvmArgs);
     }
 }


### PR DESCRIPTION
The underlying problem was fixed in Kotlin 1.5.0

Fixes https://github.com/gradle/gradle/issues/17075