### PR TITLE
Cap number of reported configuration cache problems

### DIFF
--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -92,6 +92,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
         val cacheAction: String,
         val documentationLink: String,
         val totalProblems: Int,
+        val reportedProblems: Int,
         val messageTree: ProblemTreeModel,
         val locationTree: ProblemTreeModel,
         val displayFilter: DisplayFilter = DisplayFilter.All,
@@ -147,7 +148,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
             learnMore(model.documentationLink),
             div(
                 attributes { className("title") },
-                h1("${model.totalProblems} problems were found ${model.cacheAction} the configuration cache"),
+                h1(model.summary()),
                 div(
                     attributes { className("filters") },
                     div(
@@ -175,6 +176,13 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
             }
         )
     )
+
+    private
+    fun Model.summary() =
+        "$totalProblems problems were found $cacheAction the configuration cache".let {
+            if (totalProblems > reportedProblems) "$it, only the first $reportedProblems were included in this report"
+            else it
+        }
 
     private
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -179,10 +179,14 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     fun Model.summary() =
-        "$totalProblems problems were found $cacheAction the configuration cache".let {
+        "$totalProblems ${problemOrProblems()} found $cacheAction the configuration cache".let {
             if (totalProblems > reportedProblems) "$it, only the first $reportedProblems were included in this report"
             else it
         }
+
+    private
+    fun Model.problemOrProblems() =
+        if (totalProblems == 1) "problem was" else "problems were"
 
     private
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(

--- a/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
@@ -42,6 +42,7 @@ private
 external interface JsModel {
     val cacheAction: String
     val documentationLink: String
+    val totalProblemCount: Int
     val problems: Array<JsProblem>
 }
 
@@ -127,7 +128,8 @@ fun reportPageModelFromJsModel(jsModel: JsModel): ConfigurationCacheReportPage.M
     return ConfigurationCacheReportPage.Model(
         cacheAction = jsModel.cacheAction,
         documentationLink = jsModel.documentationLink,
-        totalProblems = jsModel.problems.size,
+        totalProblems = jsModel.totalProblemCount,
+        reportedProblems = jsModel.problems.size,
         messageTree = treeModelFor(
             ProblemNode.Label("Problems grouped by message"),
             problemNodesByMessage(problems)
@@ -135,7 +137,7 @@ fun reportPageModelFromJsModel(jsModel: JsModel): ConfigurationCacheReportPage.M
         locationTree = treeModelFor(
             ProblemNode.Label("Problems grouped by location"),
             problemNodesByLocation(problems)
-        )
+        ),
     )
 }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -91,8 +91,9 @@ class ConfigurationCacheProblems(
     }
 
     override fun onProblem(problem: PropertyProblem) {
-        summary.onProblem(problem)
-        report.onProblem(problem)
+        if (summary.onProblem(problem)) {
+            report.onProblem(problem)
+        }
     }
 
     override fun getId(): String {
@@ -111,7 +112,7 @@ class ConfigurationCacheProblems(
         }
         val cacheActionText = cacheAction.summaryText()
         val outputDirectory = outputDirectoryFor(reportDir)
-        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText)
+        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, problemCount)
         when {
             isFailOnProblems -> {
                 // TODO - always include this as a build failure;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -213,6 +213,6 @@ public class StartParameterInternal extends StartParameter {
      */
     public static boolean useLocationAsProjectRoot(@Nullable File potentialProjectLocation, List<String> requestedTaskNames) {
         return requestedTaskNames.contains("init")
-            || (potentialProjectLocation != null && potentialProjectLocation.getName().equals(BUILD_SRC));
+            || potentialProjectLocation != null && potentialProjectLocation.getName().equals(BUILD_SRC);
     }
 }


### PR DESCRIPTION
For scalability. A report with 4096 problems, the chosen limit, requires approximately 100MB.

The limit is not configurable.

The report was changed to make the distinction between total problems and reported problems clearer.

<img width="800" alt="configuration-cache-header" src="https://user-images.githubusercontent.com/51689/124663583-ac21ab80-de80-11eb-883c-be7aaea75d7c.png">
