### PR TITLE
Spike resolver specs to aid resolving specific things that subprojects might produce

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Resolver.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/Resolver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts;
+
+import java.io.File;
+import java.util.Set;
+
+public interface Resolver {
+    /**
+     * Resolves this resolver. This locates and downloads the files which make up this resolver, and returns
+     * the resulting set of files.
+     *
+     * @return The files of this resolver.
+     */
+    Set<File> resolve();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/resolvers/ResolverSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/resolvers/ResolverSpec.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.resolvers;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.model.ObjectFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ResolverSpec {
+    protected final ObjectFactory objectFactory;
+
+    private final List<Configuration> extendsFrom = new ArrayList<>();
+    private boolean lenient = false;
+
+    protected ResolverSpec(ObjectFactory objectFactory) {
+        this.objectFactory = objectFactory;
+    }
+
+    public void from(Configuration configuration) {
+        extendsFrom.add(configuration);
+    }
+
+    public void lenient() {
+        this.lenient = true;
+    }
+
+    // TODO: this should not be public API - figure a better way
+    public boolean isLenient() {
+        return lenient;
+    }
+
+    // TODO: this should not be public API - figure a better way
+    public void configure(Configuration resolver) {
+        resolver.setVisible(false);
+        resolver.setCanBeConsumed(false);
+        resolver.setCanBeResolved(true);
+        resolver.extendsFrom(extendsFrom.toArray(new Configuration[0]));
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultResolver.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Resolver;
+
+import java.io.File;
+import java.util.Set;
+
+public class DefaultResolver implements Resolver {
+
+    private final Configuration configuration;
+    private final boolean lenient;
+
+    public DefaultResolver(Configuration configuration, boolean lenient) {
+        this.configuration = configuration;
+        this.lenient = lenient;
+    }
+
+    @Override
+    public Set<File> resolve() {
+        if (lenient) {
+            return configuration.getIncoming().artifactView(a -> a.lenient(true)).getFiles().getFiles();
+        }
+        return configuration.resolve();
+    }
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCoverageAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCoverageAggregationIntegrationTest.groovy
@@ -406,17 +406,12 @@ class JacocoCoverageAggregationIntegrationTest extends AbstractIntegrationSpec {
             abstract class CustomAggregation extends DefaultTask {
                 @TaskAction
                 void aggregate() {
-                    Configuration resolver = getProject().getConfigurations().create("jacocoResolver")
-                    resolver.visible = false
-                    resolver.canBeConsumed = false
-                    resolver.canBeResolved = true
-                    resolver.extendsFrom(getProject().getConfigurations().getByName("implementation"))
-                    resolver.attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
-                        attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.DOCUMENTATION));
-                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, project.getObjects().named(DocsType.class, "jacoco-coverage-data"));
+                    def resolver = project.configurations.resolver("jacocoResolver", JacocoCoverage) {
+                        from(project.configurations.implementation)
+                        forTestTasksNamed("test")
+                        lenient()
                     }
-                    println(resolver.getIncoming().artifactView{ lenient(true) }.getFiles().getFiles())
+                    println(resolver.resolve())
                 }
             }
 

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/resolvers/JacocoCoverage.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/resolvers/JacocoCoverage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.resolvers;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.resolvers.ResolverSpec;
+import org.gradle.testing.jacoco.tasks.JacocoAggregatedReport;
+
+public abstract class JacocoCoverage extends ResolverSpec {
+    private String testTaskName = "test";
+
+    public JacocoCoverage(ObjectFactory objectFactory) {
+        super(objectFactory);
+    }
+
+    public void forTestTasksNamed(String testTaskName) {
+        this.testTaskName = testTaskName;
+    }
+
+    @Override
+    public void configure(Configuration resolver) {
+        super.configure(resolver);
+        resolver.attributes(a -> {
+            a.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+            a.attribute(Category.CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.DOCUMENTATION));
+            a.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objectFactory.named(DocsType.class, "jacoco-coverage-data"));
+            a.attribute(JacocoAggregatedReport.TestCategory.ATTRIBUTE, objectFactory.named(JacocoAggregatedReport.TestCategory.class, testTaskName));
+        });
+    }
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoAggregatedReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoAggregatedReport.java
@@ -160,7 +160,7 @@ public abstract class JacocoAggregatedReport extends JacocoReport {
         };
     }
 
-    private interface TestCategory extends Named {
+    public interface TestCategory extends Named {
         Attribute<TestCategory> ATTRIBUTE = Attribute.of("org.gradle.test-category", TestCategory.class);
     }
 }


### PR DESCRIPTION
Using Jacoco coverage data as an example.
