### PR TITLE
Detect file content type when hashing

### DIFF
--- a/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
+++ b/subprojects/base-services/src/testFixtures/groovy/org/gradle/internal/hash/TestFileHasher.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.hash
 
-class TestFileHasher implements FileHasher {
+class TestFileHasher implements FileInfoCollector {
     @Override
     HashCode hash(File file) {
         try {
@@ -29,5 +29,10 @@ class TestFileHasher implements FileHasher {
     @Override
     HashCode hash(File file, long length, long lastModified) {
         return hash(file)
+    }
+
+    @Override
+    FileInfo collect(File file, long length, long lastModified) {
+        return new FileInfo(hash(file), length, lastModified, FileContentType.UNKNOWN)
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/GradleUserHomeScopeFileTimeStampInspector.java
@@ -30,12 +30,12 @@ import java.util.Set;
  *
  * Uses the same strategy for detection of file changes as {@link FileTimeStampInspector}.
  *
- * Discards hashes for all files from the {@link CachingFileHasher} which have been queried on this daemon
+ * Discards hashes for all files from the {@link CachingFileInfoCollector} which have been queried on this daemon
  * during the last build and which have a timestamp equal to the end of build timestamp.
  */
 @ServiceScope(Scopes.UserHome.class)
 public class GradleUserHomeScopeFileTimeStampInspector extends FileTimeStampInspector implements RootBuildLifecycleListener {
-    private CachingFileHasher fileHasher;
+    private CachingFileInfoCollector fileHasher;
     private final Object lock = new Object();
     private long currentTimestamp;
     private final Set<String> filesWithCurrentTimestamp = new HashSet<>();
@@ -44,8 +44,8 @@ public class GradleUserHomeScopeFileTimeStampInspector extends FileTimeStampInsp
         super(cacheScopeMapping.getBaseDirectory(null, "file-changes", VersionStrategy.CachePerVersion));
     }
 
-    public void attach(CachingFileHasher fileHasher) {
-        this.fileHasher = fileHasher;
+    public void attach(CachingFileInfoCollector fileInfoCollector) {
+        this.fileHasher = fileInfoCollector;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultGenericFileTreeSnapshotter.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.internal.file.FileMetadata.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadata;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
-import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.FileInfoCollector;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import java.nio.file.Files;
@@ -31,17 +31,17 @@ import java.nio.file.Paths;
 
 public class DefaultGenericFileTreeSnapshotter implements GenericFileTreeSnapshotter {
 
-    private final FileHasher hasher;
+    private final FileInfoCollector fileInfoCollector;
     private final Interner<String> stringInterner;
 
-    public DefaultGenericFileTreeSnapshotter(FileHasher hasher, Interner<String> stringInterner) {
-        this.hasher = hasher;
+    public DefaultGenericFileTreeSnapshotter(FileInfoCollector fileInfoCollector, Interner<String> stringInterner) {
+        this.fileInfoCollector = fileInfoCollector;
         this.stringInterner = stringInterner;
     }
 
     @Override
     public FileSystemSnapshot snapshotFileTree(FileTreeInternal tree) {
-        FileSystemSnapshotBuilder builder = new FileSystemSnapshotBuilder(stringInterner, hasher);
+        FileSystemSnapshotBuilder builder = new FileSystemSnapshotBuilder(stringInterner, fileInfoCollector);
         tree.visit(new FileVisitor() {
             @Override
             public void visitDir(FileVisitDetails dirDetails) {

--- a/subprojects/core/src/main/java/org/gradle/internal/hash/ChecksumCacheLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/ChecksumCacheLayout.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import org.gradle.cache.internal.CacheScopeMapping;
+import org.gradle.cache.internal.CacheVersionMapping;
+import org.gradle.cache.internal.VersionStrategy;
+
+import java.io.File;
+
+public class ChecksumCacheLayout {
+    private static final CacheVersionMapping CHECKSUMS = CacheVersionMapping.introducedIn("7.2-rc-1")
+        .build();
+
+    private final CacheScopeMapping cacheScopeMapping;
+
+    public ChecksumCacheLayout(CacheScopeMapping cacheScopeMapping) {
+        this.cacheScopeMapping = cacheScopeMapping;
+    }
+
+    public File getCacheDir(File baseDir) {
+        return cacheScopeMapping.getBaseDirectory(baseDir, "checksums-" + CHECKSUMS.getLatestVersion(), VersionStrategy.SharedCache);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/BuildSessionScopeServices.java
@@ -57,6 +57,7 @@ import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.filewatch.PendingChangesManager;
+import org.gradle.internal.hash.ChecksumCacheLayout;
 import org.gradle.internal.hash.ChecksumService;
 import org.gradle.internal.hash.DefaultChecksumService;
 import org.gradle.internal.isolation.IsolatableFactory;
@@ -196,8 +197,8 @@ public class BuildSessionScopeServices {
     }
 
     CrossBuildFileHashCacheWrapper createCrossBuildChecksumCache(CacheScopeMapping cacheScopeMapping, ProjectCacheDir projectCacheDir, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {
-        File cacheDir = cacheScopeMapping.getBaseDirectory(projectCacheDir.getDir(), "checksums", VersionStrategy.SharedCache);
-        CrossBuildFileHashCache crossBuildCache = new CrossBuildFileHashCache(cacheDir, cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.CHECKSUMS);
+        ChecksumCacheLayout layout = new ChecksumCacheLayout(cacheScopeMapping);
+        CrossBuildFileHashCache crossBuildCache = new CrossBuildFileHashCache(layout.getCacheDir(projectCacheDir.getDir()), cacheRepository, inMemoryCacheDecoratorFactory, CrossBuildFileHashCache.Kind.CHECKSUMS);
         return new CrossBuildFileHashCacheWrapper(crossBuildCache);
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -37,6 +37,7 @@ import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.impl.DefaultGenericFileTreeSnapshotter;
 import org.gradle.internal.hash.DefaultFileHasher;
+import org.gradle.internal.hash.DefaultFileInfoCollector;
 import org.gradle.internal.hash.DefaultStreamHasher;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.resource.local.FileResourceConnector;
@@ -191,8 +192,12 @@ public class TestFiles {
         return new DefaultFileHasher(streamHasher());
     }
 
+    public static DefaultFileInfoCollector fileInfoCollector() {
+        return new DefaultFileInfoCollector(streamHasher());
+    }
+
     public static GenericFileTreeSnapshotter genericFileTreeSnapshotter() {
-        return new DefaultGenericFileTreeSnapshotter(fileHasher(), new StringInterner());
+        return new DefaultGenericFileTreeSnapshotter(fileInfoCollector(), new StringInterner());
     }
 
     public static DefaultFileCollectionSnapshotter fileCollectionSnapshotter() {
@@ -210,7 +215,7 @@ public class TestFiles {
 
     public static FileSystemAccess fileSystemAccess(VirtualFileSystem virtualFileSystem) {
         return new DefaultFileSystemAccess(
-            fileHasher(),
+            fileInfoCollector(),
             new StringInterner(),
             fileSystem(),
             virtualFileSystem,

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializer.java
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.history.impl;
 import com.google.common.collect.Interner;
 import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.impl.DefaultFileMetadata;
+import org.gradle.internal.hash.FileContentType;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -92,7 +93,8 @@ public class FileSystemSnapshotSerializer implements Serializer<FileSystemSnapsh
                     HashCode contentHash = readHashCode(decoder);
                     long lastModified = decoder.readSmallLong();
                     long length = decoder.readSmallLong();
-                    stack.add(new RegularFileSnapshot(internedAbsolutePath, internedName, contentHash, DefaultFileMetadata.file(lastModified, length, accessType)));
+                    FileContentType fileContentType = FileContentType.valueOf(decoder.readString());
+                    stack.add(new RegularFileSnapshot(internedAbsolutePath, internedName, contentHash, DefaultFileMetadata.file(lastModified, length, accessType), fileContentType));
                     break;
                 case MISSING:
                     stack.add(new MissingFileSnapshot(internedAbsolutePath, internedName, accessType));
@@ -135,6 +137,7 @@ public class FileSystemSnapshotSerializer implements Serializer<FileSystemSnapsh
                             FileMetadata metadata = fileSnapshot.getMetadata();
                             encoder.writeSmallLong(metadata.getLastModified());
                             encoder.writeSmallLong(metadata.getLength());
+                            encoder.writeString(fileSnapshot.getFileContentType().name());
                         } catch (IOException e) {
                             throw new UncheckedIOException(e);
                         }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -56,7 +56,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     Predicate<String> watchFilter = { path -> !ignoredForWatching.contains(path) }
     def watchableFileSystemDetector = Stub(WatchableFileSystemDetector)
     def watchableHiearchies = new WatchableHierarchies(watchableFileSystemDetector, watchFilter)
-    def directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
+    def directorySnapshotter = new DirectorySnapshotter(TestFiles.fileInfoCollector(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
     FileWatcherUpdater updater
     def virtualFileSystem = new TestVirtualFileSystem(DefaultSnapshotHierarchy.empty(CaseSensitivity.CASE_SENSITIVE)) {
         @Override

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileInfoCollector.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/DefaultFileInfoCollector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class DefaultFileInfoCollector implements FileInfoCollector {
+    private final StreamHasher streamHasher;
+
+    public DefaultFileInfoCollector(StreamHasher streamHasher) {
+        this.streamHasher = streamHasher;
+    }
+
+    @Override
+    public HashCode hash(File file) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HashCode hash(File file, long length, long lastModified) {
+        return collect(file, length, lastModified).getHash();
+    }
+
+    @Override
+    public FileInfo collect(File file, long length, long lastModified) {
+        FileContentTypeDetectingInputStream inputStream;
+        try {
+            inputStream = new FileContentTypeDetectingInputStream(new FileInputStream(file));
+        } catch (FileNotFoundException e) {
+            throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s' as it does not exist.", file), e);
+        }
+        try {
+            HashCode hashCode = streamHasher.hash(inputStream);
+            return new FileInfo(hashCode, length, lastModified, inputStream.getContentType());
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException ignored) {
+                // Ignored
+            }
+        }
+    }
+}

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileContentType.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileContentType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+public enum FileContentType {
+    BINARY, TEXT, UNKNOWN
+}

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileContentTypeDetectingInputStream.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileContentTypeDetectingInputStream.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Infers whether a file is a binary file or not by checking if there are any ASCII
+ * control characters in the file.  If so, then it is likely a binary file.
+ *
+ * Note that all operations should delegate to the underlying input stream, except
+ * for mark() and markSupported() which are unsupported.  The methods newly
+ * introduced in Java 9 (such as readAllBytes(), transferTo(), etc) are left
+ * unimplemented as this class currently must be Java 8 compatible.
+ */
+public class FileContentTypeDetectingInputStream extends InputStream {
+    private final static int CHAR_SCANNING_LIMIT = 80000;
+    private final InputStream delegate;
+    private boolean controlCharactersFound;
+    private int count;
+
+    public FileContentTypeDetectingInputStream(InputStream delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int next = delegate.read();
+        checkForControlCharacters(next);
+        return next;
+    }
+
+    @Override
+    public int read(byte[] buffer) throws IOException {
+        int read = delegate.read(buffer);
+        checkForControlCharacters(buffer, read);
+        return read;
+    }
+
+    @Override
+    public int read(byte[] buffer, int off, int len) throws IOException {
+        int read = delegate.read(buffer, off, len);
+        checkForControlCharacters(buffer, read);
+        return read;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return delegate.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return delegate.available();
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        count = 0;
+        controlCharactersFound = false;
+        delegate.reset();
+    }
+
+    void checkForControlCharacters(byte[] buffer, int length) {
+        if (count < CHAR_SCANNING_LIMIT && !controlCharactersFound) {
+            for (int i = 0; i < length; i++) {
+                checkForControlCharacters(buffer[i]);
+            }
+        }
+    }
+
+    void checkForControlCharacters(int b) {
+        if (count++ < CHAR_SCANNING_LIMIT && !controlCharactersFound && isControlCharacter(b)) {
+            controlCharactersFound = true;
+        }
+    }
+
+    private boolean isControlCharacter(int c) {
+        return isInControlRange(c) && isNotCommonTextChar(c);
+    }
+
+    private static boolean isInControlRange(int c) {
+        return c >= 0x00 && c < 0x20;
+    }
+
+    private static boolean isNotCommonTextChar(int c) {
+        return c != 0x09  // tab
+            && c != 0x0a  // line feed
+            && c != 0x0c  // form feed
+            && c != 0x0d; // carriage return
+    }
+
+    public FileContentType getContentType() {
+        return controlCharactersFound ? FileContentType.BINARY : FileContentType.TEXT;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        delegate.close();
+    }
+}

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfo.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+public class FileInfo {
+    private final HashCode hash;
+    private final long timestamp;
+    private final long length;
+    private final FileContentType contentType;
+
+    public FileInfo(HashCode hash, long length, long timestamp, FileContentType contentType) {
+        this.hash = hash;
+        this.length = length;
+        this.timestamp = timestamp;
+        this.contentType = contentType;
+    }
+
+    public HashCode getHash() {
+        return hash;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public FileContentType getContentType() {
+        return contentType;
+    }
+}

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfoCollector.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfoCollector.java
@@ -37,7 +37,7 @@ public interface FileInfoCollector extends FileHasher {
 
         @Override
         public HashCode hash(File file) {
-            throw new UnsupportedOperationException();
+            return delegate.hash(file);
         }
 
         @Override

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfoCollector.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/FileInfoCollector.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash;
+
+import java.io.File;
+
+public interface FileInfoCollector extends FileHasher {
+    /**
+     * Returns the {@link FileInfo} of the current content of the given file, assuming the given file metadata. The provided file must exist and be a file (rather than, say, a directory).
+     */
+    FileInfo collect(File file, long length, long lastModified);
+
+    /**
+     * Adapts a {@link FileHasher} to a {@link FileInfoCollector} object, returning a {@link FileInfo} object
+     * with an UNKNOWN file content type.
+     */
+    class Adapter implements FileInfoCollector {
+        private final FileHasher delegate;
+
+        public Adapter(FileHasher delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public HashCode hash(File file) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public HashCode hash(File file, long length, long lastModified) {
+            return delegate.hash(file, length, lastModified);
+        }
+
+        @Override
+        public FileInfo collect(File file, long length, long lastModified) {
+            return new FileInfo(delegate.hash(file, length, lastModified), length, lastModified, FileContentType.UNKNOWN);
+        }
+
+        static FileInfoCollector from(FileHasher fileHasher) {
+            return new Adapter(fileHasher);
+        }
+    }
+}

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/FileContentTypeDetectingInputStreamTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/FileContentTypeDetectingInputStreamTest.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.charset.Charset
+
+class FileContentTypeDetectingInputStreamTest extends Specification {
+    @Unroll
+    def "can detect #expectedType files with #description"() {
+        def inputStream = inputStream(content)
+
+        when:
+        def contentRead = readAllBytesWithRead(inputStream)
+
+        then:
+        contentRead == content
+
+        and:
+        inputStream.contentType == expectedType
+
+        when:
+        inputStream.reset()
+
+        then:
+        inputStream.contentType == FileContentType.TEXT
+
+        when:
+        contentRead = readAllBytesWithReadBuffer(inputStream)
+
+        then:
+        contentRead == content
+
+        and:
+        inputStream.contentType == expectedType
+
+        where:
+        expectedType           | description                   | content
+        FileContentType.TEXT   | "new lines"                   | "this is\na text file\n".bytes
+        FileContentType.TEXT   | "new lines with CR-LF"        | "this is\r\na text file\r\n".bytes
+        FileContentType.TEXT   | "no new lines"                | "No new lines\tin this file".bytes
+        FileContentType.TEXT   | "utf8 content"                | "here's some UTF8 content: €ЇΩ".getBytes(Charset.forName("UTF-8"))
+        FileContentType.BINARY | "png content"                 | [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as byte[]
+        FileContentType.BINARY | "jpg content"                 | [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0xff, 0xda] as byte[]
+        FileContentType.BINARY | "java class file content"     | [0xca, 0xfe, 0xba, 0xbe, 0x00, 0x00, 0x00, 0x37, 0x0a, 0x00] as byte[]
+    }
+
+    def "delegate is called when operating on input stream"() {
+        def delegate = Mock(InputStream)
+        def inputStream = new FileContentTypeDetectingInputStream(delegate)
+        byte[] buffer = []
+
+        when:
+        inputStream.read()
+
+        then:
+        1 * delegate.read()
+
+        when:
+        inputStream.read(buffer)
+
+        then:
+        1 * delegate.read(buffer)
+
+        when:
+        inputStream.reset()
+
+        then:
+        1 * delegate.reset()
+
+        when:
+        inputStream.read(buffer, 0, 1)
+
+        then:
+        1 * delegate.read(buffer, 0, 1)
+
+        when:
+        inputStream.skip(1)
+
+        then:
+        1 * delegate.skip(1)
+
+        when:
+        inputStream.available()
+
+        then:
+        1 * delegate.available()
+
+        when:
+        inputStream.close()
+
+        then:
+        1 * delegate.close()
+    }
+
+    static FileContentTypeDetectingInputStream inputStream(byte[] bytes) {
+        return new FileContentTypeDetectingInputStream(new ByteArrayInputStream(bytes))
+    }
+
+    static byte[] readAllBytesWithRead(InputStream inputStream) {
+        ArrayList<Byte> bytes = []
+        int b
+        while ((b = inputStream.read()) != -1) {
+            bytes.add(Byte.valueOf((byte)b))
+        }
+        return bytes as byte[]
+    }
+
+    static byte[] readAllBytesWithReadBuffer(InputStream inputStream) {
+        ArrayList<Byte> bytes = []
+        byte[] buffer = new byte[8]
+        int read
+        while ((read = inputStream.read(buffer)) != -1) {
+            bytes.addAll(buffer[0..(read-1)].collect { Byte.valueOf(it) })
+        }
+        return bytes as byte[]
+    }
+}

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/FileContentTypeDetectingInputStreamTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/FileContentTypeDetectingInputStreamTest.groovy
@@ -76,7 +76,7 @@ class FileContentTypeDetectingInputStreamTest extends Specification {
         inputStream.read(buffer)
 
         then:
-        1 * delegate.read(buffer)
+        1 * delegate.read(buffer, 0, 0)
 
         when:
         inputStream.reset()

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/RegularFileSnapshot.java
@@ -18,6 +18,7 @@ package org.gradle.internal.snapshot;
 
 import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileType;
+import org.gradle.internal.hash.FileContentType;
 import org.gradle.internal.hash.HashCode;
 
 import java.util.Optional;
@@ -30,11 +31,17 @@ import java.util.Optional;
 public class RegularFileSnapshot extends AbstractFileSystemLocationSnapshot implements FileSystemLeafSnapshot {
     private final HashCode contentHash;
     private final FileMetadata metadata;
+    private final FileContentType fileContentType;
 
     public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata) {
+        this(absolutePath, name, contentHash, metadata, FileContentType.UNKNOWN);
+    }
+
+    public RegularFileSnapshot(String absolutePath, String name, HashCode contentHash, FileMetadata metadata, FileContentType fileContentType) {
         super(absolutePath, name, metadata.getAccessType());
         this.contentHash = contentHash;
         this.metadata = metadata;
+        this.fileContentType = fileContentType;
     }
 
     @Override
@@ -50,6 +57,10 @@ public class RegularFileSnapshot extends AbstractFileSystemLocationSnapshot impl
     // Used by the Maven caching client. Do not remove
     public FileMetadata getMetadata() {
         return metadata;
+    }
+
+    public FileContentType getFileContentType() {
+        return fileContentType;
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -73,7 +73,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
     }
 
     private DirectorySnapshotter directorySnapshotter() {
-        new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
+        new DirectorySnapshotter(TestFiles.fileInfoCollector(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
     }
 
     private static List<FileVisitDetails> walkFiles(rootDir) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
@@ -23,7 +23,10 @@ import org.gradle.internal.file.FileException
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileType
 import org.gradle.internal.file.Stat
+import org.gradle.internal.hash.FileContentType
 import org.gradle.internal.hash.FileHasher
+import org.gradle.internal.hash.FileInfo
+import org.gradle.internal.hash.FileInfoCollector
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -71,7 +74,7 @@ abstract class AbstractFileSystemAccessTest extends Specification {
         return result.get()
     }
 
-    static class AllowingHasher implements FileHasher {
+    static class AllowingHasher implements FileHasher, FileInfoCollector {
 
         private final FileHasher delegate
         private boolean hashingAllowed
@@ -90,6 +93,11 @@ abstract class AbstractFileSystemAccessTest extends Specification {
         HashCode hash(File file, long length, long lastModified) {
             checkIfAllowed()
             return delegate.hash(file, length, lastModified)
+        }
+
+        @Override
+        FileInfo collect(File file, long length, long lastModified) {
+            return new FileInfo(hash(file), length, lastModified, FileContentType.UNKNOWN)
         }
 
         private void checkIfAllowed() {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -47,7 +47,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
 
     private static final SnapshotHierarchy EMPTY = DefaultSnapshotHierarchy.empty(CASE_SENSITIVE)
 
-    DirectorySnapshotter directorySnapshotter = new DirectorySnapshotter(TestFiles.fileHasher(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
+    DirectorySnapshotter directorySnapshotter = new DirectorySnapshotter(TestFiles.fileInfoCollector(), new StringInterner(), [], Stub(DirectorySnapshotterStatistics.Collector))
 
     def diffListener = new SnapshotHierarchy.NodeDiffListener() {
         @Override


### PR DESCRIPTION
This is preliminary work for enabling line ending normalization in Task/Transform inputs.  This allows Gradle to capture the file content type (i.e. whether a file is text or binary) while streaming the file contents during hashing.  We can later use this information to determine whether a given file should be hashed again to normalize line endings (if specified).

There are two significant changes:
- We expand upon `FileHasher` to introduce a `FileInfoCollector` object which contains the hash and other useful metadata for the file (such as file content type).
- We make the checksum hash cache a versioned, shared cache.  The checksums themselves are unlikely to ever change, but the format of the data in the cache may change from time to time, so having a version allows us to make improvements without affecting the backwards compatibility of the shared cache file.