### PR TITLE
Add transitive implementation dependencies to the PMD auxclasspath

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -24,14 +24,17 @@ import static org.gradle.util.Matchers.containsText
 import static org.hamcrest.CoreMatchers.containsString
 
 class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionIntegrationTest {
+    private static final String JUNIT_STR = "'junit:junit:3.8.1'"
+    private static final String JUNIT_IMPL_DEPENDENCY = "implementation $JUNIT_STR"
+    private static final String JUNIT_COMPILE_ONLY_DEPENDENCY = "compileOnly $JUNIT_STR"
+    private static final String JUNIT_PMDAUX_DEPENDENCY = "pmdAux $JUNIT_STR"
 
     static boolean supportsAuxclasspath() {
         return VersionNumber.parse("5.2.0") < versionNumber
     }
 
     def setup() {
-        settingsFile << 'include "pmd-rule", "rule-using"'
-
+        includeProject("pmd-rule")
         buildFile << """
             allprojects {
                 ${mavenCentralRepository()}
@@ -46,12 +49,22 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
                     implementation "${calculateDefaultDependencyNotation()}"
                 }
             }
+        """.stripIndent()
 
+        file("pmd-rule/src/main/resources/rulesets/java/auxclasspath.xml") << rulesetXml()
+        file("pmd-rule/src/main/java/org/gradle/pmd/rules/AuxclasspathRule.java") << ruleCode()
+    }
+
+    private void setupRuleUsingProject(String analyzedCode, String... dependencies) {
+        includeProject("rule-using")
+
+        String dependenciesString = dependencies.join('\n')
+        buildFile << """
             project("rule-using") {
                 apply plugin: 'pmd'
 
                 dependencies {
-                    implementation "junit:junit:3.8.1"
+                    $dependenciesString
 
                     pmd project(":pmd-rule")
                 }
@@ -63,14 +76,33 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
             }
         """.stripIndent()
 
-        file("pmd-rule/src/main/resources/rulesets/java/auxclasspath.xml") << rulesetXml()
-        file("pmd-rule/src/main/java/org/gradle/pmd/rules/AuxclasspathRule.java") << ruleCode()
+        file("rule-using/src/main/java/org/gradle/ruleusing/Class1.java") << analyzedCode
+    }
 
-        file("rule-using/src/main/java/org/gradle/ruleusing/Class1.java") << analyzedCode()
+    private void setupIntermediateProject(String dependency) {
+        includeProject("intermediate")
+        buildFile << """
+            project("intermediate") {
+                dependencies {
+                    $dependency
+                }
+            }
+        """.stripIndent()
+
+        file("intermediate/src/main/java/org/gradle/intermediate/IntermediateClass.java") << """
+        package org.gradle.intermediate;
+
+        public class IntermediateClass {
+            private static junit.framework.TestCase sTestCase = null;
+        }
+        """.stripIndent()
     }
 
     def "auxclasspath configured for rule-using project"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
+
+        given:
+        setupRuleUsingProject(classExtendingJunit(), JUNIT_IMPL_DEPENDENCY)
 
         expect:
         fails ":rule-using:pmdMain"
@@ -84,6 +116,8 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
         given:
+        setupRuleUsingProject(classExtendingJunit(), JUNIT_IMPL_DEPENDENCY)
+
         buildFile << """
 project("rule-using") {
     tasks.withType(Pmd) {
@@ -100,11 +134,53 @@ project("rule-using") {
             assertContents(containsText("auxclasspath not configured"))
     }
 
+    def "auxclasspath contains transitive implementation dependencies"() {
+        Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
+
+        setupIntermediateProject(JUNIT_IMPL_DEPENDENCY)
+        setupRuleUsingProject(classReferencingIntermediate(), "implementation project(':intermediate')")
+
+        expect:
+        fails ":rule-using:pmdMain"
+
+        file("rule-using/build/reports/pmd/main.xml").
+            assertContents(containsClass("org.gradle.ruleusing.Class1")).
+            assertContents(containsText("auxclasspath configured"))
+    }
+
+    def "auxclasspath does not contain transitive compileOnly dependencies"() {
+        Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
+
+        setupIntermediateProject(JUNIT_COMPILE_ONLY_DEPENDENCY)
+        setupRuleUsingProject(classReferencingIntermediate(), "implementation project(':intermediate')")
+
+        expect:
+        fails ":rule-using:pmdMain"
+
+        file("rule-using/build/reports/pmd/main.xml").
+            assertContents(containsClass("org.gradle.ruleusing.Class1")).
+            assertContents(containsText("auxclasspath not configured"))
+    }
+
+    def "auxclasspath contains pmdAux dependencies"() {
+        Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
+
+        setupIntermediateProject(JUNIT_COMPILE_ONLY_DEPENDENCY)
+        setupRuleUsingProject(classReferencingIntermediate(), "implementation project(':intermediate')", JUNIT_PMDAUX_DEPENDENCY)
+
+        expect:
+        fails ":rule-using:pmdMain"
+
+        file("rule-using/build/reports/pmd/main.xml").
+            assertContents(containsClass("org.gradle.ruleusing.Class1")).
+            assertContents(containsText("auxclasspath configured"))
+    }
+
     private static Matcher<String> containsClass(String className) {
         containsLine(containsString(className.replace(".", File.separator)))
     }
 
-    private ruleCode() {
+    private static ruleCode() {
         """
             package org.gradle.pmd.rules;
 
@@ -130,7 +206,7 @@ project("rule-using") {
         """
     }
 
-    private rulesetXml() {
+    private static rulesetXml() {
         """
             <ruleset name="auxclasspath"
                 xmlns="http://pmd.sf.net/ruleset/2.0.0"
@@ -146,10 +222,23 @@ project("rule-using") {
         """
     }
 
-    private analyzedCode() {
+    private static classExtendingJunit() {
         """
             package org.gradle.ruleusing;
             public class Class1 extends junit.framework.TestCase { }
         """
+    }
+
+    private static classReferencingIntermediate() {
+        """
+        package org.gradle.ruleusing;
+        public class Class1 {
+            private org.gradle.intermediate.IntermediateClass mClass = null;
+        }
+       """
+    }
+
+    private void includeProject(String projectName) {
+        settingsFile << "include '$projectName'\n"
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -17,15 +17,18 @@ package org.gradle.api.plugins.quality;
 
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.ConventionMapping;
+import org.gradle.api.plugins.jvm.internal.JvmPluginServices;
 import org.gradle.api.plugins.quality.internal.AbstractCodeQualityPlugin;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.util.internal.VersionNumber;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +39,9 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.action;
  * A plugin for the <a href="https://pmd.github.io/">PMD</a> source code analyzer.
  * <p>
  * Declares a <tt>pmd</tt> configuration which needs to be configured with the PMD library to be used.
+ * <p>
+ * Declares a <tt>pmdAux</tt> configuration to add transitive compileOnly dependencies to the PMD's auxclasspath. This is only needed if PMD complains about NoClassDefFoundError during type
+ * resolution.
  * <p>
  * For each source set that is to be analyzed, a {@link Pmd} task is created and configured to analyze all Java code.
  * <p>
@@ -48,7 +54,15 @@ import static org.gradle.api.internal.lambdas.SerializableLambdas.action;
 public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
 
     public static final String DEFAULT_PMD_VERSION = "6.31.0";
+    private static final String PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION = "pmdAux";
+
     private PmdExtension extension;
+
+    @Inject
+    protected JvmPluginServices getJvmPluginServices() {
+        // Constructor injection is not used to keep binary compatibility
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     protected String getToolName() {
@@ -79,6 +93,17 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
             // Use same fallback as PMD
             return TargetJdk.VERSION_1_4;
         }
+    }
+
+    @Override
+    protected void createConfigurations() {
+        super.createConfigurations();
+        project.getConfigurations().create(PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION, additionalAuxDepsConfiguration -> {
+            additionalAuxDepsConfiguration.setDescription("The additional libraries that are available for type resolution during analysis");
+            additionalAuxDepsConfiguration.setCanBeResolved(false);
+            additionalAuxDepsConfiguration.setCanBeConsumed(false);
+            additionalAuxDepsConfiguration.setVisible(false);
+        });
     }
 
     @Override
@@ -146,7 +171,19 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         task.setDescription("Run PMD analysis for " + sourceSet.getName() + " classes");
         task.setSource(sourceSet.getAllJava());
         ConventionMapping taskMapping = task.getConventionMapping();
-        taskMapping.map("classpath", () ->
-            sourceSet.getOutput().plus(sourceSet.getCompileClasspath()));
+        ConfigurationContainer configurations = project.getConfigurations();
+
+        Configuration compileClasspath = configurations.getByName(sourceSet.getCompileClasspathConfigurationName());
+        Configuration pmdAdditionalAuxDepsConfiguration = configurations.getByName(PMD_ADDITIONAL_AUX_DEPS_CONFIGURATION);
+
+        // TODO: Consider checking if the resolution consistency is enabled for compile/runtime.
+        Configuration pmdAuxClasspath = configurations.create(sourceSet.getName() + "PmdAuxClasspath");
+        pmdAuxClasspath.extendsFrom(compileClasspath, pmdAdditionalAuxDepsConfiguration);
+        pmdAuxClasspath.setCanBeConsumed(false);
+        pmdAuxClasspath.setVisible(false);
+        // This is important to get transitive implementation dependencies. PMD may load referenced classes for analysis so it expects the classpath to be "closed" world.
+        getJvmPluginServices().configureAsRuntimeClasspath(pmdAuxClasspath);
+
+        taskMapping.map("classpath", () -> sourceSet.getOutput().plus(pmdAuxClasspath));
     }
 }

--- a/subprojects/docs/src/docs/userguide/core-plugins/pmd_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/pmd_plugin.adoc
@@ -68,6 +68,7 @@ The PMD plugin adds the following dependency configurations:
 |===
 | Name | Meaning
 | `pmd` | The PMD libraries to use
+| `pmdAux` | The additional libraries that are available for type resolution during analysis. This might be useful if PMD complains about missing classes.
 |===
 
 [[sec:pmd_configuration]]


### PR DESCRIPTION
Certain PMD diagnostics load classes referenced in the analyzed source
file, for example, to reconstruct type hierarchies. Such classes are
loaded from the auxclasspath. Prior to this CL only compile outputs and
compile classpath were used as auxclasspath. PMD was complaining about
missing class if some library on compile classpath was referencing other
class from its `implementation` dependency because Gradle doesn't add
transitive `implementation` dependencies to the compile classpath.

This CL introduces new internal configuration `sourcesetPmdAuxClasspath`
that extends compile classpath but is resolved as a runtime classpath
thus including all transitive `implementation` dependencies.

This CL doesn't cover all possible corner cases because referenced
classes from transitive `compileOnly` dependencies are not available.
An additional user-visible configuration `pmdAux` is added to work
around this. The user who encounters the NoClassDefFoundError due to
compileOnly dependency can add it to `pmdAux` configuration while
avoiding pollution of the compile classpath.

Fixes #17410

See https://pmd.github.io/latest/pmd_userdocs_cli_reference.html#auxclasspath