### PR TITLE
Use 7.0 as first version to run on Java 16

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -182,7 +182,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
 
     static String determineMinimumVersionThatRunsOnCurrentJavaVersion(String desiredGradleVersion) {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-            def compatibleVersion = GradleVersion.version("7.0-20210224105427+0000")
+            def compatibleVersion = GradleVersion.version("7.0")
             if (GradleVersion.version(desiredGradleVersion) < compatibleVersion) {
                 return compatibleVersion.version
             }


### PR DESCRIPTION
in BaseGradleRunnerIntegrationTest.
The nightly we have been using does not exist any more and causes tests to fail.