### PR TITLE
Allow overriding of the wrapper network timeout

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Incubating;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.file.FileOperations;
@@ -100,6 +101,7 @@ public class Wrapper extends DefaultTask {
     private DistributionType distributionType = DistributionType.BIN;
     private String archivePath;
     private PathBase archiveBase = PathBase.GRADLE_USER_HOME;
+    private Integer networkTimeout;
     private final DistributionLocator locator = new DistributionLocator();
 
     public Wrapper() {
@@ -160,6 +162,9 @@ public class Wrapper extends DefaultTask {
         wrapperProperties.put(WrapperExecutor.DISTRIBUTION_PATH_PROPERTY, distributionPath);
         wrapperProperties.put(WrapperExecutor.ZIP_STORE_BASE_PROPERTY, archiveBase.toString());
         wrapperProperties.put(WrapperExecutor.ZIP_STORE_PATH_PROPERTY, archivePath);
+        if (networkTimeout != null) {
+            wrapperProperties.put(WrapperExecutor.NETWORK_TIMEOUT_PROPERTY, networkTimeout.toString());
+        }
         try {
             PropertiesUtils.store(wrapperProperties, propertiesFileDestination);
         } catch (IOException e) {
@@ -426,5 +431,31 @@ public class Wrapper extends DefaultTask {
      */
     public void setArchiveBase(PathBase archiveBase) {
         this.archiveBase = archiveBase;
+    }
+
+    /**
+     * The network timeout specifies how many ms to wait for when the wrapper is performing network operations, such
+     * as downloading the wrapper jar.
+     *
+     * @since 7.3
+     */
+    @Option(option = "network-timeout", description = "Timeout in ms to use when the wrapper is performing network operations")
+    @Incubating
+    public void setNetworkTimeout(@Nullable String networkTimeout) {
+        this.networkTimeout = networkTimeout == null ? null : Integer.parseInt(networkTimeout);
+    }
+
+    /**
+     * The network timeout specifies how many ms to wait for when the wrapper is performing network operations, such
+     * as downloading the wrapper jar.
+     *
+     * @since 7.3
+     */
+    @Nullable
+    @Optional
+    @Input
+    @Incubating
+    public String getNetworkTimeout() {
+        return networkTimeout == null ? null : String.valueOf(networkTimeout);
     }
 }

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -63,6 +63,7 @@ class WrapperTest extends AbstractTaskTest {
         Wrapper.PathBase.GRADLE_USER_HOME == wrapper.getArchiveBase()
         wrapper.getDistributionUrl() != null
         wrapper.getDistributionSha256Sum() == null
+        wrapper.getNetworkTimeout() == null
     }
 
     def "determines Windows script path from unix script path"() {
@@ -128,6 +129,14 @@ class WrapperTest extends AbstractTaskTest {
         "somehash" == wrapper.getDistributionSha256Sum()
     }
 
+    def "uses defined network timeout"() {
+        given:
+        wrapper.setNetworkTimeout('5000')
+
+        expect:
+        '5000' == wrapper.getNetworkTimeout()
+    }
+
     def "execute with non extant wrapper jar parent directory"() {
         when:
         def unjarDir = temporaryFolder.createDir("unjar")
@@ -145,11 +154,23 @@ class WrapperTest extends AbstractTaskTest {
         properties.getProperty(WrapperExecutor.ZIP_STORE_PATH_PROPERTY) == wrapper.getArchivePath()
     }
 
+    def "execute with networkTimeout set"() {
+        given:
+        wrapper.setNetworkTimeout('6000')
+
+        when:
+        execute(wrapper)
+        def properties = GUtil.loadProperties(expectedTargetWrapperProperties)
+
+        then:
+        properties.getProperty(WrapperExecutor.NETWORK_TIMEOUT_PROPERTY) == '6000'
+    }
+
     def "check inputs"() {
         expect:
         TaskPropertyTestUtils.getProperties(wrapper).keySet() == WrapUtil.toSet(
             "distributionBase", "distributionPath", "distributionUrl", "distributionSha256Sum",
-            "distributionType", "archiveBase", "archivePath", "gradleVersion")
+            "distributionType", "archiveBase", "archivePath", "gradleVersion", "networkTimeout")
     }
 
     def "execute with extant wrapper jar parent directory and extant wrapper jar"() {

--- a/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/gradle_wrapper.adoc
@@ -56,6 +56,7 @@ The generated Wrapper properties file, `gradle/wrapper/gradle-wrapper.properties
 * The server hosting the Gradle distribution.
 * The type of Gradle distribution. By default that’s the `-bin` distribution containing only the runtime but no sample code and documentation.
 * The Gradle version used for executing the build. By default the `wrapper` task picks the exact same Gradle version that was used to generate the Wrapper files.
+* Optionally, a timeout in ms used when downloading the gradle distribution.
 
 
 .Example: The generated distribution URL
@@ -78,6 +79,9 @@ The full URL pointing to Gradle distribution ZIP file. Using this option makes `
 
 `--gradle-distribution-sha256-sum`::
 The SHA256 hash sum used for <<#sec:verification,verifying the downloaded Gradle distribution>>.
+
+`--network-timeout`::
+The network timeout to use when downloading the gradle distribution, in ms.
 
 Let’s assume the following use case to illustrate the use of the command line options. You would like to generate the Wrapper with version {gradleVersion} and use the `-all` distribution to enable your IDE to enable code-completion and being able to navigate to the Gradle source code. Those requirements are captured by the following command line execution:
 

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("3f30387b80de413202d00fb5e7fb98b8389ebdd12c83fe2d4f2a3064019e5352")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash
@@ -133,6 +133,14 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionSha256Sum=somehash")
+    }
+
+    def "generated wrapper scripts for given network timeout from command-line"() {
+        when:
+        run "wrapper", "--network-timeout", "7000"
+
+        then:
+        file("gradle/wrapper/gradle-wrapper.properties").text.contains("networkTimeout=7000")
     }
 
     def "wrapper JAR does not contain version in manifest"() {

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpIntegrationTest.groovy
@@ -107,7 +107,7 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         def failure = wrapperExecuter.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout")
+        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (10000ms)")
         failure.assertHasErrorOutput('Read timed out')
     }
 
@@ -122,10 +122,26 @@ class WrapperHttpIntegrationTest extends AbstractWrapperIntegrationSpec {
         def failure = wrapperExecuter.runWithFailure()
 
         then:
-        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout")
+        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (10000ms)")
         failure.assertHasErrorOutput('Read timed out')
         failure.assertNotOutput("username")
         failure.assertNotOutput("password")
+    }
+
+    def "reads timeout from wrapper properties"() {
+        given:
+        prepareWrapper("http://localhost:${server.port}")
+        server.expectAndBlock(server.get("/gradlew/dist"))
+
+        and:
+        file('gradle/wrapper/gradle-wrapper.properties') << "networkTimeout=5000"
+
+        when:
+        wrapperExecuter.withStackTraceChecksDisabled()
+        def failure = wrapperExecuter.runWithFailure()
+
+        then:
+        failure.assertHasErrorOutput("Downloading from http://localhost:${server.port}/gradlew/dist failed: timeout (5000ms)")
     }
 
     def "downloads wrapper via proxy"() {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Download.java
@@ -36,19 +36,23 @@ import java.util.Properties;
 
 public class Download implements IDownload {
     public static final String UNKNOWN_VERSION = "0";
+    public static final int DEFAULT_NETWORK_TIMEOUT_MILLISECONDS = 10 * 1000;
 
     private static final int BUFFER_SIZE = 10 * 1024;
     private static final int PROGRESS_CHUNK = 1024 * 1024;
-    private static final int CONNECTION_TIMEOUT_MILLISECONDS = 10 * 1000;
-    private static final int READ_TIMEOUT_MILLISECONDS = 10 * 1000;
     private final Logger logger;
     private final String appName;
     private final String appVersion;
     private final DownloadProgressListener progressListener;
     private final Map<String, String> systemProperties;
+    private final int networkTimeout;
 
     public Download(Logger logger, String appName, String appVersion) {
         this(logger, null, appName, appVersion, convertSystemProperties(System.getProperties()));
+    }
+
+    public Download(Logger logger, String appName, String appVersion, int networkTimeout) {
+        this(logger, null, appName, appVersion, convertSystemProperties(System.getProperties()), networkTimeout);
     }
 
     private static Map<String, String> convertSystemProperties(Properties properties) {
@@ -60,11 +64,16 @@ public class Download implements IDownload {
     }
 
     public Download(Logger logger, DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties) {
+        this(logger, progressListener, appName, appVersion, systemProperties, DEFAULT_NETWORK_TIMEOUT_MILLISECONDS);
+    }
+
+    public Download(Logger logger, DownloadProgressListener progressListener, String appName, String appVersion, Map<String, String> systemProperties, int networkTimeout) {
         this.logger = logger;
         this.appName = appName;
         this.appVersion = appVersion;
         this.systemProperties = systemProperties;
         this.progressListener = new DefaultDownloadProgressListener(logger, progressListener);
+        this.networkTimeout = networkTimeout;
         configureProxyAuthentication();
     }
 
@@ -95,8 +104,8 @@ public class Download implements IDownload {
             addBasicAuthentication(address, conn);
             final String userAgentValue = calculateUserAgent();
             conn.setRequestProperty("User-Agent", userAgentValue);
-            conn.setConnectTimeout(CONNECTION_TIMEOUT_MILLISECONDS);
-            conn.setReadTimeout(READ_TIMEOUT_MILLISECONDS);
+            conn.setConnectTimeout(networkTimeout);
+            conn.setReadTimeout(networkTimeout);
             in = conn.getInputStream();
             byte[] buffer = new byte[BUFFER_SIZE];
             int numRead;
@@ -119,7 +128,7 @@ public class Download implements IDownload {
                 out.write(buffer, 0, numRead);
             }
         } catch (SocketTimeoutException e) {
-            throw new IOException("Downloading from " + safeUrl + " failed: timeout", e);
+            throw new IOException("Downloading from " + safeUrl + " failed: timeout (" + networkTimeout + "ms)", e);
         } finally {
             logger.log("");
             if (in != null) {

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -60,9 +60,12 @@ public class GradleWrapperMain {
         Logger logger = logger(options);
 
         WrapperExecutor wrapperExecutor = WrapperExecutor.forWrapperPropertiesFile(propertiesFile);
+        WrapperConfiguration configuration = wrapperExecutor.getConfiguration();
+        IDownload download = new Download(logger, "gradlew", UNKNOWN_VERSION, configuration.getNetworkTimeout());
+
         wrapperExecutor.execute(
                 args,
-                new Install(logger, new Download(logger, "gradlew", UNKNOWN_VERSION), new PathAssembler(gradleUserHome, rootDir)),
+                new Install(logger, download, new PathAssembler(gradleUserHome, rootDir)),
                 new BootstrapMainStarter());
     }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -24,6 +24,7 @@ public class WrapperConfiguration {
     private String distributionSha256Sum;
     private String zipBase = PathAssembler.GRADLE_USER_HOME_STRING;
     private String zipPath = Install.DEFAULT_DISTRIBUTION_PATH;
+    private int networkTimeout = Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS;
 
     public URI getDistribution() {
         return distribution;
@@ -71,5 +72,13 @@ public class WrapperConfiguration {
 
     public void setZipPath(String zipPath) {
         this.zipPath = zipPath;
+    }
+
+    public int getNetworkTimeout() {
+        return networkTimeout;
+    }
+
+    public void setNetworkTimeout(int networkTimeout) {
+        this.networkTimeout = networkTimeout;
     }
 }

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -30,6 +30,7 @@ public class WrapperExecutor {
     public static final String DISTRIBUTION_SHA_256_SUM = "distributionSha256Sum";
     public static final String ZIP_STORE_BASE_PROPERTY = "zipStoreBase";
     public static final String ZIP_STORE_PATH_PROPERTY = "zipStorePath";
+    public static final String NETWORK_TIMEOUT_PROPERTY = "networkTimeout";
     private final Properties properties;
     private final File propertiesFile;
     private final WrapperConfiguration config = new WrapperConfiguration();
@@ -57,6 +58,7 @@ public class WrapperExecutor {
                 config.setDistributionSha256Sum(getProperty(DISTRIBUTION_SHA_256_SUM, config.getDistributionSha256Sum(), false));
                 config.setZipBase(getProperty(ZIP_STORE_BASE_PROPERTY, config.getZipBase()));
                 config.setZipPath(getProperty(ZIP_STORE_PATH_PROPERTY, config.getZipPath()));
+                config.setNetworkTimeout(getProperty(NETWORK_TIMEOUT_PROPERTY, config.getNetworkTimeout()));
             } catch (Exception e) {
                 throw new RuntimeException(String.format("Could not load wrapper properties from '%s'.", propertiesFile), e);
             }
@@ -114,6 +116,10 @@ public class WrapperExecutor {
 
     private String getProperty(String propertyName, String defaultValue) {
         return getProperty(propertyName, defaultValue, true);
+    }
+
+    private int getProperty(String propertyName, int defaultValue) {
+        return Integer.parseInt(getProperty(propertyName, String.valueOf(defaultValue)));
     }
 
     private String getProperty(String propertyName, String defaultValue, boolean required) {

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -39,6 +39,7 @@ class WrapperExecutorTest extends Specification {
         properties.zipStoreBase = 'testZipBase'
         properties.zipStorePath = 'testZipPath'
         properties.distributionSha256Sum = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        properties.networkTimeout = '11000'
         propertiesFile.parentFile.mkdirs()
         propertiesFile.withOutputStream { properties.store(it, 'header') }
     }
@@ -54,6 +55,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipBase == 'testZipBase'
         wrapper.configuration.zipPath == 'testZipPath'
         wrapper.configuration.distributionSha256Sum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        wrapper.configuration.networkTimeout == 11000
     }
 
     def "loads wrapper meta data from specified project directory"() {
@@ -67,6 +69,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipBase == 'testZipBase'
         wrapper.configuration.zipPath == 'testZipPath'
         wrapper.configuration.distributionSha256Sum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        wrapper.configuration.networkTimeout == 11000
     }
 
     def "uses default meta data when properties file does not exist in project directory"() {
@@ -80,6 +83,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.zipBase == PathAssembler.GRADLE_USER_HOME_STRING
         wrapper.configuration.zipPath == Install.DEFAULT_DISTRIBUTION_PATH
         wrapper.configuration.distributionSha256Sum == null
+        wrapper.configuration.networkTimeout == Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS
     }
 
     def "properties file need contain only the distribution URL"() {
@@ -97,6 +101,7 @@ class WrapperExecutorTest extends Specification {
         wrapper.configuration.distributionPath == Install.DEFAULT_DISTRIBUTION_PATH
         wrapper.configuration.zipBase == PathAssembler.GRADLE_USER_HOME_STRING
         wrapper.configuration.zipPath == Install.DEFAULT_DISTRIBUTION_PATH
+        wrapper.configuration.networkTimeout == Download.DEFAULT_NETWORK_TIMEOUT_MILLISECONDS
     }
 
     def "execute installs distribution and launches application"() {


### PR DESCRIPTION
Fixes #17575 

### Context
As discussed in the issue, experience in our own organisation shows that the default timeout of 10 seconds can result in build failures when the download source of the wrapper is responding slowly.  Rather than hardcode an arbitrary higher timeout, this PR allows users to set their own.

Based on the feedback in the issue triage, I have introduced a single `networkTimeout` property to gradle-wrapper.properties which is used for both Connection and Read timeouts.  This can also be set at wrapper init time like the other properties

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
