### PR TITLE
Split ConfigurationCacheIncludedBuildChangesIntegrationTest

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
@@ -26,55 +26,6 @@ import static org.junit.Assume.assumeFalse
 class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     @Unroll
-    def "invalidates cache upon change to included #fixtureSpec"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        def fixture = fixtureSpec.fixtureForProjectDir(file('build-logic'))
-        fixture.setup()
-        settingsFile << """
-            pluginManagement {
-                includeBuild 'build-logic'
-            }
-        """
-        buildFile << """
-            plugins { id('$fixture.pluginId') }
-        """
-
-        when:
-        configurationCacheRunLenient fixture.task
-
-        then:
-        outputContains fixture.expectedOutputBeforeChange
-        configurationCache.assertStateStored()
-
-        when:
-        configurationCacheRunLenient fixture.task
-
-        then:
-        outputContains fixture.expectedOutputBeforeChange
-        configurationCache.assertStateLoaded()
-
-        when:
-        fixture.applyChange()
-        configurationCacheRunLenient fixture.task
-
-        then:
-        outputContains fixture.expectedCacheInvalidationMessage
-        outputContains fixture.expectedOutputAfterChange
-        configurationCache.assertStateStored()
-
-        when:
-        configurationCacheRunLenient fixture.task
-
-        then:
-        outputContains fixture.expectedOutputAfterChange
-        configurationCache.assertStateLoaded()
-
-        where:
-        fixtureSpec << BuildLogicChangeFixture.specs()
-    }
-
-    @Unroll
     def "invalidates cache upon change to #inputName used by included build"() {
 
         assumeFalse(

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildChangesIntegrationTest.groovy
@@ -19,58 +19,11 @@ package org.gradle.configurationcache
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.configurationcache.fixtures.BuildLogicChangeFixture
-import org.gradle.configurationcache.fixtures.ScriptChangeFixture
 import spock.lang.Unroll
 
 import static org.junit.Assume.assumeFalse
 
 class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-
-    @Unroll
-    def "invalidates cache upon change to #scriptChangeSpec of included build"() {
-        given:
-        def configurationCache = newConfigurationCacheFixture()
-        def fixture = scriptChangeSpec.fixtureForProjectDir(file('build-logic'), testDirectory)
-        fixture.setup()
-        def build = { configurationCacheRunLenient(*fixture.buildArguments) }
-        settingsFile << """
-            includeBuild 'build-logic'
-        """
-
-        when:
-        build()
-
-        then:
-        outputContains fixture.expectedOutputBeforeChange
-        configurationCache.assertStateStored()
-
-        when:
-        build()
-
-        then: 'scripts are not executed when loading from cache'
-        outputDoesNotContain fixture.expectedOutputBeforeChange
-        configurationCache.assertStateLoaded()
-
-        when:
-        fixture.applyChange()
-        build()
-
-        then:
-        outputContains fixture.expectedCacheInvalidationMessage
-        outputContains fixture.expectedOutputAfterChange
-        configurationCache.assertStateStored()
-
-        when:
-        build()
-
-        then:
-        outputDoesNotContain fixture.expectedOutputBeforeChange
-        outputDoesNotContain fixture.expectedOutputAfterChange
-        configurationCache.assertStateLoaded()
-
-        where:
-        scriptChangeSpec << ScriptChangeFixture.specs()
-    }
 
     @Unroll
     def "invalidates cache upon change to included #fixtureSpec"() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildInputsChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildInputsChangesIntegrationTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Unroll
 
 import static org.junit.Assume.assumeFalse
 
-class ConfigurationCacheIncludedBuildChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+class ConfigurationCacheIncludedBuildInputsChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
     @Unroll
     def "invalidates cache upon change to #inputName used by included build"() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildLogicChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildLogicChangesIntegrationTest.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.configurationcache.fixtures.BuildLogicChangeFixture
+import spock.lang.Unroll
+
+class ConfigurationCacheIncludedBuildLogicChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Unroll
+    def "invalidates cache upon change to included #fixtureSpec"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        def fixture = fixtureSpec.fixtureForProjectDir(file('build-logic'))
+        fixture.setup()
+        settingsFile << """
+            pluginManagement {
+                includeBuild 'build-logic'
+            }
+        """
+        buildFile << """
+            plugins { id('$fixture.pluginId') }
+        """
+
+        when:
+        configurationCacheRunLenient fixture.task
+
+        then:
+        outputContains fixture.expectedOutputBeforeChange
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRunLenient fixture.task
+
+        then:
+        outputContains fixture.expectedOutputBeforeChange
+        configurationCache.assertStateLoaded()
+
+        when:
+        fixture.applyChange()
+        configurationCacheRunLenient fixture.task
+
+        then:
+        outputContains fixture.expectedCacheInvalidationMessage
+        outputContains fixture.expectedOutputAfterChange
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRunLenient fixture.task
+
+        then:
+        outputContains fixture.expectedOutputAfterChange
+        configurationCache.assertStateLoaded()
+
+        where:
+        fixtureSpec << BuildLogicChangeFixture.specs()
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildScriptChangesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildScriptChangesIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.configurationcache.fixtures.ScriptChangeFixture
+import spock.lang.Unroll
+
+class ConfigurationCacheIncludedBuildScriptChangesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Unroll
+    def "invalidates cache upon change to #scriptChangeSpec of included build"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        def fixture = scriptChangeSpec.fixtureForProjectDir(file('build-logic'), testDirectory)
+        fixture.setup()
+        def build = { configurationCacheRunLenient(*fixture.buildArguments) }
+        settingsFile << """
+            includeBuild 'build-logic'
+        """
+
+        when:
+        build()
+
+        then:
+        outputContains fixture.expectedOutputBeforeChange
+        configurationCache.assertStateStored()
+
+        when:
+        build()
+
+        then: 'scripts are not executed when loading from cache'
+        outputDoesNotContain fixture.expectedOutputBeforeChange
+        configurationCache.assertStateLoaded()
+
+        when:
+        fixture.applyChange()
+        build()
+
+        then:
+        outputContains fixture.expectedCacheInvalidationMessage
+        outputContains fixture.expectedOutputAfterChange
+        configurationCache.assertStateStored()
+
+        when:
+        build()
+
+        then:
+        outputDoesNotContain fixture.expectedOutputBeforeChange
+        outputDoesNotContain fixture.expectedOutputAfterChange
+        configurationCache.assertStateLoaded()
+
+        where:
+        scriptChangeSpec << ScriptChangeFixture.specs()
+    }
+}


### PR DESCRIPTION
into categorised classes to reduce feedback time by allowing more tests to run in parallel