### PR TITLE
Don't start another daemon process from launcher when the first one is not accessible

### DIFF
--- a/subprojects/docs/src/docs/userguide/troubleshooting.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting.adoc
@@ -152,6 +152,44 @@ If you're using link:https://projects.eclipse.org/projects/tools.buildship[Build
 .Refreshing a Gradle project in Eclipse Buildship
 image::troubleshooting-refresh-eclipse.png[]
 
+[[network_connection]]
+=== Troubleshooting daemon connection issues
+
+If your Gradle build fails before running any tasks, you may be encountering problems with your network configuration. When Gradle is unable to communicate with the Gradle daemon process, the build will immediately fail with a message similar to this:
+
+```
+$ gradle help
+
+Starting a Gradle Daemon, 1 stopped Daemon could not be reused, use --status for details
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+A new daemon was started but could not be connected to: pid=DaemonInfo{pid=55913, address=[7fb34c82-1907-4c32-afda-888c9b6e2279 port:42751, addresses:[/127.0.0.1]], state=Busy, ...
+```
+
+We have observed this can occur when network address translation (NAT) masquerade is used. When NAT masquerade is enabled, connections that should be considered local to the machine are masked to appear from external IP addresses. Gradle refuses to connect to any external IP address as a security precaution.
+
+The solution to this problem is to adjust your network configuration such that local connections are not modified to appear as from external addresses. 
+
+You can monitor the detected network setup and the connection requests in the daemon log file (`<GRADLE_USER_HOME>/daemon/<Gradle version>/daemon-<PID>.out.log`).
+
+```
+2021-08-12T12:01:50.755+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding IP addresses for network interface enp0s3
+2021-08-12T12:01:50.759+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Is this a loopback interface? false
+2021-08-12T12:01:50.769+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding remote address /fe80:0:0:0:85ba:3f3e:1b88:c0e1%enp0s3
+2021-08-12T12:01:50.770+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding remote address /10.0.2.15
+2021-08-12T12:01:50.770+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding IP addresses for network interface lo
+2021-08-12T12:01:50.771+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Is this a loopback interface? true
+2021-08-12T12:01:50.771+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding loopback address /0:0:0:0:0:0:0:1%lo
+2021-08-12T12:01:50.771+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding loopback address /127.0.0.1
+2021-08-12T12:01:50.775+0200 [DEBUG] [org.gradle.internal.remote.internal.inet.TcpIncomingConnector] Listening on [7fb34c82-1907-4c32-afda-888c9b6e2279 port:42751, addresses:[localhost/127.0.0.1]].
+...
+2021-08-12T12:01:50.797+0200 [INFO] [org.gradle.launcher.daemon.server.DaemonRegistryUpdater] Advertising the daemon address to the clients: [7fb34c82-1907-4c32-afda-888c9b6e2279 port:42751, addresses:[localhost/127.0.0.1]]
+...
+2021-08-12T12:01:50.923+0200 [ERROR] [org.gradle.internal.remote.internal.inet.TcpIncomingConnector] Cannot accept connection from remote address /10.0.2.15.
+```
+
 == Getting additional help
 
 If you didn't find a fix for your issue here, please reach out to the Gradle community on the link:https://discuss.gradle.org/c/help-discuss[help forum] or search relevant developer resources using link:https://help.gradle.org/[help.gradle.org].

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonConnector.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonConnector.java
@@ -54,10 +54,11 @@ public interface DaemonConnector {
     void markDaemonAsUnavailable(DaemonConnectDetails daemon);
 
     /**
-     * Connects to a daemon that matches the given constraint, starting one if required.
+     * Connects to a daemon that matches the given constraint.
      *
-     * @return A connection to a matching daemon. Never returns null.
+     * @return A connection to a matching daemon. Returns null if no matching daemon is available.
      */
+    @Nullable
     DaemonClientConnection connect(ExplainingSpec<DaemonContext> constraint);
 
     /**

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonConnector.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonConnector.java
@@ -135,7 +135,7 @@ public class DefaultDaemonConnector implements DaemonConnector {
 
         // No compatible daemons available - start a new daemon
         handleStopEvents(idleDaemons, busyDaemons);
-        return startDaemon(constraint);
+        return null;
     }
 
     private void handleStopEvents(Collection<DaemonInfo> idleDaemons, Collection<DaemonInfo> busyDaemons) {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
@@ -46,7 +46,7 @@ class DaemonClientTest extends ConcurrentSpecification {
     final ProcessEnvironment processEnvironment = Mock()
     final DaemonClient client = new DaemonClient(connector, outputEventListener, compatibilitySpec, new ByteArrayInputStream(new byte[0]), executorFactory, idGenerator, processEnvironment)
 
-    def executesAction() {
+    def "executes action"() {
         def resultMessage = Stub(BuildActionResult)
 
         when:
@@ -65,7 +65,7 @@ class DaemonClientTest extends ConcurrentSpecification {
         0 * _
     }
 
-    def rethrowsFailureToExecuteAction() {
+    def "rethrows failure to execute action"() {
         RuntimeException failure = new RuntimeException()
 
         when:
@@ -172,6 +172,7 @@ class DaemonClientTest extends ConcurrentSpecification {
     def "does not loop forever finding usable daemons"() {
         given:
         connector.connect(compatibilitySpec) >> connection
+        connector.startDaemon(compatibilitySpec) >> connection
         connection.daemon >> Stub(DaemonConnectDetails)
         connection.receive() >> Mock(DaemonUnavailable)
 
@@ -180,5 +181,28 @@ class DaemonClientTest extends ConcurrentSpecification {
 
         then:
         thrown(NoUsableDaemonFoundException)
+    }
+
+    def "does not try to start more than one daemon"() {
+        given:
+        DaemonClientConnection connection2 = Mock()
+        DaemonClientConnection connection3 = Mock()
+        connector.connect(compatibilitySpec) >>> [connection, null]
+        connector.startDaemon(compatibilitySpec) >>> [connection2, connection3]
+        connection.daemon >> Stub(DaemonConnectDetails)
+        connection.receive() >> Mock(DaemonUnavailable)
+        connection2.daemon >> Stub(DaemonConnectDetails)
+        connection2.receive() >> Mock(DaemonUnavailable)
+
+        when:
+        client.execute(Stub(BuildAction), Stub(BuildActionParameters), Stub(BuildRequestContext))
+
+        then:
+        1 * connection.stop()
+        1 * connection2.stop()
+        0 * connection3.stop()
+        def exception = thrown(NoUsableDaemonFoundException)
+        exception.message.contains 'A new daemon was started but could not be connected to'
+        exception.message.contains 'userguide/troubleshooting.html#network_connection for more details'
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DefaultDaemonConnectorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DefaultDaemonConnectorTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.launcher.daemon.client
 
 import org.gradle.api.internal.specs.ExplainingSpec
-import org.gradle.api.internal.specs.ExplainingSpecs
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.remote.Address
 import org.gradle.internal.remote.internal.ConnectCompletion
@@ -151,16 +150,16 @@ class DefaultDaemonConnectorTest extends Specification {
         numAllDaemons == 2
     }
 
-    def "connect() starts a new daemon when no daemon matches spec"() {
+    def "connect() returns null when no daemon matches spec"() {
         given:
         startIdleDaemon()
 
         expect:
         def connection = connector.connect({it.pid > 0} as DummyExplainingSpec)
-        connection && connection.connection.num > 0
+        connection == null
 
         and:
-        numAllDaemons == 2
+        numAllDaemons == 1
     }
 
     def "connect() will not use existing connection if it fails the compatibility spec"() {
@@ -169,18 +168,10 @@ class DefaultDaemonConnectorTest extends Specification {
 
         expect:
         def connection = connector.connect({it.pid != 0} as DummyExplainingSpec)
-        connection && connection.connection.num != 0
+        connection == null
 
         and:
-        numAllDaemons == 2
-    }
-
-    def "connect() will fail early if newly started daemon fails the compatibility spec"() {
-        when:
-        connector.connect(ExplainingSpecs.satisfyNone())
-
-        then:
-        thrown(DaemonConnectionException)
+        numAllDaemons == 1
     }
 
     def "suspect address is removed from the registry on connect failure"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/Documentation.java
@@ -24,7 +24,7 @@ public abstract class Documentation {
 
     static final Documentation NO_DOCUMENTATION = new NullDocumentation();
 
-    static Documentation userManual(String id, String section) {
+    public static Documentation userManual(String id, String section) {
         return new UserGuide(id, section);
     }
 


### PR DESCRIPTION
Partial fix for #12232

In some network configurations, it can happen that the daemon client can start a new daemon, but the new process cannot be connected. The client, however, does not distinguish between new and existing daemon connections and performs retries. Since the retry limit is set to 100, the result is that the client spams the entire memory with inaccessible Gradle daemons.

The solution is to make the client know if a new daemon was started. If the connection fails in that case then the client does not do further retries. This is also the behavior of the single-use daemons.
