### PR TITLE
Do not initialize FS-watching in CLI and TAPI

### DIFF
--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
@@ -40,7 +40,14 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.nio.file.attribute.PosixFilePermission.*;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 @Fork(1)
 @Warmup(iterations = 10)
@@ -67,7 +74,7 @@ public class ChmodBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() throws IOException {
         this.tempRootDir = Files.createTempDirectory("chmod-benchmark");
-        NativeServices.initialize(tempRootDir.toFile());
+        NativeServices.initializeOnDaemon(tempRootDir.toFile());
         this.fileSystem = FileSystems.getDefault();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -107,7 +107,7 @@ public class ProjectBuilderImpl {
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
         StartParameterInternal startParameter = new StartParameterInternal();
         startParameter.setGradleUserHomeDir(userHomeDir);
-        NativeServices.initialize(userHomeDir);
+        NativeServices.initializeOnDaemon(userHomeDir);
 
         final ServiceRegistry globalServices = getGlobalServices();
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/NoDaemonFilesystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/NoDaemonFilesystemWatchingIntegrationTest.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch
+
+
+import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.FileSystemWatchingFixture
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.Requires
+
+@Requires({ GradleContextualExecuter.noDaemon })
+class NoDaemonFilesystemWatchingIntegrationTest extends AbstractIntegrationSpec implements FileSystemWatchingFixture {
+
+    def "is disabled by default for --no-daemon"() {
+        buildFile << """
+            apply plugin: "java"
+        """
+
+        when:
+        run("assemble", "--info", "--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}")
+        then:
+        outputContains("Watching the file system is not supported.")
+    }
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -57,7 +57,7 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
     @Override
     public boolean afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
         if (watchMode == WatchMode.ENABLED) {
-            LOGGER.warn("Watching the file system is not supported on this operating system.");
+            LOGGER.warn("Watching the file system is not supported.");
         }
         rootReference.update(vfsRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -28,7 +28,7 @@ public class NativeServicesTestFixture {
         if (!initialized) {
             System.setProperty("org.gradle.native", "true");
             File nativeDir = getNativeServicesDir();
-            NativeServices.initialize(nativeDir);
+            NativeServices.initializeOnDaemon(nativeDir);
             initialized = true;
         }
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/NativeServicesInitializingAction.java
@@ -39,7 +39,7 @@ public class NativeServicesInitializingAction implements Action<ExecutionListene
 
     @Override
     public void execute(ExecutionListener executionListener) {
-        NativeServices.initialize(buildLayout.getGradleUserHomeDir());
+        NativeServices.initializeOnClient(buildLayout.getGradleUserHomeDir());
         loggingManager.attachProcessConsole(loggingConfiguration.getConsoleOutput());
         action.execute(executionListener);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonMain.java
@@ -104,7 +104,7 @@ public class DaemonMain extends EntryPoint {
             throw new UncheckedIOException(e);
         }
 
-        NativeServices.initialize(gradleHomeDir);
+        NativeServices.initializeOnDaemon(gradleHomeDir);
         DaemonServerConfiguration parameters = new DefaultDaemonServerConfiguration(daemonUid, daemonBaseDir, idleTimeoutMs, periodicCheckIntervalMs, singleUse, priority, startupOpts);
         LoggingServiceRegistry loggingRegistry = LoggingServiceRegistry.newCommandLineProcessLogging();
         LoggingManagerInternal loggingManager = loggingRegistry.newInstance(LoggingManagerInternal.class);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DefaultConnection.java
@@ -20,6 +20,7 @@ import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.internal.Cast;
 import org.gradle.internal.concurrent.CompositeStoppable;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
@@ -40,12 +41,12 @@ import org.gradle.tooling.internal.protocol.InternalInvalidatableVirtualFileSyst
 import org.gradle.tooling.internal.protocol.InternalParameterAcceptingConnection;
 import org.gradle.tooling.internal.protocol.InternalPhasedAction;
 import org.gradle.tooling.internal.protocol.InternalPhasedActionConnection;
+import org.gradle.tooling.internal.protocol.InternalStopWhenIdleConnection;
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException;
 import org.gradle.tooling.internal.protocol.ModelIdentifier;
 import org.gradle.tooling.internal.protocol.PhasedActionResultListener;
 import org.gradle.tooling.internal.protocol.ProjectVersion3;
 import org.gradle.tooling.internal.protocol.ShutdownParameters;
-import org.gradle.tooling.internal.protocol.InternalStopWhenIdleConnection;
 import org.gradle.tooling.internal.protocol.StoppableConnection;
 import org.gradle.tooling.internal.protocol.exceptions.InternalUnsupportedBuildArgumentException;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionConnection;
@@ -55,7 +56,6 @@ import org.gradle.tooling.internal.provider.connection.ProviderBuildResult;
 import org.gradle.tooling.internal.provider.connection.ProviderConnectionParameters;
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters;
 import org.gradle.tooling.internal.provider.test.ProviderInternalTestExecutionRequest;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.IncubationLogger;
 import org.slf4j.Logger;
@@ -112,7 +112,7 @@ public class DefaultConnection implements ConnectionVersion4, org.gradle.tooling
     }
 
     private void initializeServices(File gradleUserHomeDir) {
-        NativeServices.initialize(gradleUserHomeDir);
+        NativeServices.initializeOnClient(gradleUserHomeDir);
         LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newEmbeddableLogging();
         services = ServiceRegistryBuilder.builder()
             .displayName("Connection services")

--- a/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -50,14 +50,14 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
         buildFile << """
             import org.gradle.cache.FileLockManager
             import org.gradle.cache.internal.filelock.LockOptionsBuilder
-            
+
             abstract class FileLocker extends DefaultTask {
                 @Inject
                 abstract FileLockManager getFileLockManager()
-                
+
                 @Inject
                 abstract ProjectLayout getProjectLayout()
-                
+
                 @TaskAction
                 void lockIt() {
                     def lock
@@ -68,7 +68,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
                     }
                 }
             }
-            
+
             tasks.register("lock", FileLocker)
         """
     }
@@ -275,7 +275,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
 
                 public static ZincCompilerServices getInstance(File gradleUserHome) {
                     if (instance == null) {
-                        NativeServices.initialize(gradleUserHome);
+                        NativeServices.initializeOnWorker(gradleUserHome);
                         instance = new ZincCompilerServices(gradleUserHome);
                     }
                     return instance;

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerFileSystemWatchingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testkit.runner
 
 import org.gradle.initialization.StartParameterBuildOptions
+import org.gradle.testkit.runner.fixtures.Debug
 import org.gradle.testkit.runner.fixtures.NoDebug
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
@@ -24,8 +25,6 @@ import org.gradle.util.TestPrecondition
 
 import static org.junit.Assume.assumeTrue
 
-// There are problems loading the native libraries for FS-watching when using TestKit with debug
-@NoDebug
 @SuppressWarnings('IntegrationTestFixtures')
 class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerIntegrationTest {
 
@@ -38,6 +37,7 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
         assumeTrue("File system watching is enabled by default", gradleVersion >= GradleVersion.version("7.0"))
     }
 
+    @NoDebug
     @Requires(TestPrecondition.WINDOWS)
     def "disables file system watching on Windows"() {
         when:
@@ -46,6 +46,7 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
         assertFileSystemWatchingDisabled(result)
     }
 
+    @NoDebug
     @Requires(TestPrecondition.NOT_WINDOWS)
     def "file system watching is enabled on non-Windows OSes"() {
         when:
@@ -54,6 +55,7 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
         assertFileSystemWatchingEnabled(result)
     }
 
+    @NoDebug
     def "can enable file system watching via '#enableFlag'"() {
         when:
         def result = runAssemble(enableFlag)
@@ -62,6 +64,18 @@ class GradleRunnerFileSystemWatchingIntegrationTest extends BaseGradleRunnerInte
 
         where:
         enableFlag << ["--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}", "-D${StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY}=true"]
+    }
+
+    @Debug
+    def "file system watching is disabled when using --debug"() {
+        when:
+        def result = runAssemble(*extraArguments)
+        then:
+        assertFileSystemWatchingDisabled(result)
+        println(result.output)
+
+        where:
+        extraArguments << [[], ["--${StartParameterBuildOptions.WatchFileSystemOption.LONG_OPTION}"]]
     }
 
     private BuildResult runAssemble(String... extraArguments) {

--- a/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/worker-processes/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -99,7 +99,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
 
         // Read server address and start connecting
         MultiChoiceAddress serverAddress = new MultiChoiceAddressSerializer().read(decoder);
-        NativeServices.initialize(gradleUserHomeDir, false);
+        NativeServices.initializeOnWorker(gradleUserHomeDir);
         DefaultServiceRegistry basicWorkerServices = new DefaultServiceRegistry(NativeServices.getInstance(), loggingServiceRegistry);
         basicWorkerServices.add(ExecutorFactory.class, new DefaultExecutorFactory());
         basicWorkerServices.addProvider(new MessagingServices());


### PR DESCRIPTION
Do not initialize file system watching (aka loading the fs-events library) in the client JVMs for the CLI and tooling API launchers. Note that this disables file system watching when running with `--no-daemon`, since then the CLI jvm is re-used.

Fixes #17128