### PR TITLE
Publish module for functional project

### DIFF
--- a/subprojects/functional/build.gradle.kts
+++ b/subprojects/functional/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("gradlebuild.distribution.implementation-java")
+    id("gradlebuild.publish-public-libraries")
 }
 
 description = "Tools to work with functional code, including data structures"


### PR DESCRIPTION
This is now a dependency of snapshots which means it needs to be available as a dependency, too.

