### PR TITLE
Not compile test sources in compileAll

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -5,8 +5,8 @@ import model.Stage
 
 class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id(buildTypeId(model))
-    name = "Compile All"
-    description = "Compiles all the source code and warms up the build cache"
+    name = "Compile All Production"
+    description = "Compiles all production source code and warms up the build cache"
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/CompileAllProduction.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAllProduction.kt
@@ -3,7 +3,7 @@ package configurations
 import model.CIBuildModel
 import model.Stage
 
-class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
+class CompileAllProduction(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id(buildTypeId(model))
     name = "Compile All Production"
     description = "Compiles all production source code and warms up the build cache"

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -223,9 +223,9 @@ fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, notQuick
             }
         }
     }
-    if (buildType !is CompileAll) {
+    if (buildType !is CompileAllProduction) {
         buildType.dependencies {
-            compileAllDependency(CompileAll.buildTypeId(model))
+            compileAllDependency(CompileAllProduction.buildTypeId(model))
         }
     }
 }

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -8,7 +8,7 @@ import common.VersionedSettingsBranch
 import configurations.BaseGradleBuildType
 import configurations.BuildDistributions
 import configurations.CheckLinks
-import configurations.CompileAll
+import configurations.CompileAllProduction
 import configurations.FunctionalTest
 import configurations.Gradleception
 import configurations.SanityCheck
@@ -385,7 +385,7 @@ const val GRADLE_BUILD_SMOKE_TEST_NAME = "gradleBuildSmokeTest"
 enum class SpecificBuild {
     CompileAll {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return CompileAll(model, stage)
+            return CompileAllProduction(model, stage)
         }
     },
     SanityCheck {

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -26,7 +26,7 @@ import common.functionalTestExtraParameters
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
-import configurations.CompileAll
+import configurations.CompileAllProduction
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
@@ -105,6 +105,6 @@ class RerunFlakyTest(os: Os) : BuildType({
     }
 
     dependencies {
-        compileAllDependency(CompileAll.buildTypeId("Check"))
+        compileAllDependency(CompileAllProduction.buildTypeId("Check"))
     }
 })

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.basics.testing
 
+
 enum class TestType(val prefix: String, val executers: List<String>) {
     INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "configCache")),
     CROSSVERSION("crossVersion", listOf("embedded", "forking"))

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/testing/TestType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package gradlebuild.testing
-
+package gradlebuild.basics.testing
 
 enum class TestType(val prefix: String, val executers: List<String>) {
     INTEGRATION("integ", listOf("embedded", "forking", "noDaemon", "parallel", "configCache")),

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.cross-version-tests.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import gradlebuild.testing.TestType
+import gradlebuild.basics.testing.TestType
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.addSourceSet
 import gradlebuild.integrationtests.configureIde

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild.integration-tests.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import gradlebuild.testing.TestType
+import gradlebuild.basics.testing.TestType
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.addSourceSet
 import gradlebuild.integrationtests.configureIde

--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/shared-configuration.kt
@@ -22,7 +22,7 @@ import gradlebuild.basics.repoRoot
 import gradlebuild.integrationtests.extension.IntegrationTestExtension
 import gradlebuild.integrationtests.tasks.IntegrationTest
 import gradlebuild.modules.extension.ExternalModulesExtension
-import gradlebuild.testing.TestType
+import gradlebuild.basics.testing.TestType
 import gradlebuild.testing.services.BuildBucketProvider
 import org.gradle.api.Action
 import org.gradle.api.Project

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -16,7 +16,6 @@
 
 import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
 import gradlebuild.basics.BuildEnvironment
-import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
 import gradlebuild.filterEnvironmentVariables
@@ -140,11 +139,18 @@ fun addDependencies() {
 fun addCompileAllTask() {
     tasks.register("compileAll") {
         val compileTasks = project.tasks.matching {
-            it is JavaCompile || it is GroovyCompile
+            (it is JavaCompile || it is GroovyCompile) && !it.isTestCompile()
         }
         dependsOn(compileTasks)
     }
 }
+
+fun Task.isTestCompile() =
+    listOf(
+        "compileCrossVersionTest",
+        "compileTest",
+        "compileIntegTest"
+    ).any { name.startsWith(it) }
 
 fun configureJarTasks() {
     tasks.withType<Jar>().configureEach {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -147,7 +147,7 @@ fun addCompileAllTask() {
 }
 
 val testCompileTasks
-    get() = TestType.values().map { "compile${it.prefix.toUpperCase()}Test" } + "compileTest"
+    get() = TestType.values().map { "compile${it.prefix.toUpperCase()}Test" } + listOf("compileTestGroovy", "compileTestKotlin")
 
 fun Task.isTestCompile() = testCompileTasks.any { name.startsWith(it) }
 

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -18,6 +18,7 @@ import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistribu
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
+import gradlebuild.basics.testing.TestType
 import gradlebuild.filterEnvironmentVariables
 import gradlebuild.jvm.argumentproviders.CiEnvironmentProvider
 import gradlebuild.jvm.extension.UnitTestAndCompileExtension
@@ -145,12 +146,10 @@ fun addCompileAllTask() {
     }
 }
 
-fun Task.isTestCompile() =
-    listOf(
-        "compileCrossVersionTest",
-        "compileTest",
-        "compileIntegTest"
-    ).any { name.startsWith(it) }
+val testCompileTasks
+    get() = TestType.values().map { "compile${it.prefix.toUpperCase()}Test" } + "compileTest"
+
+fun Task.isTestCompile() = testCompileTasks.any { name.startsWith(it) }
 
 fun configureJarTasks() {
     tasks.withType<Jar>().configureEach {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -139,6 +139,15 @@ fun addDependencies() {
 
 fun addCompileAllTask() {
     tasks.register("compileAll") {
+        description = "Compile all source code, including main, test, integTest, crossVersionTest, testFixtures, etc."
+        val compileTasks = project.tasks.matching {
+            it is JavaCompile || it is GroovyCompile
+        }
+        dependsOn(compileTasks)
+    }
+
+    tasks.register("compileAllProduction") {
+        description = "Compile all production source code, usually only main and testFixtures."
         val compileTasks = project.tasks.matching {
             (it is JavaCompile || it is GroovyCompile) && !it.isTestCompile()
         }

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.ci-lifecycle.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.ci-lifecycle.gradle.kts
@@ -33,7 +33,7 @@ fun TaskContainer.registerEarlyFeedbackLifecycleTasks() {
     register("compileAllBuild") {
         description = "Initialize CI Pipeline by priming the cache before fanning out"
         group = ciGroup
-        dependsOn("compileAll")
+        dependsOn("compileAllProduction")
     }
 
     register("sanityCheck") {


### PR DESCRIPTION
Let's see how much it can save from `compileAll` build.