### PR TITLE
Be more lenient when we have data in the VFS for new watchable hierarchies

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -55,7 +55,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "run", "--info"
         then:
         assertWatchableHierarchies([ImmutableSet.of(testDirectory)])
-        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     def "watches the project directory when buildSrc is present"() {
@@ -71,7 +70,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         then:
         outputContains "Hello from original task!"
         assertWatchableHierarchies([ImmutableSet.of(testDirectory), ImmutableSet.of(testDirectory, file("buildSrc"))])
-        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     def "works with composite build"() {
@@ -106,7 +104,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         then:
         executedAndNotSkipped(":includedBuild:jar")
         assertWatchableHierarchies(expectedWatchableHierarchies)
-        assertNoContentRemovedUnderNewWatchableHierarchies()
 
         when:
         withWatchFs().run("assemble", "--info")
@@ -115,7 +112,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         // configuration cache registers all build directories at startup so the cache fingerprint can be checked
         def expectedWatchableCount = GradleContextualExecuter.isConfigCache() ? 3 : 2
         assertWatchableHierarchies([ImmutableSet.of(consumer, includedBuild)] * expectedWatchableCount)
-        assertNoContentRemovedUnderNewWatchableHierarchies()
 
         when:
         includedBuild.file("src/main/java/NewClass.java")  << "public class NewClass {}"
@@ -196,13 +192,11 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "buildInBuild", "--info"
         then:
         assertWatchableHierarchies(expectedWatchableHierarchies)
-        assertNoContentRemovedUnderNewWatchableHierarchies()
 
         when:
         withWatchFs().run "buildInBuild", "--info"
         then:
         assertWatchableHierarchies(expectedWatchableHierarchies)
-        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     def "gracefully handle the root project directory not being available"() {
@@ -330,7 +324,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "retrieve", "--info"
         then:
         assertWatchedHierarchies([projectDir])
-        assertNoContentRemovedUnderNewWatchableHierarchies()
 
         where:
         repositoryType | artifactFileProperty
@@ -376,7 +369,6 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         then:
         projectDir.file('build/foo-1.0.jar').assertIsCopyOf(m2Module.artifactFile)
         assertWatchedHierarchies([projectDir])
-        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     def "stops watching hierarchies when the limit has been reached"() {
@@ -434,6 +426,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
 
     void assertWatchableHierarchies(List<Set<File>> expectedWatchableHierarchies) {
         assert determineWatchableHierarchies(output) == expectedWatchableHierarchies
+        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     void assertWatchedHierarchies(Iterable<File> expected) {
@@ -450,6 +443,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
             }
 
         assert watchedHierarchies == (expected as Set)
+        assertNoContentRemovedUnderNewWatchableHierarchies()
     }
 
     void assertNoContentRemovedUnderNewWatchableHierarchies() {

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -152,7 +152,8 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         executer.inDirectory(consumer)
 
         then:
-        withWatchFs().succeeds("assemble")
+        withWatchFs().succeeds("assemble", "--info")
+        outputContains("Removed existing content under new watchable hierarchy ${includedPluginBuild.absolutePath}")
     }
 
     def "works with GradleBuild task"() {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -50,9 +50,12 @@ public interface FileWatcherRegistry extends Closeable {
      *
      * The watcher registry will only watch for changes in watchable hierarchies.
      *
+     * All existing content for newly watched hierarchies will be removed from the root by this method.
+     *
      * @throws WatchingNotSupportedException when the native watchers can't be updated.
      */
-    void registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root);
+    @CheckReturnValue
+    SnapshotHierarchy registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root);
 
     /**
      * Updates the watchers after changes to the root.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -50,8 +50,7 @@ public interface FileWatcherRegistry extends Closeable {
      *
      * The watcher registry will only watch for changes in watchable hierarchies.
      *
-     * All existing content for newly watched hierarchies will be removed from the root by this method.
-     *
+     * @return the snapshot hierarchy without the existing content for newly watched hierarchies.
      * @throws WatchingNotSupportedException when the native watchers can't be updated.
      */
     @CheckReturnValue

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -31,7 +31,8 @@ public interface FileWatcherUpdater {
      *
      * @see FileWatcherRegistry#registerWatchableHierarchy(File, SnapshotHierarchy)
      */
-    void registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root);
+    @CheckReturnValue
+    SnapshotHierarchy registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root);
 
     /**
      * Updates the watchers after changes to the root.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -138,8 +138,8 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
     }
 
     @Override
-    public void registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
-        fileWatcherUpdater.registerWatchableHierarchy(watchableHierarchy, root);
+    public SnapshotHierarchy registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
+        return fileWatcherUpdater.registerWatchableHierarchy(watchableHierarchy, root);
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -87,9 +87,10 @@ public class HierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public void registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
-        watchableHierarchies.registerWatchableHierarchy(watchableHierarchy, root);
-        updateWatchedHierarchies(root);
+    public SnapshotHierarchy registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
+        SnapshotHierarchy newRoot = watchableHierarchies.registerWatchableHierarchy(watchableHierarchy, root);
+        updateWatchedHierarchies(newRoot);
+        return newRoot;
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -84,8 +84,8 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
     }
 
     @Override
-    public void registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
-        watchableHierarchies.registerWatchableHierarchy(watchableHierarchy, root);
+    public SnapshotHierarchy registerWatchableHierarchy(File watchableHierarchy, SnapshotHierarchy root) {
+        return watchableHierarchies.registerWatchableHierarchy(watchableHierarchy, root);
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -142,7 +142,7 @@ public class NonHierarchicalFileWatcherUpdater implements FileWatcherUpdater {
         if (watchedDirectories.isEmpty()) {
             LOGGER.info("Not watching anything anymore");
         }
-        LOGGER.info("Watching {} directories to track changes", watchedDirectories.entrySet().size());
+        LOGGER.debug("Watching {} directories to track changes", watchedDirectories.entrySet().size());
         try {
             if (!directoriesToStopWatching.isEmpty()) {
                 fileWatcher.stopWatching(directoriesToStopWatching);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -153,6 +153,16 @@ public class WatchableHierarchies {
         return newRoot;
     }
 
+    /**
+     * Removes all content which is not watched under an existing snapshot hierarchy.
+     *
+     * When Gradle starts watching a hierarchy, it may be that there is already some existing content in the VFS.
+     * For example this happens when Gradle references a file in an included build directly by path,
+     * even before the included build is declared.
+     *
+     * This visitor then removes that existing content, so when we later start watching the hierarchy,
+     * we can be sure that the VFS and the file system is in sync.
+     */
     private class RemoveUnwatchedContentVisitor implements SnapshotHierarchy.SnapshotVisitor {
         private SnapshotHierarchy vfsRoot;
 
@@ -163,6 +173,7 @@ public class WatchableHierarchies {
         @Override
         public void visitSnapshotRoot(FileSystemLocationSnapshot snapshotRoot) {
             if (!isInWatchableHierarchy(snapshotRoot.getAbsolutePath()) && !ignoredForWatching(snapshotRoot)) {
+                LOGGER.debug("Removing existing content under new watchable hierarchy: '{}'", snapshotRoot.getAbsolutePath());
                 vfsRoot = vfsRoot.invalidate(snapshotRoot.getAbsolutePath(), SnapshotHierarchy.NodeDiffListener.NOOP);
             }
         }

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -126,7 +126,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         vfsHasSnapshotsAt(fileInDirectoryIgnoredForWatching)
     }
 
-    def "fails when discovering a hierarchy to watch and there is already something in the VFS"() {
+    def "removes existing snapshots when registering a new hierarchy to watch"() {
         def watchableHierarchy = file("watchable").createDir()
         def fileInWatchableHierarchy = watchableHierarchy.file("some/dir/file.txt").createFile()
 
@@ -138,8 +138,8 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
         when:
         registerWatchableHierarchies([watchableHierarchy])
         then:
-        def exception = thrown(IllegalStateException)
-        exception.message == "Found existing snapshot at '${fileInWatchableHierarchy.absolutePath}' for unwatched hierarchy '${watchableHierarchy.absolutePath}'"
+        0 * _
+        !vfsHasSnapshotsAt(watchableHierarchy)
     }
 
     def "does not watch symlinks and removes symlinks at the end of the build"() {
@@ -279,7 +279,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
 
     void registerWatchableHierarchies(Iterable<File> watchableHierarchies) {
         watchableHierarchies.each { watchableHierarchy ->
-            updater.registerWatchableHierarchy(watchableHierarchy, virtualFileSystem.root)
+            virtualFileSystem.root = updater.registerWatchableHierarchy(watchableHierarchy, virtualFileSystem.root)
         }
     }
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -134,24 +134,24 @@ class WatchingVirtualFileSystemTest extends Specification {
         then:
         1 * watcherRegistryFactory.createFileWatcherRegistry(_) >> watcherRegistry
         1 * watcherRegistry.setDebugLoggingEnabled(false)
-        1 * watcherRegistry.registerWatchableHierarchy(watchableHierarchy, _)
+        1 * watcherRegistry.registerWatchableHierarchy(watchableHierarchy, _) >> rootReference.root
         0 * _
 
         when:
         watchingVirtualFileSystem.registerWatchableHierarchy(anotherWatchableHierarchy)
         then:
-        1 * watcherRegistry.registerWatchableHierarchy(anotherWatchableHierarchy, _)
+        1 * watcherRegistry.registerWatchableHierarchy(anotherWatchableHierarchy, _) >> rootReference.root
 
         when:
         watchingVirtualFileSystem.beforeBuildFinished(WatchMode.ENABLED, VfsLogging.NORMAL, WatchLogging.NORMAL, buildOperationRunner, Integer.MAX_VALUE)
         then:
         1 * watcherRegistry.getAndResetStatistics() >> Stub(FileWatcherRegistry.FileWatchingStatistics)
-        1 * watcherRegistry.buildFinished(_, WatchMode.ENABLED, Integer.MAX_VALUE) >> rootReference.getRoot()
+        1 * watcherRegistry.buildFinished(_, WatchMode.ENABLED, Integer.MAX_VALUE) >> rootReference.root
         0 * _
 
         when:
         watchingVirtualFileSystem.registerWatchableHierarchy(newWatchableHierarchy)
         then:
-        1 * watcherRegistry.registerWatchableHierarchy(newWatchableHierarchy, _)
+        1 * watcherRegistry.registerWatchableHierarchy(newWatchableHierarchy, _) >> rootReference.root
     }
 }


### PR DESCRIPTION
In some cases, we already have data in the VFS at new watchable hierarchies. This can for example happen when we reference a file from another build directly from the build script classpath, and later this build is included.

Fixes https://github.com/gradle/gradle/issues/17621.