### PR TITLE
Enable stricter task validation for the Gradle build

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -57,7 +57,7 @@ tasks.codeQuality {
 
 tasks.validatePlugins {
     failOnWarning.set(true)
-    enableStricterValidation.set(false)
+    enableStricterValidation.set(true)
 }
 
 

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/CleanAcceptedApiChanges.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/CleanAcceptedApiChanges.groovy
@@ -21,10 +21,12 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * A task used for cleaning up all accepted API changes. The functionality is called whenever the release process initiates "branching".
  */
+@DisableCachingByDefault(because = "Not worth caching")
 class CleanAcceptedApiChanges extends DefaultTask {
 
     @PathSensitive(PathSensitivity.ABSOLUTE)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/ExplodeZipAndFindJars.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/ExplodeZipAndFindJars.groovy
@@ -26,12 +26,14 @@ import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
 import java.nio.file.Files
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 @CompileStatic
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class ExplodeZipAndFindJars implements TransformAction<TransformParameters.None> {
 
     @PathSensitive(PathSensitivity.NAME_ONLY)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/ExplodeZipAndFindJars.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/ExplodeZipAndFindJars.groovy
@@ -33,7 +33,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 @CompileStatic
-@DisableCachingByDefault(because = "Only filters the input artifact")
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class ExplodeZipAndFindJars implements TransformAction<TransformParameters.None> {
 
     @PathSensitive(PathSensitivity.NAME_ONLY)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleClasspath.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleClasspath.groovy
@@ -25,8 +25,10 @@ import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
 @CompileStatic
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindGradleClasspath implements TransformAction<TransformParameters.None> {
 
     @PathSensitive(PathSensitivity.NAME_ONLY)

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleJars.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/transforms/FindGradleJars.groovy
@@ -30,13 +30,16 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
 @CompileStatic
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindGradleJars implements TransformAction<Parameters> {
 
     @CompileStatic
     interface Parameters extends TransformParameters {
         @InputFiles
+        @PathSensitive(PathSensitivity.NAME_ONLY)
         ConfigurableFileCollection getCurrentJars()
 
         @Input

--- a/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/tasks/GenerateSample.kt
+++ b/build-logic/build-init-samples/src/main/kotlin/gradlebuild/samples/tasks/GenerateSample.kt
@@ -29,9 +29,11 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.buildinit.plugins.internal.ProjectLayoutSetupRegistry
 import org.gradle.buildinit.plugins.internal.modifiers.ModularizationOption
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class GenerateSample : DefaultTask() {
 
     @get:Input

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/CheckSubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/CheckSubprojectsInfo.kt
@@ -18,8 +18,10 @@ package gradlebuild.buildutils.tasks
 
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class CheckSubprojectsInfo : SubprojectsInfo() {
 
     @TaskAction

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/GenerateSubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/GenerateSubprojectsInfo.kt
@@ -20,7 +20,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
 
-@DisableCachingByDefault(because = "Only filters the input artifact")
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class GenerateSubprojectsInfo : SubprojectsInfo() {
 
     @TaskAction

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/GenerateSubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/GenerateSubprojectsInfo.kt
@@ -17,8 +17,10 @@
 package gradlebuild.buildutils.tasks
 
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class GenerateSubprojectsInfo : SubprojectsInfo() {
 
     @TaskAction

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/SubprojectsInfo.kt
@@ -20,9 +20,11 @@ import com.google.gson.GsonBuilder
 import gradlebuild.buildutils.model.GradleSubproject
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class SubprojectsInfo : DefaultTask() {
 
     private

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateAgpVersions.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateAgpVersions.kt
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.util.PropertiesUtils
+import org.gradle.work.DisableCachingByDefault
 import org.w3c.dom.Element
 import java.util.Properties
 import javax.xml.parsers.DocumentBuilderFactory
@@ -31,6 +32,7 @@ import javax.xml.parsers.DocumentBuilderFactory
  * Fetch the latest AGP versions and write a properties file.
  * Never up-to-date, non-cacheable.
  */
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class UpdateAgpVersions : DefaultTask() {
 
     @get:Internal

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
@@ -26,9 +26,11 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.util.PropertiesUtils
 import org.gradle.util.VersionNumber
+import org.gradle.work.DisableCachingByDefault
 import java.util.Properties
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class UpdateInitPluginTemplateVersionFile : DefaultTask() {
 
     private

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateReleasedVersions.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateReleasedVersions.kt
@@ -26,9 +26,11 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GradleVersion
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class UpdateReleasedVersions : DefaultTask() {
 
     @get:Internal

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.task-properties-validation.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.task-properties-validation.gradle.kts
@@ -26,5 +26,5 @@ tasks.register<ValidatePlugins>(validateTaskName) {
     classes.from(main.output)
     classpath.from(main.runtimeClasspath)
     outputFile.set(project.reporting.baseDirectory.file(reportFileName))
-    enableStricterValidation.set(false)
+    enableStricterValidation.set(true)
 }

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/configcachereport/tasks/VerifyDevWorkflow.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/configcachereport/tasks/VerifyDevWorkflow.kt
@@ -22,8 +22,10 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class VerifyDevWorkflow : DefaultTask() {
 
     @get:InputDirectory

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/quickcheck/tasks/QuickCheckTask.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/quickcheck/tasks/QuickCheckTask.kt
@@ -24,8 +24,10 @@ import org.gradle.cache.internal.GeneratedGradleJarCache
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.experiments.plugins.GradleKotlinDslKtlintConventionPlugin
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class QuickCheckTask : DefaultTask() {
 
     @TaskAction

--- a/build-logic/cleanup/src/main/kotlin/gradlebuild/cleanup/tasks/KillLeakingJavaProcesses.kt
+++ b/build-logic/cleanup/src/main/kotlin/gradlebuild/cleanup/tasks/KillLeakingJavaProcesses.kt
@@ -21,8 +21,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Has no cacheable output")
 abstract class KillLeakingJavaProcesses : DefaultTask() {
     @get:Internal
     abstract val tracker: Property<DaemonTracker>

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/tasks/DistributionTest.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/tasks/DistributionTest.kt
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.kotlin.dsl.*
 import org.gradle.process.CommandLineArgumentProvider
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.util.SortedSet
 
@@ -47,6 +48,7 @@ import java.util.SortedSet
  * to test functionality that requires rea distributions (like the wrapper)
  * or separately published libraries (like the Tooling API Jar).
  */
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class DistributionTest : Test() {
 
     /**

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/CheckKotlinCompilerEmbeddableDependencies.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/compiler/tasks/CheckKotlinCompilerEmbeddableDependencies.kt
@@ -22,11 +22,13 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
 /**
  * Used to validate that :kotlinCompilerEmbeddable dependencies are aligned with the original dependencies.
  */
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class CheckKotlinCompilerEmbeddableDependencies : DefaultTask() {
 
     /**

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/CodeGenerationTask.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/CodeGenerationTask.kt
@@ -20,10 +20,12 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 import java.io.File
 
 
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class CodeGenerationTask : DefaultTask() {
 
     @get:OutputDirectory

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDependencyExtensions.kt
@@ -18,11 +18,13 @@ package gradlebuild.kotlindsl.generator.tasks
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.work.DisableCachingByDefault
 
 import java.io.File
 
 
 @Suppress("unused")
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class GenerateKotlinDependencyExtensions : CodeGenerationTask() {
 
     @get:Input

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDslPluginsExtensions.kt
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild/kotlindsl/generator/tasks/GenerateKotlinDslPluginsExtensions.kt
@@ -18,11 +18,13 @@ package gradlebuild.kotlindsl.generator.tasks
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.work.DisableCachingByDefault
 
 import java.io.File
 
 
 @Suppress("unused")
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class GenerateKotlinDslPluginsExtensions : CodeGenerationTask() {
 
     @get:Input

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/tasks/BuildReceipt.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/tasks/BuildReceipt.kt
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -34,6 +35,7 @@ import java.util.Properties
 import java.util.TimeZone
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class BuildReceipt : DefaultTask() {
     companion object {
         private

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/run/tasks/RunEmbeddedGradle.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/run/tasks/RunEmbeddedGradle.kt
@@ -24,9 +24,11 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class RunEmbeddedGradle : DefaultTask() {
 
     @get:Classpath

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/shade/tasks/ShadedJar.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/shade/tasks/ShadedJar.kt
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -38,6 +39,7 @@ import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class ShadedJar : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles

--- a/build-logic/packaging/src/main/kotlin/gradlebuild/shade/transforms/ShadeClasses.kt
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild/shade/transforms/ShadeClasses.kt
@@ -31,6 +31,7 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
 
 private
@@ -86,7 +87,9 @@ abstract class ShadeClasses : TransformAction<ShadeClasses.Parameters> {
 }
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindClassTrees : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 
@@ -96,7 +99,9 @@ abstract class FindClassTrees : TransformAction<TransformParameters.None> {
 }
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindEntryPoints : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 
@@ -106,7 +111,9 @@ abstract class FindEntryPoints : TransformAction<TransformParameters.None> {
 }
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindRelocatedClasses : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 
@@ -116,7 +123,9 @@ abstract class FindRelocatedClasses : TransformAction<TransformParameters.None> 
 }
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindManifests : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 
@@ -129,7 +138,9 @@ abstract class FindManifests : TransformAction<TransformParameters.None> {
 }
 
 
+@DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindBuildReceipt : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -30,10 +30,12 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Original tangled mess of a project generator.
  */
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class AbstractProjectGeneratorTask extends TemplateProjectGeneratorTask {
 
     @Input

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/BuildBuilderGenerator.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/BuildBuilderGenerator.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecSpec
+import org.gradle.work.DisableCachingByDefault
 
 import javax.inject.Inject
 import java.util.concurrent.Callable
@@ -36,6 +37,7 @@ import java.util.concurrent.Callable
  *
  * @see <a href="https://github.com/adammurdoch/build-builder">build builder</a>
  */
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class BuildBuilderGenerator extends ProjectGeneratorTask {
     /**
      * Installation directory of the build-builder tool.

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/CppMultiProjectGeneratorTask.groovy
@@ -18,8 +18,10 @@ package gradlebuild.performance.generator.tasks
 
 import gradlebuild.performance.generator.TestProject
 import org.gradle.api.tasks.Internal
+import org.gradle.work.DisableCachingByDefault
 
 // TODO: Remove this and replace it with a BuildBuilderGenerator instead.
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class CppMultiProjectGeneratorTask extends AbstractProjectGeneratorTask {
     @Internal
     gradlebuild.performance.generator.DependencyGenerator.DependencyInfo depInfo

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/JavaExecProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/JavaExecProjectGeneratorTask.groovy
@@ -16,6 +16,8 @@
 package gradlebuild.performance.generator.tasks
 
 import org.gradle.api.tasks.JavaExec
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Gradle would require more information to cache this task")
 class JavaExecProjectGeneratorTask extends JavaExec {
 }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/KtsProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/KtsProjectGeneratorTask.groovy
@@ -15,6 +15,9 @@
  */
 package gradlebuild.performance.generator.tasks
 
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class KtsProjectGeneratorTask extends JvmProjectGeneratorTask {
 
     KtsProjectGeneratorTask() {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/MonolithicNativeProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/MonolithicNativeProjectGeneratorTask.groovy
@@ -17,6 +17,7 @@
 package gradlebuild.performance.generator.tasks
 
 import gradlebuild.performance.generator.TestProject
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Generates native projects with prebuilt library dependencies, using a non-standard layout
@@ -34,6 +35,7 @@ import gradlebuild.performance.generator.TestProject
  * to build multiple components where none/some/a lot of the source files are shared between components
  * in a way that doesn't allow us to reuse the compilation steps (we don't do this now).
  */
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class MonolithicNativeProjectGeneratorTask extends AbstractProjectGeneratorTask {
 
     def generateRootProject() {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/NativeProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/NativeProjectGeneratorTask.groovy
@@ -17,12 +17,14 @@
 package gradlebuild.performance.generator.tasks
 
 import gradlebuild.performance.generator.TestProject
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Generates source code for projects using a standard layout (src/componentname/c).
  *
  * Currently only supports C and PCH.
  */
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class NativeProjectGeneratorTask extends AbstractProjectGeneratorTask {
 
     void generateProjectSource(File projectDir, TestProject testProject, Map args) {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/NativeProjectWithDepsGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/NativeProjectWithDepsGeneratorTask.groovy
@@ -25,10 +25,12 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.nativeplatform.NativeExecutableSpec
 import org.gradle.nativeplatform.NativeLibrarySpec
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Generates a multi-project native build that has project dependencies and tests.
  */
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 class NativeProjectWithDepsGeneratorTask extends TemplateProjectGeneratorTask {
 
     /** Represents a native library requirement */

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/ProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/ProjectGeneratorTask.groovy
@@ -17,7 +17,9 @@
 package gradlebuild.performance.generator.tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class ProjectGeneratorTask extends DefaultTask {
 
 }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/RemoteProject.groovy
@@ -25,11 +25,13 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
  * Checkout a project template from a git repository.
  */
 @CompileStatic
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class RemoteProject extends DefaultTask {
 
     /**

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/TemplateProjectGeneratorTask.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/generator/tasks/TemplateProjectGeneratorTask.groovy
@@ -21,7 +21,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.work.DisableCachingByDefault
 
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class TemplateProjectGeneratorTask extends ProjectGeneratorTask {
 
     @OutputDirectory

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/RebaselinePerformanceTests.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/RebaselinePerformanceTests.groovy
@@ -22,8 +22,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
 
 @CompileStatic
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class RebaselinePerformanceTests extends SourceTask {
 
     @Input

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.caching.http.HttpBuildCache
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 
 
@@ -38,6 +39,7 @@ private
 val commitVersionRegex = """(\d+(\.\d+)+)-commit-[a-f0-9]+""".toRegex()
 
 
+@DisableCachingByDefault(because = "Child Gradle build will do its own caching")
 abstract class BuildCommitDistribution : DefaultTask() {
     @get:Input
     @get:Optional

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.*
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
 
@@ -36,6 +37,7 @@ const val forceDefaultBaseline = "force-defaults"
 const val flakinessDetectionCommitBaseline = "flakiness-detection-commit"
 
 
+@DisableCachingByDefault(because = "Not worth caching")
 abstract class DetermineBaselines @Inject constructor(@get:Internal val distributed: Boolean) : DefaultTask() {
 
     @get:Internal

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/PerformanceTestReport.kt
@@ -37,9 +37,11 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.process.ExecOperations
+import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
 
+@DisableCachingByDefault(because = "Uses data from the database, which can't be tracked as an input")
 abstract class PerformanceTestReport : DefaultTask() {
 
     @get:Classpath

--- a/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
@@ -68,7 +68,7 @@ abstract class AbstractExtractCodeQualityBuildScanData : DefaultTask() {
 }
 
 
-@DisableCachingByDefault(because = "Does not have cacheable outputs")
+@DisableCachingByDefault(because = "Does not produce cacheable outputs")
 abstract class ExtractCheckstyleBuildScanData : AbstractExtractCodeQualityBuildScanData() {
 
     override val buildScanValueName: String = "Checkstyle Issue"
@@ -85,7 +85,7 @@ abstract class ExtractCheckstyleBuildScanData : AbstractExtractCodeQualityBuildS
 }
 
 
-@DisableCachingByDefault(because = "Does not have cacheable outputs")
+@DisableCachingByDefault(because = "Does not produce cacheable outputs")
 abstract class ExtractCodeNarcBuildScanData : AbstractExtractCodeQualityBuildScanData() {
 
     override val buildScanValueName: String = "CodeNarc Issue"

--- a/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
@@ -23,11 +23,13 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.specs.Specs
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import java.io.File
 
 
+@DisableCachingByDefault(because = "Abstract super-class, not to be instantiated directly")
 abstract class AbstractExtractCodeQualityBuildScanData : DefaultTask() {
 
     @get:Internal
@@ -66,6 +68,7 @@ abstract class AbstractExtractCodeQualityBuildScanData : DefaultTask() {
 }
 
 
+@DisableCachingByDefault(because = "Does not have cacheable outputs")
 abstract class ExtractCheckstyleBuildScanData : AbstractExtractCodeQualityBuildScanData() {
 
     override val buildScanValueName: String = "Checkstyle Issue"
@@ -82,6 +85,7 @@ abstract class ExtractCheckstyleBuildScanData : AbstractExtractCodeQualityBuildS
 }
 
 
+@DisableCachingByDefault(because = "Does not have cacheable outputs")
 abstract class ExtractCodeNarcBuildScanData : AbstractExtractCodeQualityBuildScanData() {
 
     override val buildScanValueName: String = "CodeNarc Issue"

--- a/build-logic/profiling/src/main/kotlin/gradlebuild/jmh/tasks/JmhHTMLReport.kt
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild/jmh/tasks/JmhHTMLReport.kt
@@ -24,8 +24,10 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 
+@DisableCachingByDefault(because = "Not made cacheable, yet")
 abstract class JmhHTMLReport : DefaultTask() {
 
     @get:InputFile

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 extensions.create<PluginPublishExtension>("pluginPublish", gradlePlugin, pluginBundle)
 
 tasks.validatePlugins {
-    enableStricterValidation.set(false)
+    enableStricterValidation.set(true)
 }
 
 // Remove gradleApi() and gradleTestKit() as we want to compile/run against Gradle modules

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -34,7 +34,6 @@ import org.gradle.api.tasks.TaskInputs;
 import org.gradle.api.tasks.TaskLocalState;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskState;
-import org.gradle.work.DisableCachingByDefault;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -157,7 +156,6 @@ import java.util.Set;
  * Parallel execution can be enabled by the <code>--parallel</code> flag when the build is initiated.
  * In parallel mode, the tasks of different projects (i.e. in a multi project build) are able to be executed in parallel.
  */
-@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface Task extends Comparable<Task>, ExtensionAware {
     String TASK_NAME = "name";
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.TaskInputs;
 import org.gradle.api.tasks.TaskLocalState;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.TaskState;
+import org.gradle.work.DisableCachingByDefault;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -156,6 +157,7 @@ import java.util.Set;
  * Parallel execution can be enabled by the <code>--parallel</code> flag when the build is initiated.
  * In parallel mode, the tasks of different projects (i.e. in a multi project build) are able to be executed in parallel.
  */
+@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface Task extends Comparable<Task>, ExtensionAware {
     String TASK_NAME = "name";
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -30,13 +30,11 @@ import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Configurable;
 import org.gradle.util.Path;
-import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.util.List;
 import java.util.Set;
 
-@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface TaskInternal extends Task, Configurable<Task> {
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -30,11 +30,13 @@ import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Configurable;
 import org.gradle.util.Path;
+import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface TaskInternal extends Task, Configurable<Task> {
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
@@ -45,14 +45,14 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
  * minus the extension.
  */
 @DisableCachingByDefault(because = "Not worth caching")
-public interface UnzipTransform extends TransformAction<TransformParameters.None> {
+public abstract class UnzipTransform implements TransformAction<TransformParameters.None> {
 
     @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputArtifact
-    Provider<FileSystemLocation> getZippedFile();
+    public abstract Provider<FileSystemLocation> getZippedFile();
 
     @Override
-    default void transform(TransformOutputs outputs) {
+    public void transform(TransformOutputs outputs) {
         File zippedFile = getZippedFile().get().getAsFile();
         String unzippedDirName = removeExtension(zippedFile.getName());
         File unzipDir = outputs.dir(unzippedDirName);
@@ -63,7 +63,7 @@ public interface UnzipTransform extends TransformAction<TransformParameters.None
         }
     }
 
-    static void unzipTo(File headersZip, File unzipDir) throws IOException {
+    private static void unzipTo(File headersZip, File unzipDir) throws IOException {
         try (ZipInputStream inputStream = new ZipInputStream(new BufferedInputStream(new FileInputStream(headersZip)))) {
             ZipEntry entry;
             while ((entry = inputStream.getNextEntry()) != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
@@ -24,7 +24,10 @@ import org.gradle.api.artifacts.transform.TransformOutputs;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.internal.UncheckedException;
+import org.gradle.work.DisableCachingByDefault;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -41,8 +44,10 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
  * is located in the output directory of the transform and is named after the zipped file name
  * minus the extension.
  */
+@DisableCachingByDefault(because = "Not worth caching")
 public interface UnzipTransform extends TransformAction<TransformParameters.None> {
 
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputArtifact
     Provider<FileSystemLocation> getZippedFile();
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/FindGradleSources.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/FindGradleSources.java
@@ -30,9 +30,9 @@ import org.gradle.work.DisableCachingByDefault;
 import java.io.File;
 import java.util.Arrays;
 
-@DisableCachingByDefault(because = "Only selects locations in the input artifact")
+@DisableCachingByDefault(because = "Only filters the input artifact")
 public abstract class FindGradleSources implements TransformAction<TransformParameters.None> {
-    @PathSensitive(PathSensitivity.NONE)
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputArtifact
     protected abstract Provider<FileSystemLocation> getInputArtifact();
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
@@ -36,6 +36,7 @@ import java.io.File
  */
 @DisableCachingByDefault(because = "Only filters the input artifact")
 abstract class FindGradleSources : TransformAction<TransformParameters.None> {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputArtifact
     abstract val input: Provider<FileSystemLocation>
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
@@ -17,12 +17,10 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.Task;
-import org.gradle.work.DisableCachingByDefault;
 
 /**
  * A task that combines a set of object files into a single binary.
  */
-@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface ObjectFilesToBinary extends Task {
     /**
      * Adds a set of object files to be combined into the file binary.

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ObjectFilesToBinary.java
@@ -17,10 +17,12 @@
 package org.gradle.nativeplatform.tasks;
 
 import org.gradle.api.Task;
+import org.gradle.work.DisableCachingByDefault;
 
 /**
  * A task that combines a set of object files into a single binary.
  */
+@DisableCachingByDefault(because = "Interface, not to be instantiated directly")
 public interface ObjectFilesToBinary extends Task {
     /**
      * Adds a set of object files to be combined into the file binary.

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -131,7 +131,11 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
     }
 
     private static void validateCacheabilityAnnotationPresent(Class<?> topLevelBean, boolean cacheable, Class<? extends Annotation> cacheableAnnotationClass, DefaultTypeValidationContext validationContext) {
-        if (!topLevelBean.isInterface() && !cacheable && topLevelBean.getAnnotation(DisableCachingByDefault.class) == null) {
+        if (topLevelBean.isInterface()) {
+            // Won't validate interfaces
+            return;
+        }
+        if (!cacheable && topLevelBean.getAnnotation(DisableCachingByDefault.class) == null) {
             boolean isTask = Task.class.isAssignableFrom(topLevelBean);
             String cacheableAnnotation = "@" + cacheableAnnotationClass.getSimpleName();
             String disableCachingAnnotation = "@" + DisableCachingByDefault.class.getSimpleName();

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -131,7 +131,7 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
     }
 
     private static void validateCacheabilityAnnotationPresent(Class<?> topLevelBean, boolean cacheable, Class<? extends Annotation> cacheableAnnotationClass, DefaultTypeValidationContext validationContext) {
-        if (!cacheable && topLevelBean.getAnnotation(DisableCachingByDefault.class) == null) {
+        if (!topLevelBean.isInterface() && !cacheable && topLevelBean.getAnnotation(DisableCachingByDefault.class) == null) {
             boolean isTask = Task.class.isAssignableFrom(topLevelBean);
             String cacheableAnnotation = "@" + cacheableAnnotationClass.getSimpleName();
             String disableCachingAnnotation = "@" + DisableCachingByDefault.class.getSimpleName();


### PR DESCRIPTION
So we validate the presence of `DisableCachingByDefault` for our custom tasks in the Gradle build as well.

As a follow up to #17568.