### PR TITLE
Treat non-existing files as regular files when detecting missing task dependencies

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionNodeAccessHierarchy.java
@@ -77,7 +77,9 @@ public class ExecutionNodeAccessHierarchy {
     }
 
     private boolean relativePathMatchesSpec(Spec<FileTreeElement> filter, File element, String relativePathString) {
-        boolean elementIsFile = element.isFile();
+        // A better solution for output files would be to record the type of the output file and then using this type here instead of looking at the disk.
+        // Though that is more involved and as soon as the file has been produced, the right file type will be detected here as well.
+        boolean elementIsFile = !element.isDirectory();
         RelativePath relativePath = RelativePath.parse(elementIsFile, relativePathString);
         if (!filter.isSatisfiedBy(new ReadOnlyFileTreeElement(element, relativePath, stat))) {
             return false;

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/ExecutionNodeAccessHierarchyTest.groovy
@@ -114,7 +114,7 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
         hierarchy.recordNodeAccessingLocations(node6, [temporaryFolder.createDir("other").file("third").absolutePath])
 
         expect:
-        nodesRelatedTo(root, "*/within") == ([rootNode, node1, node3, node4, node5] as Set)
+        nodesRelatedTo(root, "*/within") == ([rootNode, node3, node5, node7] as Set)
         nodesRelatedTo(root, "included/*") == ([rootNode, node4, node7] as Set)
         nodesRelatedTo(root, "included/within") == ([rootNode, node4] as Set)
     }
@@ -133,8 +133,8 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
         hierarchy.recordNodeAccessingLocations(file, [root.createFile("file").absolutePath])
 
         expect:
-        nodesRelatedTo(root, "**/within") == ([rootNode, missing, directory] as Set)
-        nodesRelatedTo(root, "**/file") == ([rootNode, missing, directory, file] as Set)
+        nodesRelatedTo(root, "**/within") == ([rootNode, directory] as Set)
+        nodesRelatedTo(root, "**/file") == ([rootNode, directory, file] as Set)
         nodesRelatedTo(root, "directory/**") == ([rootNode, directory] as Set)
         nodesRelatedTo(root, "missing/**") == ([rootNode, missing] as Set)
         nodesRelatedTo(root, "file/**") == ([rootNode, file] as Set)
@@ -153,11 +153,14 @@ class ExecutionNodeAccessHierarchyTest extends Specification {
     def "can record filtered roots"() {
         def root = temporaryFolder.file("root")
         def node1 = Mock(Node)
+        root.file("sub/included").createDir()
 
         hierarchy.recordNodeAccessingFileTree(node1, root.absolutePath, includes("sub/included/*"))
 
         expect:
         nodesRelatedTo(root.file("sub/included")) == ([node1] as Set)
+        nodesRelatedTo(root.file("sub/included/within")) == ([node1] as Set)
+        nodesRelatedTo(root.file("sub/included/within/notMatched")) == Collections.emptySet()
     }
 
     def "can visit root path"() {


### PR DESCRIPTION
This allows excluding/including non-existing files via `**/...` patterns.

Fixes #17561