### PR TITLE
Remove some assumptions that only task graphs can be cached in the configuration cache

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -30,16 +30,11 @@ import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
-import org.gradle.internal.buildtree.BuildTreeModelCreator;
+import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor;
-import org.gradle.internal.buildtree.BuildTreeWorkPreparer;
-import org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController;
-import org.gradle.internal.buildtree.DefaultBuildTreeModelCreator;
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
-import org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer;
 import org.gradle.internal.concurrent.Stoppable;
-import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 import org.gradle.util.Path;
 
@@ -55,6 +50,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     private final BuildIdentifier buildIdentifier;
     private final BuildDefinition buildDefinition;
     private final BuildLifecycleController buildLifecycleController;
+    private final BuildTreeLifecycleController buildTreeLifecycleController;
 
     DefaultNestedBuild(BuildIdentifier buildIdentifier,
                        Path identityPath,
@@ -68,8 +64,26 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         this.buildDefinition = buildDefinition;
         this.owner = owner;
         this.projectStateRegistry = projectStateRegistry;
+
         BuildScopeServices buildScopeServices = new BuildScopeServices(buildTree.getServices());
         this.buildLifecycleController = buildLifecycleControllerFactory.newInstance(buildDefinition, this, owner.getMutableModel(), buildScopeServices);
+
+        IncludedBuildControllers controllers = buildScopeServices.get(IncludedBuildControllers.class);
+        ExceptionAnalyser exceptionAnalyser = buildScopeServices.get(ExceptionAnalyser.class);
+        BuildModelParameters modelParameters = buildScopeServices.get(BuildModelParameters.class);
+        BuildTreeWorkExecutor workExecutor = new DefaultBuildTreeWorkExecutor(controllers, buildLifecycleController);
+        BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildScopeServices.get(BuildTreeLifecycleControllerFactory.class);
+
+        // On completion of the action, finish only this build and do not finish any other builds
+        // When the build model is required, then do not finish anything on completion of the action
+        // The root build will take care of finishing this build later, if not finished now
+        BuildTreeFinishExecutor finishExecutor;
+        if (modelParameters.isRequiresBuildModel()) {
+            finishExecutor = new DoNothingBuildFinishExecutor();
+        } else {
+            finishExecutor = new FinishThisBuildOnlyFinishExecutor(exceptionAnalyser);
+        }
+        buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createController(buildLifecycleController, workExecutor, finishExecutor);
     }
 
     @Override
@@ -104,24 +118,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
 
     @Override
     public <T> T run(Function<? super BuildTreeLifecycleController, T> buildAction) {
-        ServiceRegistry services = buildLifecycleController.getGradle().getServices();
-        IncludedBuildControllers controllers = services.get(IncludedBuildControllers.class);
-        ExceptionAnalyser exceptionAnalyser = services.get(ExceptionAnalyser.class);
-        BuildModelParameters modelParameters = services.get(BuildModelParameters.class);
-        BuildTreeWorkPreparer workPreparer = new DefaultBuildTreeWorkPreparer(buildLifecycleController, controllers);
-        BuildTreeWorkExecutor workExecutor = new DefaultBuildTreeWorkExecutor(controllers, buildLifecycleController);
-        BuildTreeModelCreator modelCreator = new DefaultBuildTreeModelCreator(buildLifecycleController);
-
-        // On completion of the action, finish only this build and do not finish any other builds
-        // When the build model is required, then do not finish anything on completion of the action
-        BuildTreeFinishExecutor finishExecutor;
-        if (modelParameters.isRequiresBuildModel()) {
-            finishExecutor = new DoNothingBuildFinishExecutor();
-        } else {
-            finishExecutor = new FinishThisBuildOnlyFinishExecutor(exceptionAnalyser);
-        }
-        DefaultBuildTreeLifecycleController buildController = new DefaultBuildTreeLifecycleController(buildLifecycleController, workPreparer, workExecutor, modelCreator, finishExecutor, exceptionAnalyser);
-        return buildAction.apply(buildController);
+        return buildAction.apply(buildTreeLifecycleController);
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -37,11 +37,15 @@ import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.buildtree.BuildOperationFiringBuildTreeWorkExecutor;
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
+import org.gradle.internal.buildtree.BuildTreeModelCreator;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor;
+import org.gradle.internal.buildtree.BuildTreeWorkPreparer;
 import org.gradle.internal.buildtree.DefaultBuildTreeFinishExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController;
+import org.gradle.internal.buildtree.DefaultBuildTreeModelCreator;
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
+import org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer;
 import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.composite.IncludedRootBuild;
 import org.gradle.internal.concurrent.Stoppable;
@@ -74,9 +78,11 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
         ExceptionAnalyser exceptionAnalyser = buildScopeServices.get(ExceptionAnalyser.class);
         BuildOperationExecutor buildOperationExecutor = buildScopeServices.get(BuildOperationExecutor.class);
         BuildStateRegistry buildStateRegistry = buildScopeServices.get(BuildStateRegistry.class);
+        BuildTreeWorkPreparer workPreparer = new DefaultBuildTreeWorkPreparer(buildLifecycleController, controllers);
         BuildTreeWorkExecutor workExecutor = new BuildOperationFiringBuildTreeWorkExecutor(new DefaultBuildTreeWorkExecutor(controllers, buildLifecycleController), buildOperationExecutor);
+        BuildTreeModelCreator modelCreator = new DefaultBuildTreeModelCreator(buildLifecycleController);
         BuildTreeFinishExecutor finishExecutor = new DefaultBuildTreeFinishExecutor(controllers, buildStateRegistry, exceptionAnalyser, buildLifecycleController);
-        this.buildController = new DefaultBuildTreeLifecycleController(buildLifecycleController, controllers, workExecutor, finishExecutor, exceptionAnalyser);
+        this.buildController = new DefaultBuildTreeLifecycleController(buildLifecycleController, workPreparer, workExecutor, modelCreator, finishExecutor, exceptionAnalyser);
     }
 
     @Override

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -33,7 +33,6 @@ import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.service.DefaultServiceRegistry
 import spock.lang.Specification
 
