### PR TITLE
Add line break before using multiline parameters

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -46,6 +46,8 @@
       <option name="FOR_BRACE_FORCE" value="3" />
     </codeStyleSettings>
     <codeStyleSettings language="JAVA">
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
       <option name="IF_BRACE_FORCE" value="3" />
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
I find this much more readable:
- The parameters are further left, so you need less line length
- The body is nicely separated from the list of arguments

Before:
```java
public DefaultAfterPreviousExecutionState(OriginMetadata originMetadata,
                                          ImplementationSnapshot implementation,
                                          ImmutableList<ImplementationSnapshot> additionalImplementations,
                                          ImmutableSortedMap<String, ValueSnapshot> inputProperties,
                                          ImmutableSortedMap<String, FileCollectionFingerprint> inputFileProperties,
                                          ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork,
                                          boolean successful) {
    super(implementation, additionalImplementations, inputProperties, inputFileProperties);
```

After:

```java
public DefaultAfterPreviousExecutionState(
    OriginMetadata originMetadata,
    ImplementationSnapshot implementation,
    ImmutableList<ImplementationSnapshot> additionalImplementations,
    ImmutableSortedMap<String, ValueSnapshot> inputProperties,
    ImmutableSortedMap<String, FileCollectionFingerprint> inputFileProperties,
    ImmutableSortedMap<String, FileSystemSnapshot> outputFilesProducedByWork,
    boolean successful
) {
    super(implementation, additionalImplementations, inputProperties, inputFileProperties);
```

