### PR TITLE
Let eclipse-wtp replace default facet versions

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -8,6 +8,7 @@ We would like to thank the following community members for their contributions t
  [Zoroark](https://github.com/utybo)
  [Stefan Oehme](https://github.com/oehme)
  [KotlinIsland](https://github.com/KotlinIsland)
+ [Herbert von Broeuschmeul](https://github.com/HvB)
 
 ## Upgrade instructions
 Switch your build to use Gradle @version@ by updating your wrapper:

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.gradle.util.internal.ConfigureUtil.configure;
 
@@ -138,10 +140,12 @@ public class EclipseWtpFacet {
      * @param args A map that must contain a 'name' and 'version' key with corresponding values.
      */
     public void facet(Map<String, ?> args) {
+        Facet newFacet = ConfigureUtil.configureByMap(args, new Facet());
         facets = Lists.newArrayList(Iterables.concat(
-            getFacets(),
-            Collections.singleton(ConfigureUtil.configureByMap(args, new Facet()))
-        ));
+            getFacets().stream()
+                       .filter(f -> f.getType() != newFacet.getType() || !Objects.equals(f.getName(), newFacet.getName()))
+                       .collect(Collectors.toList()),
+            Collections.singleton(newFacet)));
     }
 
     @SuppressWarnings("unchecked")

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
@@ -45,7 +45,7 @@ import static org.gradle.util.internal.ConfigureUtil.configure;
  * eclipse {
  *   wtp {
  *     facet {
- *       //you can add some extra wtp facets; mandatory keys: 'name', 'version':
+ *       //you can add some extra wtp facets or update existing ones; mandatory keys: 'name', 'version':
  *       facet name: 'someCoolFacet', version: '1.3'
  *
  *       file {
@@ -134,6 +134,8 @@ public class EclipseWtpFacet {
 
     /**
      * Adds a facet.
+     * <p>
+     * If a facet already exists with the given name then its version will be updated.
      * <p>
      * For examples see docs for {@link EclipseWtpFacet}
      *

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -261,7 +261,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
                 new Facet(FacetType.installed, 'someFancyFacet', '2.0')])
     }
 
-    @Issue('GRADLE-1377')
+    @Issue('https://github.com/gradle/gradle/issues/945')
     def "can overwrite ear default 'jst.ear' facet"() {
         when:
         project.apply(plugin: 'ear')
@@ -279,7 +279,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
                 new Facet(FacetType.installed, "jst.ear", "8.0")])
     }
 
-    @Issue('GRADLE-1377')
+    @Issue('https://github.com/gradle/gradle/issues/945')
     def "can overwrite war default 'jst.web' facet"() {
         when:
         project.apply(plugin: 'war')

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -261,6 +261,45 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
                 new Facet(FacetType.installed, 'someFancyFacet', '2.0')])
     }
 
+    @Issue('GRADLE-1377')
+    def "can overwrite ear default 'jst.ear' facet"() {
+        when:
+        project.apply(plugin: 'ear')
+        project.apply(plugin: 'eclipse-wtp')
+
+        project.eclipse.wtp {
+            facet {
+                facet name: 'jst.ear', version: '8.0'
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, "jst.ear", null),
+                new Facet(FacetType.installed, "jst.ear", "8.0")])
+    }
+
+    @Issue('GRADLE-1377')
+    def "can overwrite war default 'jst.web' facet"() {
+        when:
+        project.apply(plugin: 'war')
+        project.apply(plugin: 'eclipse-wtp')
+        project.sourceCompatibility = 1.4
+
+        project.eclipse.wtp {
+            facet {
+                facet name: 'jst.web', version: '4.0'
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, "jst.java", null),
+                new Facet(FacetType.fixed, "jst.web", null),
+                new Facet(FacetType.installed, "jst.web", "4.0"),
+                new Facet(FacetType.installed, "jst.java", "1.4")])
+    }
+
     @Issue(['GRADLE-2186', 'GRADLE-2221'])
     def "can change WTP components and add facets when java plugin is applied"() {
         when:


### PR DESCRIPTION
Fixes #945

### Context
Eclipse IDE uses facets to configure the Java EE or Jakarta EE specifications a war project (or a ear project or an ejb project) targets. 
The eclipse-wtp plugin populates these facets with default values (eg `jst.web` with version `2.4` for a Java EE web project or `jst.ear` with version `5.0` for ear projects).  However these default facets are often not the one many users want.

The pull request lets users replace the default facets populated by the plugin with new ones, letting Eclipse IDE know which Java EE or Jakarta EE specifications gradle projects really target.

For example in a war project, the code bellow will now replace the default 'jst.web' facet (with version '2.4') with the new one, letting eclipse know that you're targeting the servlet spec 4.0.

```gradle
apply plugin: 'war'
apply plugin: 'eclipse-wtp'

eclipse.wtp.facet {
  facet name: 'jst.web', version: '4.0'
}
```

Relevant issues: #945 #1334 

Relevant forum discussions: 
- [Be able to easily customize the eclipse-wtp facet version](https://discuss.gradle.org/t/be-able-to-easily-customize-the-eclipse-wtp-facet-version/444)
- [Configure ear project in eclipse](https://discuss.gradle.org/t/configure-ear-project-in-eclipse/25755)
- [Eclipse-wtp facet creates duplicates](https://discuss.gradle.org/t/eclipse-wtp-facet-creates-duplicates/23940)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
