### PR TITLE
Fix wrong metadata cache version in `dependency_resolution` page

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_resolution.adoc
@@ -261,7 +261,9 @@ If multiple incompatible Gradle versions are in play, all should be used when se
 
 | `modules-2`           | `files-2.1`           | `metadata-2.95`           | Gradle 6.1 to Gradle 6.3
 
-| `modules-2`           | `files-2.1`           | `metadata-2.96`           | Gradle 6.4 and above
+| `modules-2`           | `files-2.1`           | `metadata-2.96`           | Gradle 6.4 to Gradle 6.7
+
+| `modules-2`           | `files-2.1`           | `metadata-2.97`           | Gradle 6.8 and above
 |===
 
 [[sub:shared-readonly-cache]]


### PR DESCRIPTION
### Context
I'm updating the table in the page https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:cache_copy

According to the source code: https://github.com/gradle/gradle/blob/c2d9b07c4bd66cc2b65fa8fc6416012d88ba1d80/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java#L44-L74

The `metadata` folder from Gradle 6.8 is called `metadata-2.97`

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
