### PR TITLE
Remove commented-out sample for jacoco aggregation of all Test tasks

### DIFF
--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -55,9 +55,4 @@ configurations.create('coverageDataElements') {
     outgoing.artifact(tasks.named("test").map { task ->
         task.extensions.getByType(JacocoTaskExtension).destinationFile
     })
-
-    // Request coverage data from all test tasks (note: this realizes all Test tasks)
-    // outgoing.artifact(tasks.withType(Test).map { task ->
-    //     task.extensions.getByType(JacocoTaskExtension).destinationFile
-    // })
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -55,9 +55,4 @@ configurations.create("coverageDataElements") {
     outgoing.artifact(tasks.test.map { task ->
         task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
     })
-
-    // Request coverage data from all test tasks (note: this realizes all Test tasks)
-    // outgoing.artifact(tasks.withType<Test>().map { task ->
-    //     task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
-    // })
 }


### PR DESCRIPTION
The commented out code that is shown in the sample is not correct. tasks.withType(Test) will not realize all the test tasks, but rather iterate over an empty list and yield nothing in this case if the tasks have not yet been configured. An alternative would be to wrap this code in afterEvaluate {}.
