### PR TITLE
Revert "Update groovy from 3.0.7 to 3.0.8"

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 // Here you should declare versions which should be shared by the different modules of buildSrc itself
 val javaParserVersion = "3.18.0"
-val groovyVersion = "3.0.8"
+val groovyVersion = "3.0.7"
 val asmVersion = "9.1"
 
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")

--- a/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
+++ b/subprojects/docs/src/samples/groovy/library-publishing/kotlin/my-library/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.codehaus.groovy:groovy-all:3.0.8")
+    implementation("org.codehaus.groovy:groovy-all:3.0.7")
 }
 
 publishing {


### PR DESCRIPTION
The PR #17645 is incomplete for bumping the groovy version and more work is needed.