### PR TITLE
Make Gradle init not destructive when issued in the user home folder

### DIFF
--- a/subprojects/build-init/build.gradle.kts
+++ b/subprojects/build-init/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":plugins"))
     implementation(project(":workers"))
     implementation(project(":wrapper"))
+    implementation(project(":persistent-cache"))
 
     implementation(libs.groovy)
     implementation(libs.groovyTemplates)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -334,6 +334,31 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         succeeds "init"
     }
 
+    def "skips init task if user home directory overlaps with project cache directory"() {
+        when:
+        def dotGradleDir = targetDir.file('.gradle')
+        dotGradleDir.mkdirs()
+        executer.withGradleUserHomeDir(dotGradleDir)
+
+        then:
+        succeeds "init"
+        result.assertTaskSkipped ":init"
+        result.assertTaskNotExecuted":wrapper"
+        result.assertOutputContains("Gradle user home directory ($dotGradleDir) overlaps with the project cache directory")
+    }
+
+    def "does not skip init task if user home directory has custom name"() {
+        when:
+        def dotGradleDir = targetDir.file('.guh')
+        dotGradleDir.mkdirs()
+        executer.withGradleUserHomeDir(dotGradleDir)
+
+        then:
+        succeeds "init"
+        result.assertTaskExecuted ":init"
+        result.assertTaskExecuted ":wrapper"
+    }
+
     private ExecutionResult runInitWith(BuildInitDsl dsl) {
         run 'init', '--dsl', dsl.id
     }

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -344,7 +344,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         succeeds "init"
         result.assertTaskSkipped ":init"
         result.assertTaskNotExecuted":wrapper"
-        result.assertOutputContains("Gradle user home directory ($dotGradleDir) overlaps with the project cache directory")
+        outputContains("Gradle user home directory ($dotGradleDir) overlaps with the project cache directory")
     }
 
     def "does not skip init task if user home directory has custom name"() {

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -344,7 +344,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         succeeds "init"
         result.assertTaskSkipped ":init"
         result.assertTaskNotExecuted":wrapper"
-        outputContains("Gradle user home directory ($dotGradleDir) overlaps with the project cache directory")
+        outputContains("Gradle user home directory '$dotGradleDir' overlaps with the project cache directory")
     }
 
     def "does not skip init task if user home directory has custom name"() {

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
@@ -121,7 +121,7 @@ public class BuildInitPlugin implements Plugin<Project> {
 
     private static String reasonToSkip(File buildFile, ProjectLayout layout, boolean hasSubProjects, File userHome, File projectRoot) {
         if (projectRoot.equals(userHome)) {
-            return "Gradle user home directory (" + userHome + ") overlaps with the project cache directory";
+            return "Gradle user home directory '" + userHome + "' overlaps with the project cache directory";
         }
 
         for (BuildInitDsl dsl : BuildInitDsl.values()) {

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/BuildInitPlugin.java
@@ -41,6 +41,8 @@ public class BuildInitPlugin implements Plugin<Project> {
         if (project.getParent() == null) {
             project.getTasks().register("init", InitBuild.class, initBuild -> {
 
+                checkForGradleUserHomeConflict(project);
+
                 initBuild.setGroup("Build Setup");
                 initBuild.setDescription("Initializes a new Gradle build.");
 
@@ -53,6 +55,13 @@ public class BuildInitPlugin implements Plugin<Project> {
                 ProjectInternal.DetachedResolver detachedResolver = ((ProjectInternal) project).newDetachedResolver();
                 initBuild.getProjectLayoutRegistry().getBuildConverter().configureClasspath(detachedResolver, project.getObjects());
             });
+        }
+    }
+
+    private void checkForGradleUserHomeConflict(Project project) {
+        File gradleUserHome = project.getGradle().getGradleUserHomeDir();
+        if (new File(project.getProjectDir(), ".gradle").equals(gradleUserHome)) {
+            throw new RuntimeException("Not cool");
         }
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Partial solution for https://github.com/gradle/gradle/issues/17803

The PR addresses the issue partially. It only checks if the project directory, where `gradle init` is run is the same as the user home directory and if there is already a `.gradle` folder there, in which case the `init` task won't run. 