### PR TITLE
Fix incremental annotation processing for package info files

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -71,13 +71,20 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
     }
 
     protected final File java(String... classBodies) {
+        javaInPackage('', classBodies)
+    }
+
+    protected final File javaInPackage(String packageName, String... classBodies) {
         File out
+        def packageStatement = packageName.empty ? "" : "package ${packageName};\n"
+        def packagePathPrefix = packageName.empty ? '' : "${packageName.replace('.', '/')}/"
         for (String body : classBodies) {
             def className = (body =~ /(?s).*?class (\w+) .*/)[0][1]
             assert className: "unable to find class name"
-            def f = file("src/main/java/${className}.java")
+            def f = file("src/main/java/${packagePathPrefix}${className}.java")
             f.createFile()
-            f.text = body
+            f.text = packageStatement
+            f << body
             out = f
         }
         out

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -178,7 +178,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         run "compileJava"
 
         then:
-        outputs.recompiledFiles('com/foo/$Configuration')
+        outputs.recompiledFiles('A', 'B', '$Configuration', 'package-info')
     }
 
     File annotatedPackageInfo(String packageName, String annotation) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -21,10 +21,10 @@ import org.gradle.api.internal.tasks.compile.CompileJavaBuildOperationType
 import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType
 import org.gradle.language.fixtures.AnnotatedGeneratedClassProcessorFixture
 import org.gradle.language.fixtures.HelperProcessorFixture
+import org.gradle.language.fixtures.PackageInfoGeneratedClassProcessorFixture
 import org.gradle.language.fixtures.ResourceGeneratingProcessorFixture
 import org.gradle.language.fixtures.ServiceRegistryProcessorFixture
 import spock.lang.Issue
-import spock.lang.Unroll
 
 import javax.tools.StandardLocation
 
