### PR TITLE
Publish to /artifactory/ url instead of /gradle/

### DIFF
--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -31,7 +31,7 @@ publishing {
         maven {
             name = "remote"
             val libsType = moduleIdentity.snapshot.map { if (it) "snapshots" else "releases" }
-            url = uri("https://repo.gradle.org/gradle/libs-${libsType.get()}-local")
+            url = uri("https://repo.gradle.org/artifactory/libs-${libsType.get()}-local")
             credentials {
                 username = artifactoryUserName
                 password = artifactoryUserPassword

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -36,6 +36,9 @@ publishing {
                 username = artifactoryUserName
                 password = artifactoryUserPassword
             }
+            authentication {
+                create<BasicAuthentication>("basic")
+            }
         }
     }
     configurePublishingTasks()

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -31,7 +31,7 @@ publishing {
         maven {
             name = "remote"
             val libsType = moduleIdentity.snapshot.map { if (it) "snapshots" else "releases" }
-            url = uri("https://repo.gradle.org/artifactory/libs-${libsType.get()}-local")
+            url = uri("https://repo.gradle.org/gradle/libs-${libsType.get()}-local")
             credentials {
                 username = artifactoryUserName
                 password = artifactoryUserPassword


### PR DESCRIPTION
until repo.gradle.org is fixed again.
