### PR TITLE
Re-use fingerprints from execution history when possible

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinter.java
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -28,8 +27,8 @@ import org.gradle.internal.service.scopes.ServiceScope;
 @ServiceScope(Scopes.BuildSession.class)
 public class AbsolutePathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public AbsolutePathFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(new AbsolutePathFingerprintingStrategy(directorySensitivity, lineEndingSensitivity, normalizedContentHasher), fileCollectionSnapshotter);
+    public AbsolutePathFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(new AbsolutePathFingerprintingStrategy(directorySensitivity, normalizedContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -28,6 +28,8 @@ import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
+import javax.annotation.Nullable;
+
 /**
  * Responsible for calculating a {@link FileCollectionFingerprint} for a particular {@link FileCollection}.
  */
@@ -43,9 +45,9 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     }
 
     @Override
-    public CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
+    public CurrentFileCollectionFingerprint fingerprint(FileCollection files, @Nullable FileCollectionFingerprint previousFingerprint) {
         FileSystemSnapshot roots = fileCollectionSnapshotter.snapshot(files);
-        return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy);
+        return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy, previousFingerprint);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -52,7 +52,7 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
 
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot roots) {
-        return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy);
+        return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy, null);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -51,11 +51,6 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     }
 
     @Override
-    public CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot roots) {
-        return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy, null);
-    }
-
-    @Override
     public String normalizePath(FileSystemLocationSnapshot root) {
         return fingerprintingStrategy.normalizePath(root);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -21,10 +21,8 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
@@ -58,15 +56,5 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     @Override
     public CurrentFileCollectionFingerprint empty() {
         return fingerprintingStrategy.getEmptyFingerprint();
-    }
-
-    @Override
-    public DirectorySensitivity getDirectorySensitivity() {
-        return fingerprintingStrategy.getDirectorySensitivity();
-    }
-
-    @Override
-    public LineEndingSensitivity getLineEndingNormalization() {
-        return fingerprintingStrategy.getLineEndingNormalization();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
@@ -76,7 +76,6 @@ public class FileCollectionFingerprinterRegistrations {
                         directorySensitivity,
                         Stream.of(
                             fullySensitiveFingerprinters(
-                                lineEndingSensitivity,
                                 directorySensitivity,
                                 stringInterner,
                                 fileCollectionSnapshotter,
@@ -94,16 +93,15 @@ public class FileCollectionFingerprinterRegistrations {
      * These fingerprinters are fully sensitive to both line endings and empty directories
      */
     private static List<? extends FileCollectionFingerprinter> fullySensitiveFingerprinters(
-        LineEndingSensitivity lineEndingSensitivity,
         DirectorySensitivity directorySensitivity,
         StringInterner stringInterner,
         FileCollectionSnapshotter fileCollectionSnapshotter,
         FileSystemLocationSnapshotHasher normalizedContentHasher
     ) {
         return Lists.newArrayList(
-            new AbsolutePathFileCollectionFingerprinter(directorySensitivity, lineEndingSensitivity, fileCollectionSnapshotter, normalizedContentHasher),
-            new RelativePathFileCollectionFingerprinter(stringInterner, directorySensitivity, lineEndingSensitivity, fileCollectionSnapshotter, normalizedContentHasher),
-            new NameOnlyFileCollectionFingerprinter(directorySensitivity, lineEndingSensitivity, fileCollectionSnapshotter, normalizedContentHasher)
+            new AbsolutePathFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher),
+            new RelativePathFileCollectionFingerprinter(stringInterner, directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher),
+            new NameOnlyFileCollectionFingerprinter(directorySensitivity, fileCollectionSnapshotter, normalizedContentHasher)
         );
     }
 
@@ -121,7 +119,7 @@ public class FileCollectionFingerprinterRegistrations {
         StringInterner stringInterner
     ) {
         return Lists.newArrayList(
-            new IgnoredPathFileCollectionFingerprinter(fileCollectionSnapshotter, lineEndingSensitivity, normalizedContentHasher),
+            new IgnoredPathFileCollectionFingerprinter(fileCollectionSnapshotter, normalizedContentHasher),
             new DefaultClasspathFingerprinter(
                 resourceSnapshotterCacheService,
                 fileCollectionSnapshotter,

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FingerprinterRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FingerprinterRegistration.java
@@ -41,10 +41,6 @@ public class FingerprinterRegistration {
         return fingerprinter;
     }
 
-    public static FingerprinterRegistration registration(FileCollectionFingerprinter fingerprinter) {
-        return registration(fingerprinter.getDirectorySensitivity(), fingerprinter.getLineEndingNormalization(), fingerprinter);
-    }
-
     public static FingerprinterRegistration registration(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileCollectionFingerprinter fingerprinter) {
         return new FingerprinterRegistration(
             DefaultFileNormalizationSpec.from(fingerprinter.getRegisteredType(), directorySensitivity, lineEndingSensitivity),

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileCollectionFingerprinter.java
@@ -19,13 +19,12 @@ package org.gradle.internal.fingerprint.impl;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 
 public class IgnoredPathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public IgnoredPathFileCollectionFingerprinter(FileCollectionSnapshotter fileCollectionSnapshotter, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(new IgnoredPathFingerprintingStrategy(lineEndingSensitivity, normalizedContentHasher), fileCollectionSnapshotter);
+    public IgnoredPathFileCollectionFingerprinter(FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(new IgnoredPathFingerprintingStrategy(normalizedContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFileCollectionFingerprinter.java
@@ -19,14 +19,13 @@ package org.gradle.internal.fingerprint.impl;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.NameOnlyInputNormalizer;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 
 public class NameOnlyFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public NameOnlyFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(new NameOnlyFingerprintingStrategy(directorySensitivity, lineEndingSensitivity, normalizedContentHasher), fileCollectionSnapshotter);
+    public NameOnlyFileCollectionFingerprinter(DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(new NameOnlyFingerprintingStrategy(directorySensitivity, normalizedContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFileCollectionFingerprinter.java
@@ -20,14 +20,13 @@ import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 
 public class RelativePathFileCollectionFingerprinter extends AbstractFileCollectionFingerprinter {
 
-    public RelativePathFileCollectionFingerprinter(StringInterner stringInterner, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(new RelativePathFingerprintingStrategy(stringInterner, directorySensitivity, lineEndingSensitivity, normalizedContentHasher), fileCollectionSnapshotter);
+    public RelativePathFileCollectionFingerprinter(StringInterner stringInterner, DirectorySensitivity directorySensitivity, FileCollectionSnapshotter fileCollectionSnapshotter, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(new RelativePathFingerprintingStrategy(stringInterner, directorySensitivity, normalizedContentHasher), fileCollectionSnapshotter);
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -42,9 +42,9 @@ import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.exceptions.MultiCauseException
 import org.gradle.internal.execution.DefaultOutputSnapshotter
 import org.gradle.internal.execution.OutputChangeListener
+import org.gradle.internal.execution.WorkValidationContext
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinterRegistry
 import org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter
-import org.gradle.internal.execution.WorkValidationContext
 import org.gradle.internal.execution.history.AfterPreviousExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.OverlappingOutputDetector
@@ -69,7 +69,6 @@ import org.gradle.internal.execution.steps.SkipUpToDateStep
 import org.gradle.internal.execution.steps.ValidateStep
 import org.gradle.internal.file.ReservedFileSystemLocationRegistry
 import org.gradle.internal.fingerprint.DirectorySensitivity
-import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
@@ -126,7 +125,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def fileCollectionSnapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
     def outputSnapshotter = new DefaultOutputSnapshotter(fileCollectionSnapshotter)
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
     def fingerprinterRegistry = Stub(FileCollectionFingerprinterRegistry) {
         getFingerprinter(_) >> fingerprinter
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.internal.execution.history.changes.ChangeTypeInternal
 import org.gradle.internal.execution.history.changes.DefaultFileChange
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
-import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -33,7 +32,7 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def fileCollectionSnapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
     def listener = Mock(ChangeListener)
 
     @Rule

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -289,6 +289,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction<?>> 
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
             visitor -> propertyWalker.visitProperties(parameterObject, validationContext, new PropertyVisitor.Adapter() {
                 @Override
                 public void visitInputProperty(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -94,8 +94,8 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     def fileCollectionFactory = TestFiles.fileCollectionFactory()
     def artifactTransformListener = Mock(ArtifactTransformListener)
 
-    def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
-    def fileCollectionFingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(dependencyFingerprinter)])
+    def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
+    def fileCollectionFingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, dependencyFingerprinter)])
     def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionFingerprinterRegistry, valueSnapshotter)
 
     def projectServiceRegistry = Stub(ServiceRegistry) {

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -100,7 +100,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def virtualFileSystem = TestFiles.virtualFileSystem()
     def fileSystemAccess = TestFiles.fileSystemAccess(virtualFileSystem)
     def snapshotter = new DefaultFileCollectionSnapshotter(fileSystemAccess, TestFiles.genericFileTreeSnapshotter(), TestFiles.fileSystem())
-    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, snapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
+    def fingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, snapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
     def executionHistoryStore = new TestExecutionHistoryStore()
     def outputChangeListener = new OutputChangeListener() {
 
@@ -120,7 +120,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         isGeneratedByGradle() >> true
     }
     def outputSnapshotter = new DefaultOutputSnapshotter(snapshotter)
-    def fingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(fingerprinter)])
+    def fingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, fingerprinter)])
     def valueSnapshotter = new DefaultValueSnapshotter(classloaderHierarchyHasher, null)
     def inputFingerprinter = new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter)
     def buildCacheController = Mock(BuildCacheController)

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
@@ -19,9 +19,12 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
+
+import javax.annotation.Nullable;
 
 public interface FileCollectionFingerprinter {
     /**
@@ -32,7 +35,14 @@ public interface FileCollectionFingerprinter {
     /**
      * Creates a fingerprint of the contents of the given collection.
      */
-    CurrentFileCollectionFingerprint fingerprint(FileCollection files);
+    default CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
+        return fingerprint(files, null);
+    }
+
+    /**
+     * Creates a fingerprint of the contents of the given collection.
+     */
+    CurrentFileCollectionFingerprint fingerprint(FileCollection files, @Nullable FileCollectionFingerprint previousFingerprint);
 
     /**
      * Creates a fingerprint of the contents of the given roots.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
@@ -22,7 +22,6 @@ import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
-import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import javax.annotation.Nullable;
 
@@ -43,11 +42,6 @@ public interface FileCollectionFingerprinter {
      * Creates a fingerprint of the contents of the given collection.
      */
     CurrentFileCollectionFingerprint fingerprint(FileCollection files, @Nullable FileCollectionFingerprint previousFingerprint);
-
-    /**
-     * Creates a fingerprint of the contents of the given roots.
-     */
-    CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot roots);
 
     /**
      * Returns an empty fingerprint.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
@@ -18,9 +18,7 @@ package org.gradle.internal.execution.fingerprint;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 
 import javax.annotation.Nullable;
@@ -52,14 +50,4 @@ public interface FileCollectionFingerprinter {
      * Returns the normalized path to use for the given root
      */
     String normalizePath(FileSystemLocationSnapshot root);
-
-    /**
-     * Returns the directory sensitivity associated with this fingerprinter.
-     */
-    DirectorySensitivity getDirectorySensitivity();
-
-    /**
-     * Returns the line ending normalization associated with this fingerprinter.
-     */
-    LineEndingSensitivity getLineEndingNormalization();
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
 public interface InputFingerprinter {
     Result fingerprintInputProperties(
         ImmutableSortedMap<String, ValueSnapshot> previousValueSnapshots,
+        ImmutableSortedMap<String, ? extends FileCollectionFingerprint> previousInputFileFingerprints,
         ImmutableSortedMap<String, ValueSnapshot> knownValueSnapshots,
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownFingerprints,
         Consumer<InputVisitor> inputs

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
@@ -32,9 +32,9 @@ import java.util.function.Supplier;
 public interface InputFingerprinter {
     Result fingerprintInputProperties(
         ImmutableSortedMap<String, ValueSnapshot> previousValueSnapshots,
-        ImmutableSortedMap<String, ? extends FileCollectionFingerprint> previousInputFileFingerprints,
-        ImmutableSortedMap<String, ValueSnapshot> knownValueSnapshots,
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownFingerprints,
+        ImmutableSortedMap<String, ? extends FileCollectionFingerprint> previousFingerprints,
+        ImmutableSortedMap<String, ValueSnapshot> knownCurrentValueSnapshots,
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownCurrentFingerprints,
         Consumer<InputVisitor> inputs
     );
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
@@ -93,9 +93,9 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
     }
 
     private static ImmutableSortedMap<String, FileCollectionFingerprint> prepareForSerialization(ImmutableSortedMap<String, CurrentFileCollectionFingerprint> fingerprints) {
-        return copyOfSorted(transformValues(fingerprints, value -> {
-            //noinspection ConstantConditions
-            return new SerializableFileCollectionFingerprint(value.getFingerprints(), value.getRootHashes());
-        }));
+        return copyOfSorted(transformValues(
+            fingerprints,
+            value -> new SerializableFileCollectionFingerprint(value.getFingerprints(), value.getRootHashes(), value.getStrategyConfigurationHash())
+        ));
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializer.java
@@ -49,7 +49,8 @@ public class FileCollectionFingerprintSerializer implements Serializer<FileColle
             return FileCollectionFingerprint.EMPTY;
         }
         ImmutableMultimap<String, HashCode> rootHashes = readRootHashes(decoder);
-        return new SerializableFileCollectionFingerprint(fingerprints, rootHashes);
+        HashCode strategyConfigurationHash = hashCodeSerializer.read(decoder);
+        return new SerializableFileCollectionFingerprint(fingerprints, rootHashes, strategyConfigurationHash);
     }
 
     private ImmutableMultimap<String, HashCode> readRootHashes(Decoder decoder) throws IOException {
@@ -71,6 +72,7 @@ public class FileCollectionFingerprintSerializer implements Serializer<FileColle
         fingerprintMapSerializer.write(encoder, value.getFingerprints());
         if (!value.getFingerprints().isEmpty()) {
             writeRootHashes(encoder, value.getRootHashes());
+            hashCodeSerializer.write(encoder, value.getStrategyConfigurationHash());
         }
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/SerializableFileCollectionFingerprint.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/SerializableFileCollectionFingerprint.java
@@ -27,10 +27,12 @@ public class SerializableFileCollectionFingerprint implements FileCollectionFing
 
     private final Map<String, FileSystemLocationFingerprint> fingerprints;
     private final ImmutableMultimap<String, HashCode> rootHashes;
+    private final HashCode strategyConfigurationHash;
 
-    public SerializableFileCollectionFingerprint(Map<String, FileSystemLocationFingerprint> fingerprints, ImmutableMultimap<String, HashCode> rootHashes) {
+    public SerializableFileCollectionFingerprint(Map<String, FileSystemLocationFingerprint> fingerprints, ImmutableMultimap<String, HashCode> rootHashes, HashCode strategyConfigurationHash) {
         this.fingerprints = fingerprints;
         this.rootHashes = rootHashes;
+        this.strategyConfigurationHash = strategyConfigurationHash;
     }
 
     @Override
@@ -43,4 +45,8 @@ public class SerializableFileCollectionFingerprint implements FileCollectionFing
         return rootHashes;
     }
 
+    @Override
+    public HashCode getStrategyConfigurationHash() {
+        return strategyConfigurationHash;
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStep.java
@@ -30,6 +30,7 @@ import org.gradle.internal.execution.history.OverlappingOutputDetector;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.impl.DefaultBeforeExecutionState;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -149,6 +150,9 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPre
         ImmutableSortedMap<String, ValueSnapshot> previousInputProperties = afterPreviousExecutionState
             .map(ExecutionState::getInputProperties)
             .orElse(ImmutableSortedMap.of());
+        ImmutableSortedMap<String, ? extends FileCollectionFingerprint> previousInputFileFingerprints = afterPreviousExecutionState
+            .map(ExecutionState::getInputFileProperties)
+            .orElse(ImmutableSortedMap.of());
         ImmutableSortedMap<String, FileSystemSnapshot> outputSnapshotsAfterPreviousExecution = afterPreviousExecutionState
             .map(AfterPreviousExecutionState::getOutputFilesProducedByWork)
             .orElse(ImmutableSortedMap.of());
@@ -169,6 +173,7 @@ public class CaptureStateBeforeExecutionStep extends BuildOperationStep<AfterPre
 
         InputFingerprinter.Result newInputs = work.getInputFingerprinter().fingerprintInputProperties(
             previousInputProperties,
+            previousInputFileFingerprints,
             context.getInputProperties(),
             context.getInputFileProperties(),
             work::visitRegularInputs

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -55,6 +55,7 @@ public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> i
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
             work::visitIdentityInputs
         );
         ImmutableSortedMap<String, ValueSnapshot> identityInputProperties = inputs.getValueSnapshots();

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -63,7 +63,7 @@ class DefaultInputFingerprinterTest extends Specification {
 
         then:
         1 * valueSnapshotter.snapshot(input) >> inputSnapshot
-        1 * fingerprinter.fingerprint(fileInput) >> fileInputFingerprint
+        1 * fingerprinter.fingerprint(fileInput, null) >> fileInputFingerprint
         0 * _
 
         then:
@@ -74,6 +74,7 @@ class DefaultInputFingerprinterTest extends Specification {
     def "ignores already known properties"() {
         when:
         def result = fingerprintInputProperties(
+            ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of("input", inputSnapshot),
             ImmutableSortedMap.of("file", fileInputFingerprint)
@@ -112,10 +113,11 @@ class DefaultInputFingerprinterTest extends Specification {
 
     private Result fingerprintInputProperties(
         ImmutableSortedMap<String, ValueSnapshot> previousValueSnapshots = ImmutableSortedMap.of(),
+        ImmutableSortedMap<String, ValueSnapshot> previousFingerprints = ImmutableSortedMap.of(),
         ImmutableSortedMap<String, ValueSnapshot> knownValueSnapshots = ImmutableSortedMap.of(),
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownFingerprints = ImmutableSortedMap.of(),
         Consumer<InputVisitor> inputs
     ) {
-        inputFingerprinter.fingerprintInputProperties(previousValueSnapshots, knownValueSnapshots, knownFingerprints, inputs)
+        inputFingerprinter.fingerprintInputProperties(previousValueSnapshots, previousFingerprints, knownValueSnapshots, knownFingerprints, inputs)
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.execution.fingerprint.InputFingerprinter.InputVisitor
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.Result
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.snapshot.ValueSnapshot
 import org.gradle.internal.snapshot.ValueSnapshotter
@@ -113,11 +114,11 @@ class DefaultInputFingerprinterTest extends Specification {
 
     private Result fingerprintInputProperties(
         ImmutableSortedMap<String, ValueSnapshot> previousValueSnapshots = ImmutableSortedMap.of(),
-        ImmutableSortedMap<String, ValueSnapshot> previousFingerprints = ImmutableSortedMap.of(),
-        ImmutableSortedMap<String, ValueSnapshot> knownValueSnapshots = ImmutableSortedMap.of(),
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownFingerprints = ImmutableSortedMap.of(),
+        ImmutableSortedMap<String, FileCollectionFingerprint> previousFingerprints = ImmutableSortedMap.of(),
+        ImmutableSortedMap<String, ValueSnapshot> knownCurrentValueSnapshots = ImmutableSortedMap.of(),
+        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> knownCurrentFingerprints = ImmutableSortedMap.of(),
         Consumer<InputVisitor> inputs
     ) {
-        inputFingerprinter.fingerprintInputProperties(previousValueSnapshots, previousFingerprints, knownValueSnapshots, knownFingerprints, inputs)
+        inputFingerprinter.fingerprintInputProperties(previousValueSnapshots, previousFingerprints, knownCurrentValueSnapshots, knownCurrentFingerprints, inputs)
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
@@ -171,8 +171,9 @@ class ClasspathCompareStrategyTest extends Specification {
 
     def changes(Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
         def visitor = new CollectingChangeVisitor()
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)))
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous,  ImmutableMultimap.of("some", HashCode.fromInt(4321)))
+        def strategyConfigurationHash = HashCode.fromInt(1234)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", HashCode.fromInt(4321)), strategyConfigurationHash)
         CLASSPATH.visitChangesSince(previousFingerprint, currentFingerprint, "test", visitor)
         visitor.getChanges().toList()
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -299,8 +299,9 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def changes(FingerprintCompareStrategy strategy, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)))
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous,  ImmutableMultimap.of("some", HashCode.fromInt(4321)))
+        def strategyConfigurationHash = HashCode.fromInt(5432)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", HashCode.fromInt(4321)), strategyConfigurationHash)
         changes(strategy, currentFingerprint, previousFingerprint)
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -34,7 +34,8 @@ class NonIncrementalInputChangesTest extends Specification {
     def "can iterate changes more than once"() {
         def fingerprint = DefaultCurrentFileCollectionFingerprint.from(
             new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
-            AbsolutePathFingerprintingStrategy.DEFAULT
+            AbsolutePathFingerprintingStrategy.DEFAULT,
+            null
         )
 
         Provider<FileSystemLocation> value = Mock()

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
@@ -46,12 +46,13 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
                 "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE,
                 "/2", HashCode.fromInt(5678),
                 "/3", HashCode.fromInt(1234))
+        def strategyConfigurationHash = HashCode.fromInt(6543)
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
                 '/1': new DefaultFileSystemLocationFingerprint("1", FileType.Directory, FileSystemLocationFingerprint.DIR_SIGNATURE),
                 '/2': IgnoredPathFileSystemLocationFingerprint.create(FileType.RegularFile, hash),
                 '/3': new DefaultFileSystemLocationFingerprint("/3", FileType.Missing, FileSystemLocationFingerprint.DIR_SIGNATURE),
-                rootHashes
+                rootHashes, strategyConfigurationHash
         ), serializer)
 
         then:
@@ -83,7 +84,7 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
                 ImmutableMultimap.of(
                         "/3", HashCode.fromInt(1234),
                         "/2", HashCode.fromInt(5678),
-                        "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE)
+                        "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE), HashCode.fromInt(5432)
         ), serializer)
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
@@ -43,16 +43,17 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
         def hash = HashCode.fromInt(1234)
 
         def rootHashes = ImmutableMultimap.of(
-                "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE,
-                "/2", HashCode.fromInt(5678),
-                "/3", HashCode.fromInt(1234))
+            "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE,
+            "/2", HashCode.fromInt(5678),
+            "/3", HashCode.fromInt(1234))
         def strategyConfigurationHash = HashCode.fromInt(6543)
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
-                '/1': new DefaultFileSystemLocationFingerprint("1", FileType.Directory, FileSystemLocationFingerprint.DIR_SIGNATURE),
-                '/2': IgnoredPathFileSystemLocationFingerprint.create(FileType.RegularFile, hash),
-                '/3': new DefaultFileSystemLocationFingerprint("/3", FileType.Missing, FileSystemLocationFingerprint.DIR_SIGNATURE),
-                rootHashes, strategyConfigurationHash
+            '/1': new DefaultFileSystemLocationFingerprint("1", FileType.Directory, FileSystemLocationFingerprint.DIR_SIGNATURE),
+            '/2': IgnoredPathFileSystemLocationFingerprint.create(FileType.RegularFile, hash),
+            '/3': new DefaultFileSystemLocationFingerprint("/3", FileType.Missing, FileSystemLocationFingerprint.DIR_SIGNATURE),
+            rootHashes,
+            strategyConfigurationHash
         ), serializer)
 
         then:
@@ -78,13 +79,14 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
     def "should retain order in serialization"() {
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
-                "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, HashCode.fromInt(1234)),
-                "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, HashCode.fromInt(5678)),
-                "/1": new DefaultFileSystemLocationFingerprint('1', FileType.Missing, FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
-                ImmutableMultimap.of(
-                        "/3", HashCode.fromInt(1234),
-                        "/2", HashCode.fromInt(5678),
-                        "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE), HashCode.fromInt(5432)
+            "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, HashCode.fromInt(1234)),
+            "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, HashCode.fromInt(5678)),
+            "/1": new DefaultFileSystemLocationFingerprint('1', FileType.Missing, FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
+            ImmutableMultimap.of(
+                "/3", HashCode.fromInt(1234),
+                "/2", HashCode.fromInt(5678),
+                "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
+            HashCode.fromInt(5432)
         ), serializer)
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -112,6 +112,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
         _ * context.inputFileProperties >> ImmutableSortedMap.of("known-file", knownFileFingerprint)
         1 * inputFingerprinter.fingerprintInputProperties(
             ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
             ImmutableSortedMap.of("known", knownSnapshot),
             ImmutableSortedMap.of("known-file", knownFileFingerprint),
             _
@@ -161,6 +162,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
         then:
         _ * context.afterPreviousExecutionState >> Optional.of(afterPreviousExecutionState)
         1 * afterPreviousExecutionState.inputProperties >> ImmutableSortedMap.of()
+        1 * afterPreviousExecutionState.inputFileProperties >> ImmutableSortedMap.of()
         1 * afterPreviousExecutionState.outputFilesProducedByWork >> afterPreviousOutputSnapshots
         _ * outputSnapshotter.snapshotOutputs(work, _) >> beforeExecutionOutputSnapshots
 
@@ -183,7 +185,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
         _ * work.visitImplementations(_ as UnitOfWork.ImplementationVisitor) >> { UnitOfWork.ImplementationVisitor visitor ->
             visitor.visitImplementation(implementationSnapshot)
         }
-        _ * inputFingerprinter.fingerprintInputProperties(_, _, _, _) >> new DefaultInputFingerprinter.InputFingerprints(ImmutableSortedMap.of(), ImmutableSortedMap.of())
+        _ * inputFingerprinter.fingerprintInputProperties(_, _, _, _, _) >> new DefaultInputFingerprinter.InputFingerprints(ImmutableSortedMap.of(), ImmutableSortedMap.of())
         _ * work.overlappingOutputHandling >> IGNORE_OVERLAPS
         _ * outputSnapshotter.snapshotOutputs(work, _) >> ImmutableSortedMap.of()
         _ * context.history >> Optional.of(executionHistoryStore)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -48,6 +48,7 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
+            ImmutableSortedMap.of(),
             _
         ) >> new DefaultInputFingerprinter.InputFingerprints(
             ImmutableSortedMap.of("input", inputSnapshot),

--- a/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionHistoryStore.java
+++ b/subprojects/execution/src/testFixtures/groovy/org/gradle/internal/execution/TestExecutionHistoryStore.java
@@ -73,10 +73,10 @@ public class TestExecutionHistoryStore implements ExecutionHistoryStore {
     }
 
     private static ImmutableSortedMap<String, FileCollectionFingerprint> prepareForSerialization(ImmutableSortedMap<String, CurrentFileCollectionFingerprint> fingerprints) {
-        return copyOfSorted(transformValues(fingerprints, value -> {
-            //noinspection ConstantConditions
-            return new SerializableFileCollectionFingerprint(value.getFingerprints(), value.getRootHashes());
-        }));
+        return copyOfSorted(transformValues(
+            fingerprints,
+            value -> new SerializableFileCollectionFingerprint(value.getFingerprints(), value.getRootHashes(), value.getStrategyConfigurationHash())
+        ));
     }
 
     public Map<String, AfterPreviousExecutionState> getExecutionHistory() {

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -24,10 +24,8 @@ import org.gradle.api.internal.changedetection.state.IgnoringResourceHasher;
 import org.gradle.api.internal.changedetection.state.LineEndingNormalizingResourceHasher;
 import org.gradle.api.internal.changedetection.state.MetaInfAwareClasspathResourceHasher;
 import org.gradle.api.internal.changedetection.state.PropertiesFileAwareClasspathResourceHasher;
-import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotContext;
 import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
-import org.gradle.internal.fingerprint.hashing.ResourceHasher;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.RuntimeClasspathResourceHasher;
 import org.gradle.api.internal.changedetection.state.ZipHasher;
@@ -37,6 +35,8 @@ import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
+import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotContext;
+import org.gradle.internal.fingerprint.hashing.ResourceHasher;
 import org.gradle.internal.fingerprint.impl.AbstractFingerprintingStrategy;
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.impl.IgnoredPathFileSystemLocationFingerprint;
@@ -88,7 +88,7 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
                                             ResourceSnapshotterCacheService cacheService,
                                             Interner<String> stringInterner,
                                             LineEndingSensitivity lineEndingSensitivity) {
-        super(identifier, DirectorySensitivity.DEFAULT, lineEndingSensitivity);
+        super(identifier, DirectorySensitivity.DEFAULT, lineEndingSensitivity, zipHasher);
         this.nonZipFingerprintingStrategy = nonZipFingerprintingStrategy;
         this.classpathResourceHasher = classpathResourceHasher;
         this.cacheService = cacheService;

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -81,14 +81,15 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
     private final Interner<String> stringInterner;
     private final HashCode zipHasherConfigurationHash;
 
-    private ClasspathFingerprintingStrategy(String identifier,
-                                            NonJarFingerprintingStrategy nonZipFingerprintingStrategy,
-                                            ResourceHasher classpathResourceHasher,
-                                            ZipHasher zipHasher,
-                                            ResourceSnapshotterCacheService cacheService,
-                                            Interner<String> stringInterner,
-                                            LineEndingSensitivity lineEndingSensitivity) {
-        super(identifier, DirectorySensitivity.DEFAULT, lineEndingSensitivity, zipHasher);
+    private ClasspathFingerprintingStrategy(
+        String identifier,
+        NonJarFingerprintingStrategy nonZipFingerprintingStrategy,
+        ResourceHasher classpathResourceHasher,
+        ZipHasher zipHasher,
+        ResourceSnapshotterCacheService cacheService,
+        Interner<String> stringInterner
+    ) {
+        super(identifier, DirectorySensitivity.DEFAULT, zipHasher);
         this.nonZipFingerprintingStrategy = nonZipFingerprintingStrategy;
         this.classpathResourceHasher = classpathResourceHasher;
         this.cacheService = cacheService;
@@ -114,17 +115,17 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         resourceHasher = metaInfAwareClasspathResourceHasher(resourceHasher, manifestAttributeResourceEntryFilter);
         resourceHasher = ignoringResourceHasher(resourceHasher, classpathResourceFilter);
         ZipHasher zipHasher = new ZipHasher(resourceHasher);
-        return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner, lineEndingSensitivity);
+        return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner) {
         ZipHasher zipHasher = new ZipHasher(classpathResourceHasher);
-        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner, LineEndingSensitivity.DEFAULT);
+        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner, ZipHasher.HashingExceptionReporter hashingExceptionReporter) {
         ZipHasher zipHasher = new ZipHasher(classpathResourceHasher, hashingExceptionReporter);
-        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner, LineEndingSensitivity.DEFAULT);
+        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     private static ResourceHasher ignoringResourceHasher(ResourceHasher delegate, ResourceFilter resourceFilter) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FileCollectionFingerprint.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
 
 import java.util.Map;
 
@@ -46,6 +47,8 @@ public interface FileCollectionFingerprint {
     }
 
     FileCollectionFingerprint EMPTY = new FileCollectionFingerprint() {
+        private final HashCode strategyConfigurationHash = Hashing.signature(getClass());
+
         @Override
         public Map<String, FileSystemLocationFingerprint> getFingerprints() {
             return ImmutableSortedMap.of();
@@ -62,8 +65,15 @@ public interface FileCollectionFingerprint {
         }
 
         @Override
+        public HashCode getStrategyConfigurationHash() {
+            return strategyConfigurationHash;
+        }
+
+        @Override
         public String toString() {
             return "EMPTY";
         }
     };
+
+    HashCode getStrategyConfigurationHash();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.fingerprint;
 
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
@@ -53,4 +54,6 @@ public interface FingerprintingStrategy {
     DirectorySensitivity getDirectorySensitivity();
 
     LineEndingSensitivity getLineEndingNormalization();
+
+    HashCode getConfigurationHash();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -51,9 +51,5 @@ public interface FingerprintingStrategy {
 
     String normalizePath(FileSystemLocationSnapshot snapshot);
 
-    DirectorySensitivity getDirectorySensitivity();
-
-    LineEndingSensitivity getLineEndingNormalization();
-
     HashCode getConfigurationHash();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
@@ -45,7 +44,7 @@ public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingSt
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public AbsolutePathFingerprintingStrategy(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity);
+        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -21,7 +21,6 @@ import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -43,13 +42,13 @@ public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingSt
 
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
-    public AbsolutePathFingerprintingStrategy(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
+    public AbsolutePathFingerprintingStrategy(DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 
     private AbsolutePathFingerprintingStrategy(DirectorySensitivity directorySensitivity) {
-        this(directorySensitivity, LineEndingSensitivity.DEFAULT, FileSystemLocationSnapshotHasher.DEFAULT);
+        this(directorySensitivity, FileSystemLocationSnapshotHasher.DEFAULT);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
@@ -19,7 +19,6 @@ package org.gradle.internal.fingerprint.impl;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
@@ -35,19 +34,16 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
     private final String identifier;
     private final CurrentFileCollectionFingerprint emptyFingerprint;
     private final DirectorySensitivity directorySensitivity;
-    private final LineEndingSensitivity lineEndingSensitivity;
     private final HashCode configurationHash;
 
     public AbstractFingerprintingStrategy(
         String identifier,
         DirectorySensitivity directorySensitivity,
-        LineEndingSensitivity lineEndingSensitivity,
         ConfigurableNormalizer contentNormalizer
     ) {
         this.identifier = identifier;
         this.emptyFingerprint = new EmptyCurrentFileCollectionFingerprint(identifier);
         this.directorySensitivity = directorySensitivity;
-        this.lineEndingSensitivity = lineEndingSensitivity;
         Hasher hasher = Hashing.newHasher();
         hasher.putString(getClass().getName());
         contentNormalizer.appendConfigurationToHasher(hasher);
@@ -79,12 +75,6 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
         return String.format("Failed to normalize content of '%s'.", snapshot.getAbsolutePath());
     }
 
-    @Override
-    public LineEndingSensitivity getLineEndingNormalization() {
-        return lineEndingSensitivity;
-    }
-
-    @Override
     public DirectorySensitivity getDirectorySensitivity() {
         return directorySensitivity;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -39,6 +39,7 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     private final String identifier;
     private final FileSystemSnapshot roots;
     private final ImmutableMultimap<String, HashCode> rootHashes;
+    private final HashCode strategyConfigurationHash;
     private HashCode hash;
 
     public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy) {
@@ -52,7 +53,7 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
 
         ImmutableMultimap<String, HashCode> rootHashes = SnapshotUtil.getRootHashes(roots);
         Map<String, FileSystemLocationFingerprint> fingerprints;
-        if (candidate != null && Iterables.elementsEqual(candidate.getRootHashes().entries(), rootHashes.entries())) {
+        if (candidate != null && candidate.getStrategyConfigurationHash().equals(strategy.getConfigurationHash()) && Iterables.elementsEqual(candidate.getRootHashes().entries(), rootHashes.entries())) {
             fingerprints = candidate.getFingerprints();
         } else {
             fingerprints = strategy.collectFingerprints(roots);
@@ -60,15 +61,23 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
         if (fingerprints.isEmpty()) {
             return strategy.getEmptyFingerprint();
         }
-        return new DefaultCurrentFileCollectionFingerprint(fingerprints, strategy.getHashingStrategy(), strategy.getIdentifier(), roots, rootHashes);
+        return new DefaultCurrentFileCollectionFingerprint(fingerprints, strategy.getHashingStrategy(), strategy.getIdentifier(), roots, rootHashes, strategy.getConfigurationHash());
     }
 
-    private DefaultCurrentFileCollectionFingerprint(Map<String, FileSystemLocationFingerprint> fingerprints, FingerprintHashingStrategy hashingStrategy, String identifier, FileSystemSnapshot roots, ImmutableMultimap<String, HashCode> rootHashes) {
+    private DefaultCurrentFileCollectionFingerprint(
+        Map<String, FileSystemLocationFingerprint> fingerprints,
+        FingerprintHashingStrategy hashingStrategy,
+        String identifier,
+        FileSystemSnapshot roots,
+        ImmutableMultimap<String, HashCode> rootHashes,
+        HashCode strategyConfigurationHash
+    ) {
         this.fingerprints = fingerprints;
         this.hashingStrategy = hashingStrategy;
         this.identifier = identifier;
         this.roots = roots;
         this.rootHashes = rootHashes;
+        this.strategyConfigurationHash = strategyConfigurationHash;
     }
 
     @Override
@@ -105,6 +114,11 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     @Override
     public FileSystemSnapshot getSnapshot() {
         return roots;
+    }
+
+    @Override
+    public HashCode getStrategyConfigurationHash() {
+        return strategyConfigurationHash;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -49,7 +49,10 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
 
         ImmutableMultimap<String, HashCode> rootHashes = SnapshotUtil.getRootHashes(roots);
         Map<String, FileSystemLocationFingerprint> fingerprints;
-        if (candidate != null && candidate.getStrategyConfigurationHash().equals(strategy.getConfigurationHash()) && Iterables.elementsEqual(candidate.getRootHashes().entries(), rootHashes.entries())) {
+        if (candidate != null
+            && candidate.getStrategyConfigurationHash().equals(strategy.getConfigurationHash())
+            && equalRootHashes(candidate.getRootHashes(), rootHashes)
+        ) {
             fingerprints = candidate.getFingerprints();
         } else {
             fingerprints = strategy.collectFingerprints(roots);
@@ -58,6 +61,11 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
             return strategy.getEmptyFingerprint();
         }
         return new DefaultCurrentFileCollectionFingerprint(fingerprints, roots, rootHashes, strategy);
+    }
+
+    private static boolean equalRootHashes(ImmutableMultimap<String, HashCode> first, ImmutableMultimap<String, HashCode> second) {
+        // We cannot use `first.equals(second)`, since the order of the root hashes matters
+        return Iterables.elementsEqual(first.entries(), second.entries());
     }
 
     private DefaultCurrentFileCollectionFingerprint(

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -42,10 +42,6 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     private final HashCode strategyConfigurationHash;
     private HashCode hash;
 
-    public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy) {
-        return from(roots, strategy, null);
-    }
-
     public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy, @Nullable  FileCollectionFingerprint candidate) {
         if (roots == FileSystemSnapshot.EMPTY) {
             return strategy.getEmptyFingerprint();
@@ -61,23 +57,21 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
         if (fingerprints.isEmpty()) {
             return strategy.getEmptyFingerprint();
         }
-        return new DefaultCurrentFileCollectionFingerprint(fingerprints, strategy.getHashingStrategy(), strategy.getIdentifier(), roots, rootHashes, strategy.getConfigurationHash());
+        return new DefaultCurrentFileCollectionFingerprint(fingerprints, roots, rootHashes, strategy);
     }
 
     private DefaultCurrentFileCollectionFingerprint(
         Map<String, FileSystemLocationFingerprint> fingerprints,
-        FingerprintHashingStrategy hashingStrategy,
-        String identifier,
         FileSystemSnapshot roots,
         ImmutableMultimap<String, HashCode> rootHashes,
-        HashCode strategyConfigurationHash
+        FingerprintingStrategy strategy
     ) {
         this.fingerprints = fingerprints;
-        this.hashingStrategy = hashingStrategy;
-        this.identifier = identifier;
+        this.identifier = strategy.getIdentifier();
+        this.hashingStrategy = strategy.getHashingStrategy();
+        this.strategyConfigurationHash = strategy.getConfigurationHash();
         this.roots = roots;
         this.rootHashes = rootHashes;
-        this.strategyConfigurationHash = strategyConfigurationHash;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -68,6 +68,11 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     }
 
     @Override
+    public HashCode getStrategyConfigurationHash() {
+        return SIGNATURE;
+    }
+
+    @Override
     public String getStrategyIdentifier() {
         return identifier;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -46,7 +46,7 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public IgnoredPathFingerprintingStrategy(LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, DirectorySensitivity.DEFAULT, lineEndingSensitivity);
+        super(IDENTIFIER, DirectorySensitivity.DEFAULT, lineEndingSensitivity, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -45,13 +44,13 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
 
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
-    public IgnoredPathFingerprintingStrategy(LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, DirectorySensitivity.DEFAULT, lineEndingSensitivity, normalizedContentHasher);
+    public IgnoredPathFingerprintingStrategy(FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(IDENTIFIER, DirectorySensitivity.DEFAULT, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 
     private IgnoredPathFingerprintingStrategy() {
-        this(LineEndingSensitivity.DEFAULT, FileSystemLocationSnapshotHasher.DEFAULT);
+        this(FileSystemLocationSnapshotHasher.DEFAULT);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -44,7 +44,7 @@ public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrate
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity);
+        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -21,7 +21,6 @@ import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -43,13 +42,13 @@ public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrate
     public static final String IDENTIFIER = "NAME_ONLY";
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
-    public NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
+    public NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 
     private NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity) {
-        this(directorySensitivity, LineEndingSensitivity.DEFAULT, FileSystemLocationSnapshotHasher.DEFAULT);
+        this(directorySensitivity, FileSystemLocationSnapshotHasher.DEFAULT);
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -46,7 +46,7 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity);
+        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
         this.stringInterner = stringInterner;
         this.normalizedContentHasher = normalizedContentHasher;
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -22,7 +22,6 @@ import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
-import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -45,14 +44,14 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
     private final Interner<String> stringInterner;
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
-    public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, lineEndingSensitivity, normalizedContentHasher);
+    public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
         this.stringInterner = stringInterner;
         this.normalizedContentHasher = normalizedContentHasher;
     }
 
     public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity) {
-        this(stringInterner, directorySensitivity, LineEndingSensitivity.DEFAULT, FileSystemLocationSnapshotHasher.DEFAULT);
+        this(stringInterner, directorySensitivity, FileSystemLocationSnapshotHasher.DEFAULT);
     }
 
     @Override


### PR DESCRIPTION
This makes up-to-date tasks faster, since we don't need create fingerprints from the snapshots, but can easily re-use the fingerprints from the last execution. The effect is rather dramatic on the fully up-to-date scenarios and removes the up-to-date overhead introduced by #17648 and adds some improvements on top of it.

![image](https://user-images.githubusercontent.com/423186/125911567-3434546f-c58c-4aaa-a1ca-303bf106b148.png)