@@ -121,7 +121,6 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     @Issue("https://github.com/gradle/gradle/issues/13767")
-    @Unroll
     def "generated files with annotations are not reprocessed when a file is added (#label)"() {
         def fixture = new AnnotatedGeneratedClassProcessorFixture()
         if (generateClass) {
@@ -156,6 +155,39 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         true          | "generate class files"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/17572")
+    def "can have an aggregating annotation processor for package info"() {
+        def fixture = new PackageInfoGeneratedClassProcessorFixture()
+        withProcessor(fixture)
+        buildFile << """
+            repositories {
+                ${fixture.repositoriesBlock}
+            }
+        """
+
+        def processedPackage = 'com.foo'
+        def a = javaInPackage processedPackage, "class A {}"
+        javaInPackage processedPackage, "class B {}"
+        annotatedPackageInfo(processedPackage, 'com.my.processor.Configuration')
+        javaInPackage 'com.unprocessed', "class Unrelated {}"
+
+        outputs.snapshot { run "compileJava" }
+
+        when:
+        a.text = "class A { public void foo() {} }"
+        run "compileJava"
+
+        then:
+        outputs.recompiledFiles('com/foo/$Configuration')
+    }
+
+    File annotatedPackageInfo(String packageName, String annotation) {
+        file("src/main/java/${packageName.replace('.', '/')}/package-info.java") << """
+            @${annotation}
+            package ${packageName};
+        """
+    }
+
     private void makeGeneratedClassFilesAccessible() {
         // On Java 8 and earlier, generated classes are not automatically
         // available to the compile classpath so we need to expose them
@@ -170,7 +202,6 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
 
-    @Unroll
     def "generated files with annotations are reprocessed when a file is deleted (#label)"() {
         def fixture = new AnnotatedGeneratedClassProcessorFixture()
         if (generateClass) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -178,7 +178,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         run "compileJava"
 
         then:
-        outputs.recompiledFiles('A', 'B', '$Configuration', 'package-info')
+        outputs.recompiledFiles('A', '$Configuration', 'package-info')
     }
 
     File annotatedPackageInfo(String packageName, String annotation) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -160,12 +160,7 @@ public class ClassSetAnalysis {
         if (!constants.isEmpty() && !compilerApiData.isSupportsConstantsMapping()) {
             return DependentsSet.dependencyToAll("an inlineable constant in '" + className + "' has changed");
         }
-        Set<String> classesDependingOnAllOthers = new HashSet<>(annotationProcessingData.participatesInClassGeneration(className) ? annotationProcessingData.getGeneratedTypesDependingOnAllOthers() : Collections.emptySet());
-        annotationProcessingData.getAggregatedTypes()
-            .stream()
-            .map(annotationProcessingData::getOriginOf)
-            .filter(ClassSetAnalysis::isPackageInfo)
-            .forEach(classesDependingOnAllOthers::add);
+        Set<String> classesDependingOnAllOthers = annotationProcessingData.participatesInClassGeneration(className) ? annotationProcessingData.getGeneratedTypesDependingOnAllOthers() : Collections.emptySet();
         Set<GeneratedResource> resourcesDependingOnAllOthers = annotationProcessingData.participatesInResourceGeneration(className) ? annotationProcessingData.getGeneratedResourcesDependingOnAllOthers() : Collections.emptySet();
 
         DependentsSet constantDeps = getConstantDependents(className);
@@ -200,7 +195,6 @@ public class ClassSetAnalysis {
         return annotationProcessingData.getAggregatedTypes()
             .stream()
             .map(annotationProcessingData::getOriginOf)
-            .filter(name -> !isPackageInfo(name))
             .collect(Collectors.toSet());
     }
 
@@ -299,10 +293,6 @@ public class ClassSetAnalysis {
 
     public IntSet getConstants(String className) {
         return classAnalysis.getConstants(className);
-    }
-
-    private static boolean isPackageInfo(String className) {
-        return className.endsWith("package-info");
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
@@ -23,6 +23,9 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static org.gradle.api.internal.tasks.compile.incremental.recomp.WellKnownSourceFileClassNameConverter.isModuleInfo;
+import static org.gradle.api.internal.tasks.compile.incremental.recomp.WellKnownSourceFileClassNameConverter.isPackageInfo;
+
 public class RecompilationSpec {
     private final Set<String> classesToCompile = new LinkedHashSet<>();
     private final Collection<String> classesToProcess = new LinkedHashSet<>();
@@ -77,7 +80,7 @@ public class RecompilationSpec {
 
     public void addClassesToProcess(Collection<String> classes) {
         classes.forEach(classToReprocess -> {
-            if (classToReprocess.endsWith("package-info")) {
+            if (isPackageInfo(classToReprocess) || isModuleInfo(classToReprocess)) {
                 classesToCompile.add(classToReprocess);
             } else {
                 classesToProcess.add(classToReprocess);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpec.java
@@ -76,7 +76,13 @@ public class RecompilationSpec {
     }
 
     public void addClassesToProcess(Collection<String> classes) {
-        classesToProcess.addAll(classes);
+        classes.forEach(classToReprocess -> {
+            if (classToReprocess.endsWith("package-info")) {
+                classesToCompile.add(classToReprocess);
+            } else {
+                classesToProcess.add(classToReprocess);
+            }
+        });
     }
 
     public Collection<String> getClassesToProcess() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/WellKnownSourceFileClassNameConverter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/WellKnownSourceFileClassNameConverter.java
@@ -25,6 +25,9 @@ import java.util.Collections;
  * Handles classes which can affect other classes simply by being newly added to a source set.
  */
 public class WellKnownSourceFileClassNameConverter implements SourceFileClassNameConverter {
+    private static final String MODULE_INFO = "module-info";
+    private static final String PACKAGE_INFO = "package-info";
+
     private final SourceFileClassNameConverter delegate;
     private final String fileExtension;
 
@@ -33,13 +36,21 @@ public class WellKnownSourceFileClassNameConverter implements SourceFileClassNam
         this.fileExtension = fileExtension;
     }
 
+    public static boolean isPackageInfo(String className) {
+        return className.endsWith(PACKAGE_INFO);
+    }
+
+    public static boolean isModuleInfo(String className) {
+        return className.equals(MODULE_INFO);
+    }
+
     @Override
     public Collection<String> getClassNames(String sourceFileRelativePath) {
         String withoutExtension = StringUtils.removeEnd(sourceFileRelativePath, fileExtension);
-        if (withoutExtension.endsWith("module-info")) {
-            return Collections.singleton("module-info");
+        if (isModuleInfo(withoutExtension)) {
+            return Collections.singleton(MODULE_INFO);
         }
-        if (withoutExtension.endsWith("package-info")) {
+        if (isPackageInfo(withoutExtension)) {
             String packageName = withoutExtension.replace('/', '.');
             return Collections.singleton(packageName);
         }
@@ -48,7 +59,7 @@ public class WellKnownSourceFileClassNameConverter implements SourceFileClassNam
 
     @Override
     public Collection<String> getRelativeSourcePaths(String className) {
-        if (className.equals("module-info") || className.endsWith("package-info")) {
+        if (isModuleInfo(className) || isPackageInfo(className)) {
             return Collections.singleton(className.replace('.', '/') + fileExtension);
         }
         return delegate.getRelativeSourcePaths(className);

--- a/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/AnnotationProcessorFixture.groovy
+++ b/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/AnnotationProcessorFixture.groovy
@@ -32,15 +32,26 @@ import org.gradle.test.fixtures.file.TestFile
 @CompileStatic
 abstract class AnnotationProcessorFixture {
     protected final String annotationName
+    protected final String annotationPackageName
+    protected final String fqAnnotationName
     IncrementalAnnotationProcessorType declaredType
 
     AnnotationProcessorFixture(String annotationName) {
+        this('', annotationName)
+    }
+
+    AnnotationProcessorFixture(String annotationPackageName, String annotationName) {
         this.annotationName = annotationName
+        this.annotationPackageName = annotationPackageName
+        this.fqAnnotationName = annotationPackageName.empty ? annotationName : "${annotationPackageName}.${annotationName}"
     }
 
     final void writeApiTo(TestFile projectDir) {
+        def packagePathPrefix = annotationPackageName.empty ? '' : "${annotationPackageName.replace('.', '/')}/"
+        def packageStatement = annotationPackageName.empty ? '' : "package ${annotationPackageName};"
         // Annotation handled by processor
-        projectDir.file("src/main/java/${annotationName}.java").text = """
+        projectDir.file("src/main/java/${packagePathPrefix}${annotationName}.java").text = """
+            ${packageStatement}
             public @interface $annotationName {
             }
 """
@@ -73,6 +84,7 @@ abstract class AnnotationProcessorFixture {
             import javax.lang.model.element.*;
             import javax.lang.model.util.*;
             import javax.tools.*;
+            ${annotationPackageName.empty ? '' : "import ${fqAnnotationName};"}
 
             import static javax.tools.StandardLocation.*;
 

--- a/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/PackageInfoGeneratedClassProcessorFixture.groovy
+++ b/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/PackageInfoGeneratedClassProcessorFixture.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.fixtures
+
+import groovy.transform.CompileStatic
+import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType
+
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
+
+@CompileStatic
+class PackageInfoGeneratedClassProcessorFixture extends AnnotationProcessorFixture {
+    PackageInfoGeneratedClassProcessorFixture() {
+        super("com.my.processor", "Configuration")
+        declaredType = IncrementalAnnotationProcessorType.AGGREGATING
+    }
+
+    @Override
+    String getDependenciesBlock() {
+        """
+            implementation 'org.ow2.asm:asm:9.0'
+        """
+    }
+
+    @Override
+    String getRepositoriesBlock() {
+        """
+            ${mavenCentralRepositoryDefinition()}
+        """
+    }
+
+    @Override
+    protected String getGeneratorCode() {
+        """
+
+        for (PackageElement element : ElementFilter.packagesIn(elements)) {
+            String className = element.getQualifiedName().toString() + ".\$" + "Configuration";
+
+            org.objectweb.asm.ClassWriter classWriter = new org.objectweb.asm.ClassWriter(0);
+            org.objectweb.asm.MethodVisitor mv = null;
+            classWriter.visit(org.objectweb.asm.Opcodes.V1_8, org.objectweb.asm.Opcodes.ACC_PUBLIC | org.objectweb.asm.Opcodes.ACC_SUPER, className, null, "java/lang/Object", new String[0]);
+            mv = classWriter.visitMethod(org.objectweb.asm.Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+            mv.visitCode();
+            mv.visitMethodInsn(org.objectweb.asm.Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            mv.visitInsn(org.objectweb.asm.Opcodes.RETURN);
+            mv.visitEnd();
+            classWriter.visitEnd();
+            try {
+                JavaFileObject classFile = filer.createClassFile(className, element);
+                OutputStream out = classFile.openOutputStream();
+                try {
+                    out.write(classWriter.toByteArray());
+                } finally {
+                    out.close();
+                }
+            } catch (IOException e) {
+                messager.printMessage(Diagnostic.Kind.ERROR, "Failed to generate class file " + className + ". " + e.getMessage(), element);
+            }
+            return false;
+        }
+        """
+    }
+}


### PR DESCRIPTION
`package-info` classes cannot be passed as classes to reprocess to the Java compiler. Therefore, we need to recompile them every time anything changes if they are processed by an aggregating annotation processor.

Fixes #17572.