### PR TITLE
Add a parameter to control TD partition size

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -37,7 +37,7 @@ class FunctionalTest(
         model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
             listOf(functionalTestExtraParameters("FunctionalTest", testCoverage.os, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)) +
-                if (enableTestDistribution) "-DenableTestDistribution=%enableTestDistribution%" else "" +
+                if (enableTestDistribution) "-DenableTestDistribution=%enableTestDistribution% -DmaxTestDistributionPartitionSecond=%maxTestDistributionPartitionSecond%" else "" +
                 extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
         timeout = testCoverage.testType.timeout,

--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -37,7 +37,7 @@ class FunctionalTest(
         model, this, testTasks, notQuick = !testCoverage.isQuick, os = testCoverage.os,
         extraParameters = (
             listOf(functionalTestExtraParameters("FunctionalTest", testCoverage.os, testCoverage.testJvmVersion.major.toString(), testCoverage.vendor.name)) +
-                if (enableTestDistribution) "-DenableTestDistribution=%enableTestDistribution% -DmaxTestDistributionPartitionSecond=%maxTestDistributionPartitionSecond%" else "" +
+                if (enableTestDistribution) "-DenableTestDistribution=%enableTestDistribution% -DtestDistributionPartitionSizeInSeconds=%testDistributionPartitionSizeInSeconds%" else "" +
                 extraParameters
             ).filter { it.isNotBlank() }.joinToString(separator = " "),
         timeout = testCoverage.testType.timeout,

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -281,12 +281,12 @@ fun removeTeamcityTempProperty() {
 
 fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
 
-val isExperimentalTestFilteringEnabled
-    get() = System.getProperty("gradle.internal.testselection.enabled").toBoolean()
+val Project.isExperimentalTestFilteringEnabled
+    get() = providers.systemProperty("gradle.internal.testselection.enabled").forUseAtConfigurationTime().getOrElse("false").toBoolean()
 
 // Controls the test distribution partition size. The test classes smaller than this value will be merged into a "partition"
 val Project.maxTestDistributionPartitionSecond: Long?
-    get() = System.getProperty("maxTestDistributionPartitionSecond")?.toLong()
+    get() = providers.systemProperty("testDistributionPartitionSizeInSeconds").forUseAtConfigurationTime().orNull?.toLong()
 
 val Project.maxParallelForks: Int
     get() = (findProperty("maxParallelForks")?.toString()?.toInt() ?: 4) * (if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") 2 else 1)


### PR DESCRIPTION
We've tested the performance of different TD partition size. 

For a single job occupying all TD agents, the overall time only depends on the largest test class - it's almost same with different partition size. 

For many concurrent jobs, 30 seconds seems to be a better value:

`./gradlew eIT` without partition size configuration, https://ge.gradle.org/s/sbwu4to5j5rs2 13m35s
`./gradlew eIT`, with partition size=10s, https://ge.gradle.org/s/bvqt2s227mds2 16m28s
`./gradlew eIT`, with partition size=20s, https://ge.gradle.org/s/skechl6jsi7um 12m58s
`./gradlew eIT`, with partition size=30s, https://ge.gradle.org/s/b7ulih64qvbdm 12m17s
`./gradlew eIT`, with partition size=60s, https://ge.gradle.org/s/ts63kiuqoypia 13m11s
