### PR TITLE
Enable debug output in WatchedDirectoriesFileSystemWatchingIntegrationTest

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -372,7 +372,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         file("input.txt").text = "input"
 
         when:
-        run "myTask", "--info"
+        run "myTask", "--debug"
         then:
         assertWatchedHierarchies([testDirectory])
         result.assertNotPostBuildOutput("Some of the file system contents retained in the virtual file system are on file systems that Gradle doesn't support watching.")


### PR DESCRIPTION
so we see the file systems which we do not support for watching in the test output.