-import java.util.function.Consumer
 import java.util.function.Function
 
 class DefaultRootBuildStateTest extends Specification {
@@ -59,6 +58,8 @@ class DefaultRootBuildStateTest extends Specification {
         sessionServices.add(exceptionAnalyzer)
         sessionServices.add(Stub(DefaultDeploymentRegistry))
         sessionServices.add(Stub(BuildStateRegistry))
+        sessionServices.add(new TestBuildTreeLifecycleControllerFactory())
+
         _ * launcher.gradle >> gradle
         _ * gradle.services >> sessionServices
         _ * buildTree.services >> sessionServices
@@ -165,21 +166,6 @@ class DefaultRootBuildStateTest extends Specification {
         0 * lifecycleListener._
     }
 
-    def "cannot request configuration after build has been run"() {
-        given:
-        action.apply(!null) >> { BuildTreeLifecycleController controller ->
-            controller.scheduleAndRunTasks()
-            controller.fromBuildModel(false) { '<result>' }
-        }
-
-        when:
-        build.run(action)
-
-        then:
-        IllegalStateException e = thrown()
-        e.message == 'Cannot run more than one action for this build.'
-    }
-
     def "forwards action failure and cleans up"() {
         def failure = new RuntimeException()
 
@@ -218,11 +204,11 @@ class DefaultRootBuildStateTest extends Specification {
 
         and:
         1 * launcher.executeTasks() >> { throw failure }
-        2 * exceptionAnalyzer.transform(_) >> { ex ->
+        1 * exceptionAnalyzer.transform(_) >> { ex ->
             assert ex[0] == [failure]
             return transformedFailure
         }
-        1 * launcher.finishBuild(transformedFailure, _)
+        1 * launcher.finishBuild(transformedFailure, _) >> { throw transformedFailure }
 
         and:
         1 * lifecycleListener.beforeComplete()
@@ -250,76 +236,13 @@ class DefaultRootBuildStateTest extends Specification {
 
         and:
         1 * launcher.getConfiguredBuild() >> { throw failure }
-        2 * exceptionAnalyzer.transform(_) >> { ex ->
+        1 * exceptionAnalyzer.transform(_) >> { ex ->
             assert ex[0] == [failure]
             return transformedFailure
         }
-        1 * launcher.finishBuild(transformedFailure, _)
+        1 * launcher.finishBuild(transformedFailure, _) >> { throw transformedFailure }
 
         and:
-        1 * lifecycleListener.beforeComplete()
-        0 * lifecycleListener._
-    }
-
-    def "collects and transforms build execution and finish failures"() {
-        def failure1 = new RuntimeException()
-        def failure2 = new RuntimeException()
-        def failure3 = new RuntimeException()
-        def transformedFailure = new RuntimeException()
-        def finalFailure = new RuntimeException()
-
-        when:
-        build.run(action)
-
-        then:
-        RuntimeException e = thrown()
-        e == finalFailure
-
-        and:
-        1 * action.apply(!null) >> { BuildTreeLifecycleController controller ->
-            controller.scheduleAndRunTasks()
-        }
-
-        and:
-        1 * lifecycleListener.afterStart()
-
-        and:
-        1 * launcher.executeTasks() >> { throw failure1 }
-        1 * includedBuildControllers.awaitTaskCompletion(_) >> { Consumer consumer -> consumer.accept(failure2) }
-        1 * exceptionAnalyzer.transform(_) >> { ex ->
-            assert ex[0] == [failure1, failure2]
-            return transformedFailure
-        }
-        1 * launcher.finishBuild(transformedFailure, _) >> { Throwable throwable, Consumer consumer -> consumer.accept(failure3) }
-        1 * exceptionAnalyzer.transform(_) >> { ex ->
-            assert ex[0] == [failure1, failure2, failure3]
-            return finalFailure
-        }
-
-        and:
-        1 * lifecycleListener.beforeComplete()
-        0 * lifecycleListener._
-    }
-
-    def "cannot run after configuration failure"() {
-        when:
-        build.run(action)
-
-        then:
-        IllegalStateException e = thrown()
-        e.message == 'Cannot run more than one action for this build.'
-
-        and:
-        1 * lifecycleListener.afterStart()
-        1 * launcher.configuredBuild >> { throw new RuntimeException() }
-        1 * action.apply(!null) >> { BuildTreeLifecycleController controller ->
-            try {
-                controller.fromBuildModel(false) { '<result>' }
-            } catch (RuntimeException) {
-                // Ignore
-            }
-            controller.scheduleAndRunTasks()
-        }
         1 * lifecycleListener.beforeComplete()
         0 * lifecycleListener._
     }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.SettingsInternal
+import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.buildtree.BuildTreeFinishExecutor
+import org.gradle.internal.buildtree.BuildTreeLifecycleController
+import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
+import org.gradle.internal.buildtree.BuildTreeWorkExecutor
+
+import java.util.function.Function
+
+class TestBuildTreeLifecycleControllerFactory implements BuildTreeLifecycleControllerFactory {
+    @Override
+    BuildTreeLifecycleController createController(BuildLifecycleController targetBuild, BuildTreeWorkExecutor workExecutor, BuildTreeFinishExecutor finishExecutor) {
+        return new TestBuildTreeLifecycleController(targetBuild, workExecutor, finishExecutor)
+    }
+
+    class TestBuildTreeLifecycleController implements BuildTreeLifecycleController {
+        private final BuildTreeFinishExecutor buildTreeFinishExecutor
+        private final BuildLifecycleController targetBuild
+        private final BuildTreeWorkExecutor workExecutor
+
+        TestBuildTreeLifecycleController(BuildLifecycleController targetBuild, BuildTreeWorkExecutor workExecutor, BuildTreeFinishExecutor buildTreeFinishExecutor) {
+            this.workExecutor = workExecutor
+            this.targetBuild = targetBuild
+            this.buildTreeFinishExecutor = buildTreeFinishExecutor
+        }
+
+        @Override
+        GradleInternal getGradle() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        def <T> T withEmptyBuild(Function<? super SettingsInternal, T> action) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void scheduleAndRunTasks() {
+            targetBuild.scheduleRequestedTasks()
+            def failures = []
+            workExecutor.execute({ failures.add(it) })
+            buildTreeFinishExecutor.finishBuildTree(failures, { throw it })
+        }
+
+        @Override
+        <T> T fromBuildModel(boolean runTasks, Function<? super GradleInternal, T> action) {
+            def failures = []
+            T result = null
+            try {
+                result = action.apply(targetBuild.configuredBuild)
+            } catch (Throwable t) {
+                failures.add(t)
+            }
+            buildTreeFinishExecutor.finishBuildTree(failures, { throw it })
+            return result
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
+
+
+@ServiceScope(Scopes.BuildTree::class)
+interface BuildTreeConfigurationCache {
+    /**
+     * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
+     * writes the result to cache.
+     */
+    fun loadOrScheduledRequestedTasks(scheduler: () -> Unit)
+
+    /**
+     * Loads the cached model, if available, or else runs the given function to create it and then writes the result to cache.
+     */
+    fun <T> loadOrCreateModel(creator: () -> T): T
+
+    // This is a temporary property to allow migration from a root build scoped cache to a build tree scoped cache
+    val isLoaded: Boolean
+
+    // This is a temporary method to allow migration from a root build scoped cache to a build tree scoped cache
+    fun attachRootBuild(host: DefaultConfigurationCache.Host)
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeModelCreator.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeModelCreator.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.internal.buildtree.BuildTreeModelCreator
+import java.util.function.Function
+
+
+class ConfigurationCacheAwareBuildTreeModelCreator(
+    private val delegate: BuildTreeModelCreator,
+    private val cache: BuildTreeConfigurationCache
+) : BuildTreeModelCreator {
+    override fun <T : Any> fromBuildModel(action: Function<in GradleInternal, T>): T {
+        return cache.loadOrCreateModel {
+            delegate.fromBuildModel(action)
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkPreparer.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkPreparer.kt
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.configurationcache
 
-import org.gradle.internal.service.scopes.Scopes
-import org.gradle.internal.service.scopes.ServiceScope
+import org.gradle.internal.buildtree.BuildTreeWorkPreparer
 
 
-@ServiceScope(Scopes.Gradle::class)
-interface ConfigurationCache {
-    fun canLoad(): Boolean
-    fun load()
-    fun prepareForConfiguration()
-    fun save()
+class ConfigurationCacheAwareBuildTreeWorkPreparer(
+    private val delegate: BuildTreeWorkPreparer,
+    private val cache: BuildTreeConfigurationCache
+) : BuildTreeWorkPreparer {
+    override fun scheduleRequestedTasks() {
+        cache.loadOrScheduledRequestedTasks {
+            delegate.scheduleRequestedTasks()
+        }
+    }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -32,11 +32,14 @@ import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.file.FileAccessTimeJournal
 import org.gradle.internal.file.impl.SingleDepthFileAccessTracker
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 
 
+@ServiceScope(Scopes.BuildTree::class)
 internal
 class ConfigurationCacheRepository(
     cacheRepository: CacheRepository,

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -71,6 +71,8 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheClassLoaderScopeRegistryListener::class.java)
             add(DefaultConfigurationCacheProblemsListener::class.java)
             add(DefaultBuildTreeLifecycleControllerFactory::class.java)
+            add(ConfigurationCacheRepository::class.java)
+            add(DefaultConfigurationCache::class.java)
         }
     }
 
@@ -87,22 +89,24 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
 
     override fun registerGradleServices(registration: ServiceRegistration) {
         registration.run {
-            add(ConfigurationCacheRepository::class.java)
             add(ConfigurationCacheHost::class.java)
             add(ConfigurationCacheIO::class.java)
-            add(DefaultConfigurationCache::class.java)
         }
     }
 
     class BuildScopeServicesProvider {
-        fun createBuildModelController(build: BuildState, gradle: GradleInternal, startParameter: ConfigurationCacheStartParameter): BuildModelController {
+        fun createBuildModelController(
+            build: BuildState,
+            gradle: GradleInternal,
+            startParameter: ConfigurationCacheStartParameter,
+            configurationCache: BuildTreeConfigurationCache
+        ): BuildModelController {
             if (build is ConfigurationCacheIncludedBuildState) {
                 return NoOpBuildModelController(gradle)
             }
             val projectsPreparer: ProjectsPreparer = gradle.services.get()
             val settingsPreparer: SettingsPreparer = gradle.services.get()
             val taskExecutionPreparer: TaskExecutionPreparer = gradle.services.get()
-            val configurationCache: ConfigurationCache = gradle.services.get()
             val vintageController = VintageBuildModelController(gradle, projectsPreparer, settingsPreparer, taskExecutionPreparer)
             return if (startParameter.isEnabled) {
                 ConfigurationCacheAwareBuildModelController(gradle, vintageController, configurationCache)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheServices.kt
@@ -70,6 +70,7 @@ class ConfigurationCacheServices : AbstractPluginServiceRegistry() {
             add(ConfigurationCacheProblems::class.java)
             add(ConfigurationCacheClassLoaderScopeRegistryListener::class.java)
             add(DefaultConfigurationCacheProblemsListener::class.java)
+            add(DefaultBuildTreeLifecycleControllerFactory::class.java)
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.composite.internal.IncludedBuildControllers
+import org.gradle.initialization.exception.ExceptionAnalyser
+import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.buildtree.BuildTreeFinishExecutor
+import org.gradle.internal.buildtree.BuildTreeLifecycleController
+import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
+import org.gradle.internal.buildtree.BuildTreeModelCreator
+import org.gradle.internal.buildtree.BuildTreeWorkExecutor
+import org.gradle.internal.buildtree.BuildTreeWorkPreparer
+import org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController
+import org.gradle.internal.buildtree.DefaultBuildTreeModelCreator
+import org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer
+
+
+class DefaultBuildTreeLifecycleControllerFactory(
+    private val controllers: IncludedBuildControllers,
+    private val exceptionAnalyser: ExceptionAnalyser
+) : BuildTreeLifecycleControllerFactory {
+    override fun createController(targetBuild: BuildLifecycleController, workExecutor: BuildTreeWorkExecutor, finishExecutor: BuildTreeFinishExecutor): BuildTreeLifecycleController {
+        val workPreparer: BuildTreeWorkPreparer = DefaultBuildTreeWorkPreparer(targetBuild, controllers)
+        val modelCreator: BuildTreeModelCreator = DefaultBuildTreeModelCreator(targetBuild)
+        return DefaultBuildTreeLifecycleController(targetBuild, workPreparer, workExecutor, modelCreator, finishExecutor, exceptionAnalyser)
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -25,7 +25,6 @@ import org.gradle.configurationcache.ConfigurationCacheRepository.CheckedFingerp
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.fingerprint.InvalidationReason
-import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.serialization.DefaultWriteContext
@@ -44,23 +43,21 @@ import java.io.OutputStream
 
 
 class DefaultConfigurationCache internal constructor(
-    private val host: Host,
     private val startParameter: ConfigurationCacheStartParameter,
-    private val buildEnablement: ConfigurationCacheBuildEnablement,
     private val cacheKey: ConfigurationCacheKey,
     private val problems: ConfigurationCacheProblems,
-    private val systemPropertyListener: SystemPropertyAccessListener,
     private val scopeRegistryListener: ConfigurationCacheClassLoaderScopeRegistryListener,
-    private val cacheIO: ConfigurationCacheIO,
-    private val gradlePropertiesController: GradlePropertiesController,
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
     private val buildActionModelRequirements: BuildActionModelRequirements,
+    private val projectStateRegistry: ProjectStateRegistry,
+    private val virtualFileSystem: BuildLifecycleAwareVirtualFileSystem,
+    private val buildOperationExecutor: BuildOperationExecutor,
     /**
      * Force the [FileSystemAccess] service to be initialized as it initializes important static state.
      */
     @Suppress("unused")
     private val fileSystemAccess: FileSystemAccess
-) : ConfigurationCache {
+) : BuildTreeConfigurationCache {
 
     interface Host {
 
@@ -73,8 +70,66 @@ class DefaultConfigurationCache internal constructor(
         fun <T> factory(serviceType: Class<T>): Factory<T>
     }
 
-    override fun canLoad(): Boolean = when {
-        !isConfigurationCacheEnabled -> {
+    private
+    val canLoad by lazy { canLoad() }
+    private
+    var rootBuild: Host? = null
+
+    private
+    val host: Host
+        get() = rootBuild!!
+
+    private
+    val cacheRepository: ConfigurationCacheRepository
+        get() = host.service()
+
+    private
+    val cacheIO: ConfigurationCacheIO
+        get() = host.service()
+
+    private
+    val gradlePropertiesController: GradlePropertiesController
+        get() = host.service()
+
+    private
+    val cacheFingerprintController: ConfigurationCacheFingerprintController
+        get() = host.service()
+
+    private
+    val systemPropertyListener: SystemPropertyAccessListener
+        get() = host.service()
+
+    override val isLoaded: Boolean
+        get() = canLoad
+
+    override fun attachRootBuild(host: Host) {
+        require(rootBuild == null)
+        rootBuild = host
+    }
+
+    override fun loadOrScheduledRequestedTasks(scheduler: () -> Unit) {
+        if (canLoad) {
+            load()
+            // This is required to signal that the task graphs are ready for execution. It should not actually end up scheduling any further tasks
+            // TODO - It would be better to have the load() method signal this instead
+            scheduler()
+        } else {
+            prepareForConfiguration()
+            scheduler()
+            save()
+        }
+    }
+
+    override fun <T> loadOrCreateModel(creator: () -> T): T {
+        if (canLoad) {
+            // Just do the check for now
+        }
+        return creator()
+    }
+
+    private
+    fun canLoad(): Boolean = when {
+        !startParameter.isEnabled -> {
             false
         }
         startParameter.recreateCache -> {
@@ -139,19 +194,15 @@ class DefaultConfigurationCache internal constructor(
         )
     }
 
-    override fun prepareForConfiguration() {
-
-        if (!isConfigurationCacheEnabled) return
-
+    private
+    fun prepareForConfiguration() {
         prepareConfigurationTimeBarrier()
         startCollectingCacheFingerprint()
         Instrumented.setListener(systemPropertyListener)
     }
 
-    override fun save() {
-
-        if (!isConfigurationCacheEnabled) return
-
+    private
+    fun save() {
         crossConfigurationTimeBarrier()
 
         // TODO - fingerprint should be collected until the state file has been written, as user code can run during this process
@@ -180,10 +231,8 @@ class DefaultConfigurationCache internal constructor(
         }
     }
 
-    override fun load() {
-
-        require(isConfigurationCacheEnabled)
-
+    private
+    fun load() {
         prepareConfigurationTimeBarrier()
         problems.loading()
 
@@ -222,7 +271,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     fun writeConfigurationCacheState(stateFile: ConfigurationCacheStateFile): Set<File> =
-        service<ProjectStateRegistry>().withMutableStateOfAllProjects(
+        projectStateRegistry.withMutableStateOfAllProjects(
             Factory { cacheIO.writeRootBuildStateTo(stateFile) }
         )
 
@@ -283,20 +332,10 @@ class DefaultConfigurationCache internal constructor(
         }
 
     private
-    val cacheFingerprintController: ConfigurationCacheFingerprintController by lazy {
-        service()
-    }
-
-    private
-    val cacheRepository: ConfigurationCacheRepository by lazy {
-        service()
-    }
-
-    private
     fun registerWatchableBuildDirectories(buildDirs: Set<File>) {
         if (buildDirs.isNotEmpty()) {
             buildDirs.forEach(
-                service<BuildLifecycleAwareVirtualFileSystem>()::registerWatchableHierarchy
+                virtualFileSystem::registerWatchableHierarchy
             )
         }
     }
@@ -322,18 +361,6 @@ class DefaultConfigurationCache internal constructor(
     fun log(message: String, vararg args: Any?) {
         logger.log(configurationCacheLogLevel, message, *args)
     }
-
-    private
-    val buildOperationExecutor: BuildOperationExecutor
-        get() = service()
-
-    private
-    inline fun <reified T> service() =
-        host.service<T>()
-
-    private
-    val isConfigurationCacheEnabled: Boolean
-        get() = buildEnablement.isEnabledForCurrentBuild
 
     private
     val configurationCacheLogLevel: LogLevel

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheBuildEnablement.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheBuildEnablement.kt
@@ -25,10 +25,6 @@ class ConfigurationCacheBuildEnablement(
     private val buildPath: PublicBuildPath,
     private val startParameter: ConfigurationCacheStartParameter
 ) {
-    val isEnabledForCurrentBuild by lazy {
-        startParameter.isEnabled && buildPath.buildPath == Path.ROOT
-    }
-
     val isProblemListenerEnabledForCurrentBuild by lazy {
         startParameter.isEnabled && BUILD_SRC != buildPath.buildPath.lastSegment()
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildActionTarget.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildActionTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,16 @@
 
 package org.gradle.internal.build;
 
+import org.gradle.internal.buildtree.BuildTreeLifecycleController;
+
+import java.util.function.Function;
+
 /**
- * A stand alone nested build, which is a nested build that runs as part of some containing build as a single atomic step, without participating in task execution of the containing build.
+ * A build which can be the target of a build action.
  */
-public interface StandAloneNestedBuild extends NestedBuildState, BuildActionTarget {
+public interface BuildActionTarget extends BuildState {
+    /**
+     * Runs a single invocation of this build, executing the given action and returning the result. Should be called once only for a given build instance.
+     */
+    <T> T run(Function<? super BuildTreeLifecycleController, T> buildAction);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -117,6 +117,9 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
     @Override
     public void executeTasks() {
         withModel(buildModelController -> {
+            if (state != State.TaskGraph) {
+                throw new IllegalStateException("Cannot execute tasks as none have been scheduled for this build yet.");
+            }
             runWork();
             return null;
         });

--- a/subprojects/core/src/main/java/org/gradle/internal/build/RootBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/RootBuildState.java
@@ -17,21 +17,13 @@
 package org.gradle.internal.build;
 
 import org.gradle.api.internal.StartParameterInternal;
-import org.gradle.internal.buildtree.BuildTreeLifecycleController;
-
-import java.util.function.Function;
 
 /**
  * Represents the root build of a build tree.
  */
-public interface RootBuildState extends CompositeBuildParticipantBuildState {
+public interface RootBuildState extends CompositeBuildParticipantBuildState, BuildActionTarget {
     /**
      * Returns the start parameter used to define this build.
      */
     StartParameterInternal getStartParameter();
-
-    /**
-     * Runs a single invocation of this build, executing the given action and returning the result. Should be called once only for a given build instance.
-     */
-    <T> T run(Function<? super BuildTreeLifecycleController, T> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.SettingsInternal;
 import java.util.function.Function;
 
 /**
- * Controls the lifecycle of the build tree, allowing a single action to be run against the root build.
+ * Controls the lifecycle of the build tree, allowing a single action to be run against the build tree.
  */
 public interface BuildTreeLifecycleController {
 
@@ -40,6 +40,8 @@ public interface BuildTreeLifecycleController {
     /**
      * Creates the task graph for the tasks specified in the {@link org.gradle.StartParameter} associated with the build, runs the tasks and finishes up the build.
      * When this method returns, all user code will have completed, including 'build finished' hooks.
+     *
+     * <p>This method may or may nor configure the build. When a cached task graph is available, this may be used instead of configuring the build.
      */
     void scheduleAndRunTasks();
 
@@ -47,7 +49,7 @@ public interface BuildTreeLifecycleController {
      * Configures the build, optionally schedules and runs any tasks, calls the given action and finally finishes up the build.
      * When this method returns, all user code will have completed, including 'build finished' hooks.
      *
-     * Does not call the given action if execution fails.
+     * Does not call the given action when task execution fails.
      */
     <T> T fromBuildModel(boolean runTasks, Function<? super GradleInternal, T> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleControllerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleControllerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.build;
+package org.gradle.internal.buildtree;
 
-/**
- * A stand alone nested build, which is a nested build that runs as part of some containing build as a single atomic step, without participating in task execution of the containing build.
- */
-public interface StandAloneNestedBuild extends NestedBuildState, BuildActionTarget {
+import org.gradle.internal.build.BuildLifecycleController;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+@ServiceScope(Scopes.BuildTree.class)
+public interface BuildTreeLifecycleControllerFactory {
+    BuildTreeLifecycleController createController(BuildLifecycleController targetBuild, BuildTreeWorkExecutor workExecutor, BuildTreeFinishExecutor finishExecutor);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelControllerServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelControllerServices.java
@@ -28,9 +28,9 @@ public interface BuildTreeModelControllerServices {
      *
      * <p>Contributes the following services:</p>
      * <ul>
-     *     <li>{@link org.gradle.api.internal.BuildType}</li>.
-     *     <li>{@link BuildModelParameters}</li>.
-     *     <li>{@link BuildActionModelRequirements}</li>.
+     *     <li>{@link org.gradle.api.internal.BuildType}</li>
+     *     <li>{@link BuildModelParameters}</li>
+     *     <li>{@link BuildActionModelRequirements}</li>
      * <ul>
      */
     Supplier servicesForBuildTree(BuildActionModelRequirements actionModelRequirements);

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeModelCreator.java
@@ -16,11 +16,13 @@
 
 package org.gradle.internal.buildtree;
 
-import java.util.function.Consumer;
+import org.gradle.api.internal.GradleInternal;
+
+import java.util.function.Function;
 
 /**
- * Responsible for running all scheduled work for the build tree.
+ * Responsible for creating a model from the build tree model.
  */
-public interface BuildTreeWorkExecutor {
-    void execute(Consumer<? super Throwable> consumer);
+public interface BuildTreeModelCreator {
+    <T> T fromBuildModel(Function<? super GradleInternal, T> action);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeWorkPreparer.java
@@ -16,11 +16,12 @@
 
 package org.gradle.internal.buildtree;
 
-import java.util.function.Consumer;
-
 /**
- * Responsible for running all scheduled work for the build tree.
+ * Responsible for preparing the work graph for the build tree.
  */
-public interface BuildTreeWorkExecutor {
-    void execute(Consumer<? super Throwable> consumer);
+public interface BuildTreeWorkPreparer {
+    /**
+     * Prepares the work graph for execution. May configure the build and calculate the task graph, or may load a cached task graph if available.
+     */
+    void scheduleRequestedTasks();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeModelCreator.java
@@ -16,11 +16,21 @@
 
 package org.gradle.internal.buildtree;
 
-import java.util.function.Consumer;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.build.BuildLifecycleController;
 
-/**
- * Responsible for running all scheduled work for the build tree.
- */
-public interface BuildTreeWorkExecutor {
-    void execute(Consumer<? super Throwable> consumer);
+import java.util.function.Function;
+
+public class DefaultBuildTreeModelCreator implements BuildTreeModelCreator {
+    private final BuildLifecycleController buildController;
+
+    public DefaultBuildTreeModelCreator(BuildLifecycleController buildLifecycleController) {
+        this.buildController = buildLifecycleController;
+    }
+
+    @Override
+    public <T> T fromBuildModel(Function<? super GradleInternal, T> action) {
+        buildController.getConfiguredBuild();
+        return action.apply(buildController.getGradle());
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/DefaultBuildTreeWorkPreparer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import org.gradle.composite.internal.IncludedBuildControllers;
+import org.gradle.internal.build.BuildLifecycleController;
+
+public class DefaultBuildTreeWorkPreparer implements BuildTreeWorkPreparer {
+    private final BuildLifecycleController buildController;
+    private final IncludedBuildControllers includedBuildControllers;
+
+    public DefaultBuildTreeWorkPreparer(BuildLifecycleController buildLifecycleController, IncludedBuildControllers includedBuildControllers) {
+        this.buildController = buildLifecycleController;
+        this.includedBuildControllers = includedBuildControllers;
+    }
+
+    @Override
+    public void scheduleRequestedTasks() {
+        buildController.scheduleRequestedTasks();
+        includedBuildControllers.populateTaskGraphs();
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
@@ -181,20 +181,26 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         0 * consumer._
     }
 
-    void testExecuteTasksDoesNotImplicitlyConfigureBuildOrScheduleTasks() {
-        when:
+    void testCannotExecuteTasksWhenNothingHasBeenScheduled() {
+        given:
         isRootBuild()
-        expectTasksRun()
 
-        then:
+        when:
         def controller = controller()
         controller.executeTasks()
+
+        then:
+        def t = thrown RuntimeException
+        t == transformedException
+
+        and:
+        1 * exceptionAnalyser.transform({ it instanceof IllegalStateException }) >> transformedException
 
         when:
         controller.finishBuild(null, consumer)
 
         then:
-        1 * buildBroadcaster.buildFinished({ it.failure == null })
+        1 * buildBroadcaster.buildFinished({ it.failure == transformedException })
         0 * consumer._
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -49,9 +49,12 @@ public class BuildModelActionRunner implements BuildActionRunner {
         try {
             if (buildModelAction.isCreateModel()) {
                 gradle.addBuildListener(new ForceFullConfigurationListener());
+                Object result = buildController.fromBuildModel(buildModelAction.isRunTasks(), createAction);
+                return Result.of(result);
+            } else {
+                buildController.scheduleAndRunTasks();
+                return Result.of(null);
             }
-            Object result = buildController.fromBuildModel(buildModelAction.isRunTasks(), createAction);
-            return Result.of(result);
         } catch (RuntimeException e) {
             RuntimeException clientFailure = e;
             if (createAction.modelLookupFailure != null) {


### PR DESCRIPTION

### Context

Some refactors to later allow tooling models to be stored in the configuration cache. This PR doesn't actually cache tooling models, but removes some assumptions that a task graph will be cached.

Also some initial changes to move the configuration cache implementation up to tree scope rather than its current "root build" scope (build scoped services that only do their thing when the current build is the root build, and that reach across build boundaries to mess with other builds).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
