### PR TITLE
Increase connection timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,9 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Set the property here so it matches the configuration cache fingerprint of the :build-logic-commons and :build-logic builds
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
+
+# For some reason, after an upgrade of repo.gradle.org, we run into connection timeouts when uploading the artifacts in the promotion build.
+# Increasing the timeout seems to fix the problem.
+# We should remove this when the problems with artifactory are fixed.
+systemProp.org.gradle.internal.http.connectionTimeout=300000
+systemProp.org.gradle.internal.http.socketTimeout=300000


### PR DESCRIPTION
Fixes the promotion jobs when uploading to artifactory.

For some reason, after an upgrade of repo.gradle.org, we run into connection timeouts when uploading the artifacts in the promotion build. Increasing the timeout seems to fix the problem.

Let's use this as a stop-gap measure for now.