### PR TITLE
[SPIKE] Aggregate jacoco coverage report from multiple subprojects

### DIFF
--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/aggregation/test-coverage/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/aggregation/test-coverage/build.gradle
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     // Trasitively collect coverage data from all features and their dependencies
-    aggregate('com.example.myproduct.user-feature:table')
-    aggregate('com.example.myproduct.admin-feature:config')
+    jacocoAggregation('com.example.myproduct.user-feature:table')
+    jacocoAggregation('com.example.myproduct.admin-feature:config')
 }

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/build-logic/commons/src/main/groovy/com.example.jacoco.gradle
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/build-logic/commons/src/main/groovy/com.example.jacoco.gradle
@@ -7,33 +7,3 @@ plugins {
 tasks.jacocoTestReport.configure {
     enabled = false
 }
-
-// Share sources folder with other projects for aggregated JaCoCo reports
-configurations.create('transitiveSourcesElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
-    sourceSets.main.java.srcDirs.forEach { outgoing.artifact(it) }
-}
-
-// Share the coverage data to be aggregated for the whole product
-configurations.create('coverageDataElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-    outgoing.artifact(tasks.named('test').map { task ->
-        task.extensions.getByType(JacocoTaskExtension).destinationFile
-    })
-}

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/build-logic/report-aggregation/src/main/groovy/com.example.report-aggregation.gradle
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/build-logic/report-aggregation/src/main/groovy/com.example.report-aggregation.gradle
@@ -3,59 +3,8 @@ plugins {
     id('jacoco')
 }
 
-// Configurations to declare dependencies
-def aggregate = configurations.create('aggregate') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = false
-}
-
-// Resolvable configuration to resolve the classes of all dependencies
-def classPath = configurations.create('classPath') {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.LIBRARY))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.CLASSES))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
-    }
-}
-
-// A resolvable configuration to collect source code
-def sourcesPath = configurations.create('sourcesPath') {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
-}
-
-// A resolvable configuration to collect JaCoCo coverage data
-def coverageDataPath = configurations.create('coverageDataPath') {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-}
-
 // Register a code coverage report task to generate the aggregated report
-def codeCoverageReport = tasks.register('codeCoverageReport', JacocoReport) {
-    additionalClassDirs(classPath.filter { it.isDirectory() })
-    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
-
+def codeCoverageReport = tasks.register('codeCoverageReport', AggregatedJacocoReport) {
     reports {
         html.required = true
         xml.required = true

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/aggregation/test-coverage/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/aggregation/test-coverage/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     // Trasitively collect coverage data from all features and their dependencies
-    aggregate("com.example.myproduct.user-feature:table")
-    aggregate("com.example.myproduct.admin-feature:config")
+    jacocoAggregation("com.example.myproduct.user-feature:table")
+    jacocoAggregation("com.example.myproduct.admin-feature:config")
 }

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/build-logic/commons/src/main/kotlin/com.example.jacoco.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/build-logic/commons/src/main/kotlin/com.example.jacoco.gradle.kts
@@ -7,33 +7,3 @@ plugins {
 tasks.jacocoTestReport.configure {
     enabled = false
 }
-
-// Share sources folder with other projects for aggregated JaCoCo reports
-configurations.create("transitiveSourcesElements") {
-    isVisible = false
-    isCanBeResolved = false
-    isCanBeConsumed = true
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
-    }
-    sourceSets.main.get().java.srcDirs.forEach { outgoing.artifact(it) }
-}
-
-// Share the coverage data to be aggregated for the whole product
-configurations.create("coverageDataElements") {
-    isVisible = false
-    isCanBeResolved = false
-    isCanBeConsumed = true
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
-    }
-    outgoing.artifact(tasks.test.map { task ->
-        task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
-    })
-}

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/build-logic/report-aggregation/src/main/kotlin/com.example.report-aggregation.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/build-logic/report-aggregation/src/main/kotlin/com.example.report-aggregation.gradle.kts
@@ -3,59 +3,8 @@ plugins {
     id("jacoco")
 }
 
-// Configurations to declare dependencies
-val aggregate by configurations.creating {
-    isVisible = false
-    isCanBeResolved = false
-    isCanBeConsumed = false
-}
-
-// Resolvable configuration to resolve the classes of all dependencies
-val classPath by configurations.creating {
-    isVisible = false
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
-        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.CLASSES))
-        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
-    }
-}
-
-// A resolvable configuration to collect source code
-val sourcesPath by configurations.creating {
-    isVisible = false
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
-    }
-}
-
-// A resolvable configuration to collect JaCoCo coverage data
-val coverageDataPath by configurations.creating {
-    isVisible = false
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(aggregate)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
-    }
-}
-
 // Register a code coverage report task to generate the aggregated report
