### PR TITLE
Add `@ServiceScope` to AsyncIOScopeFactory build scoped service

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
-    @ToBeFixedForConfigurationCache
     fun `generated code follows kotlin-dsl coding conventions`() {
 
         assumeNonEmbeddedGradleExecuter() // ktlint plugin issue in embedded mode

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/IO.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/concurrent/IO.kt
@@ -17,6 +17,8 @@
 package org.gradle.kotlin.dsl.concurrent
 
 import org.gradle.api.Project
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
 
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.kotlin.dsl.support.useToRun
@@ -64,6 +66,7 @@ interface IOScope : IO, AutoCloseable
 /**
  * A Gradle build service to offload IO actions to a dedicated thread.
  */
+@ServiceScope(Scopes.Build::class)
 interface AsyncIOScopeFactory {
     fun newScope(): IOScope
 }


### PR DESCRIPTION
in order to fix configuration cache problems with the `GeneratePrecompiledScriptPluginAccessors` task from the `kotlin-dsl` plugin
