### PR TITLE
Fix terse time formatting 

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
@@ -43,18 +43,24 @@ public class TimeFormatting {
 
     public static String formatDurationTerse(long elapsedTimeInMs) {
         StringBuilder result = new StringBuilder();
-        if (elapsedTimeInMs > MILLIS_PER_HOUR) {
+        if (elapsedTimeInMs >= MILLIS_PER_HOUR) {
             result.append(elapsedTimeInMs / MILLIS_PER_HOUR).append("h ");
         }
-        if (elapsedTimeInMs > MILLIS_PER_MINUTE) {
-            result.append((elapsedTimeInMs % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE).append("m ");
+        if (elapsedTimeInMs >= MILLIS_PER_MINUTE) {
+            long hours = (elapsedTimeInMs % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE;
+            if (hours > 0) {
+                result.append(hours).append("m ");
+            }
         }
         if (elapsedTimeInMs >= MILLIS_PER_SECOND) {
-            result.append((elapsedTimeInMs % MILLIS_PER_MINUTE) / 1000).append("s");
+            long seconds = (elapsedTimeInMs % MILLIS_PER_MINUTE) / 1000;
+            if (seconds > 0) {
+                result.append(seconds).append("s");
+            }
         } else {
             result.append(elapsedTimeInMs).append("ms");
         }
-        return result.toString();
+        return result.toString().trim();
     }
 
     public static String formatDurationVeryTerse(long duration) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/time/TimeFormattingTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/time/TimeFormattingTest.groovy
@@ -62,15 +62,24 @@ class TimeFormattingTest extends Specification {
         result == output
 
         where:
-        lowerBoundInclusive | upperBoundExclusive | input             | output
-        "None"              | "1 second"          | seconds(0.421345) | "421ms"
-        "1 second"          | "10 seconds"        | seconds(4.21345)  | "4s"
-        "10 seconds"        | "1 minute"          | seconds(42.1234)  | "42s"
-        "1 minute"          | "10 minutes"        | minutes(4.21234)  | "4m 12s"
-        "10 minutes"        | "1 hour"            | minutes(42.1234)  | "42m 7s"
-        "1 hour"            | "10 hours"          | hours(4.2123456)  | "4h 12m 44s"
-        "10 hours"          | "100 hours"         | hours(42.123456)  | "42h 7m 24s"
-        "100 hours"         | "None"              | hours(421.23456)  | "421h 14m 4s"
+        lowerBoundInclusive | upperBoundExclusive | input                               | output
+        "None"              | "1 second"          | seconds(0.421345)                   | "421ms"
+        "1 second"          | "10 seconds"        | seconds(4.21345)                    | "4s"
+        "10 seconds"        | "1 minute"          | seconds(42.1234)                    | "42s"
+        "10 seconds"        | "1 minute"          | seconds(60)                         | "1m"
+        "1 minute"          | "10 minutes"        | seconds(61)                         | "1m 1s"
+        "1 minute"          | "10 minutes"        | minutes(1)                          | "1m"
+        "1 minute"          | "10 minutes"        | minutes(4.21234)                    | "4m 12s"
+        "10 minutes"        | "1 hour"            | minutes(42.1234)                    | "42m 7s"
+        "10 minutes"        | "1 hour"            | minutes(60)                         | "1h"
+        "1 hour"            | "10 hours"          | minutes(61)                         | "1h 1m"
+        "1 hour"            | "10 hours"          | hours(1)                            | "1h"
+        "1 hour"            | "10 hours"          | hours(4.2123456)                    | "4h 12m 44s"
+        "10 hours"          | "100 hours"         | hours(42.123456)                    | "42h 7m 24s"
+        "100 hours"         | "None"              | hours(421.23456)                    | "421h 14m 4s"
+        "1 hour"            | "10 hours"          | hours(1) + minutes(1)               | "1h 1m"
+        "1 hour"            | "10 hours"          | hours(1) + seconds(1)               | "1h 1s"
+        "1 hour"            | "10 hours"          | hours(1) + minutes(1) + seconds(1)  | "1h 1m 1s"
     }
 
     private static long hours(double value) {


### PR DESCRIPTION
when debugging an issue, I found a rather funny message : 

Requesting stop of task ':camera:integration-tests:camera-testapp-view:minifyReleaseWithR8' as it has exceeded its configured timeout of 0m 0s.

note the "0m 0s", that was for a timeout of 60 minutes.