-val codeCoverageReport by tasks.registering(JacocoReport::class) {
-    additionalClassDirs(classPath.filter { it.isDirectory() })
-    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
-
+val codeCoverageReport by tasks.registering(AggregatedJacocoReport::class) {
     reports {
         html.required.set(true)
         xml.required.set(true)
@@ -63,6 +12,6 @@ val codeCoverageReport by tasks.registering(JacocoReport::class) {
 }
 
 // Make JaCoCo report generation part of the 'check' lifecycle phase
-tasks.check {
+tasks.named("check") {
     dependsOn(codeCoverageReport)
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'java-base'
     id 'jacoco'
 }
 
@@ -7,38 +7,8 @@ repositories {
     mavenCentral()
 }
 
-// A resolvable configuration to collect source code
-def sourcesPath = configurations.create("sourcesPath") {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
-}
-
-// A resolvable configuration to collect JaCoCo coverage data
-def coverageDataPath = configurations.create("coverageDataPath") {
-    visible = false
-    canBeResolved = true
-    canBeConsumed = false
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-}
-
 // Task to gather code coverage from multiple subprojects
-def codeCoverageReport = tasks.register('codeCoverageReport', JacocoReport) {
-    additionalClassDirs(configurations.runtimeClasspath)
-    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
-
+def codeCoverageReport = tasks.register('codeCoverageReport', AggregatedJacocoReport) {
     reports {
         // xml is usually used to integrate code coverage with
         // other tools like SonarQube, Coveralls or Codecov

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -23,36 +23,3 @@ dependencies {
 tasks.named("jacocoTestReport") {
     enabled = false
 }
-
-// Share sources folder with other projects for aggregated JaCoCo reports
-configurations.create('transitiveSourcesElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-folders'))
-    }
-    sourceSets.main.java.srcDirs.forEach {
-        outgoing.artifact(it)
-    }
-}
-
-// Share the coverage data to be aggregated for the whole product
-configurations.create('coverageDataElements') {
-    visible = false
-    canBeResolved = false
-    canBeConsumed = true
-    extendsFrom(configurations.implementation)
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'jacoco-coverage-data'))
-    }
-    // This will cause the test task to run if the coverage data is requested by the aggregation task
-    outgoing.artifact(tasks.named("test").map { task ->
-        task.extensions.getByType(JacocoTaskExtension).destinationFile
-    })
-}

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/code-coverage-report/build.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/groovy/code-coverage-report/build.gradle
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation project(':application')
+    jacocoAggregation project(':application')
 }

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.jacoco-aggregation.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.jacoco-aggregation.gradle.kts
@@ -1,44 +1,14 @@
 plugins {
-    java
-    jacoco
+    id("java-base")
+    id("jacoco")
 }
 
 repositories {
     mavenCentral()
 }
 
-// A resolvable configuration to collect source code
-val sourcesPath: Configuration by configurations.creating {
-    isVisible = false
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
-    }
-}
-
-// A resolvable configuration to collect JaCoCo coverage data
-val coverageDataPath: Configuration by configurations.creating {
-    isVisible = false
-    isCanBeResolved = true
-    isCanBeConsumed = false
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
-    }
-}
-
 // Task to gather code coverage from multiple subprojects
