### PR TITLE
Deprecate and replace public API ExclusiveContentRepository.forReposi…

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.java
@@ -18,6 +18,8 @@ package org.gradle.api.artifacts.repositories;
 import org.gradle.api.Action;
 import org.gradle.internal.Factory;
 
+import java.util.concurrent.Callable;
+
 /**
  * Describes one or more repositories which together constitute the only possible
  * source for an artifact, independently of the others.
@@ -32,8 +34,16 @@ public interface ExclusiveContentRepository {
      * Declares the repository
      * @param repository the repository for which we declare exclusive content
      * @return this repository descriptor
+     * @deprecated Use {@link #forRepository(Callable)} to avoid an internal Gradle API
      */
     ExclusiveContentRepository forRepository(Factory<? extends ArtifactRepository> repository);
+
+    /**
+     * Declares the repository
+     * @param repository the repository for which we declare exclusive content
+     * @return this repository descriptor
+     */
+    ExclusiveContentRepository forRepository(Callable<? extends ArtifactRepository> repository);
 
     /**
      * Declares the repository

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -53,6 +53,11 @@ Historically, Gradle also loads the serialized value from the last execution and
 Doing so is error prone, doesn't work with the build cache and has a performance impact, therefore it has been deprecated.
 Instead of using at `@Input` on a type Gradle doesn't understand directly, use `@Nested` and annotate the properties of the type accordingly.
 
+[[forRepository_internal_api]]
+==== `ExclusiveContentRepository.forRepository(Factory<? extends ArtifactRepository>)` will be removed in Gradle 8
+
+This method inadvertently used an internal type (`Factory`) in its parameters. A replacement method has been added that instead uses `Callable`.
+
 [[changes_7.1]]
 == Upgrading from 7.0 and earlier
 


### PR DESCRIPTION
…tory that relied on internal type

The ExclusiveContentRepository API accidentally used the internal Factory type instead of the public Callable type.

This change adds a deprecation, upgrade guide section and new replacement method for this.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
