### PR TITLE
Create a non-blocking seprate CheckLinks job

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
+++ b/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
@@ -3,7 +3,11 @@ package configurations
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import model.Stage
 
-open class BaseGradleBuildType(val stage: Stage? = null, init: BaseGradleBuildType.() -> Unit = {}) : BuildType() {
+open class BaseGradleBuildType(
+    val stage: Stage? = null,
+    val failStage: Boolean = true,
+    init: BaseGradleBuildType.() -> Unit = {}
+) : BuildType() {
     init {
         this.init()
     }

--- a/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
@@ -3,7 +3,7 @@ package configurations
 import model.CIBuildModel
 import model.Stage
 
-class CheckLinks(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, failStage = true, init = {
+class CheckLinks(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, failStage = false, init = {
     id("${model.projectId}_CheckLinks")
     name = "CheckLinks"
     description = "Check links in documentations"

--- a/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
+++ b/.teamcity/src/main/kotlin/configurations/CheckLinks.kt
@@ -1,0 +1,17 @@
+package configurations
+
+import model.CIBuildModel
+import model.Stage
+
+class CheckLinks(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, failStage = true, init = {
+    id("${model.projectId}_CheckLinks")
+    name = "CheckLinks"
+    description = "Check links in documentations"
+
+    applyDefaults(
+        model,
+        this,
+        ":docs:checkLinks",
+        extraParameters = buildScanTag("CheckLinks") + " " + "-Porg.gradle.java.installations.auto-download=false"
+    )
+})

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -39,7 +39,6 @@ class FunctionalTest(
         model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
             listOf(functionalTestExtraParameters("FunctionalTest", testCoverage.os, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)) +
-                enableCheckLinksParameter(testCoverage, subprojects) +
                 enableTestDistributionParameter(testCoverage, subprojects) +
                 extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
@@ -66,8 +65,6 @@ class FunctionalTest(
         }
     }
 })
-
-fun enableCheckLinksParameter(testCoverage: TestCoverage, subprojects: List<String>) = if (testCoverage.isPlatform && subprojects.contains("docs")) "-PenableCheckLinks=false" else ""
 
 fun enableTestDistributionParameter(testCoverage: TestCoverage, subprojects: List<String>) =
     if (enableExperimentalTestDistribution(testCoverage, subprojects)) "-DenableTestDistribution=%enableTestDistribution%" else ""

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -35,15 +35,18 @@ class FunctionalTest(
 
     val enableTestDistribution = testCoverage.testDistribution
 
-    applyTestDefaults(model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
+    applyTestDefaults(
+        model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
             listOf(functionalTestExtraParameters("FunctionalTest", testCoverage.os, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)) +
-                if (enableExperimentalTestDistribution(testCoverage, subprojects)) "-DenableTestDistribution=%enableTestDistribution%" else "" +
-                    extraParameters
+                enableCheckLinksParameter(testCoverage, subprojects) +
+                enableTestDistributionParameter(testCoverage, subprojects) +
+                extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
         timeout = testCoverage.testType.timeout,
         extraSteps = extraBuildSteps,
-        preSteps = preBuildSteps)
+        preSteps = preBuildSteps
+    )
 
     params {
         if (enableTestDistribution) {
@@ -64,7 +67,13 @@ class FunctionalTest(
     }
 })
 
-fun enableExperimentalTestDistribution(testCoverage: TestCoverage, subprojects: List<String>) = testCoverage.os == Os.LINUX && (subprojects == listOf("core") || subprojects == listOf("dependency-management"))
+fun enableCheckLinksParameter(testCoverage: TestCoverage, subprojects: List<String>) = if (testCoverage.isPlatform && subprojects.contains("docs")) "-PenableCheckLinks=false" else ""
+
+fun enableTestDistributionParameter(testCoverage: TestCoverage, subprojects: List<String>) =
+    if (enableExperimentalTestDistribution(testCoverage, subprojects)) "-DenableTestDistribution=%enableTestDistribution%" else ""
+
+fun enableExperimentalTestDistribution(testCoverage: TestCoverage, subprojects: List<String>) =
+    testCoverage.os == Os.LINUX && (subprojects == listOf("core") || subprojects == listOf("dependency-management"))
 
 fun getTestTaskName(testCoverage: TestCoverage, subprojects: List<String>): String {
     val testTaskName = "${testCoverage.testType.name}Test"

--- a/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
+++ b/.teamcity/src/main/kotlin/configurations/PartialTrigger.kt
@@ -17,10 +17,9 @@
 package configurations
 
 import common.applyDefaultSettings
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import model.CIBuildModel
 
-class PartialTrigger<T : BuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(init = {
+class PartialTrigger<T : BaseGradleBuildType>(triggerName: String, triggerId: String, model: CIBuildModel, dependencies: Iterable<T>) : BaseGradleBuildType(init = {
     id("${model.projectId}_${triggerId}_Trigger")
     name = "$triggerName (Trigger)"
     type = Type.COMPOSITE

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -20,83 +20,83 @@ import common.Os
 import common.applyDefaultSettings
 import jetbrains.buildServer.configs.kotlin.v2019_2.ReuseBuilds
 import model.CIBuildModel
-import model.PerformanceTestProjectSpec
 import model.PerformanceTestType
 import projects.PerformanceTestProject
 
-class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(init = {
-    id("${performanceTestProject.spec.asConfigurationId(model)}_Trigger")
-    val performanceTestSpec = performanceTestProject.spec
-    name = performanceTestProject.name + " (Trigger)"
+class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: PerformanceTestProject) : BaseGradleBuildType(
+    failStage = performanceTestProject.spec.failsStage,
+    init = {
+        id("${performanceTestProject.spec.asConfigurationId(model)}_Trigger")
+        val performanceTestSpec = performanceTestProject.spec
+        name = performanceTestProject.name + " (Trigger)"
 
-    val os = Os.LINUX
-    val type = performanceTestSpec.type
+        val os = Os.LINUX
+        val type = performanceTestSpec.type
 
-    applyDefaultSettings(os)
-    params {
-        param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
-        param("performance.db.username", "tcagent")
-        param("performance.channel", performanceTestSpec.channel())
-    }
+        applyDefaultSettings(os)
+        params {
+            param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
+            param("performance.db.username", "tcagent")
+            param("performance.channel", performanceTestSpec.channel())
+        }
 
-    features {
-        publishBuildStatusToGithub(model)
-    }
+        features {
+            publishBuildStatusToGithub(model)
+        }
 
-    val performanceResultsDir = "perf-results"
-    val performanceProjectName = "performance"
+        val performanceResultsDir = "perf-results"
+        val performanceProjectName = "performance"
 
-    val taskName = if (performanceTestSpec.type == PerformanceTestType.flakinessDetection)
-        "performanceTestFlakinessReport"
-    else
-        "performanceTestReport"
+        val taskName = if (performanceTestSpec.type == PerformanceTestType.flakinessDetection)
+            "performanceTestFlakinessReport"
+        else
+            "performanceTestReport"
 
-    artifactRules = """
+        artifactRules = """
 subprojects/$performanceProjectName/build/performance-test-results.zip
 """
-    if (performanceTestProject.performanceTests.any { it.testProjects.isNotEmpty() }) {
-        val dependencyBuildIds = performanceTestProject.performanceTests
-            .filter { it.testProjects.isNotEmpty() }
-            .joinToString(",") { "%dep.${it.id}.env.BUILD_ID%" }
+        if (performanceTestProject.performanceTests.any { it.testProjects.isNotEmpty() }) {
+            val dependencyBuildIds = performanceTestProject.performanceTests
+                .filter { it.testProjects.isNotEmpty() }
+                .joinToString(",") { "%dep.${it.id}.env.BUILD_ID%" }
 
-        gradleRunnerStep(
-            model,
-            ":$performanceProjectName:$taskName --channel %performance.channel%",
-            extraParameters = listOf(
-                "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
-                "-Porg.gradle.performance.db.url" to "%performance.db.url%",
-                "-Porg.gradle.performance.db.username" to "%performance.db.username%",
-                "-Porg.gradle.performance.dependencyBuildIds" to dependencyBuildIds
-            ).joinToString(" ") { (key, value) -> os.escapeKeyValuePair(key, value) }
-        )
-    }
-
-    dependencies {
-        snapshotDependencies(performanceTestProject.performanceTests) {
-            if (type == PerformanceTestType.flakinessDetection) {
-                reuseBuilds = ReuseBuilds.NO
-            }
+            gradleRunnerStep(
+                model,
+                ":$performanceProjectName:$taskName --channel %performance.channel%",
+                extraParameters = listOf(
+                    "-Porg.gradle.performance.branchName" to "%teamcity.build.branch%",
+                    "-Porg.gradle.performance.db.url" to "%performance.db.url%",
+                    "-Porg.gradle.performance.db.username" to "%performance.db.username%",
+                    "-Porg.gradle.performance.dependencyBuildIds" to dependencyBuildIds
+                ).joinToString(" ") { (key, value) -> os.escapeKeyValuePair(key, value) }
+            )
         }
-        performanceTestProject.performanceTests.forEachIndexed { index, performanceTest ->
-            if (performanceTest.testProjects.isNotEmpty()) {
-                artifacts(performanceTest.id!!) {
-                    id = "ARTIFACT_DEPENDENCY_${performanceTest.id!!}"
-                    cleanDestination = true
-                    val perfResultArtifactRule = """results/performance/build/test-results-*.zip!performance-tests/perf-results*.json => $performanceResultsDir/${performanceTest.bucketIndex}/"""
-                    artifactRules = if (index == 0) {
-                        // The artifact rule report/css/*.css => performanceResultsDir is there to clean up the target directory.
-                        // If we don't clean that up there might be leftover json files from other report builds running on the same machine.
-                        """
+
+        dependencies {
+            snapshotDependencies(performanceTestProject.performanceTests) {
+                if (type == PerformanceTestType.flakinessDetection) {
+                    reuseBuilds = ReuseBuilds.NO
+                }
+            }
+            performanceTestProject.performanceTests.forEachIndexed { index, performanceTest ->
+                if (performanceTest.testProjects.isNotEmpty()) {
+                    artifacts(performanceTest.id!!) {
+                        id = "ARTIFACT_DEPENDENCY_${performanceTest.id!!}"
+                        cleanDestination = true
+                        val perfResultArtifactRule = """results/performance/build/test-results-*.zip!performance-tests/perf-results*.json => $performanceResultsDir/${performanceTest.bucketIndex}/"""
+                        artifactRules = if (index == 0) {
+                            // The artifact rule report/css/*.css => performanceResultsDir is there to clean up the target directory.
+                            // If we don't clean that up there might be leftover json files from other report builds running on the same machine.
+                            """
                             results/performance/build/test-results-*.zip!performance-tests/report/css/*.css => $performanceResultsDir/
                             $perfResultArtifactRule
                         """.trimIndent()
-                    } else {
-                        perfResultArtifactRule
+                        } else {
+                            perfResultArtifactRule
+                        }
                     }
                 }
             }
         }
     }
-}) {
-    val performanceSpec: PerformanceTestProjectSpec = performanceTestProject.spec
-}
+)

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -1,6 +1,7 @@
 package projects
 
 import common.failedTestArtifactDestination
+import configurations.BaseGradleBuildType
 import configurations.FunctionalTest
 import configurations.FunctionalTestsPass
 import configurations.PartialTrigger
@@ -9,7 +10,6 @@ import configurations.PerformanceTestsPass
 import configurations.SanityCheck
 import configurations.SmokeTests
 import configurations.buildReportTab
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.IdOwner
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
@@ -31,11 +31,11 @@ class StageProject(model: CIBuildModel, functionalTestBucketProvider: Functional
     this.name = stage.stageName.stageName
     this.description = stage.stageName.description
 }) {
-    val specificBuildTypes: List<BuildType>
+    val specificBuildTypes: List<BaseGradleBuildType>
 
     val performanceTests: List<PerformanceTestsPass>
 
-    val functionalTests: List<BuildType>
+    val functionalTests: List<BaseGradleBuildType>
 
     init {
         features {

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -4,6 +4,7 @@ import org.gradle.docs.samples.internal.tasks.InstallSample
 
 import static gradlebuild.basics.BuildEnvironmentKt.repoRoot
 import static gradlebuild.basics.Repositories_extensionsKt.googleApisJs
+import org.gradle.docs.internal.tasks.CheckLinks
 
 plugins {
     id 'gradlebuild.internal.java'
@@ -556,4 +557,14 @@ class GradleInstallationForTestEnvironmentProvider implements CommandLineArgumen
          "-DintegTest.samplesdir=${samplesdir.get().asFile}",
          "-DintegTest.gradleUserHomeDir=${repoRoot(project).dir("intTestHomeDir/$distributionName").asFile}"]
     }
+}
+
+tasks.withType(CheckLinks) {
+    enabled = Boolean.parseBoolean(providers.gradleProperty("enableCheckLinks")
+        .forUseAtConfigurationTime()
+        .getOrElse("true"))
+}
+
+tasks.register("checkLinks") {
+    dependsOn(tasks.withType(CheckLinks))
 }

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -559,10 +559,8 @@ class GradleInstallationForTestEnvironmentProvider implements CommandLineArgumen
     }
 }
 
-tasks.withType(CheckLinks) {
-    enabled = Boolean.parseBoolean(providers.gradleProperty("enableCheckLinks")
-        .forUseAtConfigurationTime()
-        .getOrElse("true"))
+tasks.withType(CheckLinks).configureEach {
+    enabled = !gradle.startParameter.taskNames.contains("docs:platformTest")
 }
 
 tasks.register("checkLinks") {


### PR DESCRIPTION
### Context

We've been bitten by flaky `CheckLinks` failure for a looong time. This PR adds a switch for `CheckLinks` tasks so we can enable/disable those tasks via parameter. It also creates a `CheckLinks` job in ReadyForMerge stage which doesn't block the main pipeline. This can mitigate our pain.