### PR TITLE
Catch and log exceptions thrown by toString when printing properties

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/PropertyReportRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/PropertyReportRenderer.java
@@ -15,10 +15,16 @@
  */
 package org.gradle.api.tasks.diagnostics.internal;
 
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import javax.annotation.Nullable;
+
 /**
  * <p>A {@code PropertyReportRenderer} is responsible for rendering the model of a property report.</p>
  */
 public class PropertyReportRenderer extends TextReportRenderer {
+    private static final Logger LOGGER = Logging.getLogger(PropertyReportRenderer.class);
 
     /**
      * Writes a property for the current project.
@@ -26,7 +32,15 @@ public class PropertyReportRenderer extends TextReportRenderer {
      * @param name The name of the property
      * @param value The value of the property
      */
-    public void addProperty(String name, Object value) {
-        getTextOutput().formatln("%s: %s", name, value);
+    public void addProperty(String name, @Nullable Object value) {
+        String strValue;
+        try {
+            strValue = String.valueOf(value);
+        } catch (Exception e) {
+            String valueClass = value != null ? String.valueOf(value.getClass()) : "null";
+            LOGGER.warn("Rendering of the property '{}' with value type '{}' failed with exception", name, valueClass, e);
+            strValue = valueClass + " [Rendering failed]";
+        }
+        getTextOutput().formatln("%s: %s", name, strValue);
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/PropertyReportRendererTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/PropertyReportRendererTest.groovy
@@ -33,4 +33,29 @@ class PropertyReportRendererTest extends Specification {
         then:
         assert containsLine(out.toString(), "prop: value")
     }
+
+    def 'writes null property'() {
+        when:
+        renderer.addProperty("prop", null)
+
+        then:
+        assert containsLine(out.toString(), "prop: null")
+    }
+
+    void 'writes property that throws in toString'() {
+        when:
+        renderer.addProperty("prop", new RenderFailedValue())
+
+        then:
+        assert containsLine(out.toString(), 'prop: ' +
+            'class org.gradle.api.tasks.diagnostics.internal.PropertyReportRendererTest$RenderFailedValue ' +
+            '[Rendering failed]')
+    }
+
+    private static class RenderFailedValue {
+        @Override
+        String toString() {
+            throw new UnsupportedOperationException("You cannot toString me!")
+        }
+    }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/PropertyReportRendererTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/PropertyReportRendererTest.groovy
@@ -13,23 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.tasks.diagnostics.internal;
+package org.gradle.api.tasks.diagnostics.internal
 
-import org.gradle.internal.logging.text.TestStyledTextOutput;
-import org.junit.Test;
+import org.gradle.internal.logging.text.TestStyledTextOutput
+import spock.lang.Specification
 
-import static org.gradle.util.Matchers.containsLine;
+import static org.gradle.util.Matchers.containsLine
 
-public class PropertyReportRendererTest {
-    private final TestStyledTextOutput out = new TestStyledTextOutput();
+class PropertyReportRendererTest extends Specification {
+    private final TestStyledTextOutput out = new TestStyledTextOutput()
     private final PropertyReportRenderer renderer = new PropertyReportRenderer(){{
-        setOutput(out);
-    }};
+        setOutput(out)
+    }}
 
-    @Test
-    public void writesProperty() {
-        renderer.addProperty("prop", "value");
+    def 'writes property'() {
+        when:
+        renderer.addProperty("prop", "value")
 
-        assert containsLine(out.toString(), "prop: value");
+        then:
+        assert containsLine(out.toString(), "prop: value")
     }
 }


### PR DESCRIPTION
Parallel run of `properties` tasks seems to be causing issues when
stringifying some property-like objects. It isn't clear what exactly is
broken because the observed stacktraces make little sense. The current
hypothesis is that `toString` methods of some objects aren't
thread-safe.

This CL aims at two things:
 1. It makes an exception thrown by `toString()` non-fatal allowing the
    build to proceed.
 2. It explicitly logs the exception and some additional information
    about the type of the value being stringified to add some more
    context to further attempts of figuring out what is broken.
