### PR TITLE
Re-add test filtering plugin

### DIFF
--- a/build-logic-settings/settings.gradle.kts
+++ b/build-logic-settings/settings.gradle.kts
@@ -23,4 +23,5 @@ dependencyResolutionManagement {
 }
 
 include("allprojects-plugin")
+include("testfiltering-plugin")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,8 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     id("com.gradle.enterprise.test-distribution").version("2.1.1") // Sync with `build-logic/build-platform/build.gradle.kts`
-    id("com.gradle.internal.test-selection").version("0.6.0-rc-1")
+    id("gradlebuild.internal.testfiltering")
+    id("com.gradle.internal.test-selection").version("0.6.4-rc-1")
 }
 
 includeBuild("build-logic-commons")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
     id("com.gradle.enterprise.test-distribution").version("2.1.1") // Sync with `build-logic/build-platform/build.gradle.kts`
+    id("com.gradle.internal.test-selection").version("0.6.0-rc-1")
 }
 
 includeBuild("build-logic-commons")


### PR DESCRIPTION
This undoes https://github.com/gradle/gradle/pull/17691 and updates the plugin to the latest version