### PR TITLE
Pass Java installations to TAPI toolchain tests

### DIFF
--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -207,9 +207,10 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         when:
         succeeds("runTask",
-                "-PclientJdk=" + clientJdkVersion.majorVersion,
-                "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
-                "-PgradleVersion=" + gradleVersion)
+            "-PclientJdk=" + clientJdkVersion.majorVersion,
+            "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
+            "-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(",")}",
+            "-PgradleVersion=" + gradleVersion)
 
         then:
         output.contains("BUILD SUCCESSFUL")
@@ -242,9 +243,10 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
 
         when:
         succeeds("buildAction",
-                "-PclientJdk=" + clientJdkVersion.majorVersion,
-                "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
-                "-PgradleVersion=" + gradleVersion)
+            "-PclientJdk=" + clientJdkVersion.majorVersion,
+            "-PtargetJdk=" + gradleDaemonJdk.javaHome.absolutePath,
+            "-Porg.gradle.java.installations.paths=${AvailableJavaHomes.getAvailableJvms().collect { it.javaHome.absolutePath }.join(",")}",
+            "-PgradleVersion=" + gradleVersion)
 
         then:
         output.contains("BUILD SUCCESSFUL")


### PR DESCRIPTION
For some reason, toolchain tests running on TAPI complain "No compatible toolchains found for request filter". This PR fixes it by passing `org.gradle.java.installations.paths` into TAPI tests.