### PR TITLE
Repeat flakiness detection performance build in the same build

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -29,6 +29,7 @@ import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import model.CIBuildModel
 import model.PerformanceTestBuildSpec
+import model.PerformanceTestType
 import model.Stage
 
 class PerformanceTest(
@@ -68,20 +69,22 @@ class PerformanceTest(
                 killGradleProcessesStep(os)
                 substDirOnWindows(os)
 
-                gradleWrapper {
-                    name = "GRADLE_RUNNER"
-                    tasks = ""
-                    workingDir = os.perfTestWorkingDir
-                    gradleParams = (
-                        performanceTestCommandLine(
-                            "clean ${performanceTestTaskNames.joinToString(" ") { "$it --channel %performance.channel% ${type.extraParameters}" }}",
-                            "%performance.baselines%",
-                            extraParameters,
-                            os
-                        ) +
-                            buildToolGradleParameters() +
-                            buildScanTag("PerformanceTest")
-                        ).joinToString(separator = " ")
+                repeat(if (performanceTestBuildSpec.type == PerformanceTestType.flakinessDetection) 2 else 1) {
+                    gradleWrapper {
+                        name = "GRADLE_RUNNER${if (it != 0) "_2" else ""}"
+                        tasks = ""
+                        workingDir = os.perfTestWorkingDir
+                        gradleParams = (
+                            performanceTestCommandLine(
+                                "clean ${performanceTestTaskNames.joinToString(" ") { "$it --channel %performance.channel% ${type.extraParameters}" }}",
+                                "%performance.baselines%",
+                                extraParameters,
+                                os
+                            ) +
+                                buildToolGradleParameters() +
+                                buildScanTag("PerformanceTest")
+                            ).joinToString(separator = " ")
+                    }
                 }
                 removeSubstDirOnWindows(os)
                 checkCleanM2AndAndroidUserHome(os)

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -69,14 +69,14 @@ class PerformanceTest(
                 killGradleProcessesStep(os)
                 substDirOnWindows(os)
 
-                repeat(if (performanceTestBuildSpec.type == PerformanceTestType.flakinessDetection) 2 else 1) {
+                repeat(if (performanceTestBuildSpec.type == PerformanceTestType.flakinessDetection) 2 else 1) { repeatIndex: Int ->
                     gradleWrapper {
-                        name = "GRADLE_RUNNER${if (it != 0) "_2" else ""}"
+                        name = "GRADLE_RUNNER${if (repeatIndex == 0) "" else "_2"}"
                         tasks = ""
                         workingDir = os.perfTestWorkingDir
                         gradleParams = (
                             performanceTestCommandLine(
-                                "clean ${performanceTestTaskNames.joinToString(" ") { "$it --channel %performance.channel% ${type.extraParameters}" }}",
+                                "${if (repeatIndex == 0) "clean" else ""} ${performanceTestTaskNames.joinToString(" ") { "$it --channel %performance.channel% ${type.extraParameters}" }}",
                                 "%performance.baselines%",
                                 extraParameters,
                                 os


### PR DESCRIPTION
Previously we had issues in splitting performance test scenarios into buckets
with flakiness detection. In some corner case, the same scenarios can be split
into same bucket because of repetition, triggering IllegalArgumentException
"More than one scenario split for bucket". This PR fixes this issue by repeating
the scenario inside bucket.