### PR TITLE
Replace dev12 mirror with repo.grdev.net

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -134,7 +134,7 @@ fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os)
         }
 
         if (os == Os.MACOS) {
-            param("env.REPO_MIRROR_URLS", "")
+            param("env.REPO_MIRROR_GRDEV_URLS", "")
         }
     }
 }

--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -132,10 +132,6 @@ fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os)
         if (os == Os.LINUX || os == Os.MACOS) {
             param("env.LC_ALL", "en_US.UTF-8")
         }
-
-        if (os == Os.MACOS) {
-            param("env.REPO_MIRROR_GRDEV_URLS", "")
-        }
     }
 }
 

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -182,10 +182,6 @@ fun applyTestDefaults(
     daemon: Boolean = true,
     preSteps: BuildSteps.() -> Unit = {} // the steps before runner steps
 ) {
-    if (os == Os.MACOS) {
-        buildType.params.param("env.REPO_MIRROR_URLS", "")
-    }
-
     buildType.applyDefaultSettings(os, timeout = timeout)
 
     buildType.steps {

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -55,15 +55,6 @@ class CIConfigIntegrationTests {
     }
 
     @Test
-    fun macBuildsHasEmptyRepoMirrorUrlsParam() {
-        val rootProject = CheckProject(model, gradleBuildBucketProvider)
-        val readyForRelease = rootProject.searchSubproject("Gradle_Master_Check_Stage_ReadyforRelease")
-        val macBuilds = readyForRelease.subProjects.filter { it.name.contains("Macos") }.flatMap { (it as FunctionalTestProject).functionalTests }
-        assertTrue(macBuilds.isNotEmpty())
-        assertTrue(macBuilds.all { it.params.findRawParam("env.REPO_MIRROR_URLS")!!.value == "" })
-    }
-
-    @Test
     fun macOSBuildsSubset() {
         val readyForRelease = rootProject.subProjects.find { it.name.contains(StageNames.READY_FOR_RELEASE.stageName) }!!
         val macOS = readyForRelease.subProjects.find { it.name.contains("Macos") }!!

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
@@ -49,7 +49,7 @@ class CiEnvironmentProvider(private val test: Test) : CommandLineArgumentProvide
     private
     fun collectMirrorUrls(): Map<String, String> =
         // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
-        System.getenv("REPO_MIRROR_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
+        System.getenv("REPO_MIRROR_GRDEV_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
             val (name, url) = nameToUrl.split(':', limit = 2)
             name to url
         } ?: emptyMap()

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -37,7 +37,7 @@ val originalUrls: Map<String, String> = mapOf(
 )
 
 val mirrorUrls: Map<String, String> =
-    providers.environmentVariable("REPO_MIRROR_URLS").forUseAtConfigurationTime().orNull
+    providers.environmentVariable("REPO_MIRROR_GRDEV_URLS").forUseAtConfigurationTime().orNull
         ?.ifBlank { null }
         ?.split(',')
         ?.associate { nameToUrl ->
@@ -53,7 +53,7 @@ fun isMacAgent() = System.getProperty("os.name").toLowerCase().contains("mac")
 fun ignoreMirrors() = providers.environmentVariable("IGNORE_MIRROR").forUseAtConfigurationTime().orNull?.toBoolean() == true
 
 fun withMirrors(handler: RepositoryHandler) {
-    if (!providers.environmentVariable("CI").forUseAtConfigurationTime().isPresent() || isEc2Agent()) {
+    if (!providers.environmentVariable("CI").forUseAtConfigurationTime().isPresent()) {
         return
     }
     handler.all {
@@ -77,7 +77,7 @@ fun overridesPluginPortalUrl() = providers.systemProperty(PLUGIN_PORTAL_OVERRIDE
 if (!overridesPluginPortalUrl() && !isEc2Agent() && !isMacAgent() && !ignoreMirrors()) {
     // https://github.com/gradle/gradle-private/issues/2725
     // https://github.com/gradle/gradle-private/issues/2951
-    System.setProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, "https://dev12.gradle.org/artifactory/gradle-plugins/")
+    System.setProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, "https://repo.grdev.net/artifactory/gradle-plugin-portal-prod/")
 
     abstract class ClearPortalOverride : BuildService<BuildServiceParameters.None>, OperationCompletionListener, AutoCloseable {
         override fun onFinish(event: FinishEvent) = Unit


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Replaces dev12.gradle.org with repo.grdev.net as a CI mirror for public repositories.

See https://docs.google.com/document/d/1ekk2qzxiI5gruusk12eE1K-ISEFD1lv0fja5wULmtxA/edit#heading=h.393nxyrpwikl

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
