### PR TITLE
Catch exception if settings not available

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -737,14 +737,18 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private Optional<ResolveException> failuresWithHint(Collection<? extends Throwable> causes) {
-        if (ignoresSettingsRepositories()) {
-            boolean hasModuleNotFound = causes.stream().anyMatch(ModuleVersionNotFoundException.class::isInstance);
-            if (hasModuleNotFound) {
-                return Optional.of(new ResolveExceptionWithHints(getDisplayName(), causes,
-                    "The project declares repositories, effectively ignoring the repositories you have declared in the settings.",
-                    "You can figure out how project repositories are declared by configuring your build to fail on project repositories.",
-                    "See " + documentationRegistry.getDocumentationFor("declaring_repositories", "sub:fail_build_on_project_repositories") + " for details."));
+        try {
+            if (ignoresSettingsRepositories()) {
+                boolean hasModuleNotFound = causes.stream().anyMatch(ModuleVersionNotFoundException.class::isInstance);
+                if (hasModuleNotFound) {
+                    return Optional.of(new ResolveExceptionWithHints(getDisplayName(), causes,
+                        "The project declares repositories, effectively ignoring the repositories you have declared in the settings.",
+                        "You can figure out how project repositories are declared by configuring your build to fail on project repositories.",
+                        "See " + documentationRegistry.getDocumentationFor("declaring_repositories", "sub:fail_build_on_project_repositories") + " for details."));
+                }
             }
+        } catch (Throwable e) {
+            return Optional.of(new ResolveException(getDisplayName(), ImmutableList.<Throwable>builder().addAll(causes).add(e).build()));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
Previously, if resolution exception occurs before settings instance is available,
the exception will be hidden, resulting in very confusing error message. This commit
catches the exception and displays it in the exception thrown.

Confusing exception before the change: https://ge.gradle.org/s/4qzkawqkr2rx2/tests/:ide:embeddedCrossVersionTest/Gradle%20Test%20Executor%206/Gradle%20Test%20Executor%206?expanded-stacktrace=WyIwLTEtMiJd&top-execution=1

```
Caused by: java.lang.IllegalStateException: The settings are not yet available for build 'test'
    at org.gradle.invocation.DefaultGradle.getSettings(DefaultGradle.java:208) |  
    at org.gradle.invocation.DefaultGradle_Decorated.getSettings(Unknown Source)
    at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.ignoresSettingsRepositories(DefaultConfiguration.java:756) |  
    at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.failuresWithHint(DefaultConfiguration.java:740)
```

Informative exception after the change:

```
Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.gradle:gradle-tooling-api:7.2-20210723003628+0000.
Searched in the following locations:
  - https://repo.gradle.org/gradle/repo2/org/gradle/gradle-tooling-api/7.2-20210723003628+0000/gradle-tooling-api-7.2-20210723003628+0000.pom
If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
Required by:
    project :
```