### PR TITLE
Remove maxParallelForks=16 when testDistribution enabled

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -45,12 +45,6 @@ class FunctionalTest(
         preSteps = preBuildSteps
     )
 
-    params {
-        if (enableTestDistribution) {
-            param("maxParallelForks", "16")
-        }
-    }
-
     if (testCoverage.testType == TestType.soak || testTasks.contains("plugins:")) {
         failureConditions {
             // JavaExecDebugIntegrationTest.debug session fails without debugger might cause JVM crash

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -280,11 +280,7 @@ val isExperimentalTestFilteringEnabled
     get() = System.getProperty("gradle.internal.testselection.enabled").toBoolean()
 
 val Project.maxParallelForks: Int
-    get() = if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") {
-        8
-    } else {
-        findProperty("maxParallelForks")?.toString()?.toInt() ?: 4
-    }
+    get() = (findProperty("maxParallelForks")?.toString()?.toInt() ?: 4) * (if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") 2 else 1)
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).


### PR DESCRIPTION
`maxParallelForks` only controls how many local executors used, not how many remote executors.

With TD enabled but no remote executors available, the build can be 2x slower with
maxParallelForks=16. Let's remove this special value.
