### PR TITLE
Add integration test for overriding SourceTask.getSource()

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SourceTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SourceTaskIntegrationTest.groovy
@@ -122,4 +122,62 @@ class SourceTaskIntegrationTest extends AbstractIntegrationSpec {
         outputContains("visit a/two.txt")
         outputContains("visit a/emptyDir")
     }
+
+    def "can override getSource() method in SourceTask and still ignore empty directories"() {
+        given:
+        file("src/one.txt").createFile()
+        file("src/a/two.txt").createFile()
+
+        buildFile << """
+            class TestTask extends SourceTask {
+                @OutputFile
+                File outputFile
+
+                @TaskAction
+                def list() {
+                    source.visit { fte -> println("visit " + fte.relativePath) }
+                    outputFile.text = 'executed'
+                }
+
+                @InputFiles
+                @SkipWhenEmpty
+                @PathSensitive(PathSensitivity.ABSOLUTE)
+                @Override
+                public FileTree getSource() {
+                    return super.getSource()
+                }
+            }
+
+            task source(type: TestTask) {
+                source file('src')
+                outputFile = file("\${buildDir}/output")
+            }
+        """
+
+        when:
+        run "source"
+
+        then:
+        output.count("visit ") == 3
+        outputContains("visit one.txt")
+        outputContains("visit a")
+        outputContains("visit a/two.txt")
+
+        when:
+        run "source"
+
+        then:
+        skipped(":source")
+
+        and:
+        output.count("visit ") == 0
+
+        when:
+        file("src/a/emptyDir").mkdirs()
+        run "source"
+
+        then:
+        skipped(":source")
+        output.count("visit ") == 0
+    }
 }


### PR DESCRIPTION
This just adds an additional test to validate that annotations on `SourceTask.getSource()` are inherited when a user overrides that method.
