### PR TITLE
Fix error message if Java 9+ JRE is used for compilation instead of JDK

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkTools.java
@@ -103,7 +103,14 @@ public class JdkTools {
             if (isJava9Compatible) {
                 clazz = isolatedToolsLoader.loadClass("javax.tools.ToolProvider");
                 try {
-                    return (JavaCompiler) clazz.getDeclaredMethod("getSystemJavaCompiler").invoke(null);
+                    JavaCompiler compiler = (JavaCompiler) clazz.getDeclaredMethod("getSystemJavaCompiler").invoke(null);
+                    if (compiler == null) {
+                        // We were trying to load a compiler in our process so Jvm.current() is the correct one to blame.
+                        throw new IllegalStateException("Java compiler is not available. Please check that "
+                            + Jvm.current().getJavaHome().getAbsolutePath()
+                            + " contains a valid JDK installation.");
+                    }
+                    return compiler;
                 } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                     cannotCreateJavaCompiler(e);
                 }


### PR DESCRIPTION
Apparently, JRE lacks `java.compiler` support and returns null from
`ToolsProvider.getSystemJavaCompiler` but prior to this CL a quite
unhelpful NullPointerException was thrown. This CL moves the check a bit
earlier and clarifies the error.

<!--- The issue this PR addresses -->
Fixes #17601
