### PR TITLE
Discard the object body when doing metadata request to S3

### DIFF
--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.transport.aws.s3;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
+import com.google.common.io.ByteStreams;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.ReadableContent;
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData;
@@ -72,6 +73,22 @@ public class S3ResourceConnector implements ExternalResourceConnector {
                 objectMetadata.getContentType(),
                 objectMetadata.getETag(),
                 null); // Passing null for sha1 - TODO - consider using the etag which is an MD5 hash of the file (when less than 5Gb)
+        } finally {
+            discardEmptyContentAndClose(s3Object);
+        }
+    }
+
+    private static void discardEmptyContentAndClose(S3Object s3Object) {
+        // Consume the content stream to avoid warning from S3 SDK. The response should have only 1 byte there because Range header was specified.
+        try {
+            long downloadedContentLength = ByteStreams.exhaust(s3Object.getObjectContent());
+            if (downloadedContentLength > 1L) {
+                // This may happen if the endpoint ignores Range HTTP header for whatever reason.
+                LOGGER.info("Downloaded {} bytes of the object content for metadata request which is too much.", downloadedContentLength);
+            }
+        } catch (IOException e) {
+            // Don't complain loudly to the user about the error there because we were discarding the response anyway.
+            LOGGER.debug("Exception while consuming empty object content from metadata request", e);
         } finally {
             IoActions.closeQuietly(s3Object);
         }

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ResourceConnector.java
@@ -18,6 +18,7 @@ package org.gradle.internal.resource.transport.aws.s3;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.google.common.io.ByteStreams;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.ReadableContent;
@@ -81,15 +82,20 @@ public class S3ResourceConnector implements ExternalResourceConnector {
     private static void discardEmptyContentAndClose(S3Object s3Object) {
         // Consume the content stream to avoid warning from S3 SDK. The response should have only 1 byte there because Range header was specified.
         try {
-            long downloadedContentLength = ByteStreams.exhaust(s3Object.getObjectContent());
+            S3ObjectInputStream objectContent = s3Object.getObjectContent();
+            if (objectContent == null) {
+                return;
+            }
+            long downloadedContentLength = ByteStreams.exhaust(objectContent);
             if (downloadedContentLength > 1L) {
                 // This may happen if the endpoint ignores Range HTTP header for whatever reason.
-                LOGGER.info("Downloaded {} bytes of the object content for metadata request which is too much.", downloadedContentLength);
+                LOGGER.debug("Downloaded {} bytes of the object content for metadata request which is too much.", downloadedContentLength);
             }
         } catch (IOException e) {
             // Don't complain loudly to the user about the error there because we were discarding the response anyway.
             LOGGER.debug("Exception while consuming empty object content from metadata request", e);
         } finally {
+            // This also closes objectContent, no need to close it explicitly.
             IoActions.closeQuietly(s3Object);
         }
     }


### PR DESCRIPTION
Otherwise the client library issues a warning about potential waste.
There is waste but only 1 byte (Range header is used). I've kept an
info message for the cases where more than 1 byte is downloaded - just
in case if someone needs to investigate issues with the S3-compatible
service that doesn't understand Range headers and returns the whole
object instead.

<!--- The issue this PR addresses -->
Fixes #9932 
