### PR TITLE
Increase memory for architecture tests

### DIFF
--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -17,7 +17,11 @@ dependencies {
 
 tasks.test {
     // Looks like loading all the classes requires more than the default 512M
-    maxHeapSize = "700M"
+    maxHeapSize = "900M"
+
+    // Only use one fork, so freezing doesn't have concurrency issues
+    maxParallelForks = 1
+    useJUnitPlatform()
 
     systemProperty("org.gradle.public.api.includes", gradlebuild.basics.PublicApi.includes.joinToString(":"))
     systemProperty("org.gradle.public.api.excludes", gradlebuild.basics.PublicApi.excludes.joinToString(":"))
@@ -25,8 +29,6 @@ tasks.test {
         project.file("src/changes/archunit_store"),
         providers.gradleProperty("archunitRefreeze").map { true })
     )
-
-    useJUnitPlatform()
 }
 
 class ArchUnitFreezeConfiguration(


### PR DESCRIPTION
These tests have been failing in the Gradleception build.