### PR TITLE
Fix constant analysis for package-info and module-info

### DIFF
--- a/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/AbstractCompilerPluginTest.groovy
+++ b/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/AbstractCompilerPluginTest.groovy
@@ -62,4 +62,13 @@ class AbstractCompilerPluginTest extends Specification {
         return [f]
     }
 
+    List<File> toModuleSourceFile(String body) {
+        def className = "module-info"
+        File parent = Paths.get(sourceFolder.absolutePath, "src", "main", "java").toFile()
+        File f = Paths.get(parent.absolutePath, "${className}.java").toFile()
+        parent.mkdirs()
+        f.text = body
+        return [f]
+    }
+
 }

--- a/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/listeners/ConstantsCollectorTest.groovy
+++ b/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/listeners/ConstantsCollectorTest.groovy
@@ -42,11 +42,12 @@ class ConstantsCollectorTest extends AbstractCompilerPluginTest {
         )
     }
 
-    def "should always return self as a private constant origin class"() {
+    def "should not return self as a constant origin class"() {
         given:
         String clazz = """
 class A {
     public static final int CONSTANT = 1;
+    public static final int CONSTANT2 = A.CONSTANT;
 
     @Annotation(A.CONSTANT)
     public final int field = A.CONSTANT;
@@ -57,7 +58,7 @@ class A {
         compiler.compile(toSourceFile(clazz) + getAnnotation("int"))
 
         then:
-        privateDependentToConstants["A"] == ["A"] as Set
+        privateDependentToConstants["A"] == null
         accessibleDependentToConstants["A"] == null
     }
 
@@ -79,7 +80,7 @@ class A<@Annotation(Constant2.CONSTANT2 $addition) T> {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant4", "Constant5", "Constant6"] as Set
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant4", "Constant5", "Constant6"] as Set
         accessibleDependentToConstants.isEmpty()
 
         where:
@@ -115,7 +116,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant5", "Constant6", "Constant7"] as Set
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant5", "Constant6", "Constant7"] as Set
         accessibleDependentToConstants["A"] == ["Constant4"] as Set
 
         where:
@@ -148,7 +149,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant4", "Constant5", "Constant6", "Constant7"] as Set
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant4", "Constant5", "Constant6", "Constant7"] as Set
         accessibleDependentToConstants.isEmpty()
 
         where:
@@ -181,7 +182,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant4"] as Set
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant4"] as Set
 
         where:
         constantType | constantValue | addition
@@ -223,7 +224,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant4", "Constant5",
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant4", "Constant5",
                                              "Constant6", "Constant7", "Constant8", "Constant9", "Constant10"] as Set
         accessibleDependentToConstants.isEmpty()
 
@@ -279,7 +280,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "gradle.unit.test.Constant1", "gradle.unit.test.Constant2",
+        privateDependentToConstants["A"] == ["gradle.unit.test.Constant1", "gradle.unit.test.Constant2",
                                              "gradle.unit.test.Constant3", "gradle.unit.test.Constant4", "gradle.unit.test.Constant5",
                                              "gradle.unit.test.Constant6", "gradle.unit.test.Constant7", "gradle.unit.test.Constant8",
                                              "gradle.unit.test.Constant9", "gradle.unit.test.Constant10"] as Set
@@ -313,7 +314,7 @@ public @interface A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1", "Constant2", "Constant3", "Constant4"] as Set
+        privateDependentToConstants["A"] == ["Constant1", "Constant2", "Constant3", "Constant4"] as Set
         accessibleDependentToConstants.isEmpty()
 
         where:
@@ -341,7 +342,7 @@ class A {
 
         then:
         accessibleDependentToConstants["A"] == ["Constant1"] as Set
-        privateDependentToConstants["A"] == ["A"] as Set
+        privateDependentToConstants["A"] == null
     }
 
     def "collects constants from private static fields as private dependents"() {
@@ -357,7 +358,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1"] as Set
+        privateDependentToConstants["A"] == ["Constant1"] as Set
         accessibleDependentToConstants.isEmpty()
     }
 
@@ -381,7 +382,7 @@ class A {
         accessibleDependentToConstants["C"] == ["B"] as Set
         accessibleDependentToConstants["D"] == ["C"] as Set
         accessibleDependentToConstants["E"] == null
-        privateDependentToConstants["A"] == ["A"] as Set
+        privateDependentToConstants["A"] == null
     }
 
     def "collect constants from accessible static fields as private dependents when static block is used"() {
@@ -400,7 +401,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1"] as Set
+        privateDependentToConstants["A"] == ["Constant1"] as Set
         accessibleDependentToConstants.isEmpty()
     }
 
@@ -420,7 +421,7 @@ class A {
         compiler.compile(classes)
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1"] as Set
+        privateDependentToConstants["A"] == ["Constant1"] as Set
         accessibleDependentToConstants.isEmpty()
     }
 
@@ -461,11 +462,11 @@ class OuterClass {
         compiler.compile(sourceFiles)
 
         then:
-        privateDependentToConstants["OuterClass\$1"] == ["OuterClass\$1", "Constant1", "OuterClass\$C", "OuterClass\$D"] as Set
-        privateDependentToConstants["OuterClass\$A"] == ["OuterClass\$A", "Constant2", "OuterClass\$C", "OuterClass\$D"] as Set
-        privateDependentToConstants["OuterClass\$B"] == ["OuterClass\$B", "Constant3", "OuterClass\$C", "OuterClass\$D"] as Set
-        privateDependentToConstants["OuterClass\$C"] == ["OuterClass\$C"] as Set
-        privateDependentToConstants["OuterClass\$D"] == ["OuterClass\$D"] as Set
+        privateDependentToConstants["OuterClass\$1"] == ["Constant1", "OuterClass\$C", "OuterClass\$D"] as Set
+        privateDependentToConstants["OuterClass\$A"] == ["Constant2", "OuterClass\$C", "OuterClass\$D"] as Set
+        privateDependentToConstants["OuterClass\$B"] == ["Constant3", "OuterClass\$C", "OuterClass\$D"] as Set
+        privateDependentToConstants["OuterClass\$C"] == null
+        privateDependentToConstants["OuterClass\$D"] == null
         accessibleDependentToConstants.isEmpty()
     }
 
@@ -482,7 +483,7 @@ interface A {
         compiler.compile(toSourceFile(clazz) + getAnnotation("int") + getConstants("int", "1"))
 
         then:
-        privateDependentToConstants["A"] == ["A", "Constant1"] as Set
+        privateDependentToConstants["A"] == ["Constant1"] as Set
         accessibleDependentToConstants["A"] == ["Constant2"] as Set
     }
 
@@ -496,8 +497,8 @@ interface A {
         compiler.compile(toSourceFiles(classes))
 
         then:
-        privateDependentToConstants["A"] == ["A"] as Set
-        privateDependentToConstants["B"] == ["B"] as Set
+        privateDependentToConstants["A"] == null
+        privateDependentToConstants["B"] == null
         accessibleDependentToConstants.isEmpty()
     }
 
@@ -520,10 +521,9 @@ class C {
 
         then:
         accessibleDependentToConstants["C"] == ["A"] as Set
-        privateDependentToConstants["C"] == ["C"] as Set
+        privateDependentToConstants["C"] == null
     }
 
-    @Requires({ javaVersion >= 12 })
     def "collect all constants for package-info class"() {
         String packageDefinition = """
 @PackageInfoAnnotation(Constant.CONSTANT + " world")
@@ -557,8 +557,32 @@ public class Constant {
         compiler.compile(classesSourceFiles + packageSourceFile)
 
         then:
-        privateDependentToConstants["gradle.unit.test"] == ["gradle.unit.test", "gradle.unit.test.Constant"] as Set
-        accessibleDependentToConstants.isEmpty()
+        privateDependentToConstants.isEmpty()
+        accessibleDependentToConstants["gradle.unit.test.package-info"] == ["gradle.unit.test.Constant"] as Set
+    }
+
+    @Requires({ javaVersion >= 9 })
+    def "collect all constants for module-info class"() {
+        String moduleDefinition = """
+    import gradle.unit.test.Constant;
+
+    @SuppressWarnings(Constant.CONSTANT)
+    module module {
+    }
+"""
+        List<String> classes = ["""
+package gradle.unit.test;
+public class Constant {
+    public static final String CONSTANT = "unchecked";
+}
+"""]
+
+        when:
+        compiler.compile(toModuleSourceFile(moduleDefinition) + toSourceFiles(classes))
+
+        then:
+        privateDependentToConstants.isEmpty()
+        accessibleDependentToConstants["module-info"] == ["gradle.unit.test.Constant"] as Set
     }
 
     List<File> getAnnotation(String valueType, String packageName = "") {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaSourceIncrementalCompilationIntegrationTest.groovy
@@ -505,4 +505,63 @@ class JavaSourceIncrementalCompilationIntegrationTest extends BaseJavaSourceIncr
         outputs.recompiledClasses('A', 'B')
     }
 
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "recompiles all when constant used by annotation on module-info is changed"() {
+        given:
+        source("""
+            import java.util.logging.Logger;
+            class Foo {
+                Logger logger;
+            }
+        """)
+        file("src/main/${languageName}/constant/Const.${languageName}").text = "package constant; public class Const { public static final String CONST = \"unchecked\"; }"
+        def moduleInfo = file("src/main/${language.name}/module-info.${language.name}")
+        moduleInfo.text = """
+            import constant.Const;
+
+            @SuppressWarnings(Const.CONST)
+            module foo {
+                requires java.logging;
+            }
+        """
+        outputs.snapshot { succeeds language.compileTaskName }
+
+        when:
+        file("src/main/${languageName}/constant/Const.${languageName}").text = "package constant; public class Const { public static final String CONST = \"raw-types\"; }"
+        succeeds language.compileTaskName
+
+        then:
+        outputs.recompiledClasses('Const', 'Foo', 'module-info')
+    }
+
+    def "recompiles all classes in a package if constant used by annotation on package-info is changed"() {
+        given:
+        file("src/main/${languageName}/annotations/Anno.${languageName}").text = """
+            package annotations;
+            import java.lang.annotation.*;
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target(ElementType.PACKAGE)
+            public @interface Anno {
+                   int value();
+            }
+        """
+        def packageFile = file("src/main/${languageName}/foo/package-info.${languageName}")
+        packageFile.text = """@Deprecated @annotations.Anno(Const.CONST + 1) package foo; import constant.Const;"""
+        file("src/main/${languageName}/foo/A.${languageName}").text = "package foo; class A {}"
+        file("src/main/${languageName}/foo/B.${languageName}").text = "package foo; public class B {}"
+        file("src/main/${languageName}/foo/bar/C.${languageName}").text = "package foo.bar; class C {}"
+        file("src/main/${languageName}/baz/D.${languageName}").text = "package baz; class D {}"
+        file("src/main/${languageName}/baz/E.${languageName}").text = "package baz; import foo.B; class E extends B {}"
+        file("src/main/${languageName}/constant/Const.${languageName}").text = "package constant; public class Const { public static final int CONST = 1; }"
+
+        outputs.snapshot { succeeds language.compileTaskName }
+
+        when:
+        file("src/main/${languageName}/constant/Const.${languageName}").text = "package constant; public class Const { public static final int CONST = 2; }"
+        succeeds language.compileTaskName
+
+        then:
+        outputs.recompiledClasses("A", "B", "E", "Const", "package-info")
+    }
+
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -39,6 +39,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData.MODULE_INFO;
+
+
 /**
  * An extension of {@link ClassSetAnalysisData}, which can also handle annotation processing.
  * All logic for dealing with transitive dependencies is here, since annotation processing can affect it.
@@ -159,10 +162,13 @@ public class ClassSetAnalysis {
         }
         Set<String> classesDependingOnAllOthers = annotationProcessingData.participatesInClassGeneration(className) ? annotationProcessingData.getGeneratedTypesDependingOnAllOthers() : Collections.emptySet();
         Set<GeneratedResource> resourcesDependingOnAllOthers = annotationProcessingData.participatesInResourceGeneration(className) ? annotationProcessingData.getGeneratedResourcesDependingOnAllOthers() : Collections.emptySet();
-        Set<String> accessibleConstantDependents = new ObjectOpenHashSet<>(compilerApiData.getConstantDependentsForClass(className).getAccessibleDependentClasses());
-        Set<String> privateConstantDependents = new ObjectOpenHashSet<>(compilerApiData.getConstantDependentsForClass(className).getPrivateDependentClasses());
-        processTransitiveConstantDependentClasses(new ObjectOpenHashSet<>(Collections.singleton(className)), privateConstantDependents, accessibleConstantDependents);
-        if (!deps.hasDependentClasses() && classesDependingOnAllOthers.isEmpty() && resourcesDependingOnAllOthers.isEmpty() && accessibleConstantDependents.isEmpty() && privateConstantDependents.isEmpty()) {
+
+        DependentsSet constantDeps = getConstantDependents(className);
+        if (constantDeps.isDependencyToAll()) {
+            return constantDeps;
+        }
+
+        if (!deps.hasDependentClasses() && classesDependingOnAllOthers.isEmpty() && resourcesDependingOnAllOthers.isEmpty() && !constantDeps.hasDependentClasses()) {
             return deps;
         }
 
@@ -173,7 +179,7 @@ public class ClassSetAnalysis {
         Set<GeneratedResource> resultResources = new HashSet<>(resourcesDependingOnAllOthers);
         processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, deps.getPrivateDependentClasses(), dependents);
         processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, Collections.emptySet(), classesDependingOnAllOthers);
-        processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, privateConstantDependents, accessibleConstantDependents);
+        processDependentClasses(new HashSet<>(), privateResultClasses, accessibleResultClasses, resultResources, constantDeps.getPrivateDependentClasses(), constantDeps.getAccessibleDependentClasses());
         accessibleResultClasses.remove(className);
         privateResultClasses.remove(className);
 
@@ -259,6 +265,16 @@ public class ClassSetAnalysis {
             Sets.union(dependents.getAccessibleDependentClasses(), annotationProcessingClassDeps),
             Sets.union(dependents.getDependentResources(), annotationProcessingResourceDeps)
         );
+    }
+
+    private DependentsSet getConstantDependents(String className) {
+        Set<String> accessibleConstantDependents = new ObjectOpenHashSet<>(compilerApiData.getConstantDependentsForClass(className).getAccessibleDependentClasses());
+        Set<String> privateConstantDependents = new ObjectOpenHashSet<>(compilerApiData.getConstantDependentsForClass(className).getPrivateDependentClasses());
+        processTransitiveConstantDependentClasses(new ObjectOpenHashSet<>(Collections.singleton(className)), privateConstantDependents, accessibleConstantDependents);
+        if (accessibleConstantDependents.contains(MODULE_INFO)) {
+            return DependentsSet.dependencyToAll("module-info has changed");
+        }
+        return DependentsSet.dependents(privateConstantDependents, accessibleConstantDependents, Collections.emptySet());
     }
 
     private void processTransitiveConstantDependentClasses(Set<Object> visited, Set<String> privateConstantDependents, Set<String> accessibleConstantDependents) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -58,8 +58,8 @@ import java.util.function.Supplier;
  */
 public class ClassSetAnalysisData {
 
-    private static final String MODULE_INFO = "module-info";
-    private static final String PACKAGE_INFO = "package-info";
+    static final String MODULE_INFO = "module-info";
+    static final String PACKAGE_INFO = "package-info";
 
     /**
      * Merges the given class sets, applying classpath shadowing semantics. I.e. only the first occurrency of each class will be kept.


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/17488

### Context
As written in https://github.com/gradle/gradle/issues/17488 problem was how package-info was handled on JDK8. This fixes it, additionally it adds proper integration tests.

Additionally to package-info case it fixes also module-info case that was missing. 

Tested also with Micronaut-kafka with JDK8, 11 and 16.

This is https://github.com/gradle/gradle/pull/17504 rebased on the release branch.