### PR TITLE
Some initial caching of tooling API models when isolated projects is enabled

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -243,7 +243,7 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
         configurationCacheRunLenient("help")
 
         then:
-        problems.assertFailureHasProblems(failure) {
+        problems.assertResultHasProblems(result) {
             withUniqueProblems(expectedProblem)
             withProblemsWithStackTraceCount(0)
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -95,7 +95,7 @@ trait ToolingApiSpec {
         """.stripIndent()
     }
 
-    SomeToolingModel fetchModel() {
+    def <T> T fetchModel(Class<T> type = SomeToolingModel.class) {
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
         def args = executer.allArgs
@@ -103,7 +103,7 @@ trait ToolingApiSpec {
 
         def model = null
         toolingApiExecutor.usingToolingConnection(testDirectory) { connection ->
-            model = connection.model(SomeToolingModel)
+            model = connection.model(type)
                 .addJvmArguments(executer.jvmArgs)
                 .withArguments(args)
                 .setStandardOutput(new TeeOutputStream(output, System.out))
@@ -129,7 +129,7 @@ trait ToolingApiSpec {
                     .setStandardError(new TeeOutputStream(error, System.err))
                     .get()
             }
-        } catch(Throwable t) {
+        } catch (Throwable t) {
             failure = OutputScrapingExecutionFailure.from(output.toString(), error.toString())
             return
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -155,20 +155,20 @@ trait ToolingApiSpec {
         return model
     }
 
-    Pair<SomeToolingModel, SomeToolingModel> runPhasedBuildAction(BuildAction<SomeToolingModel> projectsLoadedAction, BuildAction<SomeToolingModel> modelAction) {
+    def <T, S> Pair<T, S> runPhasedBuildAction(BuildAction<T> projectsLoadedAction, BuildAction<S> modelAction) {
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
         def args = executer.allArgs
         args.remove("--no-daemon")
 
-        def projectsLoadedModel = null
-        def buildModel = null
+        T projectsLoadedModel = null
+        S buildModel = null
         toolingApiExecutor.usingToolingConnection(testDirectory) { connection ->
             connection.action()
-                .projectsLoaded(projectsLoadedAction, { SomeToolingModel model ->
+                .projectsLoaded(projectsLoadedAction, { Object model ->
                     projectsLoadedModel = model
                 })
-                .buildFinished(modelAction, { SomeToolingModel model ->
+                .buildFinished(modelAction, { Object model ->
                     buildModel = model
                 })
                 .build()

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -136,14 +136,17 @@ trait ToolingApiSpec {
         throw new IllegalStateException("Expected build to fail but it did not.")
     }
 
-    SomeToolingModel runBuildAction(BuildAction<SomeToolingModel> buildAction) {
+    def <T> T runBuildAction(BuildAction<T> buildAction) {
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
+        def args = executer.allArgs
+        args.remove("--no-daemon")
 
         def model = null
         toolingApiExecutor.usingToolingConnection(testDirectory) { connection ->
             model = connection.action(buildAction)
                 .addJvmArguments(executer.jvmArgs)
+                .withArguments(args)
                 .setStandardOutput(new TeeOutputStream(output, System.out))
                 .setStandardError(new TeeOutputStream(error, System.err))
                 .run()
@@ -155,6 +158,8 @@ trait ToolingApiSpec {
     Pair<SomeToolingModel, SomeToolingModel> runPhasedBuildAction(BuildAction<SomeToolingModel> projectsLoadedAction, BuildAction<SomeToolingModel> modelAction) {
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
+        def args = executer.allArgs
+        args.remove("--no-daemon")
 
         def projectsLoadedModel = null
         def buildModel = null
@@ -168,6 +173,7 @@ trait ToolingApiSpec {
                 })
                 .build()
                 .addJvmArguments(executer.jvmArgs)
+                .withArguments(args)
                 .setStandardOutput(new TeeOutputStream(output, System.out))
                 .setStandardError(new TeeOutputStream(error, System.err))
                 .run()
@@ -179,11 +185,14 @@ trait ToolingApiSpec {
     def runTestClasses(String... testClasses) {
         def output = new ByteArrayOutputStream()
         def error = new ByteArrayOutputStream()
+        def args = executer.allArgs
+        args.remove("--no-daemon")
 
         toolingApiExecutor.usingToolingConnection(testDirectory) { connection ->
             connection.newTestLauncher()
                 .withJvmTestClasses(testClasses)
                 .addJvmArguments(executer.jvmArgs)
+                .withArguments(args)
                 .setStandardOutput(new TeeOutputStream(output, System.out))
                 .setStandardError(new TeeOutputStream(error, System.err))
                 .run()

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/AbstractIsolatedProjectsToolingApiIntegrationTest.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+import org.gradle.configurationcache.fixtures.ToolingApiBackedGradleExecuter
+import org.gradle.configurationcache.fixtures.ToolingApiSpec
+import org.gradle.integtests.fixtures.executer.GradleExecuter
+
+class AbstractIsolatedProjectsToolingApiIntegrationTest extends AbstractIsolatedProjectsIntegrationTest implements ToolingApiSpec {
+    @Override
+    GradleExecuter createExecuter() {
+        return new ToolingApiBackedGradleExecuter(distribution, temporaryFolder)
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForEachProject.java
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForEachProject.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated;
+
+import org.gradle.configurationcache.fixtures.SomeToolingModel;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FetchCustomModelForEachProject implements BuildAction<Map<String, SomeToolingModel>> {
+    @Override
+    public Map<String, SomeToolingModel> execute(BuildController controller) {
+        Map<String, SomeToolingModel> result = new LinkedHashMap<>();
+        GradleBuild buildModel = controller.getBuildModel();
+        for (BasicGradleProject project : buildModel.getProjects()) {
+            SomeToolingModel model = controller.findModel(project, SomeToolingModel.class);
+            if (model != null) {
+                result.put(project.getPath(), model);
+            }
+        }
+        return result;
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         """
     }
 
-    def "does not (yet) cache tooling models"() {
+    def "caches tooling model"() {
         given:
         withSomeToolingModelBuilderPluginInBuildSrc()
         buildFile << """
@@ -49,20 +49,22 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         and:
         outputContains("Creating tooling model as no configuration cache is available for the requested model")
         outputContains("creating model for root project 'root'")
+        result.assertHasPostBuildOutput("Configuration cache entry stored.")
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        executer.withArguments(ENABLE_CLI)
         def model2 = fetchModel()
 
         then:
         model2.message == "It works!"
 
         and:
-        outputContains("Creating tooling model as no configuration cache is available for the requested model")
-        outputContains("creating model for root project 'root'")
+        outputContains("Reusing configuration cache.")
+        outputDoesNotContain("creating model for root project 'root'")
+        outputContains("Configuration cache entry reused.")
     }
 
-    def "reports cross project access from build script when fetching tooling model"() {
+    def "can ignore problems and cache model"() {
         given:
         settingsFile << """
             include('a')
@@ -83,12 +85,10 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         then:
         model.message == "It works!"
         problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Build file 'build.gradle': Cannot access project ':a' from project ':'",
-                "Build file 'build.gradle': Cannot access project ':b' from project ':'",
-            )
+            withUniqueProblems("Build file 'build.gradle': Cannot access project ':a' from project ':'",
+                "Build file 'build.gradle': Cannot access project ':b' from project ':'")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (2 problems)")
+        result.assertHasPostBuildOutput("Configuration cache entry stored with 2 problems.")
 
         when:
         executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
@@ -96,13 +96,45 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
 
         then:
         model2.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Build file 'build.gradle': Cannot access project ':a' from project ':'",
-                "Build file 'build.gradle': Cannot access project ':b' from project ':'",
-            )
+        outputContains("Reusing configuration cache.")
+        outputContains("Configuration cache entry reused.")
+    }
+
+    def "reports cross project access from build script when fetching tooling model"() {
+        given:
+        settingsFile << """
+            include('a')
+            include('b')
+        """
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            allprojects {
+                plugins.apply('java-library')
+            }
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': Cannot access project ':a' from project ':'",
+                "Build file 'build.gradle': Cannot access project ':b' from project ':'")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (2 problems)")
+        outputContains("Configuration cache entry discarded with 2 problems.")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': Cannot access project ':a' from project ':'",
+                "Build file 'build.gradle': Cannot access project ':b' from project ':'")
+        }
+        outputContains("Configuration cache entry discarded with 2 problems.")
     }
 
     def "reports cross project access from model builder while fetching tooling model"() {
@@ -119,32 +151,26 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         """
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
-                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'",
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
+                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (2 problems)")
+        outputContains("Configuration cache entry discarded with 2 problems.")
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model2 = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model2.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
-                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'",
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
+                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (2 problems)")
+        outputContains("Configuration cache entry discarded with 2 problems.")
     }
 
     def "reports configuration cache problems in build script when fetching tooling model"() {
@@ -158,30 +184,24 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         """
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported"
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (1 problem).")
+        outputContains("Configuration cache entry discarded with 1 problem.")
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model2 = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model2.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported"
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (1 problem).")
+        outputContains("Configuration cache entry discarded with 1 problem.")
     }
 
     def "reports configuration cache problems in model builder while fetching tooling model"() {
@@ -196,30 +216,23 @@ class IsolatedProjectsToolingApiInvocationIntegrationTest extends AbstractIsolat
         """
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported"
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (1 problem).")
+        outputContains("Configuration cache entry discarded with 1 problem.")
 
         when:
-        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
-        def model2 = fetchModel()
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
 
         then:
-        model2.message == "It works!"
-        problems.assertResultHasProblems(result) {
-            withUniqueProblems(
-                "Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported"
-            )
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
         }
-        result.assertHasPostBuildOutput("Configuration cache problems found (1 problem).")
+        outputContains("Configuration cache entry discarded with 1 problem.")
     }
-
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiInvocationValidationIntegrationTest.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+class IsolatedProjectsToolingApiInvocationValidationIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+    def "reports cross project access from build script when fetching custom tooling model"() {
+        given:
+        settingsFile << """
+            include('a')
+            include('b')
+        """
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            allprojects {
+                plugins.apply('java-library')
+            }
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': Cannot access project ':a' from project ':'",
+                "Build file 'build.gradle': Cannot access project ':b' from project ':'")
+        }
+        outputContains("Configuration cache entry discarded with 2 problems.")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': Cannot access project ':a' from project ':'",
+                "Build file 'build.gradle': Cannot access project ':b' from project ':'")
+        }
+        outputContains("Configuration cache entry discarded with 2 problems.")
+    }
+
+    def "reports cross project access from model builder while fetching custom tooling model"() {
+        given:
+        settingsFile << """
+            include('a')
+            include('b')
+        """
+        withSomeToolingModelBuilderPluginInBuildSrc("""
+            project.subprojects.each { it.extensions }
+        """)
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
+                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'")
+        }
+        outputContains("Configuration cache entry discarded with 2 problems.")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': Cannot access project ':a' from project ':'",
+                "Plugin class 'my.MyPlugin': Cannot access project ':b' from project ':'")
+        }
+        outputContains("Configuration cache entry discarded with 2 problems.")
+    }
+
+    def "reports configuration cache problems in build script when fetching custom tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+            gradle.buildFinished {
+                println("build finished")
+            }
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+        outputContains("Configuration cache entry discarded with 1 problem.")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Build file 'build.gradle': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+        outputContains("Configuration cache entry discarded with 1 problem.")
+    }
+
+    def "reports configuration cache problems in model builder while fetching tooling model"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc("""
+            project.gradle.buildFinished {
+                println("build finished")
+            }
+        """)
+        buildFile << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+        outputContains("Configuration cache entry discarded with 1 problem.")
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        fetchModelFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            withUniqueProblems("Plugin class 'my.MyPlugin': registration of listener on 'Gradle.buildFinished' is unsupported")
+        }
+        outputContains("Configuration cache entry discarded with 1 problem.")
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -31,7 +31,7 @@ interface BuildTreeConfigurationCache {
     /**
      * Loads the cached model, if available, or else runs the given function to create it and then writes the result to cache.
      */
-    fun <T> loadOrCreateModel(creator: () -> T): T
+    fun <T : Any> loadOrCreateModel(creator: () -> T): T
 
     // This is a temporary property to allow migration from a root build scoped cache to a build tree scoped cache
     val isLoaded: Boolean

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -19,11 +19,11 @@ package org.gradle.configurationcache
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationExecutor
-import org.gradle.internal.operations.RunnableBuildOperation
+import org.gradle.internal.operations.CallableBuildOperation
 
 
 internal
-fun BuildOperationExecutor.withLoadOperation(block: () -> Unit) =
+fun <T> BuildOperationExecutor.withLoadOperation(block: () -> T) =
     withOperation("Load configuration cache state", block)
 
 
@@ -33,14 +33,14 @@ fun BuildOperationExecutor.withStoreOperation(block: () -> Unit) =
 
 
 private
-fun BuildOperationExecutor.withOperation(displayName: String, block: () -> Unit) {
-    run(object : RunnableBuildOperation {
+fun <T> BuildOperationExecutor.withOperation(displayName: String, block: () -> T): T {
+    return call(object : CallableBuildOperation<T> {
 
         override fun description(): BuildOperationDescriptor.Builder =
             BuildOperationDescriptor.displayName(displayName)
 
-        override fun run(context: BuildOperationContext) {
-            block()
+        override fun call(context: BuildOperationContext): T {
+            return block()
         }
     })
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -119,7 +119,7 @@ class ConfigurationCacheHost internal constructor(
 
         private
         fun createProject(descriptor: DefaultProjectDescriptor): ProjectInternal {
-            val projectState = gradle.owner.getProject(descriptor.path())
+            val projectState = gradle.owner.projects.getProject(descriptor.path())
             projectState.createMutableModel(coreAndPluginsScope, coreAndPluginsScope)
             val project = projectState.mutableModel
             // Build dir is restored in order to use the correct workspace directory for transforms of project dependencies when the build dir has been customized
@@ -133,7 +133,7 @@ class ConfigurationCacheHost internal constructor(
         }
 
         override fun getProject(path: String): ProjectInternal =
-            gradle.owner.getProject(Path.path(path)).mutableModel
+            gradle.owner.projects.getProject(Path.path(path)).mutableModel
 
         override fun scheduleNodes(nodes: Collection<Node>) {
             gradle.taskGraph.run {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheRepository.kt
@@ -72,8 +72,8 @@ class ConfigurationCacheRepository(
         class Invalid(val reason: String) : CheckedFingerprint()
     }
 
-    fun useForStateLoad(cacheKey: String, action: (ConfigurationCacheStateFile) -> Unit) {
-        withBaseCacheDirFor(cacheKey) { cacheDir ->
+    fun <T> useForStateLoad(cacheKey: String, action: (ConfigurationCacheStateFile) -> T): T {
+        return withBaseCacheDirFor(cacheKey) { cacheDir ->
             action(
                 ReadableConfigurationCacheStateFile(cacheDir.stateFile)
             )

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -22,6 +22,7 @@ import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logging
 import org.gradle.configurationcache.ConfigurationCacheRepository.CheckedFingerprint
+import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprint
 import org.gradle.configurationcache.fingerprint.ConfigurationCacheFingerprintController
 import org.gradle.configurationcache.fingerprint.InvalidationReason
@@ -72,6 +73,7 @@ class DefaultConfigurationCache internal constructor(
 
     private
     val canLoad by lazy { canLoad() }
+
     private
     var rootBuild: Host? = null
 
@@ -109,22 +111,25 @@ class DefaultConfigurationCache internal constructor(
 
     override fun loadOrScheduledRequestedTasks(scheduler: () -> Unit) {
         if (canLoad) {
-            load()
+            loadWorkGraph()
             // This is required to signal that the task graphs are ready for execution. It should not actually end up scheduling any further tasks
             // TODO - It would be better to have the load() method signal this instead
             scheduler()
         } else {
             prepareForConfiguration()
             scheduler()
-            save()
+            saveWorkGraph()
         }
     }
 
-    override fun <T> loadOrCreateModel(creator: () -> T): T {
+    override fun <T : Any> loadOrCreateModel(creator: () -> T): T {
         if (canLoad) {
-            // Just do the check for now
+            return loadModel().uncheckedCast()
         }
-        return creator()
+        prepareForConfiguration()
+        val model = creator()
+        saveModel(model)
+        return model
     }
 
     private
@@ -202,7 +207,21 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun save() {
+    fun saveModel(model: Any) {
+        saveToCache { layout ->
+            cacheIO.writeModelTo(model, layout.state)
+            // TODO - separate out writing the metadata about included builds from writing the value
+            emptySet()
+        }
+    }
+
+    private
+    fun saveWorkGraph() {
+        saveToCache { layout -> writeConfigurationCacheState(layout) }
+    }
+
+    private
+    fun saveToCache(action: (ConfigurationCacheRepository.Layout) -> Set<File>) {
         crossConfigurationTimeBarrier()
 
         // TODO - fingerprint should be collected until the state file has been written, as user code can run during this process
@@ -217,7 +236,11 @@ class DefaultConfigurationCache internal constructor(
                     invalidateConfigurationCacheState(layout)
                 }
                 try {
-                    writeConfigurationCacheFiles(layout)
+                    val includedBuildRootDirs = action(layout)
+                    writeConfigurationCacheFingerprint(
+                        layout.fingerprint,
+                        ConfigurationCacheFingerprint.Header(includedBuildRootDirs)
+                    )
                 } catch (error: ConfigurationCacheError) {
                     // Invalidate state on serialization errors
                     invalidateConfigurationCacheState(layout)
@@ -232,7 +255,21 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun load() {
+    fun loadModel(): Any {
+        return loadFromCache { stateFile ->
+            cacheIO.readModelFrom(stateFile)
+        }
+    }
+
+    private
+    fun loadWorkGraph() {
+        loadFromCache { stateFile ->
+            cacheIO.readRootBuildStateFrom(stateFile)
+        }
+    }
+
+    private
+    fun <T> loadFromCache(action: (ConfigurationCacheStateFile) -> T): T {
         prepareConfigurationTimeBarrier()
         problems.loading()
 
@@ -240,12 +277,11 @@ class DefaultConfigurationCache internal constructor(
         // when loading the task graph.
         scopeRegistryListener.dispose()
 
-        buildOperationExecutor.withLoadOperation {
-            cacheRepository.useForStateLoad(cacheKey.string) { stateFile ->
-                cacheIO.readRootBuildStateFrom(stateFile)
-            }
+        val result = buildOperationExecutor.withLoadOperation {
+            cacheRepository.useForStateLoad(cacheKey.string, action)
         }
         crossConfigurationTimeBarrier()
+        return result
     }
 
     private
@@ -261,18 +297,9 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun writeConfigurationCacheFiles(layout: ConfigurationCacheRepository.Layout) {
-        val includedBuildRootDirs = writeConfigurationCacheState(layout.state)
-        writeConfigurationCacheFingerprint(
-            layout.fingerprint,
-            ConfigurationCacheFingerprint.Header(includedBuildRootDirs)
-        )
-    }
-
-    private
-    fun writeConfigurationCacheState(stateFile: ConfigurationCacheStateFile): Set<File> =
+    fun writeConfigurationCacheState(layout: ConfigurationCacheRepository.Layout): Set<File> =
         projectStateRegistry.withMutableStateOfAllProjects(
-            Factory { cacheIO.writeRootBuildStateTo(stateFile) }
+            Factory { cacheIO.writeRootBuildStateTo(layout.state) }
         )
 
     private

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -24,7 +24,6 @@ import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.util.Path;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.internal.Factory;
+import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -30,7 +31,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 /**
- * A registry of all of the projects present in a build tree.
+ * A registry of all projects present in a build tree.
  */
 @ThreadSafe
 @ServiceScope(Scopes.BuildTree.class)
@@ -51,9 +52,9 @@ public interface ProjectStateRegistry {
     ProjectState stateFor(ProjectComponentIdentifier identifier) throws IllegalArgumentException;
 
     /**
-     * Locates the state object for the given project.
+     * Locates the state objects for all projects of the given build.
      */
-    ProjectState stateFor(BuildIdentifier buildIdentifier, Path projectPath) throws IllegalArgumentException;
+    BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
 
     /**
      * Registers the projects of a build.

--- a/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/InstantiatingBuildLoader.java
@@ -31,7 +31,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
     }
 
     private void attachDefaultProject(GradleInternal gradle, DefaultProjectDescriptor defaultProjectDescriptor) {
-        ProjectState defaultProject = gradle.getOwner().getProject(defaultProjectDescriptor.path());
+        ProjectState defaultProject = gradle.getOwner().getProjects().getProject(defaultProjectDescriptor.path());
         gradle.setDefaultProject(defaultProject.getMutableModel());
     }
 
@@ -39,7 +39,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
         ClassLoaderScope baseProjectClassLoaderScope = gradle.baseProjectClassLoaderScope();
         ClassLoaderScope rootProjectClassLoaderScope = baseProjectClassLoaderScope.createChild("root-project[" + gradle.getIdentityPath() + "]");
 
-        ProjectState projectState = gradle.getOwner().getProject(rootProjectDescriptor.path());
+        ProjectState projectState = gradle.getOwner().getProjects().getProject(rootProjectDescriptor.path());
         projectState.createMutableModel(rootProjectClassLoaderScope, baseProjectClassLoaderScope);
         ProjectInternal rootProject = projectState.getMutableModel();
         gradle.setRootProject(rootProject);
@@ -50,7 +50,7 @@ public class InstantiatingBuildLoader implements BuildLoader {
     private void createChildProjectsRecursively(BuildState owner, DefaultProjectDescriptor parentProjectDescriptor, ClassLoaderScope parentProjectClassLoaderScope, ClassLoaderScope baseProjectClassLoaderScope) {
         for (DefaultProjectDescriptor childProjectDescriptor : parentProjectDescriptor.children()) {
             ClassLoaderScope childProjectClassLoaderScope = parentProjectClassLoaderScope.createChild("project-" + childProjectDescriptor.getName());
-            ProjectState projectState = owner.getProject(childProjectDescriptor.path());
+            ProjectState projectState = owner.getProjects().getProject(childProjectDescriptor.path());
             projectState.createMutableModel(childProjectClassLoaderScope, baseProjectClassLoaderScope);
             createChildProjectsRecursively(owner, childProjectDescriptor, childProjectClassLoaderScope, baseProjectClassLoaderScope);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -19,7 +19,6 @@ package org.gradle.internal.build;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
-import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.initialization.IncludedBuildSpec;
@@ -44,8 +43,8 @@ public abstract class AbstractBuildState implements BuildState {
     protected abstract ProjectStateRegistry getProjectStateRegistry();
 
     @Override
-    public ProjectState getProject(Path projectPath) {
-        return getProjectStateRegistry().stateFor(getBuildIdentifier(), projectPath);
+    public BuildProjectRegistry getProjects() {
+        return getProjectStateRegistry().projectsFor(getBuildIdentifier());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.build;
+
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.util.Path;
+
+import java.util.Set;
+
+public interface BuildProjectRegistry {
+    /**
+     * Returns all projects in this build, in public iteration order.
+     */
+    Set<? extends ProjectState> getAllProjects();
+
+    /**
+     * Locates a project of this build.
+     *
+     * @param projectPath The path relative to the root project of this build.
+     */
+    ProjectState getProject(Path projectPath);
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
-import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.util.Path;
 
@@ -77,9 +76,9 @@ public interface BuildState {
     ProjectComponentIdentifier getIdentifierForProject(Path projectPath) throws IllegalStateException;
 
     /**
-     * Locates a project of this build.
+     * Returns the projects of this build.
      */
-    ProjectState getProject(Path projectPath);
+    BuildProjectRegistry getProjects();
 
     /**
      * Asserts that the given build can be included by this build.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
@@ -49,7 +49,9 @@ public interface BuildTreeLifecycleController {
      * Configures the build, optionally schedules and runs any tasks, calls the given action and finally finishes up the build.
      * When this method returns, all user code will have completed, including 'build finished' hooks.
      *
-     * Does not call the given action when task execution fails.
+     * <p>This method may or may not run the action. When a cached result is available, this may be used instead of configuring the build and running the action.</p>
+     *
+     * <p>Does not call the given action when task execution fails.
      */
     <T> T fromBuildModel(boolean runTasks, Function<? super GradleInternal, T> action);
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/InstantiatingBuildLoaderTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.project.IProjectFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.api.internal.project.ProjectState
+import org.gradle.internal.build.BuildProjectRegistry
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -49,6 +50,7 @@ class InstantiatingBuildLoaderTest extends Specification {
     ProjectInternal childProject
     GradleInternal gradle
     SettingsInternal settingsInternal
+    BuildProjectRegistry buildProjectRegistry = Mock(BuildProjectRegistry)
     BuildState buildState = Mock(BuildState)
     ProjectState rootProjectState = Mock(ProjectState)
 
@@ -86,13 +88,14 @@ class InstantiatingBuildLoaderTest extends Specification {
         settingsInternal = Mock(SettingsInternal) {
             getProjectRegistry() >> descriptorRegistry
         }
-        buildState.getProject(Path.ROOT) >> rootProjectState
+        buildState.projects >> buildProjectRegistry
+        buildProjectRegistry.getProject(Path.ROOT) >> rootProjectState
     }
 
     def createsBuildWithRootProjectAsTheDefaultOne() {
         given:
         settingsInternal.defaultProject >> rootDescriptor
-        buildState.getProject(_) >> Stub(ProjectState)
+        buildProjectRegistry.getProject(_) >> Stub(ProjectState)
 
         when:
         buildLoader.load(settingsInternal, gradle)
@@ -111,7 +114,7 @@ class InstantiatingBuildLoaderTest extends Specification {
         def childProjectState = Mock(ProjectState)
         def childProjectClassLoaderScope = Mock(ClassLoaderScope)
         settingsInternal.defaultProject >> childDescriptor
-        buildState.getProject(_) >> childProjectState
+        buildProjectRegistry.getProject(_) >> childProjectState
         childProjectState.mutableModel >> childProject
 
         when:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -317,7 +317,7 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         }
         then:
         def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
-        (platformType == ENFORCED_PLATFORM && !failure) || failure.assertHasCause(
+        (platformType == ENFORCED_PLATFORM && failureOrNull == null) || failure.assertHasCause(
             """Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
    Constraint path ':test:unspecified' --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/DefaultIdeArtifactRegistry.java
@@ -44,7 +44,7 @@ public class DefaultIdeArtifactRegistry implements IdeArtifactRegistry {
         this.store = store;
         this.projectRegistry = projectRegistry;
         this.fileOperations = fileOperations;
-        currentProject = currentBuild.getProject(domainObjectContext.getProjectPath()).getComponentIdentifier();
+        currentProject = currentBuild.getProjects().getProject(domainObjectContext.getProjectPath()).getComponentIdentifier();
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.internal.tooling;
 
 import org.gradle.api.Project;
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.IncludedBuildState;
@@ -60,7 +61,7 @@ public class GradleBuildBuilder implements ToolingModelBuilder {
         all.put(targetBuild, model);
 
         GradleInternal gradle = targetBuild.getMutableModel();
-        addProjects(gradle, model);
+        addProjects(targetBuild, model);
         addIncludedBuilds(gradle, model, all);
 
         if (gradle.getParent() == null) {
@@ -94,15 +95,15 @@ public class GradleBuildBuilder implements ToolingModelBuilder {
         }
     }
 
-    private void addProjects(GradleInternal gradle, DefaultGradleBuild model) {
+    private void addProjects(BuildState target, DefaultGradleBuild model) {
         Map<Project, BasicGradleProject> convertedProjects = new LinkedHashMap<>();
 
-        Project rootProject = gradle.getRootProject();
+        Project rootProject = target.getMutableModel().getRootProject();
         BasicGradleProject convertedRootProject = convert(rootProject, convertedProjects);
         model.setRootProject(convertedRootProject);
 
-        for (Project project : rootProject.getAllprojects()) {
-            model.addProject(convertedProjects.get(project));
+        for (ProjectState project : target.getProjects().getAllProjects()) {
+            model.addProject(convertedProjects.get(project.getMutableModel()));
         }
     }
 

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.plugins.ide.internal.tooling
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.internal.build.BuildProjectRegistry
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.IncludedBuildState
@@ -82,6 +83,10 @@ class GradleBuildBuilderTest extends Specification {
         def build1 = Mock(GradleInternal)
         def build2 = Mock(GradleInternal)
 
+        def rootProjects = Mock(BuildProjectRegistry)
+        def projects1 = Mock(BuildProjectRegistry)
+        def projects2 = Mock(BuildProjectRegistry)
+
         def rootBuildState = Mock(BuildState)
         def includedBuildState1 = Mock(IncludedBuildState)
         def includedBuildState2 = Mock(IncludedBuildState)
@@ -107,12 +112,18 @@ class GradleBuildBuilderTest extends Specification {
         rootBuild.includedBuilds() >> [includedBuild1]
 
         rootBuildState.mutableModel >> rootBuild
+        rootBuildState.projects >> rootProjects
 
         includedBuild1.target >> includedBuildState1
         includedBuild2.target >> includedBuildState2
 
+        includedBuildState1.projects >> projects1
         includedBuildState1.configuredBuild >> build1
         includedBuildState1.importableBuild >> true
+
+        rootProjects.allProjects >> [].toSet()
+        projects1.allProjects >> [].toSet()
+        projects2.allProjects >> [].toSet()
 
         build1.owner >> includedBuildState1
         build1.includedBuilds() >> [includedBuild2]
@@ -121,6 +132,7 @@ class GradleBuildBuilderTest extends Specification {
 
         includedBuildState1.mutableModel >> build1
 
+        includedBuildState2.projects >> projects2
         includedBuildState2.configuredBuild >> build2
         includedBuildState2.importableBuild >> true
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -46,6 +46,8 @@ import org.intellij.lang.annotations.Language
 import org.junit.Rule
 import spock.lang.Specification
 
+import javax.annotation.Nullable
+
 import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.DEFAULT_TIMEOUT_SECONDS
 import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.util.Matchers.normalizedLineSeparators
@@ -319,6 +321,7 @@ class AbstractIntegrationSpec extends Specification {
         return currentResult
     }
 
+    @Nullable
     ExecutionResult getResultOrNull() {
         return currentResult
     }
@@ -332,6 +335,11 @@ class AbstractIntegrationSpec extends Specification {
         if (currentFailure == null) {
             throw new IllegalStateException("No build failure result is available yet.")
         }
+        return currentFailure
+    }
+
+    @Nullable
+    ExecutionFailure getFailureOrNull() {
         return currentFailure
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -309,6 +309,17 @@ class AbstractIntegrationSpec extends Specification {
 
     protected ExecutionResult succeeds(String... tasks) {
         result = executer.withTasks(*tasks).run()
+        return result
+    }
+
+    void setResult(ExecutionResult result) {
+        failure = null
+        this.result = result
+    }
+
+    void setFailure(ExecutionFailure failure) {
+        result = failure
+        this.failure = failure
     }
 
     protected ExecutionFailure runAndFail(String... tasks) {
@@ -317,7 +328,7 @@ class AbstractIntegrationSpec extends Specification {
 
     protected ExecutionFailure fails(String... tasks) {
         failure = executer.withTasks(*tasks).runWithFailure()
-        result = failure
+        return failure
     }
 
     protected void executedAndNotSkipped(String... tasks) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -85,8 +85,8 @@ class AbstractIntegrationSpec extends Specification {
 
     M2Installation m2 = new M2Installation(temporaryFolder)
 
-    ExecutionResult result
-    ExecutionFailure failure
+    private ExecutionResult currentResult
+    private ExecutionFailure currentFailure
     public final MavenFileRepository mavenRepo = new MavenFileRepository(temporaryFolder.testDirectory.file("maven-repo"))
     public final IvyFileRepository ivyRepo = new IvyFileRepository(temporaryFolder.testDirectory.file("ivy-repo"))
 
@@ -312,14 +312,32 @@ class AbstractIntegrationSpec extends Specification {
         return result
     }
 
+    ExecutionResult getResult() {
+        if (currentResult == null) {
+            throw new IllegalStateException("No build result is available yet.")
+        }
+        return currentResult
+    }
+
+    ExecutionResult getResultOrNull() {
+        return currentResult
+    }
+
     void setResult(ExecutionResult result) {
-        failure = null
-        this.result = result
+        currentFailure = null
+        currentResult = result
+    }
+
+    ExecutionFailure getFailure() {
+        if (currentFailure == null) {
+            throw new IllegalStateException("No build failure result is available yet.")
+        }
+        return currentFailure
     }
 
     void setFailure(ExecutionFailure failure) {
-        result = failure
-        this.failure = failure
+        currentResult = failure
+        currentFailure = failure
     }
 
     protected ExecutionFailure runAndFail(String... tasks) {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildSessionLifecycleBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildSessionLifecycleBuildActionExecuter.java
@@ -29,6 +29,7 @@ import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildActionResult;
 import org.gradle.launcher.exec.BuildExecuter;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
+import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 
 /**
  * A {@link BuildExecuter} responsible for establishing the {@link BuildSessionState} to execute a {@link BuildAction} within.
@@ -55,7 +56,12 @@ public class BuildSessionLifecycleBuildActionExecuter implements BuildActionExec
                     BuildActionRunner.Result result = context.execute(action);
                     PayloadSerializer payloadSerializer = context.getServices().get(PayloadSerializer.class);
                     if (result.getBuildFailure() == null) {
-                        return BuildActionResult.of(payloadSerializer.serialize(result.getClientResult()));
+                        if (result.getClientResult() instanceof SerializedPayload) {
+                            // Already serialized
+                            return BuildActionResult.of((SerializedPayload) result.getClientResult());
+                        } else {
+                            return BuildActionResult.of(payloadSerializer.serialize(result.getClientResult()));
+                        }
                     }
                     if (requestContext.getCancellationToken().isCancellationRequested()) {
                         return BuildActionResult.cancelled(payloadSerializer.serialize(result.getBuildFailure()));

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/DefaultPayloadClassLoaderRegistry.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/DefaultPayloadClassLoaderRegistry.java
@@ -18,7 +18,6 @@ package org.gradle.tooling.internal.provider.serialization;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.api.Transformer;
 import org.gradle.internal.classloader.ClassLoaderSpec;
 import org.gradle.internal.classloader.ClassLoaderVisitor;
@@ -28,6 +27,7 @@ import org.gradle.util.internal.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -55,8 +55,8 @@ public class DefaultPayloadClassLoaderRegistry implements PayloadClassLoaderRegi
     @Override
     public SerializeMap newSerializeSession() {
         return new SerializeMap() {
-            final Map<ClassLoader, Short> classLoaderIds = new HashMap<ClassLoader, Short>();
-            final Map<Short, ClassLoaderDetails> classLoaderDetails = new HashMap<Short, ClassLoaderDetails>();
+            final Map<ClassLoader, Short> classLoaderIds = new HashMap<>();
+            final Map<Short, ClassLoaderDetails> classLoaderDetails = new HashMap<>();
 
             @Override
             public short visitClass(Class<?> target) {
@@ -116,7 +116,7 @@ public class DefaultPayloadClassLoaderRegistry implements PayloadClassLoaderRegi
 
     private static class ClassLoaderSpecVisitor extends ClassLoaderVisitor {
         final ClassLoader classLoader;
-        final List<ClassLoader> parents = new ArrayList<ClassLoader>();
+        final List<ClassLoader> parents = new ArrayList<>();
         ClassLoaderSpec spec;
         URL[] classPath;
 
@@ -152,7 +152,7 @@ public class DefaultPayloadClassLoaderRegistry implements PayloadClassLoaderRegi
                 parents.add(getClassLoader(parentDetails));
             }
             if (parents.isEmpty()) {
-                parents.add(classLoaderFactory.getClassLoaderFor(SystemClassLoaderSpec.INSTANCE, ImmutableList.<ClassLoader>of()));
+                parents.add(classLoaderFactory.getClassLoaderFor(SystemClassLoaderSpec.INSTANCE, ImmutableList.of()));
             }
 
             LOGGER.info("Creating ClassLoader {} from {} and {}.", details.uuid, details.spec, parents);

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/WellKnownClassLoaderRegistry.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/WellKnownClassLoaderRegistry.java
@@ -53,7 +53,7 @@ public class WellKnownClassLoaderRegistry implements PayloadClassLoaderRegistry 
     public SerializeMap newSerializeSession() {
         final SerializeMap delegateSession = delegate.newSerializeSession();
         return new SerializeMap() {
-            Map<Short, ClassLoaderDetails> knownLoaders = new HashMap<Short, ClassLoaderDetails>();
+            final Map<Short, ClassLoaderDetails> knownLoaders = new HashMap<>();
 
             @Override
             public short visitClass(Class<?> target) {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractLanguageInterOpIntegrationTest.groovy
@@ -51,7 +51,7 @@ class AbstractLanguageInterOpIntegrationTest extends AbstractIntegrationSpec {
 
     def cleanup() {
         // Let's copy the Kotlin compiler logs in case of failure
-        if (result instanceof ExecutionFailure) {
+        if (resultOrNull instanceof ExecutionFailure) {
             def pattern = "kotlin-daemon.${new Date().format("yyyy-MM-dd")}.*.log"
             def kotlinCompilerLogFiles = new FileNameFinder().getFileNames(System.getenv("TMPDIR"), pattern)
             def target = buildContext.gradleUserHomeDir.createDir("kotlin-compiler-daemon").toPath()

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -42,7 +42,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .requireOwnGradleUserHomeDir()
             .withToolchainDownloadEnabled()
             .runWithFailure()
-        result = failure
 
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
@@ -75,7 +74,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .withTasks("compileJava")
             .requireOwnGradleUserHomeDir()
             .runWithFailure()
-        result = failure
 
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")
@@ -107,7 +105,6 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .requireOwnGradleUserHomeDir()
             .withToolchainDownloadEnabled()
             .runWithFailure()
-        result = failure
 
         then:
         failure.assertHasDescription("Execution failed for task ':compileJava'.")

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -28,6 +28,8 @@ import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException;
 import org.gradle.tooling.internal.provider.action.BuildModelAction;
+import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
+import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 
@@ -36,6 +38,12 @@ import java.util.Set;
 import java.util.function.Function;
 
 public class BuildModelActionRunner implements BuildActionRunner {
+    private final PayloadSerializer payloadSerializer;
+
+    public BuildModelActionRunner(PayloadSerializer payloadSerializer) {
+        this.payloadSerializer = payloadSerializer;
+    }
+
     @Override
     public Result run(BuildAction action, final BuildTreeLifecycleController buildController) {
         if (!(action instanceof BuildModelAction)) {
@@ -50,7 +58,8 @@ public class BuildModelActionRunner implements BuildActionRunner {
             if (buildModelAction.isCreateModel()) {
                 gradle.addBuildListener(new ForceFullConfigurationListener());
                 Object result = buildController.fromBuildModel(buildModelAction.isRunTasks(), createAction);
-                return Result.of(result);
+                SerializedPayload serializedResult = payloadSerializer.serialize(result);
+                return Result.of(serializedResult);
             } else {
                 buildController.scheduleAndRunTasks();
                 return Result.of(null);

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunner.java
@@ -42,17 +42,18 @@ public class ClientProvidedBuildActionRunner extends AbstractClientProvidedBuild
 
         Object clientAction = payloadSerializer.deserialize(clientProvidedBuildAction.getAction());
 
-        return runClientAction(new ClientActionImpl(clientAction, action), buildController);
+        return runClientAction(new ClientActionImpl(clientAction, action, payloadSerializer), buildController);
     }
 
     private static class ClientActionImpl implements ClientAction {
         private final Object clientAction;
         private final BuildAction action;
-        Object result;
+        private final PayloadSerializer payloadSerializer;
 
-        public ClientActionImpl(Object clientAction, BuildAction action) {
+        public ClientActionImpl(Object clientAction, BuildAction action, PayloadSerializer payloadSerializer) {
             this.clientAction = clientAction;
             this.action = action;
+            this.payloadSerializer = payloadSerializer;
         }
 
         @Override
@@ -66,18 +67,13 @@ public class ClientProvidedBuildActionRunner extends AbstractClientProvidedBuild
         }
 
         @Override
-        public void collectActionResult(Object result, PhasedActionResult.Phase phase) {
-            this.result = result;
+        public Object collectActionResult(Object result, PhasedActionResult.Phase phase) {
+            return payloadSerializer.serialize(result);
         }
 
         @Override
         public boolean isRunTasks() {
             return action.isRunTasks();
-        }
-
-        @Override
-        public Object getResult() {
-            return result;
         }
     }
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedPhasedActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedPhasedActionRunner.java
@@ -27,6 +27,8 @@ import org.gradle.tooling.internal.provider.action.ClientProvidedPhasedAction;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 
+import javax.annotation.Nullable;
+
 public class ClientProvidedPhasedActionRunner extends AbstractClientProvidedBuildActionRunner implements BuildActionRunner {
     private final PayloadSerializer payloadSerializer;
     private final BuildEventConsumer buildEventConsumer;
@@ -34,7 +36,7 @@ public class ClientProvidedPhasedActionRunner extends AbstractClientProvidedBuil
     public ClientProvidedPhasedActionRunner(BuildControllerFactory buildControllerFactory,
                                             PayloadSerializer payloadSerializer,
                                             BuildEventConsumer buildEventConsumer) {
-        super(buildControllerFactory);
+        super(buildControllerFactory, payloadSerializer);
         this.payloadSerializer = payloadSerializer;
         this.buildEventConsumer = buildEventConsumer;
     }
@@ -71,10 +73,14 @@ public class ClientProvidedPhasedActionRunner extends AbstractClientProvidedBuil
         }
 
         @Override
-        public Object collectActionResult(Object result, PhasedActionResult.Phase phase) {
-            SerializedPayload serializedResult = payloadSerializer.serialize(result);
+        public void collectActionResult(SerializedPayload serializedResult, PhasedActionResult.Phase phase) {
             PhasedBuildActionResult res = new PhasedBuildActionResult(serializedResult, phase);
             buildEventConsumer.dispatch(res);
+        }
+
+        @Nullable
+        @Override
+        public SerializedPayload getResult() {
             return null;
         }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedPhasedActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientProvidedPhasedActionRunner.java
@@ -71,20 +71,16 @@ public class ClientProvidedPhasedActionRunner extends AbstractClientProvidedBuil
         }
 
         @Override
-        public void collectActionResult(Object result, PhasedActionResult.Phase phase) {
+        public Object collectActionResult(Object result, PhasedActionResult.Phase phase) {
             SerializedPayload serializedResult = payloadSerializer.serialize(result);
             PhasedBuildActionResult res = new PhasedBuildActionResult(serializedResult, phase);
             buildEventConsumer.dispatch(res);
+            return null;
         }
 
         @Override
         public boolean isRunTasks() {
             return action.isRunTasks();
-        }
-
-        @Override
-        public Object getResult() {
-            return null;
         }
     }
 }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunnerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/ClientProvidedBuildActionRunnerTest.groovy
@@ -46,20 +46,22 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
     def "can run action and returns result when completed"() {
         given:
         def model = new Object()
+        def serialized = Stub(SerializedPayload)
         def internalAction = Mock(InternalBuildAction)
 
         when:
         def result = runner.run(clientProvidedBuildAction, buildController)
 
         then:
-        result.clientResult == model
+        result.clientResult == serialized
         result.buildFailure == null
         result.clientFailure == null
 
         and:
+        1 * payloadSerializer.deserialize(action) >> internalAction
         1 * buildController.fromBuildModel(false, _) >> { Boolean b, Function function -> function.apply(gradle) }
         1 * internalAction.execute(_) >> model
-        1 * payloadSerializer.deserialize(action) >> internalAction
+        1 * payloadSerializer.serialize(model) >> serialized
     }
 
     def "can run action and reports failure"() {
@@ -117,18 +119,20 @@ class ClientProvidedBuildActionRunnerTest extends Specification {
         given:
         def model = new Object()
         def internalAction = Mock(InternalBuildActionVersion2)
+        def serializedResult = Stub(SerializedPayload)
 
         when:
         def result = runner.run(clientProvidedBuildAction, buildController)
 
         then:
-        result.clientResult == model
+        result.clientResult == serializedResult
         result.buildFailure == null
         result.clientFailure == null
 
         and:
+        1 * payloadSerializer.deserialize(action) >> internalAction
         1 * buildController.fromBuildModel(false, _) >> { Boolean b, Function function -> function.apply(gradle) }
         1 * internalAction.execute(_) >> model
-        1 * payloadSerializer.deserialize(action) >> internalAction
+        1 * payloadSerializer.serialize(model) >> serializedResult
     }
 }

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -19,7 +19,9 @@ package org.gradle.tooling.internal.provider.runner
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.initialization.BuildCancellationToken
+import org.gradle.internal.build.BuildProjectRegistry
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.concurrent.GradleThread
@@ -33,6 +35,7 @@ import org.gradle.tooling.internal.protocol.InternalUnsupportedModelException
 import org.gradle.tooling.internal.protocol.ModelIdentifier
 import org.gradle.tooling.provider.model.UnknownModelException
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup
+import org.gradle.util.Path
 import spock.lang.Specification
 
 import java.util.function.Consumer
@@ -110,10 +113,11 @@ class DefaultBuildControllerTest extends Specification {
     def "uses builder for specified project"() {
         def rootDir = new File("dummy")
         def target = Stub(GradleProjectIdentity)
-        def rootProject = Stub(ProjectInternal)
         def buildState1 = Stub(BuildState)
         def buildState2 = Stub(BuildState)
         def buildState3 = Stub(BuildState)
+        def projects3 = Stub(BuildProjectRegistry)
+        def projectState = Stub(ProjectState)
         def model = new Object()
 
         given:
@@ -129,9 +133,9 @@ class DefaultBuildControllerTest extends Specification {
         _ * buildState2.buildRootDir >> new File("different")
         _ * buildState3.importableBuild >> true
         _ * buildState3.buildRootDir >> rootDir
-        _ * buildState3.mutableModel >> gradle
-        _ * gradle.rootProject >> rootProject
-        _ * rootProject.project(":some:path") >> project
+        _ * buildState3.projects >> projects3
+        _ * projects3.getProject(Path.path(":some:path")) >> projectState
+        _ * projectState.mutableModel >> project
         _ * registry.locateForClientOperation("some.model", false, project) >> modelBuilder
         _ * modelBuilder.build(null) >> model
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r23/ModelBuilderCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r23/ModelBuilderCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.tooling.ModelBuilder
 import org.gradle.tooling.ProjectConnection
-import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.build.BuildEnvironment
 
 class ModelBuilderCrossVersionSpec extends ToolingApiSpecification {
@@ -48,28 +47,4 @@ class ModelBuilderCrossVersionSpec extends ToolingApiSpecification {
         model != null
         OutputScrapingExecutionResult.from(outputStream.toString(), errorStream.toString()).assertTasksExecutedInOrder()
     }
-
-    def "empty list of tasks to execute when asking for model from target Gradle is treated like null tasks and executes no tasks"() {
-        projectDir.file('build.gradle') << """
-            defaultTasks 'alpha'
-            task alpha() { doLast { throw new RuntimeException() } }
-        """
-
-        def outputStream = new ByteArrayOutputStream()
-        def errorStream = new ByteArrayOutputStream()
-
-        when:
-        GradleProject model = toolingApi.withConnection { ProjectConnection connection ->
-            ModelBuilder<GradleProject> modelBuilder = connection.model(GradleProject.class)
-            modelBuilder.forTasks(new String[0])
-            modelBuilder.setStandardOutput(outputStream)
-            modelBuilder.setStandardError(errorStream)
-            modelBuilder.get()
-        }
-
-        then:
-        model != null
-        OutputScrapingExecutionResult.from(outputStream.toString(), errorStream.toString()).assertTasksExecutedInOrder()
-    }
-
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -17,19 +17,23 @@
 package org.gradle.integtests.tooling.r48
 
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure
+import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildActionExecuter
 import org.gradle.tooling.BuildActionFailureException
 import org.gradle.tooling.BuildException
 import org.gradle.tooling.UnsupportedVersionException
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.ProgressListener
+import spock.lang.Unroll
 
 import java.util.regex.Pattern
 
 @ToolingApiVersion(">=4.8")
+@TargetGradleVersion(">=4.8")
 class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
     def setup() {
         buildFile << """
@@ -49,15 +53,8 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
                 }
             }
 
-            task defTask {
-                doLast {
-                    println "default"
-                }
-            }
-
             allprojects {
                 apply plugin: CustomPlugin
-                defaultTasks 'defTask'
             }
 
             class DefaultCustomModel implements Serializable {
@@ -118,7 +115,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         """
     }
 
-    @TargetGradleVersion(">=4.8")
     def "can run phased action"() {
         IntermediateResultHandlerCollector projectsLoadedHandler = new IntermediateResultHandlerCollector()
         IntermediateResultHandlerCollector buildFinishedHandler = new IntermediateResultHandlerCollector()
@@ -136,7 +132,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         buildFinishedHandler.getResult() == "build"
     }
 
-    @TargetGradleVersion(">=4.8")
     def "failures from action are received and future actions not run"() {
         def projectsLoadedHandler = new IntermediateResultHandlerCollector()
         def buildFinishedHandler = new IntermediateResultHandlerCollector()
@@ -170,7 +165,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         assertHasConfigureFailedLogging()
     }
 
-    @TargetGradleVersion(">=4.8")
     def "actions are not run when configuration fails"() {
         def projectsLoadedHandler = new IntermediateResultHandlerCollector()
         def buildFinishedHandler = new IntermediateResultHandlerCollector()
@@ -203,7 +197,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         assertHasConfigureFailedLogging()
     }
 
-    @TargetGradleVersion(">=4.8")
     def "build finished action does not run when build fails"() {
         def projectsLoadedHandler = new IntermediateResultHandlerCollector()
         def buildFinishedHandler = new IntermediateResultHandlerCollector()
@@ -237,7 +230,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         assertHasBuildFailedLogging()
     }
 
-    @TargetGradleVersion(">=4.8")
     def "build is interrupted immediately if action fails"() {
         IntermediateResultHandlerCollector projectsLoadedHandler = new IntermediateResultHandlerCollector()
         def events = ""
@@ -261,7 +253,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         events.empty
     }
 
-    @TargetGradleVersion(">=4.8")
     def "can modify task graph in projects evaluated action"() {
         IntermediateResultHandlerCollector projectsLoadedHandler = new IntermediateResultHandlerCollector()
         def stdOut = new ByteArrayOutputStream()
@@ -280,7 +271,6 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         stdOut.toString().contains("hello")
     }
 
-    @TargetGradleVersion(">=4.8")
     def "can run pre-defined tasks and build finished action is run after tasks are executed"() {
         IntermediateResultHandlerCollector buildFinishedHandler = new IntermediateResultHandlerCollector()
         def stdOut = new ByteArrayOutputStream()
@@ -302,23 +292,116 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         stdOut.toString().contains("bye")
     }
 
-    @TargetGradleVersion(">=4.8")
-    def "default tasks are not run if no tasks are specified"() {
-        IntermediateResultHandlerCollector buildFinishedHandler = new IntermediateResultHandlerCollector()
-        def stdOut = new ByteArrayOutputStream()
+    @Unroll
+    def "do not run any tasks when none specified and #description"() {
+        file('build.gradle') << """
+            $configuration
+
+            gradle.taskGraph.whenReady {
+                throw new RuntimeException()
+            }
+        """
 
         when:
         withConnection { connection ->
-            connection.action().buildFinished(new CustomBuildFinishedAction(), buildFinishedHandler)
+            def builder = connection.action()
+                .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
                 .build()
-                .setStandardOutput(stdOut)
-                .run()
+            collectOutputs(builder)
+            builder.run()
         }
 
         then:
-        buildFinishedHandler.getResult() == "build"
-        stdOut.toString().contains("buildFinishedAction")
-        !stdOut.toString().contains("default")
+        noExceptionThrown()
+        assertHasConfigureSuccessfulLogging()
+
+        where:
+        description                                        | configuration
+        "build logic does not define any additional tasks" | ""
+        "build logic defines default tasks"                | "defaultTasks = ['broken']"
+        "build logic injects tasks into start param"       | "gradle.startParameter.taskNames = ['broken']"
+    }
+
+    @Unroll
+    def "#description means run help task"() {
+        file('build.gradle') << """
+        """
+
+        when:
+        withConnection { connection ->
+            def builder = connection.action()
+                .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
+                .build()
+            action(builder)
+            collectOutputs(builder)
+            builder.run()
+        }
+
+        then:
+        assertHasBuildSuccessfulLogging()
+        OutputScrapingExecutionResult.from(stdout.toString(), stderr.toString()).assertTasksExecuted(":help")
+
+        where:
+        description                 | action
+        "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
+        "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
+    }
+
+    @Unroll
+    def "#description means run default tasks when they are defined"() {
+        file('build.gradle') << """
+            defaultTasks = ["thing"]
+
+            task thing { }
+        """
+
+        when:
+        withConnection { connection ->
+            def builder = connection.action()
+                .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
+                .build()
+            action(builder)
+            collectOutputs(builder)
+            builder.run()
+        }
+
+        then:
+        assertHasBuildSuccessfulLogging()
+        OutputScrapingExecutionResult.from(stdout.toString(), stderr.toString()).assertTasksExecuted(":thing")
+
+        where:
+        description                 | action
+        "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
+        "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
+    }
+
+    @Unroll
+    def "#description means run tasks injected by build logic"() {
+        file('build.gradle') << """
+            gradle.startParameter.taskNames = ["thing"]
+
+            task thing { }
+        """
+
+        when:
+        withConnection { connection ->
+            def builder = connection.action()
+                .buildFinished(new CustomBuildFinishedAction(), new IntermediateResultHandlerCollector())
+                .build()
+            action(builder)
+            collectOutputs(builder)
+            builder.run()
+        }
+
+        then:
+        noExceptionThrown()
+        assertHasBuildSuccessfulLogging()
+        OutputScrapingExecutionResult.from(stdout.toString(), stderr.toString()).assertTasksExecuted(":thing")
+
+        where:
+        description                 | action
+        "empty array of task names" | { BuildActionExecuter b -> b.forTasks() }
+        "empty list of task names"  | { BuildActionExecuter b -> b.forTasks([]) }
     }
 
     @TargetGradleVersion(">=2.6 <4.8")

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseAutoBuildTasksCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseAutoBuildTasksCrossVersionSpec.groovy
@@ -112,7 +112,6 @@ class RunEclipseAutoBuildTasksCrossVersionSpec extends ToolingApiSpecification {
         taskExecuted(out, ":sub:bar")
     }
 
-
     def "execute placeholder task when no task is configured for auto-build"() {
         setup:
         def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/BuildActionExecuter.java
@@ -72,7 +72,7 @@ public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildAction
     /**
      * <p>Specifies the tasks to execute before executing the BuildAction.</p>
      *
-     * <p>If not configured, null, or an empty array is passed, then no tasks will be executed.</p>
+     * <p>If not configured or a null array, then no tasks will be executed. If an empty array, the default tasks for the build will be executed.</p>
      *
      * <p>If the target Gradle version is &gt;=6.8 then you can execute tasks from included builds. You can target tasks from included builds by specifying the task identity path (i.e. {@code
      * ':included-build-name:subproject-name:taskName'}).</p>
@@ -86,7 +86,7 @@ public interface BuildActionExecuter<T> extends ConfigurableLauncher<BuildAction
     /**
      * <p>Specifies the tasks to execute before executing the BuildAction.</p>
      *
-     * <p>If not configured, null, or an empty array is passed, then no tasks will be executed.</p>
+     * <p>If not configured or a null iterable, then no tasks will be executed. If an empty iterable, the default tasks for the build will be executed.</p>
      *
      * <p>If the target Gradle version is &gt;=6.8 then you can execute tasks from included builds. You can target tasks from included builds by specifying the task identity path (i.e. {@code
      * ':included-build-name:subproject-name:taskName'}).</p>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Adds support for caching tooling API models and the results of build actions when isolated projects is enabled.

There are a number of known issues with the caching:

- Does not work when the tooling API client also specifies some additional tasks to run. This includes specifying an empty list of names, which IDEA and Studio currently happen to do. The current contract unfortunately means "see if the build logic happens to hack the `StartParameters` to add some task names" and, equally unfortunately, this contract is taken advantage of.
- The validation does not seem to scale very well, and so ruins the performance of the Gradle invocation that writes the cache entry. Exactly which part of the validation does not scale is currently not known.
- The "BUILD SUCCESSFUL" message is missing from the console output when the cache entry is reused.
- Does not yet work with composite builds.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
