### PR TITLE
Show all selected executions in performance test report

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenario.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceReportScenario.groovy
@@ -34,17 +34,17 @@ class PerformanceReportScenario {
     /**
      * The execution read from performance database, excluding current executions
      */
-    final List<PerformanceReportScenarioHistoryExecution> recentExecutions
+    final List<PerformanceReportScenarioHistoryExecution> historyExecutions
 
     final boolean crossBuild
 
     final boolean fromCache
 
     PerformanceReportScenario(
-            List<PerformanceTestExecutionResult> teamCityExecutions,
-            List<PerformanceReportScenarioHistoryExecution> historyExecutions,
-            boolean crossBuild,
-            boolean fromCache
+        List<PerformanceTestExecutionResult> teamCityExecutions,
+        List<PerformanceReportScenarioHistoryExecution> historyExecutions,
+        boolean crossBuild,
+        boolean fromCache
     ) {
         if (teamCityExecutions.empty) {
             throw new IllegalArgumentException("teamCity executions must not be empty!")
@@ -58,9 +58,7 @@ class PerformanceReportScenario {
         this.currentExecutions = historyExecutions.findAll {
             teamCityBuildIds.contains(it.teamCityBuildId)
         }
-        this.recentExecutions = historyExecutions.findAll {
-            !teamCityBuildIds.contains(it.teamCityBuildId)
-        }
+        this.historyExecutions = historyExecutions
     }
 
     String getName() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/report/AbstractTablePageGenerator.java
@@ -230,12 +230,12 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
                     tr();
                         th().text("Date").end();
                         th().text("Commit").end();
-                        renderVersionHeader(scenario.getRecentExecutions().isEmpty() ? "" : scenario.getRecentExecutions().get(0).getBaseVersion().getName());
-                        renderVersionHeader(scenario.getRecentExecutions().isEmpty() ? "" : scenario.getRecentExecutions().get(0).getCurrentVersion().getName());
+                        renderVersionHeader(scenario.getHistoryExecutions().isEmpty() ? "" : scenario.getHistoryExecutions().get(0).getBaseVersion().getName());
+                        renderVersionHeader(scenario.getHistoryExecutions().isEmpty() ? "" : scenario.getHistoryExecutions().get(0).getCurrentVersion().getName());
                         th().text("Difference").end();
                         th().text("Confidence").end();
                     end();
-                    scenario.getRecentExecutions().forEach(execution -> {
+                    scenario.getHistoryExecutions().forEach(execution -> {
                         tr();
                             DataSeries<Duration> baseVersion = execution.getBaseVersion().getTotalTime();
                             DataSeries<Duration> currentVersion = execution.getCurrentVersion().getTotalTime();


### PR DESCRIPTION
Current performance report shows "recent exeuctions" in table, which might be empty:

https://builds.gradle.org/repository/download/Gradle_Master_Check_PerformanceTestTestLinuxbucket26/44113455:id/results/performance/build/test-results-excludeRuleMergingBuildPerformanceTest.zip!/performance-tests/report/index.html

![image](https://user-images.githubusercontent.com/12689835/121899234-cb805980-cd56-11eb-8b3f-694b6a3b4412.png)

We should show all executions to the reader.