### PR TITLE
Improve disable caching reason on DefaultTask

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -44,7 +44,7 @@ import java.util.Set;
  */
 @NoConventionMapping
 @SuppressWarnings("deprecation")
-@DisableCachingByDefault(because = "Super-class without any behavior")
+@DisableCachingByDefault(because = "Gradle would require more information to cache this task")
 public class DefaultTask extends org.gradle.api.internal.AbstractTask implements Task {
     // NOTE: These methods are duplicated here because Eclipse treats methods implemented in the deprecated
     // AbstractTask as also deprecated in DefaultTask.


### PR DESCRIPTION
Given that ad-hoc tasks have type DefaultTask, the previous message was somewhat misleading.