### PR TITLE
Split VersionRangeResolveIntegrationTest

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractVersionRangeResolveIntegrationTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
 import spock.lang.IgnoreIf
-import spock.lang.Unroll
 
 /**
  * A comprehensive test of dependency resolution of a single module version, given a set of input selectors.
@@ -33,7 +32,7 @@ import spock.lang.Unroll
     // embedded mode
     !GradleContextualExecuter.embedded
 })
-class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTest {
+abstract class AbstractVersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTest {
 
     def baseBuild
     def baseSettings
@@ -58,48 +57,6 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         baseSettings = settingsFile.text
     }
 
-    @Unroll
-    def "resolve pair #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expectedSingle = permutation.expectedSingle
-        def expectedMulti = permutation.expectedMulti
-
-        expect:
-        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_TWO_DEPENDENCIES
-    }
-
-    @Unroll
-    def "resolve prefer pair #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expectedSingle = permutation.expectedSingle
-        def expectedMulti = permutation.expectedMulti
-
-        expect:
-        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_PREFER
-    }
-
-    @Unroll
-    def "resolve reject pair #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expectedSingle = permutation.expectedSingle
-        def expectedMulti = permutation.expectedMulti
-
-        expect:
-        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_DEPENDENCY_WITH_REJECT
-    }
-
     void checkScenarioResolution(String expectedSingle, String expectedMulti, VersionRangeResolveTestScenarios.RenderableVersion... versions) {
         checkScenarioResolution(expectedSingle, expectedMulti, versions as List)
     }
@@ -118,7 +75,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             allprojects {
                 configurations { conf }
             }
-            
+
             configurations {
                 ${singleProjectConfs.join('\n')}
                 single {
@@ -131,12 +88,12 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
                 conf project(path: ':p1', configuration: 'conf')
                 ${singleProjectDeps.join('\n')}
             }
-            
+
             task resolveMultiProject(type: Sync) {
                 from configurations.conf
                 into 'libs-multi'
             }
-            
+
             task resolveSingleProject(type: Sync) {
                 from configurations.single
                 into 'libs-single'
@@ -178,8 +135,6 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             def singleProjectResolve = file('libs-single').list() as List
             assert parseResolvedVersion(singleProjectResolve) == expectedSingle
         }
-
-
     }
 
     def parseResolvedVersion(resolvedFiles) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePairIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.Unroll
+
+class VersionRangeResolvePairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
+    @Unroll
+    def "resolve pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expectedSingle = permutation.expectedSingle
+        def expectedMulti = permutation.expectedMulti
+
+        expect:
+        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.SCENARIOS_TWO_DEPENDENCIES
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePairIntegrationTest.groovy
@@ -16,9 +16,17 @@
 
 package org.gradle.integtests.resolve
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+@IgnoreIf({
+    // This test is very expensive. Ideally we shouldn't need an integration test here, but lack the
+    // infrastructure to simulate everything done here, so we're only going to execute this test in
+    // embedded mode
+    !GradleContextualExecuter.embedded
+})
 class VersionRangeResolvePairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
     @Unroll
     def "resolve pair #permutation"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePreferPairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePreferPairIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.Unroll
+
+class VersionRangeResolvePreferPairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
+    @Unroll
+    def "resolve prefer pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expectedSingle = permutation.expectedSingle
+        def expectedMulti = permutation.expectedMulti
+
+        expect:
+        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.SCENARIOS_PREFER
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePreferPairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolvePreferPairIntegrationTest.groovy
@@ -16,9 +16,17 @@
 
 package org.gradle.integtests.resolve
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+@IgnoreIf({
+    // This test is very expensive. Ideally we shouldn't need an integration test here, but lack the
+    // infrastructure to simulate everything done here, so we're only going to execute this test in
+    // embedded mode
+    !GradleContextualExecuter.embedded
+})
 class VersionRangeResolvePreferPairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
     @Unroll
     def "resolve prefer pair #permutation"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveRejectPairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveRejectPairIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.Unroll
+
+class VersionRangeResolveRejectPairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
+    @Unroll
+    def "resolve reject pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expectedSingle = permutation.expectedSingle
+        def expectedMulti = permutation.expectedMulti
+
+        expect:
+        checkScenarioResolution(expectedSingle, expectedMulti, candidates)
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.SCENARIOS_DEPENDENCY_WITH_REJECT
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveRejectPairIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveRejectPairIntegrationTest.groovy
@@ -16,9 +16,17 @@
 
 package org.gradle.integtests.resolve
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+@IgnoreIf({
+    // This test is very expensive. Ideally we shouldn't need an integration test here, but lack the
+    // infrastructure to simulate everything done here, so we're only going to execute this test in
+    // embedded mode
+    !GradleContextualExecuter.embedded
+})
 class VersionRangeResolveRejectPairIntegrationTest extends AbstractVersionRangeResolveIntegrationTest {
     @Unroll
     def "resolve reject pair #permutation"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.integtests.resolve.rules
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.TestDependency
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Ignore
 import spock.lang.Issue


### PR DESCRIPTION
Previously the whole class includes 300+ iterations and sometimes runs >8 min. Now we split it into 3 classes.