### PR TITLE
Soften the language around the deprecation of jcenter()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -121,7 +121,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * @param action a configuration action
      * @return the added repository
-     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">shutdown</a> in February 2021. Use {@link #mavenCentral()} instead.
+     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">sunset</a> in February 2021. Use {@link #mavenCentral()} instead.
      */
     @Deprecated
     MavenArtifactRepository jcenter(Action<? super MavenArtifactRepository> action);
@@ -141,7 +141,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * @return the added resolver
      * @see #jcenter(Action)
-     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">shutdown</a> in February 2021. Use {@link #mavenCentral()} instead.
+     * @deprecated JFrog announced JCenter's <a href="https://blog.gradle.org/jcenter-shutdown">sunset</a> in February 2021. Use {@link #mavenCentral()} instead.
      */
     @Deprecated
     MavenArtifactRepository jcenter();

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -68,7 +68,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
         'flat-dir'             | flatDirRepoBlock()            | expectedFlatDirRepo()            | null
         'local maven'          | mavenLocalRepoBlock()         | expectedMavenLocalRepo()         | null
         'maven central'        | mavenCentralRepoBlock()       | expectedMavenCentralRepo()       | null
-        'jcenter'              | jcenterRepoBlock()            | expectedJcenterRepo()            | "The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
+        'jcenter'              | jcenterRepoBlock()            | expectedJcenterRepo()            | "The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
         'google'               | googleRepoBlock()             | expectedGoogleRepo()             | null
         'gradle plugin portal' | gradlePluginPortalRepoBlock() | expectedGradlePluginPortalRepo() | null
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedRepositoryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/DeprecatedRepositoryIntegrationTest.groovy
@@ -30,7 +30,7 @@ class DeprecatedRepositoryIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.expectDocumentedDeprecationWarning "The RepositoryHandler.jcenter() method has been deprecated." +
-            " This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead." +
+            " This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead." +
             " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
 
         then:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -124,7 +124,7 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
     private void deprecateJCenter(String method, String replacement) {
         DeprecationLogger.deprecateMethod(RepositoryHandler.class, method)
-            .withAdvice("JFrog announced JCenter's shutdown in February 2021. Use " + replacement + " instead.")
+            .withAdvice("JFrog announced JCenter's sunset in February 2021. Use " + replacement + " instead.")
             .willBeRemovedInGradle8()
             .withUpgradeGuideSection(6, "jcenter_deprecation")
             .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_6.adoc
@@ -62,10 +62,12 @@ Users can still opt in to have this unique identifier part of the produced metad
 [[jcenter_deprecation]]
 === The `jcenter()` convenience method is now deprecated
 
-JFrog link:https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter[announced] the decommission of JCenter.
-This has the potential to https://blog.gradle.org/jcenter-shutdown[impact many Gradle builds].
-Gradle emits a deprecation warning when `jcenter()` is used in the repository configuration.
-Consider <<declaring_repositories.adoc#declaring-repositories,using>> `mavenCentral()`, `google()` or a private `maven` repository instead.
+JFrog link:https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter[announced] the sunset of the JCenter repository in February 2021. https://blog.gradle.org/jcenter-shutdown[Many Gradle builds] rely on JCenter for project dependencies.
+
+No new packages or versions are published to JCenter, but JFrog says they will keep JCenter running in a read-only state indefinitely.
+We recommend that you consider <<declaring_repositories.adoc#declaring-repositories,using>> `mavenCentral()`, `google()` or a private `maven` repository instead.
+
+Gradle emits a deprecation warning when `jcenter()` is used as a repository and this method is scheduled to be removed in Gradle 8.0.
 
 === Potential breaking changes
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -287,7 +287,7 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
 
         expect:
         executer.expectDocumentedDeprecationWarning "The RepositoryHandler.jcenter() method has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's shutdown in February 2021. Use mavenCentral() instead. " +
+            "This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. " +
             "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_6.html#jcenter_deprecation"
         succeeds "help"
     }


### PR DESCRIPTION
- Javadoc now refer to JCenter as a "sunset" vs a shutdown
- Gradle will still nag about the deprecation for jcenter related APIs
- Upgrade advice is reworded to recommend migrating away from jcenter,
but still mentioning that JCenter will be read-only indefinitely.

<!--- The issue this PR addresses -->
Fixes #17433

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
