### PR TITLE
Don't execute work on the main thread

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
@@ -69,7 +69,6 @@ public class DefaultPlanExecutor implements PlanExecutor {
         try {
             WorkerLease parentWorkerLease = workerLeaseService.getCurrentWorkerLease();
             startAdditionalWorkers(executionPlan, nodeExecutor, executor, parentWorkerLease);
-            new ExecutorWorker(executionPlan, nodeExecutor, parentWorkerLease, cancellationToken, coordinationService).run();
             awaitCompletion(executionPlan, failures);
         } finally {
             executor.stop();
@@ -93,7 +92,7 @@ public class DefaultPlanExecutor implements PlanExecutor {
     private void startAdditionalWorkers(ExecutionPlan executionPlan, Action<? super Node> nodeExecutor, Executor executor, WorkerLease parentWorkerLease) {
         LOGGER.debug("Using {} parallel executor threads", executorCount);
 
-        for (int i = 1; i < executorCount; i++) {
+        for (int i = 0; i < executorCount; i++) {
             executor.execute(new ExecutorWorker(executionPlan, nodeExecutor, parentWorkerLease, cancellationToken, coordinationService));
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultPlanExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultPlanExecutorTest.groovy
@@ -34,6 +34,7 @@ class DefaultPlanExecutorTest extends Specification {
     def executionPlan = Mock(ExecutionPlan)
     def worker = Mock(Action)
     def executorFactory = Mock(ExecutorFactory)
+    def managedExecutor = Mock(ManagedExecutor)
     def cancellationHandler = Mock(BuildCancellationToken)
     def coordinationService = Stub(ResourceLockCoordinationService) {
         withStateLock(_) >> { transformer ->
@@ -56,7 +57,8 @@ class DefaultPlanExecutorTest extends Specification {
         executor.process(executionPlan, [], worker)
 
         then:
-        1 * executorFactory.create(_) >> Mock(ManagedExecutor)
+        1 * executorFactory.create(_) >> managedExecutor
+        1 * managedExecutor.execute(_) >> { args -> args[0].run() }
         1 * cancellationHandler.isCancellationRequested() >> false
         1 * executionPlan.hasNodesRemaining() >> true
         1 * executionPlan.selectNext(_, _) >> node
@@ -84,7 +86,8 @@ class DefaultPlanExecutorTest extends Specification {
 
         then:
         1 * executionPlan.getDisplayName() >> "task plan"
-        1 * executorFactory.create(_) >> Mock(ManagedExecutor)
+        1 * executorFactory.create(_) >> managedExecutor
+        1 * managedExecutor.execute(_) >> { args -> args[0].run() }
         1 * cancellationHandler.isCancellationRequested() >> false
         1 * executionPlan.hasNodesRemaining() >> true
         1 * executionPlan.selectNext(_, _) >> node


### PR DESCRIPTION
For simplicity and homogeneous stack traces.