### PR TITLE
Fix generated plugin accessor compilation failure

### DIFF
--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import spock.lang.Issue
 
 
 @LeaksFileHandles("Kotlin Compiler Daemon working directory")
@@ -250,6 +251,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
     }
 
     @Test
+    @Issue("https://github.com/gradle/gradle/issues/17619")
     @ToBeFixedForConfigurationCache(because = "Kotlin Gradle Plugin")
     fun `accessors are available after registering plugin`() {
         withSettings(
@@ -318,8 +320,11 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
                     "src/main/java/producer/ProducerPlugin.java",
                     """
                     package producer;
-                    public class ProducerPlugin implements ${nameOf<Plugin<*>>()}<${nameOf<Project>()}> {
-                       @Override public void apply(${nameOf<Project>()} target) {}
+                    public class ProducerPlugin {
+                        // Using internal class to verify https://github.com/gradle/gradle/issues/17619
+                        public static class Implementation implements ${nameOf<Plugin<*>>()}<${nameOf<Project>()}> {
+                            @Override public void apply(${nameOf<Project>()} target) {}
+                        }
                     }
                     """
                 )
@@ -340,7 +345,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
                     plugins {
                         producer {
                             id = 'producer-plugin'
-                            implementationClass = 'producer.ProducerPlugin'
+                            implementationClass = 'producer.ProducerPlugin${'$'}Implementation'
                         }
                     }
                 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -40,6 +40,7 @@ import org.gradle.kotlin.dsl.codegen.fileHeader
 import org.gradle.kotlin.dsl.codegen.fileHeaderFor
 import org.gradle.kotlin.dsl.codegen.kotlinDslPackagePath
 import org.gradle.kotlin.dsl.codegen.pluginEntriesFrom
+import org.gradle.kotlin.dsl.codegen.sourceNameOfBinaryName
 import org.gradle.kotlin.dsl.concurrent.IO
 import org.gradle.kotlin.dsl.concurrent.withAsynchronousIO
 import org.gradle.kotlin.dsl.concurrent.withSynchronousIO
@@ -333,7 +334,7 @@ fun BufferedWriter.appendSourceCodeForPluginAccessors(
                     format(
                         """
                         /**
-                         * The `$id` plugin implemented by [${implementationClass.replace('$', '.')}].
+                         * The `$id` plugin implemented by [${sourceNameOfBinaryName(implementationClass)}].
                          */
                         val `$extendedType`.`${extension.name}`: PluginDependencySpec
                             get() = $pluginsRef.id("$id")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -333,7 +333,7 @@ fun BufferedWriter.appendSourceCodeForPluginAccessors(
                     format(
                         """
                         /**
-                         * The `$id` plugin implemented by [$implementationClass].
+                         * The `$id` plugin implemented by [${implementationClass.replace('$', '.')}].
                          */
                         val `$extendedType`.`${extension.name}`: PluginDependencySpec
                             get() = $pluginsRef.id("$id")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/ApiTypeProvider.kt
@@ -567,7 +567,7 @@ fun binaryNameOfInternalName(internalName: String): String =
     Type.getObjectType(internalName).className
 
 
-private
+internal
 fun sourceNameOfBinaryName(binaryName: String): String =
     when (binaryName) {
         "void" -> "Unit"


### PR DESCRIPTION
For internal classes the generated accessor contained a similiar comment:

    /**
     * The `my.plugin.id` plugin implemented by [my.Plugin$Impl].
     */

The dollar sign is an invalid character and should be replaced with a dot.

I've manually verified that this PR fixes #17619.