### PR TITLE
Add --illegal-access=permit to Kotlin compiler daemon on JDK16

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ThirdPartyGradleModuleMetadataSmokeTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.GradleVersion
+import org.gradle.testkit.runner.GradleRunner
 
 class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
 
@@ -117,16 +118,17 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
         result.output.split('\n').findAll { !it.empty && !it.toLowerCase().contains('warning') }
     }
 
-    private BuildResult publish() {
-        def r = runner('publish')
+    private GradleRunner setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(GradleRunner runner) {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
-            r = runner(
-                'publish',
-                '-Dorg.gradle.jvmargs=--add-opens java.base/java.util=ALL-UNNAMED',
-                '-Dkotlin.daemon.jvm.options=--illegal-access=permit'
-            )
+            // https://youtrack.jetbrains.com/issue/KT-44266#focus=Comments-27-4639508.0-0
+            runner.withJvmArguments("--illegal-access=permit", "-Dkotlin.daemon.jvm.options=--illegal-access=permit")
         }
-        r.withProjectDir(new File(testProjectDir.root, 'producer'))
+        return runner
+    }
+
+    private BuildResult publish() {
+        setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(runner('publish'))
+            .withProjectDir(new File(testProjectDir.root, 'producer'))
             .forwardOutput()
             // this deprecation is coming from the Kotlin plugin
             .expectDeprecationWarning("The AbstractCompile.destinationDir property has been deprecated. " +
@@ -138,8 +140,10 @@ class ThirdPartyGradleModuleMetadataSmokeTest extends AbstractSmokeTest {
     }
 
     private BuildResult consumer(String runTask) {
-        runner(runTask, '-q').withProjectDir(
-            new File(testProjectDir.root, 'consumer')).forwardOutput().build()
+        setIllegalAccessPermitForJDK16KotlinCompilerDaemonOptions(runner(runTask, '-q'))
+            .withProjectDir(new File(testProjectDir.root, 'consumer'))
+            .forwardOutput()
+            .build()
     }
 
     // Reevaluate if this is still needed when upgrading android plugin. Currently required with version 4.2.2


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-44266#focus=Comments-27-4639508.0-0