-val codeCoverageReport by tasks.registering(JacocoReport::class) {
-    additionalClassDirs(configurations.runtimeClasspath.get())
-    additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
-    executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
-
+val codeCoverageReport by tasks.registering(AggregatedJacocoReport::class) {
     reports {
         // xml is usually used to integrate code coverage with
         // other tools like SonarQube, Coveralls or Codecov

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -23,36 +23,3 @@ dependencies {
 tasks.jacocoTestReport {
     enabled = false
 }
-
-// Share sources folder with other projects for aggregated JaCoCo reports
-configurations.create("transitiveSourcesElements") {
-    isVisible = false
-    isCanBeResolved = false
-    isCanBeConsumed = true
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("source-folders"))
-    }
-    sourceSets.main.get().java.srcDirs.forEach {
-        outgoing.artifact(it)
-    }
-}
-
-// Share the coverage data to be aggregated for the whole product
-configurations.create("coverageDataElements") {
-    isVisible = false
-    isCanBeResolved = false
-    isCanBeConsumed = true
-    extendsFrom(configurations.implementation.get())
-    attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
-        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
-        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("jacoco-coverage-data"))
-    }
-    // This will cause the test task to run if the coverage data is requested by the aggregation task
-    outgoing.artifact(tasks.test.map { task ->
-        task.extensions.getByType<JacocoTaskExtension>().destinationFile!!
-    })
-}

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/code-coverage-report/build.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-code-coverage/kotlin/code-coverage-report/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":application"))
+    jacocoAggregation(project(":application"))
 }

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCoverageAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCoverageAggregationIntegrationTest.groovy
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportFixture
+
+class JacocoCoverageAggregationIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final AGGREGATION_TASK_NAME = "jacocoAggregatedTestReport"
+
+    def setup() {
+        writeClassWithTest("lib1", "Lib1")
+        writeClassWithTest("lib2", "Lib2")
+        writeClassWithTest("app", "App")
+        settingsFile << """
+            include("lib1", "lib2", "app")
+            dependencyResolutionManagement {
+                ${mavenCentralRepository()}
+            }
+        """
+        file("lib1/build.gradle") << """
+            plugins {
+                id("java-library")
+                id("jacoco")
+            }
+            ${configureJUnitPlatform()}
+            ${registerOutgoingCoverageVariants()}
+        """
+        file("lib2/build.gradle") << """
+            plugins {
+                id("java-library")
+                id("jacoco")
+            }
+            ${configureJUnitPlatform()}
+            ${registerOutgoingCoverageVariants()}
+        """
+        file("app/build.gradle") << """
+            plugins {
+                id("application")
+                id("jacoco")
+            }
+            ${configureJUnitPlatform()}
+            ${registerOutgoingCoverageVariants()}
+        """
+    }
+
+    def "aggregates unit test results for the app and its library dependencies"() {
+        given:
+        file("app/build.gradle") << """
+            dependencies {
+                implementation(project(":lib1"))
+                implementation(project(":lib2"))
+            }
+            ${configureAggregation()}
+        """
+
+        when:
+        succeeds(AGGREGATION_TASK_NAME)
+
+        then:
+        def aggregatedReport = htmlReport("app", AGGREGATION_TASK_NAME)
+        aggregatedReport.exists()
+        aggregatedReport.numberOfClasses() == 3
+    }
+
+    def "aggregates unit test results for the app and its library dependencies transitively"() {
+        given:
+        file("lib1/build.gradle") << """
+            dependencies {
+                implementation(project(":lib2"))
+            }
+        """
+        file("app/build.gradle") << """
+            dependencies {
+                implementation(project(":lib1"))
+            }
+            ${configureAggregation()}
+        """
+
+        when:
+        succeeds(AGGREGATION_TASK_NAME)
+
+        then:
+        def aggregatedReport = htmlReport("app", AGGREGATION_TASK_NAME)
+        aggregatedReport.exists()
+        aggregatedReport.numberOfClasses() == 3
+    }
+
+    def "excludes external dependency classes from aggregated unit test results"() {
+        given:
+        file("lib1/build.gradle") << """
+            dependencies {
+                 implementation("commons-io:commons-io:2.6")
+            }
+        """
+        file("app/build.gradle") << """
+            dependencies {
+                implementation(project(":lib1"))
+                implementation(project(":lib2"))
+                implementation("junit:junit:4.13")
+            }
+            ${configureAggregation()}
+        """
+
+        when:
+        succeeds(AGGREGATION_TASK_NAME)
+
+        then:
+        def aggregatedReport = htmlReport("app", AGGREGATION_TASK_NAME)
+        aggregatedReport.exists()
+        aggregatedReport.numberOfClasses() == 3
+    }
+
+    def "assemble does not execute tests"() {
+        given:
+        file("app/build.gradle") << """
+            dependencies {
+                implementation(project(":lib1"))
+                implementation(project(":lib2"))
+            }
+            ${configureAggregation()}
+        """
+
+        when:
+        succeeds("assemble")
+
+        then:
+        notExecuted(":app:test", ":lib1:test", ":lib2:test")
+    }
+
+    private JacocoReportFixture htmlReport(String project, String reportName) {
+        return new JacocoReportFixture(file(project + "/build/reports/jacoco/${reportName}/html"))
+    }
+
+    private static String configureAggregation() {
+        return """
+            def sourcesPath = configurations.create("sourcesPath") {
+                visible = false
+                canBeResolved = true
+                canBeConsumed = false
+                extendsFrom(configurations.implementation)
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "source-directories"))
+                }
+            }
+            def coverageDataPath = configurations.create("coverageDataPath") {
+                visible = false
+                canBeResolved = true
+                canBeConsumed = false
+                extendsFrom(configurations.implementation)
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "jacoco-coverage-data"))
+                }
+            }
+
+            def currentProjectCoverageProvider = tasks.named("test").map { task ->
+                task.extensions.getByType(JacocoTaskExtension).destinationFile
+            }
+            tasks.register("${AGGREGATION_TASK_NAME}", JacocoReport) {
+                sourceSets(sourceSets.main)
+                additionalClassDirs(configurations.runtimeClasspath.filter { it.path.contains("/build/libs/") })
+                additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
+                executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
+                executionData(currentProjectCoverageProvider)
+                reports {
+                    xml.required = true
+                    html.required = true
+                }
+            }
+        """
+    }
+
+    private static String registerOutgoingCoverageVariants() {
+        return """
+            configurations.create("transitiveSourcesElements") {
+                visible = false
+                canBeResolved = false
+                canBeConsumed = true
+                extendsFrom(configurations.implementation)
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "source-directories"))
+                }
+                sourceSets.main.java.srcDirs.forEach {
+                    outgoing.artifact(it)
+                }
+            }
+            configurations.create("coverageDataElements") {
+                visible = false
+                canBeResolved = false
+                canBeConsumed = true
+                extendsFrom(configurations.implementation)
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, "jacoco-coverage-data"))
+                }
+                outgoing.artifact(tasks.named("test").map { task ->
+                    task.extensions.getByType(JacocoTaskExtension).destinationFile
+                })
+            }
+        """
+    }
+
+    private static String configureJUnitPlatform() {
+        return """
+            dependencies {
+                testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.2")
+            }
+            tasks.named("test") {
+                useJUnitPlatform()
+            }
+        """
+    }
+
+    private void writeClassWithTest(String subproject, String className) {
+        file("${subproject}/src/main/java/com/example/${className}.java") << """
+            package com.example;
+            public class ${className} {
+                public String get${className}() {
+                    return "${className}";
+                }
+                void untested() {
+                    System.out.println();
+                }
+            }
+        """
+        file("${subproject}/src/test/java/com/example/${className}Test.java") << """
+            package com.example;
+            import org.junit.jupiter.api.Test;
+            class ${className}Test {
+                @Test
+                void returns${className}() {
+                    new ${className}().get${className}();
+                }
+            }
+        """
+    }
+}
+

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -23,7 +23,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -50,8 +49,6 @@ import org.gradle.testing.jacoco.tasks.JacocoReport;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.gradle.api.internal.lambdas.SerializableLambdas.action;
 
