### PR TITLE
Add `@since 3.0` to @Internal

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Internal.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Internal.java
@@ -28,6 +28,8 @@ import java.lang.annotation.Target;
  * Annotations on setters or just the field in Java are ignored.</p>
  *
  * <p>This will cause the task <em>not</em> to be considered out-of-date when the property has changed.</p>
+ *
+ * @since 3.0
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Based on:

https://docs.gradle.org/2.14.1/javadoc/org/gradle/api/tasks/Internal.html - not there
https://docs.gradle.org/3.0/javadoc/org/gradle/api/tasks/Internal.html - there