### PR TITLE
Don't run kotlin-dsl-tooling-builders on TD

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -196,7 +196,8 @@ class FunctionalTestBucketGenerator(private val model: CIBuildModel, testTimeDat
         // quite a few TAPI tests also don't work
         // `WatchedDirectoriesFileSystemWatchingIntegrationTest fails on local filesystem` doesn't work in remote executor
         // `workers` has a known haning issue
-        val forceNoTDSubprojects = listOf("language-native", "platform-native", "testing-native", "ide-native", "tooling-api", "file-watching", "workers")
+        // Some `kotlin-dsl-tooling-builders` tests are really flaky
+        val forceNoTDSubprojects = listOf("language-native", "platform-native", "testing-native", "ide-native", "tooling-api", "file-watching", "workers", "kotlin-dsl-tooling-builders")
         return if (testCoverage.testType == TestType.platform) {
             splitDocsSubproject(validSubprojects) + splitIntoBuckets(validSubprojects, subProjectTestClassTimes, testCoverage, listOf("docs"), forceNoTDSubprojects)
         } else {


### PR DESCRIPTION
Because we found some tests are really flaky.