### PR TITLE
A trivial fix of StringIndexOutOfBoundsException produced by a initialization script starts with dot

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -271,6 +271,19 @@ initscript {
         output.contains("Project 'root'")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/17555")
+    def "init script file is a dotfile"() {
+        def initScript = file('.empty')
+        initScript << 'println "greetings from empty init script"'
+        executer.withArguments('--init-script', initScript.absolutePath)
+
+        when:
+        run()
+
+        then:
+        output.contains("greetings from empty init script")
+    }
+
     private def createExternalJar() {
         ArtifactBuilder builder = artifactBuilder()
         builder.sourceFile('org/gradle/test/BuildClass.java') << '''

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/TextResourceScriptSource.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/TextResourceScriptSource.java
@@ -101,7 +101,7 @@ public class TextResourceScriptSource implements ScriptSource {
             className.append(
                 isJavaIdentifierPart(ch) ? ch : '_');
         }
-        if (!isJavaIdentifierStart(className.charAt(0))) {
+        if (className.length() > 0 && !isJavaIdentifierStart(className.charAt(0))) {
             className.insert(0, '_');
         }
         className.setLength(Math.min(className.length(), 30));


### PR DESCRIPTION
Fixes #17555 

### Contributor Checklist

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck` 
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist

- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

The newly added integration test passed but it seems that due to known network problems in my area, `/gradlew sanityCheck` and `/gradlew :core:quickTest` both failed. Sorry about that.