### PR TITLE
Remove usage of legacy JUnit 4 rules in Spock examples

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.groovy-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.groovy-dsl-gradle-plugin.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
 
     implementation(localGroovy())
     testImplementation("org.spockframework:spock-core")
-    testImplementation("org.spockframework:spock-junit4")
     testImplementation("net.bytebuddy:byte-buddy")
     testImplementation("org.objenesis:objenesis")
 }

--- a/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/AcceptedApiChangesJsonFileManagerTest.groovy
+++ b/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/AcceptedApiChangesJsonFileManagerTest.groovy
@@ -16,22 +16,21 @@
 
 package gradlebuild.binarycompatibility
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.TempDir
 
 class AcceptedApiChangesJsonFileManagerTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    File temporaryFolder
 
     @Subject AcceptedApiChangesJsonFileManager jsonFileManager = new AcceptedApiChangesJsonFileManager()
 
     def jsonFile
 
     def setup() {
-        jsonFile = temporaryFolder.newFile('acceptedChanges.json')
+        jsonFile = new File(temporaryFolder, 'acceptedChanges.json')
     }
 
     def "can clean existing API changes"() {

--- a/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/PublicAPIRulesTest.groovy
+++ b/build-logic/binary-compatibility/src/test/groovy/gradlebuild/binarycompatibility/PublicAPIRulesTest.groovy
@@ -30,10 +30,9 @@ import me.champeau.gradle.japicmp.report.AbstractContextAwareViolationRule
 import me.champeau.gradle.japicmp.report.Severity
 import me.champeau.gradle.japicmp.report.ViolationCheckContext
 import org.gradle.api.Incubating
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
+import spock.lang.TempDir
 
 import javax.inject.Inject
 
@@ -41,8 +40,8 @@ class PublicAPIRulesTest extends Specification {
     private final static String TEST_INTERFACE_NAME = 'org.gradle.api.ApiTest'
     private final static String TEST_INTERFACE_SIMPLE_NAME = 'ApiTest'
 
-    @Rule
-    TemporaryFolder tmp = new TemporaryFolder()
+    @TempDir
+    File tmp
     File sourceFile
 
     BinaryCompatibilityRepository repository
@@ -57,8 +56,8 @@ class PublicAPIRulesTest extends Specification {
     def injectAnnotation = Stub(JApiAnnotation)
 
     def setup() {
-        new File(tmp.root, "org/gradle/api").mkdirs()
-        sourceFile = tmp.newFile("${TEST_INTERFACE_NAME.replace('.', '/')}.java")
+        new File(tmp, "org/gradle/api").mkdirs()
+        sourceFile = new File(tmp, "${TEST_INTERFACE_NAME.replace('.', '/')}.java").tap { text = "" }
 
         jApiClassifier.fullyQualifiedName >> TEST_INTERFACE_NAME
         jApiField.name >> 'field'
@@ -73,7 +72,7 @@ class PublicAPIRulesTest extends Specification {
         overrideAnnotation.fullyQualifiedName >> Override.name
         injectAnnotation.fullyQualifiedName >> Inject.name
 
-        repository = BinaryCompatibilityRepository.openRepositoryFor([new File(tmp.root.absolutePath)], [])
+        repository = BinaryCompatibilityRepository.openRepositoryFor([new File(tmp.absolutePath)], [])
     }
 
     def cleanup() {

--- a/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateReleasedVersionsIntegrationTest.groovy
+++ b/build-logic/build-update-utils/src/test/groovy/gradlebuild/buildutils/tasks/UpdateReleasedVersionsIntegrationTest.groovy
@@ -17,9 +17,8 @@
 package gradlebuild.buildutils.tasks
 
 import gradlebuild.buildutils.model.ReleasedVersion
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import java.text.SimpleDateFormat
 
@@ -27,8 +26,8 @@ class UpdateReleasedVersionsIntegrationTest extends Specification {
 
     def format = new SimpleDateFormat('yyyyMMddHHmmssZ')
 
-    @Rule
-    TemporaryFolder tmpDir
+    @TempDir
+    File tmpDir
 
     def setup() {
         format.timeZone = TimeZone.getTimeZone("UTC")
@@ -36,7 +35,7 @@ class UpdateReleasedVersionsIntegrationTest extends Specification {
 
     def "updated released version file has expected format"() {
         given:
-        def releasedVersionsFile = tmpDir.newFile("released-versions.json")
+        def releasedVersionsFile = new File(tmpDir, "released-versions.json")
         releasedVersionsFile << '''{
   "latestReleaseSnapshot": {
     "version": "6.6-20200702230251+0000",

--- a/build-logic/documentation/src/test/groovy/gradlebuild/docs/model/SimpleClassMetaDataRepositoryTest.groovy
+++ b/build-logic/documentation/src/test/groovy/gradlebuild/docs/model/SimpleClassMetaDataRepositoryTest.groovy
@@ -15,15 +15,14 @@
  */
 package gradlebuild.docs.model
 
-
+import java.nio.file.Files
 import org.gradle.api.Action
 import org.gradle.api.UnknownDomainObjectException
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class SimpleClassMetaDataRepositoryTest extends Specification {
-    @Rule TemporaryFolder tmpDir
+    @TempDir File tmpDir
     final SimpleClassMetaDataRepository<TestDomainObject> repository = new SimpleClassMetaDataRepository<TestDomainObject>()
 
     def canAddMetaData() {
@@ -100,7 +99,7 @@ class SimpleClassMetaDataRepositoryTest extends Specification {
 
     def canPersistMetaData() {
         TestDomainObject value = new TestDomainObject('a')
-        File file = tmpDir.newFile()
+        File file = Files.createTempFile(tmpDir.toPath(), null, null).toFile()
         repository.put('class', value)
 
         when:

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/SimpleTemplateOperationSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/SimpleTemplateOperationSpec.groovy
@@ -16,13 +16,12 @@
 
 package org.gradle.buildinit.plugins.internal
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class SimpleTemplateOperationSpec extends Specification {
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    File temporaryFolder
 
     def "Template URL must not be null"() {
         when:
@@ -42,7 +41,7 @@ class SimpleTemplateOperationSpec extends Specification {
 
     def "writes file from template with binding support"() {
         setup:
-        def targetFile = temporaryFolder.newFile("test.out")
+        def targetFile = new File(temporaryFolder, "test.out")
         def templateURL = getClass().getResource("SimpleTemplateOperationSpec-binding.template")
         def templateOperation = new SimpleTemplateOperation(templateURL, targetFile, [someBindedValue: new TemplateValue("someTemplateValue")])
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
@@ -35,8 +35,6 @@ class ProjectBuilderEndUserIntegrationTest extends AbstractIntegrationSpec {
             implementation gradleApi()
             testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
             testImplementation("org.spockframework:spock-core")
-            testImplementation("org.spockframework:spock-junit4")
-            testImplementation("junit:junit:4.13.1")
         }
 
         ${mavenCentralRepository()}

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -13,8 +13,6 @@ dependencies {
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.6.2'
     testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
-    testImplementation 'org.spockframework:spock-junit4'
-    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.named('test') {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/JavaConventionPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/JavaConventionPluginTest.groovy
@@ -14,8 +14,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on checkstyle error"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
-        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/example').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/example/Foo.java') << """
             package com.example;
 
             import java.util.*;
@@ -37,8 +37,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on checkstyle warning"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
-        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/example').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/example/Foo.java') << """
             package com.example;
 
             class Foo {
@@ -60,8 +60,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on spotbugs error"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
-        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/example').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/example/Foo.java') << """
             package com.example;
 
             class Foo {
@@ -81,8 +81,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "warns on deprecated API usage"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
-        testProjectDir.newFile('src/main/java/com/example/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/example').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/example/Foo.java') << """
             package com.example;
 
             public class Foo {
@@ -91,7 +91,7 @@ class JavaConventionPluginTest extends PluginTest {
             }
         """
 
-        testProjectDir.newFile('src/main/java/com/example/Bar.java') << """
+        new File(testProjectDir, 'src/main/java/com/example/Bar.java') << """
             package com.example;
 
             public class Bar {

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/LibraryPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/LibraryPluginTest.groovy
@@ -45,8 +45,8 @@ class LibraryPluginTest extends PluginTest {
             }
         """
 
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'example')
-        testProjectDir.newFile('src/main/java/com/example/Util.java') << """
+        new File(testProjectDir, 'src/main/java/com/example').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/example/Util.java') << """
             package com.example;
 
             public class Util {
@@ -61,7 +61,7 @@ class LibraryPluginTest extends PluginTest {
         then:
         result.task(":jar").outcome == TaskOutcome.SUCCESS
         result.task(":publishLibraryPublicationToTestRepoRepository").outcome == TaskOutcome.SUCCESS
-        new File(testProjectDir.getRoot(), 'build/test-repo/com/example/my-library/0.1.0/my-library-0.1.0.jar').exists()
+        new File(testProjectDir, 'build/test-repo/com/example/my-library/0.1.0/my-library-0.1.0.jar').exists()
     }
 
     def "fails when no README exists"() {
@@ -74,7 +74,7 @@ class LibraryPluginTest extends PluginTest {
 
     def "fails when README does not have API section"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## Changelog
 - change 1
 - change 2
@@ -90,7 +90,7 @@ class LibraryPluginTest extends PluginTest {
 
     def "fails when README does not have Changelog section"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## API
 public API description
         """
@@ -104,7 +104,7 @@ public API description
     }
 
     private def readmeContainingMandatorySectionsExists() {
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## API
 public API description
 

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/PluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/src/test/groovy/com/example/PluginTest.groovy
@@ -1,24 +1,23 @@
 package com.example
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 abstract class PluginTest extends Specification {
-    @Rule
-    TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir
+    File testProjectDir
     File settingsFile
     File buildFile
 
     def setup() {
-        settingsFile = testProjectDir.newFile('settings.gradle') << "rootProject.name = 'test'"
-        buildFile = testProjectDir.newFile('build.gradle')
+        settingsFile = new File(testProjectDir, 'settings.gradle').tap { it << "rootProject.name = 'test'" }
+        buildFile = new File(testProjectDir, 'build.gradle')
     }
 
     def runTask(String task) {
         return GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments(task, '--stacktrace')
                 .withPluginClasspath()
                 .build()
@@ -26,7 +25,7 @@ abstract class PluginTest extends Specification {
 
     def runTaskWithFailure(String task) {
         return GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments(task, '--stacktrace')
                 .withPluginClasspath()
                 .buildAndFail()

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
@@ -35,8 +35,6 @@ dependencies {
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.6.2'
     testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
-    testImplementation 'org.spockframework:spock-junit4'
-    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.named('test') {

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/JavaConventionPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/JavaConventionPluginTest.groovy
@@ -14,8 +14,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on checkstyle error"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/main/java/com/myorg/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/myorg/Foo.java') << """
             package com.myorg;
 
             import java.util.*;
@@ -37,8 +37,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on checkstyle warning"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/main/java/com/myorg/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/myorg/Foo.java') << """
             package com.myorg;
 
             class Foo {
@@ -60,8 +60,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "fails on spotbugs error"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/main/java/com/myorg/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/myorg/Foo.java') << """
             package com.myorg;
 
             class Foo {
@@ -81,8 +81,8 @@ class JavaConventionPluginTest extends PluginTest {
 
     def "warns on deprecated API usage"() {
         given:
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/main/java/com/myorg/Foo.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/myorg/Foo.java') << """
             package com.myorg;
 
             public class Foo {
@@ -91,7 +91,7 @@ class JavaConventionPluginTest extends PluginTest {
             }
         """
 
-        testProjectDir.newFile('src/main/java/com/myorg/Bar.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg/Bar.java') << """
             package com.myorg;
 
             public class Bar {

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/LibraryPluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/LibraryPluginTest.groovy
@@ -45,8 +45,8 @@ class LibraryPluginTest extends PluginTest {
             }
         """
 
-        testProjectDir.newFolder('src', 'main', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/main/java/com/myorg/Util.java') << """
+        new File(testProjectDir, 'src/main/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/main/java/com/myorg/Util.java') << """
             package com.myorg;
 
             public class Util {
@@ -61,7 +61,7 @@ class LibraryPluginTest extends PluginTest {
         then:
         result.task(":jar").outcome == TaskOutcome.SUCCESS
         result.task(":publishLibraryPublicationToTestRepoRepository").outcome == TaskOutcome.SUCCESS
-        new File(testProjectDir.getRoot(), 'build/test-repo/com/myorg/my-library/0.1.0/my-library-0.1.0.jar').exists()
+        new File(testProjectDir, 'build/test-repo/com/myorg/my-library/0.1.0/my-library-0.1.0.jar').exists()
     }
 
     def "fails when no README exists"() {
@@ -74,7 +74,7 @@ class LibraryPluginTest extends PluginTest {
 
     def "fails when README does not have API section"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## Changelog
 - change 1
 - change 2
@@ -90,7 +90,7 @@ class LibraryPluginTest extends PluginTest {
 
     def "fails when README does not have Changelog section"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## API
 public API description
         """
@@ -104,7 +104,7 @@ public API description
     }
 
     private def readmeContainingMandatorySectionsExists() {
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## API
 public API description
 

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/PluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/PluginTest.groovy
@@ -1,24 +1,23 @@
 package com.myorg
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 abstract class PluginTest extends Specification {
-    @Rule
-    TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir
+    File testProjectDir
     File settingsFile
     File buildFile
 
     def setup() {
-        settingsFile = testProjectDir.newFile('settings.gradle') << "rootProject.name = 'test'"
-        buildFile = testProjectDir.newFile('build.gradle')
+        settingsFile = new File(testProjectDir, 'settings.gradle').tap { it << "rootProject.name = 'test'" }
+        buildFile = new File(testProjectDir, 'build.gradle')
     }
 
     def runTask(String task) {
         return GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments(task, '--stacktrace')
                 .withPluginClasspath()
                 .build()
@@ -26,7 +25,7 @@ abstract class PluginTest extends Specification {
 
     def runTaskWithFailure(String task) {
         return GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments(task, '--stacktrace')
                 .withPluginClasspath()
                 .buildAndFail()

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/ServicePluginTest.groovy
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/src/test/groovy/com/myorg/ServicePluginTest.groovy
@@ -15,7 +15,7 @@ class ServicePluginTest extends PluginTest {
 
     def "integrationTest and readmeCheck tasks run with check task"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 ## Service API
 
         """
@@ -37,8 +37,8 @@ class ServicePluginTest extends PluginTest {
             }
         """
 
-        testProjectDir.newFolder('src', 'integrationTest', 'java', 'com', 'myorg')
-        testProjectDir.newFile('src/integrationTest/java/com/myorg/SomeIntegrationTest.java') << """
+        new File(testProjectDir, 'src/integrationTest/java/com/myorg').mkdirs()
+        new File(testProjectDir, 'src/integrationTest/java/com/myorg/SomeIntegrationTest.java') << """
             package com.myorg;
 
             import org.junit.Test;
@@ -67,7 +67,7 @@ class ServicePluginTest extends PluginTest {
 
     def "fails when README does not have service API section"() {
         given:
-        testProjectDir.newFile('README.md') << """
+        new File(testProjectDir, 'README.md') << """
 asdfadfsasf
         """
 

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
@@ -6,8 +6,6 @@ plugins {
 dependencies {
     testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
-    testImplementation 'org.spockframework:spock-junit4'
-    testImplementation 'junit:junit:4.13.1'
 }
 
 tasks.named("test") {

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/src/test/groovy/org/example/BuildLogicFunctionalTest.groovy
@@ -1,20 +1,19 @@
 package org.example
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.testkit.runner.TaskOutcome.*
 
 class BuildLogicFunctionalTest extends Specification {
 
-    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir File testProjectDir
     File buildFile
 
     def setup() {
-        testProjectDir.newFile('settings.gradle') << ""
-        buildFile = testProjectDir.newFile('build.gradle')
+        new File(testProjectDir, 'settings.gradle') << ""
+        buildFile = new File(testProjectDir, 'build.gradle')
     }
 
     // tag::functional-test-configuration-cache[]
@@ -44,7 +43,7 @@ class BuildLogicFunctionalTest extends Specification {
 
     def runner() {
         return GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
+            .withProjectDir(testProjectDir)
             .withPluginClasspath()
     }
 }

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
@@ -50,18 +50,12 @@ repositories {
 dependencies {
     testImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
-    testImplementation 'org.spockframework:spock-junit4'
-    testImplementation 'junit:junit:4.13.1'
 
     integrationTestImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     integrationTestImplementation 'org.spockframework:spock-core'
-    integrationTestImplementation 'org.spockframework:spock-junit4'
-    integrationTestImplementation 'junit:junit:4.13.1'
 
     functionalTestImplementation platform("org.spockframework:spock-bom:2.0-groovy-3.0")
     functionalTestImplementation 'org.spockframework:spock-core'
-    functionalTestImplementation 'org.spockframework:spock-junit4'
-    functionalTestImplementation 'junit:junit:4.13.1'
 }
 
 tasks.withType(Test).configureEach {

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/src/functionalTest/groovy/org/myorg/UrlVerifierPluginFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/src/functionalTest/groovy/org/myorg/UrlVerifierPluginFunctionalTest.groovy
@@ -1,18 +1,17 @@
 package org.myorg
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class UrlVerifierPluginFunctionalTest extends Specification {
-    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir File testProjectDir
     File buildFile
 
     def setup() {
-        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile = new File(testProjectDir, 'build.gradle')
         buildFile << """
             plugins {
                 id 'org.myorg.url-verifier'
@@ -29,7 +28,7 @@ class UrlVerifierPluginFunctionalTest extends Specification {
 
         when:
         def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
+            .withProjectDir(testProjectDir)
             .withArguments('verifyUrl')
             .withPluginClasspath()
             .build()

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -50,20 +50,13 @@ repositories {
 dependencies {
     testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
     testImplementation("org.spockframework:spock-core")
-    testImplementation("org.spockframework:spock-junit4")
-    testImplementation("junit:junit:4.13.1")
 
     "integrationTestImplementation"(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
     "integrationTestImplementation"("org.spockframework:spock-core")
-    "integrationTestImplementation"("org.spockframework:spock-junit4")
-    "integrationTestImplementation"("junit:junit:4.13.1")
 
     "functionalTestImplementation"(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
     "functionalTestImplementation"("org.spockframework:spock-core")
-    "functionalTestImplementation"("org.spockframework:spock-junit4")
-    "functionalTestImplementation"("junit:junit:4.13.1")
 }
-
 
 tasks.withType<Test>().configureEach {
     // Using JUnitPlatform for running tests

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/src/functionalTest/groovy/org/myorg/UrlVerifierPluginFunctionalTest.groovy
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/src/functionalTest/groovy/org/myorg/UrlVerifierPluginFunctionalTest.groovy
@@ -1,18 +1,17 @@
 package org.myorg
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class UrlVerifierPluginFunctionalTest extends Specification {
-    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir File testProjectDir
     File buildFile
 
     def setup() {
-        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile = new File(testProjectDir, 'build.gradle')
         buildFile << """
             plugins {
                 id 'org.myorg.url-verifier'
@@ -29,7 +28,7 @@ class UrlVerifierPluginFunctionalTest extends Specification {
 
         when:
         def result = GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
+            .withProjectDir(testProjectDir)
             .withArguments('verifyUrl')
             .withPluginClasspath()
             .build()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
@@ -21,14 +21,13 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class SourceFoldersCreatorTest extends Specification {
 
-    @Rule
-    TemporaryFolder tempFolder;
+    @TempDir
+    File tempFolder;
 
     SourceSet sourceSet;
     SourceDirectorySet java
@@ -49,7 +48,7 @@ class SourceFoldersCreatorTest extends Specification {
         _ * sourceSet.allSource >> allSource
         _ * sourceSet.allJava >> java
         _ * sourceSet.resources >> resources
-        projectRootFolder = tempFolder.newFolder("project-root")
+        projectRootFolder = new File(tempFolder, "project-root").tap { mkdirs() }
         defaultOutputFolder = new File(projectRootFolder, 'bin/default')
     }
 

--- a/subprojects/internal-performance-testing/src/integTest/groovy/org/gradle/performance/fixture/MavenDownloaderTest.groovy
+++ b/subprojects/internal-performance-testing/src/integTest/groovy/org/gradle/performance/fixture/MavenDownloaderTest.groovy
@@ -23,22 +23,23 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Assume
 import org.junit.AssumptionViolatedException
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
+
+import java.nio.file.Files
 
 @Requires([TestPrecondition.ONLINE])
 class MavenDownloaderTest extends Specification {
 
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder()
+    @TempDir
+    File tmpDir
 
     def installRoot
     def downloader
 
     def setup() {
-        installRoot = tmpDir.newFolder()
+        installRoot = Files.createTempDirectory(tmpDir.toPath(), null).toFile()
         downloader = new MavenInstallationDownloader(installRoot)
         if (JavaVersion.current().isJava7()) {
             System.setProperty("https.protocols", "TLSv1.2")

--- a/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/AbstractCompilerPluginTest.groovy
+++ b/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/AbstractCompilerPluginTest.groovy
@@ -16,21 +16,21 @@
 
 package com.gradle.internal.compiler.java
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
+import java.nio.file.Files
 import java.nio.file.Paths
 
 class AbstractCompilerPluginTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    File temporaryFolder
 
     protected File sourceFolder
 
     def setup() {
-        sourceFolder = temporaryFolder.newFolder()
+        sourceFolder = Files.createTempDirectory(temporaryFolder.toPath(), null).toFile()
     }
 
     List<File> toSourceFiles(List<String> bodies) {

--- a/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/listeners/ConstantsCollectorTest.groovy
+++ b/subprojects/java-compiler-plugin/src/test/groovy/com/gradle/internal/compiler/java/listeners/ConstantsCollectorTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.internal.compiler.java.TestCompiler
 import org.gradle.internal.compiler.java.listeners.constants.ConstantDependentsConsumer
 import spock.lang.Requires
 
+import java.nio.file.Files
+
 class ConstantsCollectorTest extends AbstractCompilerPluginTest {
 
     TestCompiler compiler
@@ -35,7 +37,7 @@ class ConstantsCollectorTest extends AbstractCompilerPluginTest {
             (String constantOrigin, String dependent) -> privateDependentToConstants.computeIfAbsent(dependent, { new LinkedHashSet<>() }).add(constantOrigin)
         )
         compiler = new TestCompiler(
-            temporaryFolder.newFolder(),
+            Files.createTempDirectory(temporaryFolder.toPath(), null).toFile(),
             { f -> Optional.empty() },
             {},
             consumer

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/CachingJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/CachingJvmMetadataDetectorTest.groovy
@@ -22,14 +22,15 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
 
 class CachingJvmMetadataDetectorTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    File temporaryFolder
 
     def "returned metadata from delegate"() {
         def metadata = Mock(JvmInstallationMetadata)
@@ -69,11 +70,11 @@ class CachingJvmMetadataDetectorTest extends Specification {
         NativeServicesTestFixture.initialize()
         def metaDataDetector = new DefaultJvmMetadataDetector(
             TestFiles.execHandleFactory(),
-            TestFiles.tmpDirTemporaryFileProvider(temporaryFolder.root)
+            TestFiles.tmpDirTemporaryFileProvider(temporaryFolder)
         )
         def detector = new CachingJvmMetadataDetector(metaDataDetector)
         File javaHome1 = Jvm.current().javaHome
-        def link = new TestFile(temporaryFolder.newFolder(), "jdklink")
+        def link = new TestFile(Files.createTempDirectory(temporaryFolder.toPath(), null).toFile(), "jdklink")
         link.createLink(javaHome1)
 
         when:

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
@@ -24,19 +24,18 @@ import org.gradle.process.internal.ExecHandle
 import org.gradle.process.internal.ExecHandleBuilder
 import org.gradle.process.internal.ExecHandleFactory
 import org.gradle.test.fixtures.file.TestFile
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import org.spockframework.runtime.SpockAssertionError
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class DefaultJvmMetadataDetectorTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    File temporaryFolder
 
     TestFile tmpDir
     def setup() {
-        tmpDir = new TestFile(temporaryFolder.newFolder("tmp"))
+        tmpDir = new TestFile(new File(temporaryFolder, "tmp").tap { mkdirs() })
     }
 
     def "cleans up generated Probe class"() {
@@ -45,7 +44,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
 
         when:
         def detector = createDefaultJvmMetadataDetector(execHandleFactory)
-        def javaHome = temporaryFolder.newFolder("localGradle")
+        def javaHome = new File(temporaryFolder, "localGradle").tap { mkdirs() }
         def metadata = detector.getMetadata(javaHome)
 
         then:
@@ -59,7 +58,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
 
         when:
         def detector = createDefaultJvmMetadataDetector(execHandleFactory)
-        File javaHome = temporaryFolder.newFolder(jdk)
+        File javaHome = new File(temporaryFolder, jdk).tap { mkdirs() }
         if (!jre) {
             def binDir = new File(javaHome, "bin")
             if (binDir.mkdir()) {
@@ -123,7 +122,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
 
         when:
         def detector = createDefaultJvmMetadataDetector(execHandleFactory)
-        def javaHome = temporaryFolder.newFolder(jdk)
+        def javaHome = new File(temporaryFolder, jdk).tap { mkdirs() }
         def metadata = detector.getMetadata(javaHome)
 
         then:
@@ -152,7 +151,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         def detector = createDefaultJvmMetadataDetector(execHandleFactory)
         File javaHome = new File(jdk)
         if (exists) {
-            javaHome = temporaryFolder.newFolder(jdk)
+            javaHome = new File(temporaryFolder, jdk).tap { mkdirs() }
         }
         def metadata = detector.getMetadata(javaHome)
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
@@ -26,8 +26,8 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.internal.TextUtil
 import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.launcher.cli.DefaultCommandLineActionFactory.WELCOME_MESSAGE_ENABLED_SYSTEM_PROPERTY
 
@@ -36,8 +36,8 @@ class WelcomeMessageActionTest extends Specification {
     @Rule
     public final SetSystemProperties sysProperties = new SetSystemProperties()
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
 
     BuildLayoutResult buildLayout
     File gradleUserHomeDir
@@ -46,7 +46,7 @@ class WelcomeMessageActionTest extends Specification {
     ExecutionListener listener
 
     def setup() {
-        gradleUserHomeDir = temporaryFolder.root
+        gradleUserHomeDir = temporaryFolder
         buildLayout = Mock(BuildLayoutResult) {
             getGradleUserHomeDir() >> gradleUserHomeDir
         }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingFileSystemLocationSnapshotHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingFileSystemLocationSnapshotHasherTest.groovy
@@ -20,9 +20,8 @@ import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.snapshot.RegularFileSnapshot
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
@@ -30,8 +29,8 @@ import java.nio.charset.Charset
 import org.gradle.api.internal.changedetection.state.LineEndingContentFixture as content
 
 class LineEndingNormalizingFileSystemLocationSnapshotHasherTest extends Specification {
-    @Rule
-    TemporaryFolder tempDir = new TemporaryFolder()
+    @TempDir
+    File tempDir
 
     @Unroll
     def "calculates hash for text file with #description"() {
@@ -89,7 +88,7 @@ class LineEndingNormalizingFileSystemLocationSnapshotHasherTest extends Specific
     def "always calls delegate for directories"() {
         def delegate = Mock(LineEndingNormalizingFileSystemLocationSnapshotHasher)
         def hasher = LineEndingNormalizingFileSystemLocationSnapshotHasher.wrap(delegate, lineEndingSensitivity)
-        def dir = file('dir')
+        def dir = file('dir').tap { it.text = "" }
         def snapshot = snapshot(dir, FileType.Directory)
 
         when:
@@ -103,7 +102,7 @@ class LineEndingNormalizingFileSystemLocationSnapshotHasherTest extends Specific
     }
 
     def "throws IOException generated from hasher"() {
-        def file = file('doesNotExist')
+        def file = file('doesNotExist').tap { it.text = "" }
         def delegate = Mock(LineEndingNormalizingFileSystemLocationSnapshotHasher)
         def hasher = LineEndingNormalizingFileSystemLocationSnapshotHasher.wrap(delegate, LineEndingSensitivity.NORMALIZE_LINE_ENDINGS)
         def snapshot = this.snapshot(file)
@@ -142,7 +141,7 @@ class LineEndingNormalizingFileSystemLocationSnapshotHasherTest extends Specific
     }
 
     File file(String path) {
-        return tempDir.newFile(path)
+        return new File(tempDir, path)
     }
 
     RegularFileSnapshot snapshot(File file, FileType fileType = FileType.RegularFile) {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasherTest.groovy
@@ -16,16 +16,15 @@
 
 package org.gradle.api.internal.changedetection.state
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import org.gradle.api.internal.changedetection.state.LineEndingContentFixture as content
 
 class LineEndingNormalizingInputStreamHasherTest extends Specification {
-    @Rule
-    TemporaryFolder tempDir = new TemporaryFolder()
+    @TempDir
+    File tempDir
 
     def hasher = new LineEndingNormalizingInputStreamHasher()
 
@@ -88,7 +87,7 @@ class LineEndingNormalizingInputStreamHasherTest extends Specification {
     }
 
     File file(String path) {
-        return tempDir.newFile(path)
+        return new File(tempDir, path)
     }
 
     static InputStream inputStream(String content) {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
@@ -24,9 +24,8 @@ import org.gradle.internal.fingerprint.hashing.ResourceHasher
 import org.gradle.internal.fingerprint.hashing.ZipEntryContext
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.snapshot.RegularFileSnapshot
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
@@ -34,8 +33,8 @@ import java.nio.charset.Charset
 import org.gradle.api.internal.changedetection.state.LineEndingContentFixture as content
 
 class LineEndingNormalizingResourceHasherTest extends Specification {
-    @Rule
-    TemporaryFolder tempDir = new TemporaryFolder()
+    @TempDir
+    File tempDir
 
     @Unroll
     def "calculates hash for text file with #description"() {
@@ -127,7 +126,7 @@ class LineEndingNormalizingResourceHasherTest extends Specification {
     }
 
     def "throws IOException generated from hasher"() {
-        def file = file('doesNotExist')
+        def file = file('doesNotExist').tap { it.text = "" }
         def delegate = Mock(ResourceHasher)
         def hasher = LineEndingNormalizingResourceHasher.wrap(delegate, LineEndingSensitivity.NORMALIZE_LINE_ENDINGS)
         def snapshotContext = snapshotContext(file)
@@ -177,7 +176,7 @@ class LineEndingNormalizingResourceHasherTest extends Specification {
     }
 
     File file(String path) {
-        return tempDir.newFile(path)
+        return new File(tempDir, path)
     }
 
     static ZipEntryContext zipContext(File file, boolean directory = false) {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
@@ -25,10 +25,10 @@ import org.gradle.internal.fingerprint.hashing.ResourceHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hasher
 import org.gradle.internal.snapshot.RegularFileSnapshot
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
+import java.nio.file.Files
 import java.util.function.Supplier
 import java.util.jar.Attributes
 import java.util.jar.Manifest
@@ -36,7 +36,7 @@ import java.util.jar.Manifest
 class MetaInfAwareClasspathResourceHasherTest extends Specification {
     public static final String MANIFEST_PATH = 'META-INF/MANIFEST.MF'
 
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+    @TempDir File tmpDir
 
     ResourceEntryFilter manifestResourceFilter = new IgnoringResourceEntryFilter(ImmutableSet.copyOf("created-by"))
 
@@ -448,8 +448,7 @@ class MetaInfAwareClasspathResourceHasherTest extends Specification {
 
     def fileSnapshot(String path, Map<String, Object> attributesMap = [:], Exception exception = null) {
         ByteArrayOutputStream manifestBytes = getManifestByteStream(attributesMap)
-        tmpDir.create()
-        File root = tmpDir.newFolder()
+        File root = Files.createTempDirectory(tmpDir.toPath(), null).toFile()
         File manifestFile = new File(root, MANIFEST_PATH)
         manifestFile.parentFile.mkdirs()
         manifestFile.write(manifestBytes.toString())

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -29,17 +29,17 @@ import org.gradle.internal.hash.Hasher
 import org.gradle.internal.hash.Hashing
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.internal.util.PropertiesUtils
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import java.nio.charset.Charset
+import java.nio.file.Files
 import java.util.function.Supplier
 
 @Unroll
 class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
-    @Rule TemporaryFolder tmpdir = new TemporaryFolder()
+    @TempDir File tmpdir
     Map<String, ResourceEntryFilter> filters = Maps.newHashMap()
     ResourceHasher delegate = new RuntimeClasspathResourceHasher()
     ResourceHasher unfilteredHasher = new PropertiesFileAwareClasspathResourceHasher(delegate, PropertiesFileFilter.FILTER_NOTHING)
@@ -356,7 +356,7 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
     }
 
     RegularFileSnapshotContext fileSnapshot(String path, byte[] bytes) {
-        def dir = tmpdir.newFolder()
+        def dir = Files.createTempDirectory(tmpdir.toPath(), null).toFile()
         def file = new File(dir, path)
         file.parentFile.mkdirs()
         file << bytes

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloaderTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkDownloaderTest.groovy
@@ -25,21 +25,22 @@ import org.gradle.internal.resource.ExternalResource
 import org.gradle.internal.resource.ExternalResourceName
 import org.gradle.internal.resource.ExternalResourceRepository
 import org.gradle.internal.verifier.HttpRedirectVerifier
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
 
 class AdoptOpenJdkDownloaderTest extends Specification {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
 
     def "cancelled download does not leave destination file behind"() {
         RepositoryTransportFactory transportFactory = newFailingTransportFactory()
 
         given:
         def downloader = new AdoptOpenJdkDownloader(transportFactory)
-        def destinationFile = new File(temporaryFolder.newFolder(), "target")
+        def destinationFile = new File(Files.createTempDirectory(temporaryFolder.toPath(), null).toFile(), "target")
 
         when:
         downloader.download(URI.create("https://foo"), destinationFile)

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -26,15 +26,14 @@ import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec
 import org.gradle.util.TestUtil
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 class AdoptOpenJdkRemoteBinaryTest extends Specification {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
 
     @Unroll
     def "generates url for jdk #jdkVersion on #operatingSystemName (#architecture)"() {
@@ -124,7 +123,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader, providerFactory())
 
         when:
-        def targetFile = temporaryFolder.newFile("jdk")
+        def targetFile = new File(temporaryFolder, "jdk")
         binary.download(spec, targetFile)
 
         then:
@@ -182,7 +181,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader, providerFactory())
 
         when:
-        def targetFile = temporaryFolder.newFile("jdk")
+        def targetFile = new File(temporaryFolder, "jdk")
         binary.download(spec, targetFile)
 
         then:
@@ -203,7 +202,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         def binary = new AdoptOpenJdkRemoteBinary(systemInfo, operatingSystem, downloader, providerFactory())
 
         when:
-        def targetFile = temporaryFolder.newFile("jdk")
+        def targetFile = new File(temporaryFolder, "jdk")
         binary.download(spec, targetFile)
 
         then:

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/DefaultJavaToolchainProvisioningServiceTest.groovy
@@ -21,14 +21,13 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.cache.FileLock
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.jvm.toolchain.JavaToolchainSpec
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class DefaultJavaToolchainProvisioningServiceTest extends Specification {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
 
     def "cache is properly locked around provisioning a jdk"() {
         def cache = Mock(JdkCacheDirectory)
@@ -75,7 +74,7 @@ class DefaultJavaToolchainProvisioningServiceTest extends Specification {
         binary.canProvideMatchingJdk(spec) >> true
         cache.acquireWriteLock(_, _) >> lock
         binary.toFilename(spec) >> 'jdk-123.zip'
-        def downloadLocation = temporaryFolder.newFile("jdk.zip")
+        def downloadLocation = new File(temporaryFolder, "jdk.zip")
         downloadLocation.createNewFile()
         cache.getDownloadLocation(_ as String) >> downloadLocation
         def provisioningService = new DefaultJavaToolchainProvisioningService(binary, cache, providerFactory, new TestBuildOperationExecutor())

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/JdkCacheDirectoryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/JdkCacheDirectoryTest.groovy
@@ -26,13 +26,13 @@ import org.gradle.cache.LockOptions
 import org.gradle.initialization.GradleUserHomeDirProvider
 import org.gradle.util.internal.Resources
 import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class JdkCacheDirectoryTest extends Specification {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
 
     @Rule
     public final Resources resources = new Resources()
@@ -51,16 +51,16 @@ class JdkCacheDirectoryTest extends Specification {
     def "lists jdk directories when listing java homes"() {
         given:
         def jdkCacheDirectory = new JdkCacheDirectory(newHomeDirProvider(), Mock(FileOperations), mockLockManager())
-        def install1 = temporaryFolder.newFolder("jdks/jdk-123")
+        def install1 = new File(temporaryFolder, "jdks/jdk-123").tap { mkdirs() }
         new File(install1, "provisioned.ok").createNewFile()
 
-        def install2 = temporaryFolder.newFolder("jdks/jdk-345")
+        def install2 = new File(temporaryFolder, "jdks/jdk-345").tap { mkdirs() }
         new File(install2, "provisioned.ok").createNewFile()
 
-        def install3 = temporaryFolder.newFolder("jdks/jdk-mac/Contents/Home")
-        new File(temporaryFolder.getRoot(), "jdks/jdk-mac/provisioned.ok").createNewFile()
+        def install3 = new File(temporaryFolder, "jdks/jdk-mac/Contents/Home").tap { mkdirs() }
+        new File(temporaryFolder, "jdks/jdk-mac/provisioned.ok").createNewFile()
 
-        temporaryFolder.newFolder("jdks/notReady")
+        new File(temporaryFolder, "jdks/notReady").tap { mkdirs() }
 
         when:
         def homes = jdkCacheDirectory.listJavaHomes()
@@ -71,7 +71,7 @@ class JdkCacheDirectoryTest extends Specification {
 
     def "provisions jdk from tar.gz archive"() {
         def jdkArchive = resources.getResource("jdk.tar.gz")
-        def jdkCacheDirectory = new JdkCacheDirectory(newHomeDirProvider(), TestFiles.fileOperations(temporaryFolder.root, tmpFileProvider()), mockLockManager())
+        def jdkCacheDirectory = new JdkCacheDirectory(newHomeDirProvider(), TestFiles.fileOperations(temporaryFolder, tmpFileProvider()), mockLockManager())
 
         when:
         def installedJdk = jdkCacheDirectory.provisionFromArchive(jdkArchive)
@@ -84,7 +84,7 @@ class JdkCacheDirectoryTest extends Specification {
 
     def "provisions jdk from zip archive"() {
         def jdkArchive = resources.getResource("jdk.zip")
-        def jdkCacheDirectory = new JdkCacheDirectory(newHomeDirProvider(), TestFiles.fileOperations(temporaryFolder.root, tmpFileProvider()), mockLockManager())
+        def jdkCacheDirectory = new JdkCacheDirectory(newHomeDirProvider(), TestFiles.fileOperations(temporaryFolder, tmpFileProvider()), mockLockManager())
 
         when:
         def installedJdk = jdkCacheDirectory.provisionFromArchive(jdkArchive)
@@ -100,14 +100,13 @@ class JdkCacheDirectoryTest extends Specification {
         new GradleUserHomeDirProvider() {
             @Override
             File getGradleUserHomeDirectory() {
-                temporaryFolder.create()
-                return temporaryFolder.root
+                return temporaryFolder
             }
         }
     }
 
     TemporaryFileProvider tmpFileProvider() {
-        new DefaultTemporaryFileProvider({ temporaryFolder.root })
+        new DefaultTemporaryFileProvider({ temporaryFolder })
     }
 
     FileLockManager mockLockManager() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
@@ -22,14 +22,13 @@ import org.gradle.internal.logging.text.TestStyledTextOutput
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.jvm.toolchain.internal.task.ReportableToolchain
 import org.gradle.jvm.toolchain.internal.task.ToolchainReportRenderer
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class ToolchainReportRendererTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder
+    @TempDir
+    File temporaryFolder
 
     InstallationLocation installation = Mock(InstallationLocation)
 
@@ -57,7 +56,7 @@ class ToolchainReportRendererTest extends Specification {
 
     def "jdk is rendered properly"() {
         given:
-        File javaHome = temporaryFolder.newFolder("javahome")
+        File javaHome = new File(temporaryFolder, "javahome").tap { mkdirs() }
         def metadata = JvmInstallationMetadata.from(
             javaHome,
             "1.8.0",

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/modulemap/GenerateModuleMapFileTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/modulemap/GenerateModuleMapFileTest.groovy
@@ -16,20 +16,19 @@
 
 package org.gradle.nativeplatform.internal.modulemap
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.nativeplatform.internal.modulemap.GenerateModuleMapFile.generateFile
 import static org.gradle.util.internal.TextUtil.normaliseLineSeparators
 
 class GenerateModuleMapFileTest extends Specification {
-    @Rule TemporaryFolder tempDir = new TemporaryFolder()
+    @TempDir File tempDir
 
     def "can generate a simple module map file"() {
-        def moduleMapFile = tempDir.newFile("module.modulemap")
-        def headers = tempDir.newFolder('headers')
-        def moreHeaders = tempDir.newFolder('moreHeaders')
+        def moduleMapFile = new File(tempDir, "module.modulemap")
+        def headers = new File(tempDir, 'headers').tap { mkdirs() }
+        def moreHeaders = new File(tempDir, 'moreHeaders').tap { mkdirs() }
 
         when:
         generateFile(moduleMapFile, "foo", [headers.absolutePath, moreHeaders.absolutePath])
@@ -44,9 +43,9 @@ class GenerateModuleMapFileTest extends Specification {
     }
 
     def "does not include non-existent directories"() {
-        def moduleMapFile = tempDir.newFile("module.modulemap")
-        def headers = tempDir.newFolder('headers')
-        def moreHeaders = tempDir.newFolder('moreHeaders')
+        def moduleMapFile = new File(tempDir, "module.modulemap")
+        def headers = new File(tempDir, 'headers').tap { mkdirs() }
+        def moreHeaders = new File(tempDir, 'moreHeaders').tap { mkdirs() }
 
         when:
         generateFile(moduleMapFile, "foo", [headers.absolutePath, moreHeaders.absolutePath, new File('does-not-exist').absolutePath])
@@ -61,9 +60,9 @@ class GenerateModuleMapFileTest extends Specification {
     }
 
     def "creates parent directory if necessary"() {
-        def moduleMapFile = new File(tempDir.root, "maps/module.modulemap")
-        def headers = tempDir.newFolder('headers')
-        def moreHeaders = tempDir.newFolder('moreHeaders')
+        def moduleMapFile = new File(tempDir, "maps/module.modulemap")
+        def headers = new File(tempDir, 'headers').tap { mkdirs() }
+        def moreHeaders = new File(tempDir, 'moreHeaders').tap { mkdirs() }
 
         given:
         assert !moduleMapFile.parentFile.exists()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractGradleceptionSmokeTest.groovy
@@ -40,7 +40,7 @@ abstract class AbstractGradleceptionSmokeTest extends AbstractSmokeTest {
     protected BuildResult result
 
     def setup() {
-        new TestFile("build/gradleBuildCurrent").copyTo(testProjectDir.root)
+        new TestFile("build/gradleBuildCurrent").copyTo(testProjectDir)
 
         and:
         def buildJavaHome = AvailableJavaHomes.getAvailableJdks(new GradleBuildJvmSpec()).last().javaHome

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -34,9 +34,8 @@ import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.createMirrorInitScript
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
@@ -206,15 +205,15 @@ abstract class AbstractSmokeTest extends Specification {
 
     private static final String INIT_SCRIPT_LOCATION = "org.gradle.smoketests.init.script"
 
-    @Rule
-    final TemporaryFolder testProjectDir = new TemporaryFolder()
+    @TempDir
+    File testProjectDir
     File buildFile
 
     File settingsFile
 
     def setup() {
-        buildFile = new File(testProjectDir.root, defaultBuildFileName)
-        settingsFile = new File(testProjectDir.root, "settings.gradle")
+        buildFile = new File(testProjectDir, defaultBuildFileName)
+        settingsFile = new File(testProjectDir, "settings.gradle")
     }
 
     protected String getDefaultBuildFileName() {
@@ -222,11 +221,11 @@ abstract class AbstractSmokeTest extends Specification {
     }
 
     void withKotlinBuildFile() {
-        buildFile = new File(testProjectDir.root, "${getDefaultBuildFileName()}.kts")
+        buildFile = new File(testProjectDir, "${getDefaultBuildFileName()}.kts")
     }
 
     TestFile file(String filename) {
-        def file = new TestFile(testProjectDir.root, filename)
+        def file = new TestFile(testProjectDir, filename)
         def parentDir = file.getParentFile()
         assert parentDir.isDirectory() || parentDir.mkdirs()
 
@@ -237,7 +236,7 @@ abstract class AbstractSmokeTest extends Specification {
         def gradleRunner = GradleRunner.create()
             .withGradleInstallation(IntegrationTestBuildContext.INSTANCE.gradleHomeDir)
             .withTestKitDir(IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
-            .withProjectDir(testProjectDir.root)
+            .withProjectDir(testProjectDir)
             .forwardOutput()
             .withArguments(
                 tasks.toList() + outputParameters() + repoMirrorParameters() + configurationCacheParameters()
@@ -309,7 +308,7 @@ abstract class AbstractSmokeTest extends Specification {
 
     protected void useSample(String sampleDirectory) {
         def smokeTestDirectory = new File(this.getClass().getResource(sampleDirectory).toURI())
-        FileUtils.copyDirectory(smokeTestDirectory, testProjectDir.root)
+        FileUtils.copyDirectory(smokeTestDirectory, testProjectDir)
     }
 
     protected SmokeTestGradleRunner useAgpVersion(String agpVersion, SmokeTestGradleRunner runner) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -34,7 +34,7 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
         def springVersion = springVersion
         def bomVersion = bomVersion
 
-        def settingsFile = testProjectDir.newFile('settings.gradle')
+        def settingsFile = new File(testProjectDir, 'settings.gradle')
         settingsFile << """
             rootProject.name = 'springbootproject'
         """

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GrettySmokeTest.groovy
@@ -51,7 +51,7 @@ class GrettySmokeTest extends AbstractPluginValidatingSmokeTest {
                 httpPort = 0
                 integrationTestTask = 'checkContainerUp'
                 servletContainer = 'jetty9'
-                logDir = '${testProjectDir.root.absolutePath}/jetty-logs'
+                logDir = '${testProjectDir.absolutePath}/jetty-logs'
                 logFileName = project.name
             }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JGitPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JGitPluginSmokeTest.groovy
@@ -28,7 +28,7 @@ class JGitPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     @ToBeFixedForConfigurationCache(because = "Gradle.buildFinished")
     def 'org.ajoberstar.grgit plugin'() {
         given:
-        GitFileRepository.init(testProjectDir.root)
+        GitFileRepository.init(testProjectDir)
         buildFile << """
             plugins {
                 id "org.ajoberstar.grgit" version "${TestedVersions.grgit}"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -39,11 +39,11 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         def androidPluginVersion = AGP_VERSIONS.getLatestOfMinor("4.2")
         def arch = OperatingSystem.current().macOsX ? 'MacosX64' : 'LinuxX64'
 
-        def expectedMetadata = new File(testProjectDir.root, 'expected-metadata')
-        def actualRepo = new File(testProjectDir.root, 'producer/repo')
+        def expectedMetadata = new File(testProjectDir, 'expected-metadata')
+        def actualRepo = new File(testProjectDir, 'producer/repo')
 
         when:
-        buildFile = new File(testProjectDir.root, "producer/${defaultBuildFileName}.kts")
+        buildFile = new File(testProjectDir, "producer/${defaultBuildFileName}.kts")
         replaceVariablesInBuildFile(
             kotlinVersion: kotlinVersion,
             androidPluginVersion: androidPluginVersion)
@@ -61,7 +61,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         }
 
         when:
-        buildFile = new File(testProjectDir.root, "consumer/${defaultBuildFileName}.kts")
+        buildFile = new File(testProjectDir, "consumer/${defaultBuildFileName}.kts")
         replaceVariablesInBuildFile(
             kotlinVersion: kotlinVersion,
             androidPluginVersion: androidPluginVersion)
@@ -128,7 +128,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
 
     private BuildResult publish() {
         setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(runner('publish'))
-            .withProjectDir(new File(testProjectDir.root, 'producer'))
+            .withProjectDir(new File(testProjectDir, 'producer'))
             .forwardOutput()
             // this deprecation is coming from the Kotlin plugin
             .expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. " +
@@ -141,7 +141,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
 
     private BuildResult consumer(String runTask) {
         setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(runner(runTask, '-q'))
-            .withProjectDir(new File(testProjectDir.root, 'consumer'))
+            .withProjectDir(new File(testProjectDir, 'consumer'))
             .forwardOutput()
             .build()
     }
@@ -149,7 +149,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     // Reevaluate if this is still needed when upgrading android plugin. Currently required with version 4.2.2
     private BuildResult consumerWithJdk16WorkaroundForAndroidManifest(String runTask) {
         def runner = runner(runTask, '-q')
-            .withProjectDir(new File(testProjectDir.root, 'consumer'))
+            .withProjectDir(new File(testProjectDir, 'consumer'))
             .forwardOutput()
         if (JavaVersion.current().isJava9Compatible()) {
             runner.withJvmArguments("--add-opens", "java.base/java.io=ALL-UNNAMED")

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -34,8 +34,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
                 testImplementation gradleTestKit()
                 testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
                 testImplementation("org.spockframework:spock-core")
-                testImplementation("org.spockframework:spock-junit4")
-                testImplementation 'junit:junit:4.13.1'
             }
 
             test.useJUnitPlatform()
@@ -68,21 +66,20 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
         """
             import org.gradle.testkit.runner.GradleRunner
             import static org.gradle.testkit.runner.TaskOutcome.*
-            import org.junit.Rule
-            import org.junit.rules.TemporaryFolder
             import spock.lang.Specification
+            import spock.lang.TempDir
 
             class Test extends Specification {
-                @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+                @TempDir File testProjectDir
                 File buildFile
 
                 def setup() {
-                    def buildSrcDir = testProjectDir.newFolder('buildSrc', 'src', 'main', 'java')
+                    def buildSrcDir = new File(testProjectDir, 'buildSrc/src/main/java').tap { mkdirs() }
                     def pluginFile = new File(buildSrcDir, 'BuildScanPlugin.java')
                     pluginFile << '''${buildScanPlugin()}'''
-                    def settingsFile = testProjectDir.newFile('settings.gradle')
+                    def settingsFile = new File(testProjectDir, 'settings.gradle')
                     settingsFile << "rootProject.name = 'test'"
-                    buildFile = testProjectDir.newFile('build.gradle')
+                    buildFile = new File(testProjectDir, 'build.gradle')
                     buildFile << '''${buildScanPluginApplication()}'''
                 }
 
@@ -109,7 +106,7 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
     static String gradleRunnerWithoutStandardInput() {
         """
             GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments('$DUMMY_TASK_NAME')
                 .withDebug($debug)
                 .build()
@@ -119,7 +116,7 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
     static String gradleRunnerWithStandardInput() {
         """
             GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
+                .withProjectDir(testProjectDir)
                 .withArguments('$DUMMY_TASK_NAME')
                 .withDebug($debug)
                 .withStandardInput(System.in)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -36,8 +36,6 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
             dependencies {
                 testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
                 testImplementation("org.spockframework:spock-core")
-                testImplementation("org.spockframework:spock-junit4")
-                testImplementation 'junit:junit:4.13.1'
             }
             test.useJUnitPlatform()
         """
@@ -47,22 +45,21 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
         file("src/test/groovy/Test.groovy") << """
             import org.gradle.testkit.runner.GradleRunner
             import static org.gradle.testkit.runner.TaskOutcome.*
-            import org.junit.Rule
-            import org.junit.rules.TemporaryFolder
             import spock.lang.Specification
+            import spock.lang.TempDir
 
             class Test extends Specification {
 
-                @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+                @TempDir File testProjectDir
 
                 def "execute helloWorld task"() {
                     given:
-                    testProjectDir.newFile('settings.gradle') << "rootProject.name = 'plugin-test'"
-                    testProjectDir.newFile('build.gradle') << '''$plugin.useDeclaration'''
+                    new File(testProjectDir, 'settings.gradle') << "rootProject.name = 'plugin-test'"
+                    new File(testProjectDir, 'build.gradle') << '''$plugin.useDeclaration'''
 
                     when:
                     def result = GradleRunner.create()
-                        .withProjectDir(testProjectDir.root)
+                        .withProjectDir(testProjectDir)
                         .withArguments('helloWorld')
                         .withPluginClasspath()
                         .withDebug($debug)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
@@ -49,8 +49,6 @@ class GradleRunnerDefaultTestKitDirIntegrationTest extends BaseGradleRunnerInteg
                 implementation localGroovy()
                 testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
                 testImplementation("org.spockframework:spock-core")
-                testImplementation("org.spockframework:spock-junit4")
-                testImplementation("junit:junit:4.13.1")
             }
 
             ${mavenCentralRepository()}

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -46,8 +46,6 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
                 implementation localGroovy()
                 testImplementation(platform("org.spockframework:spock-bom:2.0-groovy-3.0"))
                 testImplementation("org.spockframework:spock-core")
-                testImplementation("org.spockframework:spock-junit4")
-                testImplementation 'junit:junit:4.13.1'
                 testImplementation gradleTestKit()
                 testImplementation files(createClasspathManifest)
             }
@@ -65,17 +63,16 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
         file("src/test/groovy/Test.groovy") << """
             import org.gradle.testkit.runner.GradleRunner
             import static org.gradle.testkit.runner.TaskOutcome.*
-            import org.junit.Rule
-            import org.junit.rules.TemporaryFolder
             import spock.lang.Specification
+            import spock.lang.TempDir
 
             class Test extends Specification {
-                @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+                @TempDir File testProjectDir
                 File buildFile
 
                 def setup() {
-                    testProjectDir.newFile('settings.gradle') << "rootProject.name = 'test'"
-                    buildFile = testProjectDir.newFile('build.gradle')
+                    new File(testProjectDir, 'settings.gradle') << "rootProject.name = 'test'"
+                    buildFile = new File(testProjectDir, 'build.gradle')
                     def pluginClasspath = getClass().classLoader.findResource("plugin-classpath.txt")
                       .readLines()
                       .collect { it.replace('\\\\', '\\\\\\\\') } // escape backslashes in Windows paths
@@ -97,7 +94,7 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
 
                     when:
                     def result = GradleRunner.create()
-                        .withProjectDir(testProjectDir.root)
+                        .withProjectDir(testProjectDir)
                         .withArguments('helloWorld')
                         .withDebug($debug)
                         .build()
@@ -119,18 +116,17 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
         file("src/test/groovy/Test.groovy") << """
             import org.gradle.testkit.runner.GradleRunner
             import static org.gradle.testkit.runner.TaskOutcome.*
-            import org.junit.Rule
-            import org.junit.rules.TemporaryFolder
             import spock.lang.Specification
+            import spock.lang.TempDir
 
             class Test extends Specification {
-                @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+                @TempDir File testProjectDir
                 File buildFile
                 List<File> pluginClasspath
 
                 def setup() {
-                    testProjectDir.newFile('settings.gradle') << "rootProject.name = 'test'"
-                    buildFile = testProjectDir.newFile('build.gradle')
+                    new File(testProjectDir, 'settings.gradle') << "rootProject.name = 'test'"
+                    buildFile = new File(testProjectDir, 'build.gradle')
                     pluginClasspath = getClass().classLoader.findResource("plugin-classpath.txt")
                       .readLines()
                       .collect { new File(it) }
@@ -142,7 +138,7 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
 
                     when:
                     def result = GradleRunner.create()
-                        .withProjectDir(testProjectDir.root)
+                        .withProjectDir(testProjectDir)
                         .withArguments('helloWorld')
                         .withPluginClasspath(pluginClasspath)
                         .withDebug($debug)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/CompositeDeduplicationCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/CompositeDeduplicationCrossVersionSpec.groovy
@@ -20,15 +20,10 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.model.eclipse.EclipseProject
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
 @ToolingApiVersion(">=5.5")
 @TargetGradleVersion(">=4.0")
 class CompositeDeduplicationCrossVersionSpec extends ToolingApiSpecification {
-
-    @Rule
-    TemporaryFolder externalProjectFolder = new TemporaryFolder()
 
     def setup() {
         buildFile << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
@@ -22,15 +22,14 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.EclipseWorkspace
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import spock.lang.TempDir
 
 @TargetGradleVersion('>=5.5')
 @ToolingApiVersion(">=5.5")
 class ReservedProjectNamesCrossVersionSpec extends ToolingApiSpecification {
 
-    @Rule
-    TemporaryFolder externalProjectFolder = new TemporaryFolder();
+    @TempDir
+    File externalProjectFolder
 
     def setup() {
         buildFile << """
@@ -160,7 +159,7 @@ class ReservedProjectNamesCrossVersionSpec extends ToolingApiSpecification {
     }
 
     EclipseWorkspace eclipseWorkspace(List<EclipseWorkspaceProject> projects) {
-        new DefaultEclipseWorkspace(externalProjectFolder.newFolder("workspace"), projects)
+        new DefaultEclipseWorkspace(new File(externalProjectFolder, "workspace").tap { mkdirs() }, projects)
     }
 
     EclipseWorkspaceProject gradleProject(String name) {
@@ -172,7 +171,7 @@ class ReservedProjectNamesCrossVersionSpec extends ToolingApiSpecification {
     }
 
     EclipseWorkspaceProject externalProject(String name) {
-        new DefaultEclipseWorkspaceProject(name, externalProjectFolder.newFolder(name))
+        new DefaultEclipseWorkspaceProject(name, new File(externalProjectFolder, name).tap { mkdirs() })
     }
 
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ClosedProjectSubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ClosedProjectSubstitutionCrossVersionSpec.groovy
@@ -22,17 +22,12 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.EclipseWorkspace
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 
 import java.util.regex.Pattern
 
 @TargetGradleVersion(">=5.6")
 @ToolingApiVersion(">=5.6")
 class ClosedProjectSubstitutionCrossVersionSpec extends ToolingApiSpecification {
-
-    @Rule
-    TemporaryFolder externalProjectFolder = new TemporaryFolder()
 
     def "will substitute and run build dependencies for closed projects on startup"() {
         setup:

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DefaultWorkerExecutorParallelTest.groovy
@@ -34,16 +34,15 @@ import org.gradle.util.UsesNativeServices
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutionException
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import spock.lang.TempDir
 import spock.lang.Unroll
 
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RETAIN_PROJECT_LOCKS
 
 @UsesNativeServices
 class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+    @TempDir
+    public File temporaryFolder
     def workerDaemonFactory = Mock(WorkerFactory)
     def workerInProcessFactory = Mock(WorkerFactory)
     def workerNoIsolationFactory = Mock(WorkerFactory)
@@ -55,7 +54,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         fileCollection() >> { TestFiles.fileCollectionFactory().configurableFiles() }
     }
     def workerDirectoryProvider = Stub(WorkerDirectoryProvider) {
-        getWorkingDirectory() >> { temporaryFolder.root }
+        getWorkingDirectory() >> { temporaryFolder }
     }
     def executionQueueFactory = Mock(WorkerExecutionQueueFactory)
     def executionQueue = Mock(ConditionalExecutionQueue)
@@ -70,7 +69,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         _ * instantiator.newInstance(DefaultClassLoaderWorkerSpec) >> { args -> new DefaultClassLoaderWorkerSpec(objectFactory) }
         _ * instantiator.newInstance(DefaultProcessWorkerSpec, _) >> { args -> new DefaultProcessWorkerSpec(args[1][0], objectFactory) }
         _ * instantiator.newInstance(DefaultWorkerExecutor.DefaultWorkQueue, _, _, _) >> { args -> new DefaultWorkerExecutor.DefaultWorkQueue(args[1][0], args[1][1], args[1][2]) }
-        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator, temporaryFolder.root)
+        workerExecutor = new DefaultWorkerExecutor(workerDaemonFactory, workerInProcessFactory, workerNoIsolationFactory, forkOptionsFactory, buildOperationWorkerRegistry, buildOperationExecutor, asyncWorkerTracker, workerDirectoryProvider, executionQueueFactory, classLoaderStructureProvider, actionExecutionSpecFactory, instantiator, temporaryFolder)
         _ * actionExecutionSpecFactory.newIsolatedSpec(_, _, _, _, _) >> Mock(IsolatedParametersActionExecutionSpec)
     }
 
@@ -147,7 +146,7 @@ class DefaultWorkerExecutorParallelTest extends ConcurrentSpec {
         @Override
         JavaForkOptionsInternal newJavaForkOptions() {
             def forkOptions = delegate.newJavaForkOptions()
-            forkOptions.setWorkingDir(temporaryFolder.root)
+            forkOptions.setWorkingDir(temporaryFolder)
             return forkOptions
         }
 


### PR DESCRIPTION
### Context
Using JUnit 4 and the `spock-junit4`  module is only necessary if you want to use JUnit 4 rules with Spock 2+.
For the `TemporaryDirectory` rule there is a built-in `TempDir` native extension as a replacement.

All other rules could be used on a best-effort basis with the `spock-junit4` module, but it is preferable to use native Spock extensions for that instead of JUnit 4 rules.

All the examples in the documentation add JUnit 4 as dependency and the `spock-junit4` module.
But this is absolutely unnecessary in all cases.
In some cases not a single `@Rule` was used and in the cases a `@Rule` was used it was always `TemporaryDirectory` which can easily be replaced by `@TempDir`.

This constellation which should only be used if you depend on JUnit 4 rules, more confuses users than it benefits and somehow gives the impression Spock would still use JUnit 4 or whatever. Anyway it is more confusing than anything else, as can also be seen for example at https://discuss.gradle.org/t/spock-tests-dont-run-with-gradle-7-groovy-3/40139/4 and https://gradle-community.slack.com/archives/CAHSN3LDN/p1626283884050700?thread_ts=1619218822.359300&cid=CAHSN3LDN.

This PR removes JUnit 4 and `spock-junit4` from all documentation samples and snippets and also replaces all Gradle internal usages of the `TemporaryDirectory` rule by the `@TempDir` extension.

My recommendation would even be to replace all the custom rules, by custom Spock extensions, but that is not in the scope of this PR which is mainly for better examples for the users.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
