### PR TITLE
Disable file system watching on FAT

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -215,10 +215,8 @@ The feature supports the following file system types:
 
 - APFS
 - btrfs
-- exFAT
 - ext3
 - ext4
-- FAT32
 - HFS+
 - NTFS
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultWatchableFileSystemDetector.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultWatchableFileSystemDetector.java
@@ -43,12 +43,8 @@ public class DefaultWatchableFileSystemDetector implements WatchableFileSystemDe
         "NTFS",
         // FAT32 on macOS
         "msdos",
-        // FAT32 on Windows
-        "FAT32",
         // exFAT on macOS
         "exfat",
-        // exFAT on Windows
-        "exFAT",
         // VirtualBox FS
         "vboxsf"
     );


### PR DESCRIPTION
We switched to `ReadDirectoryChangesExW` and that is
only supported for the NTFS file system.
So we can't watch FAT file systems on Windows any more.

#17551