@@ -138,24 +135,21 @@ public class JacocoPlugin implements Plugin<Project> {
             javaPluginExtension.getSourceSets().getByName("main").getJava().getSrcDirs()
                 .forEach(f -> transitiveSourcesElements.getOutgoing().artifact(f));
 
-            Set<String> testTasks = new HashSet<>();
-            // TODO: test task is known for java ecosystem. Can we figure what other Test tasks are there in order to wire coverage variants for them?
-            testTasks.add("test");
-            for (String testTaskName : testTasks) {
-                Configuration coverageElements = createVariant(testTaskName + "CoverageElements",
-                    AggregatedJacocoReport.coverageDataAttributes(project));
-                coverageElements.getAttributes().attribute(Attribute.of("testTask", String.class), testTaskName);
-                coverageElements.extendsFrom(implementation);
-                TaskContainer tasks = project.getTasks();
-                coverageElements.getOutgoing().artifact(
-                    tasks.named(testTaskName).map(task -> {
+            TaskContainer tasks = project.getTasks();
+            project.afterEvaluate(p -> {
+                for (String taskName : tasks.withType(Test.class).getNames()) {
+                    Configuration coverageElements = createVariant(taskName + "CoverageElements",
+                        AggregatedJacocoReport.coverageDataAttributes(project, taskName));
+                    coverageElements.extendsFrom(implementation);
+                    coverageElements.getOutgoing().artifact(tasks.named(taskName).map(task -> {
                         File destinationFile = task.getExtensions().getByType(JacocoTaskExtension.class).getDestinationFile();
                         if (destinationFile == null) {
                             throw new GradleException(DESTINATION_MUST_BE_NOT_NULL_MESSAGE);
                         }
                         return destinationFile;
                     }));
-            }
+                }
+            });
         });
 
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -69,8 +69,6 @@ public class JacocoPlugin implements Plugin<Project> {
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";
 
-    static final String DESTINATION_MUST_BE_NOT_NULL_MESSAGE = "JaCoCo destination file must not be null if output type is FILE";
-
     private final Instantiator instantiator;
     private Project project;
 
@@ -144,7 +142,7 @@ public class JacocoPlugin implements Plugin<Project> {
                     coverageElements.getOutgoing().artifact(tasks.named(taskName).map(task -> {
                         File destinationFile = task.getExtensions().getByType(JacocoTaskExtension.class).getDestinationFile();
                         if (destinationFile == null) {
-                            throw new GradleException(DESTINATION_MUST_BE_NOT_NULL_MESSAGE);
+                            throw new GradleException("JaCoCo destination file must not be null if output type is FILE");
                         }
                         return destinationFile;
                     }));

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -196,7 +196,7 @@ public class JacocoPluginExtension {
                 // The JaCoCo agent supports writing in parallel to the same file, see https://github.com/jacoco/jacoco/pull/52.
                 File coverageFile = destinationFile.getOrNull();
                 if (coverageFile == null) {
-                    throw new GradleException("JaCoCo destination file must not be null if output type is FILE");
+                    throw new GradleException(JacocoPlugin.DESTINATION_MUST_BE_NOT_NULL_MESSAGE);
                 }
                 fs.delete(spec -> spec.delete(coverageFile));
             }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPluginExtension.java
@@ -17,7 +17,6 @@ package org.gradle.testing.jacoco.plugins;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.Named;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -194,11 +193,7 @@ public class JacocoPluginExtension {
                 // Delete the coverage file before the task executes, so we don't append to a leftover file from the last execution.
                 // This makes the task cacheable even if multiple JVMs write to same destination file, e.g. when executing tests in parallel.
                 // The JaCoCo agent supports writing in parallel to the same file, see https://github.com/jacoco/jacoco/pull/52.
-                File coverageFile = destinationFile.getOrNull();
-                if (coverageFile == null) {
-                    throw new GradleException(JacocoPlugin.DESTINATION_MUST_BE_NOT_NULL_MESSAGE);
-                }
-                fs.delete(spec -> spec.delete(coverageFile));
+                fs.delete(spec -> spec.delete(destinationFile.get()));
             }
         }
     }

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/AggregatedJacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/AggregatedJacocoReport.java
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.jvm.internal.JvmEcosystemUtilities;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.internal.jacoco.AntJacocoReport;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
@@ -62,7 +63,7 @@ public abstract class AggregatedJacocoReport extends JacocoReport {
         project.getPluginManager().withPlugin("java", plugin -> {
             JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
             // TODO: what about other "production" source sets that the users might add?
-            sourceSets(javaPluginExtension.getSourceSets().getByName("main"));
+            sourceSets(javaPluginExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME));
 
             executionData(getTestCategories().map(categories -> {
                 ConfigurableFileCollection coverageFiles = project.files();

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/AggregatedJacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/AggregatedJacocoReport.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.testing.jacoco.tasks;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.jvm.internal.JvmEcosystemUtilities;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.internal.jacoco.AntJacocoReport;
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
+
+import javax.inject.Inject;
+import java.io.File;
+
+/**
+ * Task to aggregate HTML, Xml and CSV reports of Jacoco coverage data.
+ *
+ * @since 7.2
+ */
+@Incubating
+@CacheableTask
+public class AggregatedJacocoReport extends JacocoReport {
+
+    public static final String AGGREGATION_CONFIGURATION_NAME = "jacocoAggregation";
+
+    @Inject
+    public AggregatedJacocoReport(JvmEcosystemUtilities jvmEcosystemUtilities) {
+        Project project = getProject();
+        project.getPluginManager().withPlugin("java", plugin -> {
+            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            // TODO: what about other "production" source sets that the users might add?
+            sourceSets(javaPluginExtension.getSourceSets().getByName("main"));
+            executionData(project.getTasks().named("test").map(task -> task.getExtensions().getByType(JacocoTaskExtension.class).getDestinationFile()));
+        });
+
+        ConfigurationContainer configurations = project.getConfigurations();
+        Configuration jacocoAggregation = configurations.getByName(AGGREGATION_CONFIGURATION_NAME);
+
+        Configuration coverageClassesDirs = createResolver("coverageClassesDirs");
+        coverageClassesDirs.extendsFrom(jacocoAggregation);
+        jvmEcosystemUtilities.configureAsRuntimeClasspath(coverageClassesDirs);
+        // TODO: is there a better way to not include external dependency classes?
+        additionalClassDirs(coverageClassesDirs.filter(it -> it.getPath().contains(File.separator + "build" + File.separator + "libs" + File.separator)));
+
+        Configuration sourcesPath = createResolver("sourcesPath");
+        sourcesPath.extendsFrom(jacocoAggregation);
+        sourcesPath.attributes(sourceDirectoriesAttributes(project));
+        additionalSourceDirs(sourcesPath.getIncoming().artifactView(it -> it.lenient(true)).getFiles());
+
+        Configuration coverageDataPath = createResolver("coverageDataPath");
+        coverageDataPath.extendsFrom(jacocoAggregation);
+        // TODO: can we add configuration options so that users can choose which test tasks to aggregate coverage for?
+        // Given that there will be multiple variants exposing coverage data per test task
+        coverageDataPath.attributes(coverageDataAttributes(project));
+        executionData(coverageDataPath.getIncoming().artifactView(it -> it.lenient(true)).getFiles().filter(File::exists));
+    }
+
+    @Override
+    public void generate() {
+        new AntJacocoReport(getAntBuilder()).execute(
+            getJacocoClasspath(),
+            getReportProjectName().get(),
+            getAllClassDirs().filter(File::exists),
+            getAllSourceDirs().filter(File::exists),
+            getExecutionData().filter(File::exists),
+            getReports()
+        );
+    }
+
+    private Configuration createResolver(String name) {
+        ConfigurationContainer configurations = getProject().getConfigurations();
+        return configurations.create(name, c -> {
+            c.setVisible(false);
+            c.setCanBeResolved(true);
+            c.setCanBeConsumed(false);
+        });
+    }
+
+    public static Action<? super AttributeContainer> sourceDirectoriesAttributes(Project project) {
+        return a -> {
+            a.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+            a.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION));
+            a.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, project.getObjects().named(DocsType.class, "source-directories"));
+        };
+    }
+
+    public static Action<? super AttributeContainer> coverageDataAttributes(Project project) {
+        return a -> {
+            a.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+            a.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION));
+            a.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, project.getObjects().named(DocsType.class, "jacoco-coverage-data"));
+        };
+    }
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
@@ -19,7 +19,6 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
 import org.gradle.api.reporting.Reporting;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -40,7 +39,6 @@ public class JacocoReport extends JacocoReportBase implements Reporting<JacocoRe
     private final JacocoReportsContainer reports;
 
     public JacocoReport() {
-        super();
         projectName.value(getProject().getName()).disallowChanges();
         reports = getInstantiator().newInstance(JacocoReportsContainerImpl.class, this, getCallbackActionDecorator());
     }
@@ -70,7 +68,7 @@ public class JacocoReport extends JacocoReportBase implements Reporting<JacocoRe
      */
     @Override
     public JacocoReportsContainer reports(Closure closure) {
-        return reports(new ClosureBackedAction<JacocoReportsContainer>(closure));
+        return reports(new ClosureBackedAction<>(closure));
     }
 
     @Override
@@ -81,18 +79,11 @@ public class JacocoReport extends JacocoReportBase implements Reporting<JacocoRe
 
     @TaskAction
     public void generate() {
-        final Spec<File> fileExistsSpec = new Spec<File>() {
-            @Override
-            public boolean isSatisfiedBy(File file) {
-                return file.exists();
-            }
-        };
-
         new AntJacocoReport(getAntBuilder()).execute(
             getJacocoClasspath(),
             projectName.get(),
-            getAllClassDirs().filter(fileExistsSpec),
-            getAllSourceDirs().filter(fileExistsSpec),
+            getAllClassDirs().filter(File::exists),
+            getAllSourceDirs().filter(File::exists),
             getExecutionData(),
             getReports()
         );

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -205,7 +205,7 @@ public abstract class JacocoReportBase extends JacocoBase {
         for (final SourceSet sourceSet : sourceSets) {
             sourceDirectories.from(new Callable<Set<File>>() {
                 @Override
-                public Set<File> call() throws Exception {
+                public Set<File> call() {
                     return sourceSet.getAllJava().getSrcDirs();
                 }
             });


### PR DESCRIPTION
This change explores embedding the ideas from the current [jacoco coverage aggregation sample](https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage.html) into the `jacoco` plugin.

### Use cases

- Given a multi-project build that builds my product, I want a code coverage report for the whole product
- Given a multi-project build that builds my product, where I have multiple types of tests that are executed by different test tasks, I want:
  - A single code coverage report for all my test types combined, for the whole product
  - Distinct code coverage reports for each test type for the whole product
  - A code coverage report that combines some test types, but not others for the whole product

### Usage

In all the projects that should produce code coverage data, apply the `jacoco` plugin as usual.

#### Aggregating project is also a coverage data producing project

Here, the aggregation project is also a java project that packages the product, for example, an application that has project dependencies on some libraries:
```
app/build.gradle
lib1/build.gradle
lib2/build.gradle
settings.gradle
```
The `lib1` and `lib2` projects apply `java-library` and `jacoco` plugins.
The `app` project build the product and aggregates the unit test coverage data for it:
```
plugins {
    id("application") // implicitly applies `java`
    id("jacoco")
}
dependencies {
    implementation(project(":lib1"))
    implementation(project(":lib2"))
}
tasks.register("aggregatedCoverageReport", AggregatedJacocoReport) {
    testCategories = ["test"] // this can be skipped, it is the default
}
```
The aggregated report will also include any transitive project dependencies if `lib1` or `lib2` had any.

#### Aggregating project is a dedicated project that aggregates code coverage data from multiple subprojects

Say we have the following project, where `foo`, `bar`, `fizz`, `buzz` are all java projects and produce code coverage data (by applying `jacoco` plugin:
```
foo/build.gradle
bar/build.gradle
fizz/build.gradle
buzz/build.gradle
foobar-aggregation/build.gradle
settings.gradle
```
The `foobar-aggregation` project wants to aggregate coverage data from projects `foo` and `bar:
```
plugins {
    id("jacoco")
}
dependencies {
    jacocoAggregation(project(":foo"))
    jacocoAggregation(project(":bar"))
}
tasks.register("foobarCoverageReport", AggregatedJacocoReport) {
    testCategories = ["test"] // this can be skipped, it is the default
}
```

#### Aggregating coverage data from different test tasks

It is common that software projects declare different types of tests. The `java` plugin only configures the task named `test` of type `Test` that usually is used for unit testing. A project could declare another `Test` task for integration tests - `integrationTest` that might as well produce code coverage data.

By default, the aggregation task `AggregatedJacocoReport` will only aggregate the coverage data of tasks named `test`. To combine the aggregation of `test` and `integrationTest` tasks:
```
tasks.register("combinedCoverageReport", AggregatedJacocoReport) {
    testCategories = ["test", "integrationTest"]
}
```

Alternatively, multiple aggregations can be created as needed:
```
tasks.register("unitTestCoverageReport", AggregatedJacocoReport) {
    testCategories = ["test"]
}
tasks.register("integrationTestCoverageReport", AggregatedJacocoReport) {
    testCategories = ["integrationTest"]
}
tasks.register("combinedCoverageReport", AggregatedJacocoReport) {
    testCategories = ["test", "integrationTest"]
}
```

### Behind the scenes
The outgoing coverage data and source directory variant creation as well as their resolution on the aggregating side, as seen in the current sample, is moved inside the `jacoco` plugin.

The `jacoco` plugin, when used together with `java` plugin will always create the following outgoing variants:
- `sourceDirectoriesElements`, containing source directories of the `main` java source set (two concerns here: 1. this should probably live in the `java` plugin. 2. What to do with custom source sets, for example, those used in [feature variants](https://docs.gradle.org/current/userguide/feature_variants.html#sec:feature_variant_source_set))
- `{testTaskName}CoverageElements` for each task of type `Test` in the given project. This allows aggregating reports for different test categories either separately (create separate aggregations for unit tests and for integration tests), or combine them.

The plugin will also always create a `jacocoAggregation` configuration which is just a bucket for declaring dependencies. If `jacoco` plugin is used together with `java` plugin, `jacocoAggregation` will extend from `implementation` configuration.
This bucket should be used in a dedicated aggregation project (when the aggregating project itself is not a java project).
Otherwise, for applications with multiple project library dependencies, the aggregation will use project dependencies declared in `implementation` configuration.

### Concerns

- Using test task names as test categories. There is currently no concept of test category.
- How to deal with custom source sets? For example, those from [feature variants](https://docs.gradle.org/current/userguide/feature_variants.html#sec:feature_variant_source_set))
- Is it OK that `AggregatedJacocoReport` extends the `JacocoReport` task, or should it be modeled as a separate task type, potentially hiding the configurability that `JacocoReport` now exposes?
- Exposing `sourceDirectoriesElements` variant should probably be the responsibility of `java` plugin and not `jacoco` plugin.
