### PR TITLE
Only initialize JANSI when native services are enabled

### DIFF
--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -150,14 +150,14 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
      * @param requestedFeatures Whether to initialize additional native libraries like jansi and file-events.
      */
     private void initialize(File userHomeDir, EnumSet<NativeFeatures> requestedFeatures) {
-        try {
-            if (!initialized) {
+        if (!initialized) {
+            try {
                 initializeNativeIntegrations(userHomeDir);
                 initialized = true;
+                initializeFeatures(requestedFeatures);
+            } catch (RuntimeException e) {
+                throw new ServiceCreationException("Could not initialize native services.", e);
             }
-            initializeFeatures(requestedFeatures);
-        } catch (RuntimeException e) {
-            throw new ServiceCreationException("Could not initialize native services.", e);
         }
     }
 
@@ -191,8 +191,7 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     private void initializeFeatures(EnumSet<NativeFeatures> requestedFeatures) {
         if (isNativeIntegrationsEnabled()) {
             for (NativeFeatures requestedFeature : requestedFeatures) {
-                if (!initializedFeatures.contains(requestedFeature)) {
-                    initializedFeatures.add(requestedFeature);
+                if (initializedFeatures.add(requestedFeature)) {
                     if (requestedFeature.initialize(nativeBaseDir, useNativeIntegrations)) {
                         enabledFeatures.add(requestedFeature);
                     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/services/NativeServices.java
@@ -163,9 +163,9 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
 
     private void initializeNativeIntegrations(File userHomeDir) {
         this.userHomeDir = userHomeDir;
-        useNativeIntegrations = "true".equalsIgnoreCase(System.getProperty("org.gradle.native", "true"));
+        useNativeIntegrations = isNativeIntegrationsEnabled();
+        nativeBaseDir = getNativeServicesDir(userHomeDir).getAbsoluteFile();
         if (useNativeIntegrations) {
-            nativeBaseDir = getNativeServicesDir(userHomeDir).getAbsoluteFile();
             try {
                 net.rubygrapefruit.platform.Native.init(nativeBaseDir);
             } catch (NativeIntegrationUnavailableException ex) {
@@ -189,14 +189,20 @@ public class NativeServices extends DefaultServiceRegistry implements ServiceReg
     }
 
     private void initializeFeatures(EnumSet<NativeFeatures> requestedFeatures) {
-        for (NativeFeatures requestedFeature : requestedFeatures) {
-            if (!initializedFeatures.contains(requestedFeature)) {
-                initializedFeatures.add(requestedFeature);
-                if (requestedFeature.initialize(nativeBaseDir, useNativeIntegrations)) {
-                    enabledFeatures.add(requestedFeature);
+        if (isNativeIntegrationsEnabled()) {
+            for (NativeFeatures requestedFeature : requestedFeatures) {
+                if (!initializedFeatures.contains(requestedFeature)) {
+                    initializedFeatures.add(requestedFeature);
+                    if (requestedFeature.initialize(nativeBaseDir, useNativeIntegrations)) {
+                        enabledFeatures.add(requestedFeature);
+                    }
                 }
             }
         }
+    }
+
+    private static boolean isNativeIntegrationsEnabled() {
+        return "true".equalsIgnoreCase(System.getProperty("org.gradle.native", "true"));
     }
 
     private boolean isFeatureEnabled(NativeFeatures feature) {


### PR DESCRIPTION
JANSI is being initialized, even though native services have been disabled by the system property. This has been introduced by #17440.

As an additional problem, the nativeBaseDir has not been set in this case, which caused jansi to be initialized in the current working directory.

This PR fixes both problems:
- Do not initialize JANSI when native integrations are disabled.
- Always set the native base dir.
