### PR TITLE
Use line ending normalization for JavaCompile tasks

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -659,6 +659,10 @@ Implies `<<#incremental,@Incremental>>`.
 | `@link:{javadocPath}/org/gradle/api/tasks/IgnoreEmptyDirectories.html[IgnoreEmptyDirectories]`
 | `File` or `Iterable&lt;File&gt;`+++*+++
 | Used with `@InputFiles` or `@InputDirectory` to instruct Gradle to track only changes to the contents of directories and not differences in the directories themselves. For example, removing, renaming or adding an empty directory somewhere in the directory structure will not make the task out-of-date.
+
+| `@link:{javadocPath}/org/gradle/work/NormalizeLineEndings.html[NormalizeLineEndings]`
+| `Iterable&lt;File&gt;`*
+| Used with `@InputFiles`, `@InputDirectory` or `@Classpath` to instruct Gradle to normalize line endings when calculating up-to-date checks or build cache keys.  For example, switching a file between Unix line endings and Windows line endings (or vice-versa) will not make the task out-of-date.
 |===
 
 [NOTE]

--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -661,7 +661,7 @@ Implies `<<#incremental,@Incremental>>`.
 | Used with `@InputFiles` or `@InputDirectory` to instruct Gradle to track only changes to the contents of directories and not differences in the directories themselves. For example, removing, renaming or adding an empty directory somewhere in the directory structure will not make the task out-of-date.
 
 | `@link:{javadocPath}/org/gradle/work/NormalizeLineEndings.html[NormalizeLineEndings]`
-| `Iterable&lt;File&gt;`*
+| `File` or `Iterable&lt;File&gt;`+++*+++
 | Used with `@InputFiles`, `@InputDirectory` or `@Classpath` to instruct Gradle to normalize line endings when calculating up-to-date checks or build cache keys.  For example, switching a file between Unix line endings and Windows line endings (or vice-versa) will not make the task out-of-date.
 |===
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.compile
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.TextUtil
+
+class JavaCompileLineEndingSensitivityIntegrationTest extends AbstractIntegrationSpec {
+    def buildCachePath = TextUtil.normaliseFileSeparators(testDirectory.file("build-cache").absolutePath)
+    private static String compileTask = ':compileJava'
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+        """
+        settingsFile << """
+            buildCache {
+                local {
+                    directory = file('${buildCachePath}')
+                }
+            }
+        """
+    }
+
+    def "java compile is not sensitive to line endings during up-to-date checks"() {
+        writeJavaSourceWithUnixLineEndings()
+
+        when:
+        succeeds compileTask
+
+        then:
+        executedAndNotSkipped compileTask
+
+        when:
+        writeJavaSourceWithWindowsLineEndings()
+        succeeds compileTask
+
+        then:
+        skipped compileTask
+    }
+
+    def "java compile is not sensitive to line endings during build cache key calculation"() {
+        writeJavaSourceWithUnixLineEndings()
+
+        when:
+        executer.withBuildCacheEnabled()
+        succeeds compileTask
+
+        then:
+        executedAndNotSkipped compileTask
+
+        when:
+        writeJavaSourceWithWindowsLineEndings()
+        succeeds "clean"
+
+        and:
+        executer.withBuildCacheEnabled()
+        succeeds compileTask
+
+        then:
+        fromCache compileTask
+    }
+
+    void fromCache(String taskPath) {
+        assert result.groupedOutput.task(taskPath).outcome == "FROM-CACHE"
+    }
+
+    void writeJavaSourceWithUnixLineEndings() {
+        file('src/main/java/Foo.java').text = javaSourceWithLineEndings('\n')
+    }
+
+    String writeJavaSourceWithWindowsLineEndings() {
+        file('src/main/java/Foo.java').text = javaSourceWithLineEndings('\r\n')
+    }
+
+    static String javaSourceWithLineEndings(String eol) {
+        return "public class Foo {${eol}    int bar;${eol}}${eol}"
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.util.TextUtil
 
 class JavaCompileLineEndingSensitivityIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
     private static String compileTask = ':compileJava'

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileLineEndingSensitivityIntegrationTest.groovy
@@ -17,23 +17,16 @@
 package org.gradle.api.tasks.compile
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.util.TextUtil
 
-class JavaCompileLineEndingSensitivityIntegrationTest extends AbstractIntegrationSpec {
-    def buildCachePath = TextUtil.normaliseFileSeparators(testDirectory.file("build-cache").absolutePath)
+class JavaCompileLineEndingSensitivityIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
     private static String compileTask = ':compileJava'
 
     def setup() {
         buildFile << """
             plugins {
                 id 'java'
-            }
-        """
-        settingsFile << """
-            buildCache {
-                local {
-                    directory = file('${buildCachePath}')
-                }
             }
         """
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -69,6 +69,7 @@ import org.gradle.language.base.internal.compile.CompileSpec;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.work.Incremental;
 import org.gradle.work.InputChanges;
+import org.gradle.work.NormalizeLineEndings;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -408,6 +409,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
      */
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
+    @NormalizeLineEndings
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     protected FileCollection getStableSources() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -37,7 +37,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumBaseVersion = "3.5"
-        runner.targetVersions = ["7.1-20210427170827+0000"]
+        runner.targetVersions = ["7.2-branch-gh_normalization_line_ending_java-20210712154445+0000"]
     }
 
     def "clean assemble with remote http cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -37,7 +37,7 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
 
     def setup() {
         stateDirectory = temporaryFolder.file(".gradle/configuration-cache")
-        runner.targetVersions = ["7.2-20210527220045+0000"]
+        runner.targetVersions = ["7.2-branch-gh_normalization_line_ending_java-20210712154445+0000"]
         runner.minimumBaseVersion = "6.6"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -41,7 +41,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
     boolean isGroovyProject
 
     def setup() {
-        runner.targetVersions = ["7.2-20210624165551+0000"]
+        runner.targetVersions = ["7.2-branch-gh_normalization_line_ending_java-20210712154445+0000"]
         testProject = JavaTestProject.findProjectFor(runner.testProject)
         isGroovyProject = testProject?.name()?.contains("GROOVY")
         if (isGroovyProject) {


### PR DESCRIPTION
Enables line ending normalization for the `JavaCompile` task and adds documentation for the new feature.