### PR TITLE
Fix flaky ThirdPartyGradleModuleMetadataSmokeTest

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -114,7 +114,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     }
 
     private static List<String> trimmedOutput(BuildResult result) {
-        result.output.split('\n').findAll { !it.empty && !it.contains('warning') }
+        result.output.split('\n').findAll { !it.empty && !it.toLowerCase().contains('warning') }
     }
 
     private BuildResult publish() {


### PR DESCRIPTION
Sometimes the outputs are "Warning", not "warning". Check them case-insensitively: https://builds.gradle.org/viewLog.html?buildId=44778029

```
======= Failed test run #1 ==========
Condition not satisfied:

trimmedOutput(result) == []
|             |       |
|             |       false
|             <org.gradle.testkit.runner.internal.FeatureCheckBuildResult@198e4507 delegateBuildResult=org.gradle.testkit.runner.internal.DefaultBuildResult@6c9f9d0c outputFeatureCheck=org.gradle.testkit.runner.internal.feature.BuildResultOutputFeatureCheck@1bfc63a8>
[Warning: Mapping new ns http://schemas.android.com/repository/android/common/02 to old ns http://schemas.android.com/repository/android/common/01, Warning: Mapping new ns http://schemas.android.com/repository/android/generic/02 to old ns http://schemas.android.com/repository/android/generic/01, Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/addon2/02 to old ns http://schemas.android.com/sdk/android/repo/addon2/01, Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/repository2/02 to old ns http://schemas.android.com/sdk/android/repo/repository2/01, Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/sys-img2/02 to old ns http://schemas.android.com/sdk/android/repo/sys-img2/01]

```