### PR TITLE
Remove unused partial invalidation method on GradleExecuter

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -52,13 +52,6 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
 
     def operations = new BuildOperationsFixture(executer, testDirectoryProvider)
 
-    def setup() {
-        executer.beforeExecute {
-            // Don't let the incubating message interfere with logging
-            withPartialVfsInvalidation(false)
-        }
-    }
-
     @ToBeFixedForConfigurationCache(because = "different build operation tree")
     def "captures output sources with context"() {
         given:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -58,10 +58,10 @@ import org.gradle.test.fixtures.ResettableExpectations;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.testfixtures.internal.NativeServicesTestFixture;
+import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.GFileUtils;
-import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.TextUtil;
 
 import java.io.File;
@@ -1224,11 +1224,6 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     @Override
     public GradleExecuter withBuildCacheEnabled() {
         return withArgument("--build-cache");
-    }
-
-    @Override
-    public GradleExecuter withPartialVfsInvalidation(boolean enabled) {
-        return this;
     }
 
     protected Action<ExecutionResult> getResultAssertion() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -320,14 +320,6 @@ public interface GradleExecuter extends Stoppable {
     TestDirectoryProvider getTestDirectoryProvider();
 
     /**
-     * Default is enabled = true.
-     *
-     * All our tests should work with partial VFS invalidation.
-     * As soon as partial invalidation is enabled by default, we can remove this method and the field again.
-     */
-    GradleExecuter withPartialVfsInvalidation(boolean enabled);
-
-    /**
      * Expects exactly one deprecation warning in the build output. If more than one warning is produced,
      * or no warning is produced at all, the assertion fails.
      *

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -149,7 +149,6 @@ project.logger.debug("debug logging");
 
     private ExecutionResult runUsingCommandLine() {
         def executer = targetDist.executer(temporaryFolder, getBuildContext())
-            .withPartialVfsInvalidation(false) // Don't show incubating message for logging tests
             .withCommandLineGradleOpts("-Dorg.gradle.deprecation.trace=false") //suppress deprecation stack trace
 
         if (targetDist.toolingApiMergesStderrIntoStdout) {


### PR DESCRIPTION
Partial invalidation is always on since Gradle 6.5, so we don't need this method any more for our internal testing infrastructure.