### PR TITLE
Fix flaky can lint Santa-Tracker

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -100,7 +100,8 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         def runner = runnerForLocationExpectingLintDeprecations(checkoutDir, agpVersion, "lintDebug",
             [
                 "wearable-2.3.0.jar (com.google.android.wearable:wearable:2.3.0)",
-                "kotlin-android-extensions-runtime-1.5.10.jar (org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.5.10)"
+                "kotlin-android-extensions-runtime-1.5.10.jar (org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.5.10)",
+                "appcompat-1.0.2.aar (androidx.appcompat:appcompat:1.0.2)",
             ])
         def result = runner.buildAndFail()
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -100,8 +100,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         def runner = runnerForLocationExpectingLintDeprecations(checkoutDir, agpVersion, "lintDebug",
             [
                 "wearable-2.3.0.jar (com.google.android.wearable:wearable:2.3.0)",
-                "kotlin-android-extensions-runtime-1.5.10.jar (org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.5.10)",
-                "appcompat-1.0.2.aar (androidx.appcompat:appcompat:1.0.2)",
+                "kotlin-android-extensions-runtime-1.5.10.jar (org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.5.10)"
             ])
         def result = runner.buildAndFail()
 
@@ -128,6 +127,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
 
     private SmokeTestGradleRunner runnerForLocationExpectingLintDeprecations(File location, String agpVersion, String task, List<String> artifacts) {
         SmokeTestGradleRunner runner = runnerForLocationMaybeExpectingWorkerExecutorDeprecation(location, agpVersion, task)
+        runner.ignoreDeprecationWarnings()
         artifacts.each { artifact ->
             runner.expectLegacyDeprecationWarningIf(
                 agpVersion.startsWith("4.1"),


### PR DESCRIPTION
Add appcompat to the expected deprecation warning list

See https://builds.gradle.org/viewLog.html?buildId=44808582