### PR TITLE
Let eclipse-wtp remove the "jst.utility" facet in ejb modules

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,6 +10,8 @@ Include only their name, impactful features should be called out separately belo
 -->
 We would like to thank the following community members for their contributions to this release of Gradle:
 
+[Herbert von Broeuschmeul](https://github.com/HvB)
+
 ## Upgrade instructions
 
 Switch your build to use Gradle @version@ by updating your wrapper:

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -137,6 +137,21 @@ In precompiled script plugins, type safe Kotlin DSL accessor generation now fail
 
 Starting in Gradle 7.6, builds could enable this behavior with the `org.gradle.kotlin.dsl.precompiled.accessors.strict` system property. This behavior is now default. The property has been deprecated and its usage should be removed. You can find more information about this property <<upgrading_version_7.adoc#strict-kotlin-dsl-precompiled-scripts-accessors, below>>.
 
+==== Adding `jst.ejb` with the `eclipse wtp' plugin now removes the `jst.utility` facet
+
+The `eclipse wtp` plugin adds the `jst.utility` facet to java projects.
+Now, adding the `jst.ejb` facet implicitly removes the `jst.utility` facet:
+
+```
+eclipse {
+    wtp {
+        facet {
+            facet name: 'jst.ejb', version: '3.2'
+        }
+    }
+}
+```
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
@@ -24,6 +24,8 @@ import org.gradle.plugins.ide.api.XmlFileContentMerger;
 import org.gradle.util.internal.ConfigureUtil;
 
 import javax.inject.Inject;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -138,23 +140,46 @@ public class EclipseWtpFacet {
      * <p>
      * If a facet already exists with the given name then its version will be updated.
      * <p>
+     * In the case of a "jst.ejb" facet, it will also be added as a fixed facet.
+     * <p>
      * For examples see docs for {@link EclipseWtpFacet}
      *
      * @param args A map that must contain a 'name' and 'version' key with corresponding values.
      */
     public void facet(Map<String, ?> args) {
         Facet newFacet = ConfigureUtil.configureByMap(args, new Facet());
+        List<Facet> newFacets;
+        if ("jst.ejb".equals(newFacet.getName())) {
+            newFacets = Arrays.asList(new Facet(Facet.FacetType.fixed, "jst.ejb", null), newFacet);
+        } else {
+            newFacets = Collections.singletonList(newFacet);
+        }
         facets = Lists.newArrayList(Iterables.concat(
             getFacets().stream()
                        .filter(f -> f.getType() != newFacet.getType() || !Objects.equals(f.getName(), newFacet.getName()))
                        .collect(Collectors.toList()),
-            Collections.singleton(newFacet)));
+            newFacets));
+    }
+
+    /**
+     * Removes incompatible facets from a list of facets.
+     * <p>
+     * Currently removes the facet "jst.utility" when the facet "jst.ejb" is present.
+     *
+     * @param facets, a list of facets
+     * @return the modified facet list
+     */
+    List<Facet> replaceInconsistentFacets(List<Facet> facets) {
+        if (facets.stream().anyMatch(f -> "jst.ejb".equals(f.getName()))) {
+            return facets.stream().filter(f -> !"jst.utility".equals(f.getName())).collect(Collectors.toList());
+        }
+        return facets;
     }
 
     @SuppressWarnings("unchecked")
     public void mergeXmlFacet(WtpFacet xmlFacet) {
         file.getBeforeMerged().execute(xmlFacet);
-        xmlFacet.configure(getFacets());
+        xmlFacet.configure(replaceInconsistentFacets(getFacets()));
         file.getWhenMerged().execute(xmlFacet);
     }
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/EclipseWtpPluginTest.groovy
@@ -298,7 +298,28 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
                 new Facet(FacetType.installed, "jst.java", "1.4")])
     }
 
-    @Issue(['GRADLE-2186', 'GRADLE-2221'])
+    @Issue('gradle/gradle#17681')
+    def "add 'jst.ejb' facet should remove incompatible 'jst.utility' facet"() {
+        when:
+        project.apply(plugin: 'java')
+        project.apply(plugin: 'eclipse-wtp')
+        project.sourceCompatibility = 1.8
+
+        project.eclipse.wtp {
+            facet {
+                facet name: 'jst.ejb', version: '3.2'
+            }
+        }
+
+        then:
+        checkEclipseWtpFacet([
+                new Facet(FacetType.fixed, "jst.java", null),
+                new Facet(FacetType.fixed, "jst.ejb", null),
+                new Facet(FacetType.installed, "jst.ejb", "3.2"),
+                new Facet(FacetType.installed, "jst.java", "1.8")])
+    }
+
+    @Issue(['GRADLE-2186', 'GRADLE-2221', 'gradle/gradle#17681'])
     def "can change WTP components and add facets when java plugin is applied"() {
         when:
         project.apply(plugin: 'java')
@@ -319,7 +340,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         project.eclipse.wtp.component.deployName == 'ejb-jar'
         project.eclipse.wtp.component.properties == [new WbProperty('mood', ':-D')]
         checkEclipseWtpFacet([new Facet(FacetType.fixed, 'jst.java', null),
-                              new Facet(FacetType.installed, 'jst.utility', '1.0'),
+                              new Facet(FacetType.fixed, "jst.ejb", null),
                               new Facet(FacetType.installed, 'jst.java', '1.7'),
                               new Facet(FacetType.installed, 'jst.ejb', '3.0')])
     }
@@ -346,7 +367,7 @@ class EclipseWtpPluginTest extends AbstractProjectBuilderSpec {
         assert project.tasks.eclipseWtp.taskDependencies.getDependencies(project.tasks.eclipseWtp).contains(eclipseWtpFacet)
         assert eclipseWtpFacet.inputFile == project.file('.settings/org.eclipse.wst.common.project.facet.core.xml')
         assert eclipseWtpFacet.outputFile == project.file('.settings/org.eclipse.wst.common.project.facet.core.xml')
-        assert wtp.facets.sort() == expectedFacets.sort()
+        assert wtp.replaceInconsistentFacets(wtp.facets).sort() == expectedFacets.sort()
     }
 
     private void checkEclipseWtpComponentForJava() {


### PR DESCRIPTION
Fixes #17681

### Context

<!--- Why do you believe many users will benefit from this change? -->
The gradle _eclipse-wtp_ plugin adds an Eclipse `jst.utility` facet to each java project. 
If you want Eclipse IDE to recognize it as  an EJBs project, you have to add a `jst.ejb` facet:

```groovy
eclipse.wtp.facet { 
    facet name: 'jst.ejb', version: '3.2'
}
```
However as `jst.ejb` and `jst.utility` facets are incompatible, Eclipe IDE will complain and state that it is misconfigured.

If you use gradle to build projects but want to use the Eclipse  IDE, then the gradle configuration should be considered as the source of truth. However this implies that the _eclipse_ and _eclipse-wtp_ plugins must configure the corresponding Eclipse projects correctly. 

In addition, to align with the behavior of the Eclipse IDE wizard, the `jst.ejb` facet should also be defined as `fixed`.

This can be done using the `EclipseWTPFacet.file` method:

```groovy
eclipse.wtp.facet.file.whenMerged { it.facets = it.facets.findAll { it.name != 'jst.utility' }}
```
but, in my opinion, this should be reserved for tricky edge cases not basic project configuration.  

That's why I think developers using the Eclipse IDE would benefit from this change.


Relevant forum: https://discuss.gradle.org/t/easily-customize-the-eclipse-wtp-facet-version/8690

#### Remark:

I'm not sure if the `EclipseWTPFacet.facet` method is the right place to add this modification, but I haven't found a better one.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
