### PR TITLE
Check if the autoprovisioned JDK can satisfy toolchain spec early

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -55,7 +55,7 @@ public class AdoptOpenJdkRemoteBinary {
         return Optional.of(destinationFile);
     }
 
-    private boolean canProvideMatchingJdk(JavaToolchainSpec spec) {
+    public boolean canProvideMatchingJdk(JavaToolchainSpec spec) {
         final boolean matchesLanguageVersion = getLanguageVersion(spec).canCompileOrRun(8);
         final DefaultJvmVendorSpec vendorSpec = (DefaultJvmVendorSpec) spec.getVendor().get();
         JvmVendor vendor = JvmVendor.fromString("adoptopenjdk");

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningService.java
@@ -61,7 +61,7 @@ public class DefaultJavaToolchainProvisioningService implements JavaToolchainPro
     }
 
     public Optional<File> tryInstall(JavaToolchainSpec spec) {
-        if (!isAutoDownloadEnabled()) {
+        if (!isAutoDownloadEnabled() || !openJdkBinary.canProvideMatchingJdk(spec)) {
             return Optional.empty();
         }
         return provisionInstallation(spec);


### PR DESCRIPTION
If the autoprovisioned JDK is already downloaded but not suitable the
build was unpacking the downloaded archive again and using the result
violating the spec. This happened because the presence of the
downloaded archive was short-circuiting the spec check.

This CL fix both unneeded unpacking and following use of the wrong JDK
by checking if JDK for the spec can be downloaded first, before checking
for the downloaded archive's presence.

<!--- The issue this PR addresses -->
Fixes #17509
