### PR TITLE
Fix detection of test source sets in IDEA

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.test-fixtures.gradle.kts
@@ -96,8 +96,10 @@ javaComponent.withVariantsFromConfiguration(testFixturesApiElements) {
 plugins.withType<IdeaPlugin> {
     configure<IdeaModel> {
         module {
-            testSourceDirs = testSourceDirs + sourceSets.testFixtures.get().groovy.srcDirs
-            testResourceDirs = testResourceDirs + sourceSets.testFixtures.get().resources.srcDirs
+            val testFixtures = sourceSets.testFixtures.get()
+            testSourceDirs = testSourceDirs + testFixtures.java.srcDirs
+            testSourceDirs = testSourceDirs + testFixtures.groovy.srcDirs
+            testResourceDirs = testResourceDirs + testFixtures.resources.srcDirs
         }
     }
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -27,6 +27,7 @@ import java.util.jar.Attributes
 
 plugins {
     groovy
+    idea // Need to apply the idea plugin, so the extended configuration is taken into account on sync
     id("gradlebuild.module-identity")
     id("gradlebuild.dependency-modules")
     id("org.gradle.test-retry")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -258,6 +258,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         plugins.withType<IdeaPlugin> {
             configure<IdeaModel> {
                 module {
+                    testSourceDirs = testSourceDirs + performanceTestSourceSet.java.srcDirs
                     testSourceDirs = testSourceDirs + performanceTestSourceSet.groovy.srcDirs
                     testResourceDirs = testResourceDirs + performanceTestSourceSet.resources.srcDirs
                 }


### PR DESCRIPTION
The test source sets (testFixtures/integTest/etc.) have not been marked as such in idea, because:
- The idea plugin hasn't been applied to the sub-projects,  which caused the configuration not to run
- For testFixtures, we didn't mark the java sources  as test sources, though it seems that is what  idea relies on.