### PR TITLE
Remove Kotlin JPMS workaround for Java 16

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/JpmsConfiguration.java
@@ -43,21 +43,6 @@ public class JpmsConfiguration {
 
     public static final List<String> GRADLE_DAEMON_JPMS_ARGS;
 
-    public static final List<String> gradleDaemonJpmsArgs(List<String> existingJvmArgs) {
-        List<String> result = new ArrayList<String>(GRADLE_DAEMON_JPMS_ARGS);
-
-        String kotlinCompilerOptions = null;
-        for (String jvmArg : existingJvmArgs) {
-            if (jvmArg.startsWith("-Dkotlin.daemon.jvm.options=")) {
-                kotlinCompilerOptions = jvmArg.substring(28);
-            }
-        }
-        if (kotlinCompilerOptions != null) {
-            result.add(result.size() - 1, "-Dkotlin.daemon.jvm.options=--illegal-access=permit " + kotlinCompilerOptions);
-        }
-        return result;
-    }
-
     static {
         List<String> gradleDaemonJvmArgs = new ArrayList<String>();
         gradleDaemonJvmArgs.addAll(GROOVY_JPMS_ARGS);
@@ -69,10 +54,6 @@ public class JpmsConfiguration {
             "--add-opens", "java.base/java.util.concurrent.atomic=ALL-UNNAMED" // serialized from org.gradle.internal.file.StatStatistics$Collector
         ));
         gradleDaemonJvmArgs.addAll(configurationCacheJpmsArgs);
-
-        // Workaround until external kotlin-dsl plugins support JDK16 properly
-        // https://youtrack.jetbrains.com/issue/KT-43704 - should be in 1.5.x line
-        gradleDaemonJvmArgs.add("-Dkotlin.daemon.jvm.options=--illegal-access=permit");
 
         GRADLE_DAEMON_JPMS_ARGS = Collections.unmodifiableList(gradleDaemonJvmArgs);
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -126,7 +126,7 @@ public class DaemonParameters {
     public void applyDefaultsFor(JavaVersion javaVersion) {
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
             jvmOptions.jvmArgs(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
-            jvmOptions.jvmArgs(JpmsConfiguration.gradleDaemonJpmsArgs(jvmOptions.getAllJvmArgs()));
+            jvmOptions.jvmArgs(JpmsConfiguration.GRADLE_DAEMON_JPMS_ARGS);
         }
         if (hasJvmArgs) {
             return;

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.smoketests
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 import spock.lang.Unroll
@@ -58,7 +58,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         def versionNumber = VersionNumber.parse(version)
 
         when:
-        def result = runner(workers, 'run')
+        def result = runner(workers, versionNumber, 'run')
             .expectLegacyDeprecationWarningIf(workers && versionNumber < KOTLIN_VERSION_USING_NEW_WORKERS_API,
                 "The WorkerExecutor.submit() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 8.0. Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. " +
@@ -74,7 +74,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         assert result.output.contains("Hello world!")
 
         when:
-        result = runner(workers, 'run')
+        result = runner(workers, versionNumber, 'run')
             .expectLegacyDeprecationWarningIf(!GradleContextualExecuter.configCache && versionNumber < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API,
                 ARTIFACT_TRANSFORM_DEPRECATION_WARNING
             )
@@ -102,7 +102,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         def versionNumber = VersionNumber.parse(version)
 
         when:
-        def result = runner(workers, 'compileKotlin2Js')
+        def result = runner(workers, versionNumber, 'compileKotlin2Js')
             .expectLegacyDeprecationWarningIf(workers && versionNumber < KOTLIN_VERSION_USING_NEW_WORKERS_API,
                 "The WorkerExecutor.submit() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 8.0. Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. " +
@@ -161,10 +161,11 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         file("src/main/groovy/Groovy.groovy") << "class Groovy { }"
         file("src/main/kotlin/Kotlin.kt") << "class Kotlin { val groovy = Groovy() }"
         file("src/main/java/Java.java") << "class Java { private Kotlin kotlin = new Kotlin(); }" // dependency to compileJava->compileKotlin is added by Kotlin plugin
+        def versionNumber = VersionNumber.parse(kotlinVersion)
 
         when:
-        def result = runner(false, 'compileJava')
-            .expectLegacyDeprecationWarningIf(VersionNumber.parse(kotlinVersion) < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API, ARTIFACT_TRANSFORM_DEPRECATION_WARNING)
+        def result = runner(false, versionNumber, 'compileJava')
+            .expectLegacyDeprecationWarningIf(versionNumber < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API, ARTIFACT_TRANSFORM_DEPRECATION_WARNING)
             .build()
 
 
@@ -195,17 +196,18 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
             }
         """
         file("src/main/kotlin/Kotlin.kt") << "class Kotlin { }"
+        def versionNumber = VersionNumber.parse(kotlinVersion)
 
         when:
-        def result = runner(false, 'build')
-            .expectLegacyDeprecationWarningIf(VersionNumber.parse(kotlinVersion) < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API, ARTIFACT_TRANSFORM_DEPRECATION_WARNING)
+        def result = runner(false, versionNumber, 'build')
+            .expectLegacyDeprecationWarningIf(versionNumber < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API, ARTIFACT_TRANSFORM_DEPRECATION_WARNING)
             .build()
 
         then:
         result.task(':compileKotlin').outcome == SUCCESS
 
         when:
-        result = runner(false, 'build')
+        result = runner(false, versionNumber, 'build')
             .expectLegacyDeprecationWarningIf(!GradleContextualExecuter.configCache && VersionNumber.parse(kotlinVersion) < KOTLIN_VERSION_USING_NEW_TRANSFORMS_API, ARTIFACT_TRANSFORM_DEPRECATION_WARNING)
             .build()
 
@@ -216,11 +218,10 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
         kotlinVersion << TestedVersions.kotlin.versions
     }
 
-    private BuildResult build(boolean workers, String... tasks) {
-        return runner(workers, *tasks).build()
-    }
-
-    private SmokeTestGradleRunner runner(boolean workers, String... tasks) {
+    private SmokeTestGradleRunner runner(boolean workers, VersionNumber kotlinVersion, String... tasks) {
+        if (kotlinVersion.getMinor() < 5 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            return KotlinPluginSmokeTest.runnerFor(this, workers, "-Dkotlin.daemon.jvm.options=--illegal-access=permit", *tasks)
+        }
         return KotlinPluginSmokeTest.runnerFor(this, workers, *tasks)
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -118,10 +118,13 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     }
 
     private BuildResult publish() {
-        runner('publish')
-            .withProjectDir(new File(testProjectDir.root, 'producer'))
+        def r = runner('publish')
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+            r = runner('publish', '-Dkotlin.daemon.jvm.options=--illegal-access=permit')
+        }
+        r.withProjectDir(new File(testProjectDir.root, 'producer'))
             .forwardOutput()
-        // this deprecation is coming from the Kotlin plugin
+            // this deprecation is coming from the Kotlin plugin
             .expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. " +
                 "This is scheduled to be removed in Gradle 8.0. " +
                 "Please use the destinationDirectory property instead. " +
@@ -135,7 +138,7 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
             new File(testProjectDir.root, 'consumer')).forwardOutput().build()
     }
 
-    // Reevaluate if this is still needed when upgrading android plugin. Currently required with version 4.1.2
+    // Reevaluate if this is still needed when upgrading android plugin. Currently required with version 4.2.2
     private BuildResult consumerWithJdk16WorkaroundForAndroidManifest(String runTask) {
         def runner = runner(runTask, '-q')
             .withProjectDir(new File(testProjectDir.root, 'consumer'))


### PR DESCRIPTION
Since Kotlin was upgraded to 1.5.x, this workaround is no longer needed.

Fixes #17075
