### PR TITLE
Rebaseline incremental Java compilation tests after Guava upgrade

### DIFF
--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -795,6 +795,48 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel false)",
+    "groups" : [ {
+      "testProject" : "largeJavaMultiProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    }, {
+      "testProject" : "largeMonolithicJavaProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    } ]
+  }, {
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble (parallel true)",
+    "groups" : [ {
+      "testProject" : "largeJavaMultiProject",
+      "coverage" : {
+        "per_commit" : [ "linux", "windows" ]
+      }
+    } ]
+  }, {
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel false)",
+    "groups" : [ {
+      "testProject" : "largeJavaMultiProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    }, {
+      "testProject" : "largeMonolithicJavaProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    } ]
+  }, {
+    "testId" : "org.gradle.performance.regression.java.JavaIncrementalExecutionPerformanceTest.up-to-date assemble with local build cache enabled (parallel true)",
+    "groups" : [ {
+      "testProject" : "largeJavaMultiProject",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.java.JavaTasksPerformanceTest.tasks",
     "groups" : [ {
       "testProject" : "largeJavaMultiProject",

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -28,7 +28,6 @@ import org.gradle.profiler.mutations.ApplyAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.profiler.mutations.ClearBuildCacheMutator
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
 
 import static org.gradle.performance.annotations.ScenarioType.PER_COMMIT
 import static org.gradle.performance.annotations.ScenarioType.PER_DAY
@@ -42,7 +41,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
     boolean isGroovyProject
 
     def setup() {
-        runner.targetVersions = ["7.1-20210427170827+0000"]
+        runner.targetVersions = ["7.2-20210624165551+0000"]
         testProject = JavaTestProject.findProjectFor(runner.testProject)
         isGroovyProject = testProject?.name()?.contains("GROOVY")
         if (isGroovyProject) {
@@ -124,7 +123,6 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
         @Scenario(type = PER_COMMIT, operatingSystems = [LINUX, WINDOWS], testProjects = "largeJavaMultiProject", iterationMatcher = '.*parallel true.*'),
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
     ])
-    @Ignore("Needs rebaselining")
     def "up-to-date assemble (parallel #parallel)"() {
         given:
         runner.tasksToRun = ['assemble']
@@ -144,7 +142,6 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeJavaMultiProject", iterationMatcher = '.*parallel true.*'),
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeJavaMultiProject", "largeMonolithicJavaProject"], iterationMatcher = '.*parallel false.*'),
     ])
-    @Ignore("Needs rebaselining")
     def "up-to-date assemble with local build cache enabled (parallel #parallel)"() {
         given:
         runner.tasksToRun = ['assemble']


### PR DESCRIPTION
Rebaseline and re-enable performance tests disabled in https://github.com/gradle/gradle/pull/17480.