### PR TITLE
Fix variant capabilities information exposed through ArtifactViews

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CapabilitiesCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CapabilitiesCodec.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.api.capabilities.Capability
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.internal.component.external.model.ImmutableCapability
+
+
+object CapabilitiesCodec : Codec<Capability> {
+
+    override suspend fun WriteContext.encode(value: Capability) {
+        writeString(value.group)
+        writeString(value.name)
+        writeString(value.version)
+    }
+
+    override suspend fun ReadContext.decode(): Capability {
+        val group = readString()
+        val name = readString()
+        val version = readString()
+        return ImmutableCapability(group, name, version)
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -157,6 +157,7 @@ class Codecs(
         bind(IsolateTransformerParametersNodeCodec(parameterScheme, isolatableFactory, buildOperationExecutor, classLoaderHierarchyHasher, fileCollectionFactory, documentationRegistry))
         bind(FinalizeTransformDependenciesNodeCodec())
         bind(WorkNodeActionCodec)
+        bind(CapabilitiesCodec)
 
         bind(DefaultCopySpecCodec(patternSetFactory, fileCollectionFactory, instantiator))
         bind(DestinationRootCopySpecCodec(fileResolver))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.artifacts.transform.VariantTransform
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.capabilities.CapabilitiesMetadata
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT
@@ -67,6 +68,7 @@ import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
 import org.gradle.internal.Try
+import org.gradle.internal.component.external.model.ImmutableCapabilities
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata
 import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.model.CalculatedValueContainerFactory
@@ -188,6 +190,10 @@ class RecordingVariantSet(
 
     override fun getAttributes(): AttributeContainerInternal {
         return attributes
+    }
+
+    override fun getCapabilities(): CapabilitiesMetadata {
+        return ImmutableCapabilities.EMPTY
     }
 
     override fun visitDependencies(context: TaskDependencyResolveContext) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache.serialization.codecs.transform
 import com.google.common.collect.ImmutableList
 import org.gradle.api.Action
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.PreResolvedResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
@@ -50,6 +51,7 @@ class CalculateArtifactsCodec(
     override suspend fun WriteContext.encode(value: AbstractTransformedArtifactSet.CalculateArtifacts) {
         write(value.ownerId)
         write(value.targetVariantAttributes)
+//        write(value.capabilities)
         val files = mutableListOf<File>()
         value.delegate.visitExternalArtifacts { files.add(file) }
         write(files)
@@ -60,9 +62,10 @@ class CalculateArtifactsCodec(
     override suspend fun ReadContext.decode(): AbstractTransformedArtifactSet.CalculateArtifacts {
         val ownerId = readNonNull<ComponentIdentifier>()
         val targetAttributes = readNonNull<ImmutableAttributes>()
+        val capabilities: List<Capability> = emptyList()
         val files = readNonNull<List<File>>()
         val steps: List<TransformStepSpec> = readList().uncheckedCast()
-        return AbstractTransformedArtifactSet.CalculateArtifacts(ownerId, FixedFilesArtifactSet(ownerId, files, calculatedValueContainerFactory), targetAttributes, ImmutableList.copyOf(steps.map { BoundTransformationStep(it.transformation, it.recreate()) }))
+        return AbstractTransformedArtifactSet.CalculateArtifacts(ownerId, FixedFilesArtifactSet(ownerId, files, calculatedValueContainerFactory), targetAttributes, capabilities, ImmutableList.copyOf(steps.map { BoundTransformationStep(it.transformation, it.recreate()) }))
     }
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/CalculateArtifactsCodec.kt
@@ -51,7 +51,7 @@ class CalculateArtifactsCodec(
     override suspend fun WriteContext.encode(value: AbstractTransformedArtifactSet.CalculateArtifacts) {
         write(value.ownerId)
         write(value.targetVariantAttributes)
-//        write(value.capabilities)
+        writeCollection(value.capabilities)
         val files = mutableListOf<File>()
         value.delegate.visitExternalArtifacts { files.add(file) }
         write(files)
@@ -62,7 +62,7 @@ class CalculateArtifactsCodec(
     override suspend fun ReadContext.decode(): AbstractTransformedArtifactSet.CalculateArtifacts {
         val ownerId = readNonNull<ComponentIdentifier>()
         val targetAttributes = readNonNull<ImmutableAttributes>()
-        val capabilities: List<Capability> = emptyList()
+        val capabilities: List<Capability> = readList().uncheckedCast()
         val files = readNonNull<List<File>>()
         val steps: List<TransformStepSpec> = readList().uncheckedCast()
         return AbstractTransformedArtifactSet.CalculateArtifacts(ownerId, FixedFilesArtifactSet(ownerId, files, calculatedValueContainerFactory), targetAttributes, capabilities, ImmutableList.copyOf(steps.map { BoundTransformationStep(it.transformation, it.recreate()) }))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache.serialization.codecs.transform
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.PreResolvedResolvableArtifact
 import org.gradle.api.internal.artifacts.transform.BoundTransformationStep
 import org.gradle.api.internal.artifacts.transform.TransformingAsyncArtifactListener
@@ -40,6 +41,7 @@ class TransformedArtifactCodec(
     override suspend fun WriteContext.encode(value: TransformingAsyncArtifactListener.TransformedArtifact) {
         write(value.variantName)
         write(value.target)
+//        write(value.capabilities)
         write(value.artifact.id.componentIdentifier)
         write(value.artifact.file)
         write(unpackTransformationSteps(value.transformationSteps))
@@ -48,11 +50,12 @@ class TransformedArtifactCodec(
     override suspend fun ReadContext.decode(): TransformingAsyncArtifactListener.TransformedArtifact? {
         val variantName = readNonNull<DisplayName>()
         val target = readNonNull<ImmutableAttributes>()
+        val capabilities: List<Capability> = emptyList()
         val ownerId = readNonNull<ComponentIdentifier>()
         val file = readNonNull<File>()
         val artifactId = ComponentFileArtifactIdentifier(ownerId, file.name)
         val artifact = PreResolvedResolvableArtifact(null, DefaultIvyArtifactName.forFile(file, null), artifactId, calculatedValueContainerFactory.create(Describables.of(artifactId), file), TaskDependencyContainer.EMPTY, calculatedValueContainerFactory)
         val steps = readNonNull<List<TransformStepSpec>>().map { BoundTransformationStep(it.transformation, it.recreate()) }
-        return TransformingAsyncArtifactListener.TransformedArtifact(variantName, target, artifact, steps)
+        return TransformingAsyncArtifactListener.TransformedArtifact(variantName, target, capabilities, artifact, steps)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedArtifactCodec.kt
@@ -23,10 +23,13 @@ import org.gradle.api.internal.artifacts.transform.BoundTransformationStep
 import org.gradle.api.internal.artifacts.transform.TransformingAsyncArtifactListener
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.tasks.TaskDependencyContainer
+import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.readNonNull
+import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.internal.Describables
 import org.gradle.internal.DisplayName
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
@@ -41,7 +44,7 @@ class TransformedArtifactCodec(
     override suspend fun WriteContext.encode(value: TransformingAsyncArtifactListener.TransformedArtifact) {
         write(value.variantName)
         write(value.target)
-//        write(value.capabilities)
+        writeCollection(value.capabilities)
         write(value.artifact.id.componentIdentifier)
         write(value.artifact.file)
         write(unpackTransformationSteps(value.transformationSteps))
@@ -50,7 +53,7 @@ class TransformedArtifactCodec(
     override suspend fun ReadContext.decode(): TransformingAsyncArtifactListener.TransformedArtifact? {
         val variantName = readNonNull<DisplayName>()
         val target = readNonNull<ImmutableAttributes>()
-        val capabilities: List<Capability> = emptyList()
+        val capabilities: List<Capability> = readList().uncheckedCast()
         val ownerId = readNonNull<ComponentIdentifier>()
         val file = readNonNull<File>()
         val artifactId = ComponentFileArtifactIdentifier(ownerId, file.name)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache.serialization.codecs.transform
 
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.transform.TransformationNode
 import org.gradle.api.internal.artifacts.transform.TransformedProjectArtifactSet
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -36,6 +37,7 @@ class TransformedProjectArtifactSetCodec : Codec<TransformedProjectArtifactSet> 
         encodePreservingSharedIdentityOf(value) {
             write(value.ownerId)
             write(value.targetAttributes)
+//            write(value.capabilities)
             writeCollection(value.transformedArtifacts)
         }
     }
@@ -44,8 +46,9 @@ class TransformedProjectArtifactSetCodec : Codec<TransformedProjectArtifactSet> 
         return decodePreservingSharedIdentity {
             val ownerId = readNonNull<ComponentIdentifier>()
             val targetAttributes = readNonNull<ImmutableAttributes>()
+            val capabilities: List<Capability> = emptyList()
             val nodes: List<TransformationNode> = readList().uncheckedCast()
-            TransformedProjectArtifactSet(ownerId, targetAttributes, nodes)
+            TransformedProjectArtifactSet(ownerId, targetAttributes, capabilities, nodes)
         }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/transform/TransformedProjectArtifactSetCodec.kt
@@ -37,7 +37,7 @@ class TransformedProjectArtifactSetCodec : Codec<TransformedProjectArtifactSet> 
         encodePreservingSharedIdentityOf(value) {
             write(value.ownerId)
             write(value.targetAttributes)
-//            write(value.capabilities)
+            writeCollection(value.capabilities)
             writeCollection(value.transformedArtifacts)
         }
     }
@@ -46,7 +46,7 @@ class TransformedProjectArtifactSetCodec : Codec<TransformedProjectArtifactSet> 
         return decodePreservingSharedIdentity {
             val ownerId = readNonNull<ComponentIdentifier>()
             val targetAttributes = readNonNull<ImmutableAttributes>()
-            val capabilities: List<Capability> = emptyList()
+            val capabilities: List<Capability> = readList().uncheckedCast()
             val nodes: List<TransformationNode> = readList().uncheckedCast()
             TransformedProjectArtifactSet(ownerId, targetAttributes, capabilities, nodes)
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.PublishArtifact;
@@ -25,10 +24,7 @@ import org.gradle.api.internal.artifacts.configurations.Configurations;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
-import org.gradle.internal.component.external.model.CapabilityInternal;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
-import org.gradle.internal.component.external.model.ImmutableCapability;
-import org.gradle.internal.component.external.model.ShadowedCapability;
 import org.gradle.internal.component.local.model.BuildableLocalComponentMetadata;
 import org.gradle.internal.component.local.model.BuildableLocalConfigurationMetadata;
 import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
@@ -77,7 +73,7 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
         ImmutableSet<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         // Presence of capabilities is bound to the definition of a capabilities extension to the project
         ImmutableCapabilities capabilities =
-            asImmutable(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet()));
+            ImmutableCapabilities.copyAsImmutable(Configurations.collectCapabilities(configuration, Sets.newHashSet(), Sets.newHashSet()));
         return metaData.addConfiguration(configuration.getName(),
             configuration.getDescription(),
             extendsFrom,
@@ -90,24 +86,6 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
             configuration.isCanBeResolved(),
             capabilities,
             configuration.getConsistentResolutionConstraints());
-    }
-
-    private static ImmutableCapabilities asImmutable(Collection<? extends Capability> descriptors) {
-        if (descriptors.isEmpty()) {
-            return ImmutableCapabilities.EMPTY;
-        }
-
-        ImmutableList.Builder<CapabilityInternal> builder = new ImmutableList.Builder<>();
-        for (Capability descriptor : descriptors) {
-            if (descriptor instanceof ImmutableCapability) {
-                builder.add((ImmutableCapability) descriptor);
-            } else if (descriptor instanceof ShadowedCapability) {
-                builder.add((ShadowedCapability) descriptor);
-            } else {
-                builder.add(new ImmutableCapability(descriptor.getGroup(), descriptor.getName(), descriptor.getVersion()));
-            }
-        }
-        return ImmutableCapabilities.of(builder.build());
     }
 
     private static class NestedVariantIdentifier implements VariantResolveMetadata.Identifier {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -42,27 +42,29 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final VariantResolveMetadata.Identifier identifier;
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
+    private final CapabilitiesMetadata capabilities;
     private final ResolvedArtifactSet artifacts;
 
-    private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, ResolvedArtifactSet artifacts) {
+    private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, ResolvedArtifactSet artifacts) {
         this.identifier = identifier;
         this.displayName = displayName;
         this.attributes = attributes;
+        this.capabilities = capabilities;
         this.artifacts = artifacts;
     }
 
     public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Collection<? extends ResolvableArtifact> artifacts) {
         if (artifacts.isEmpty()) {
-            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, EMPTY);
+            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, EMPTY);
         }
         if (artifacts.size() == 1) {
-            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, new SingleArtifactSet(displayName, attributes, capabilities, artifacts.iterator().next()));
+            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, new SingleArtifactSet(displayName, attributes, capabilities, artifacts.iterator().next()));
         }
         List<SingleArtifactSet> artifactSets = new ArrayList<>(artifacts.size());
         for (ResolvableArtifact artifact : artifacts) {
             artifactSets.add(new SingleArtifactSet(displayName, attributes, capabilities, artifact));
         }
-        return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, CompositeResolvedArtifactSet.of(artifactSets));
+        return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, CompositeResolvedArtifactSet.of(artifactSets));
     }
 
     @Override
@@ -88,6 +90,11 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     @Override
     public AttributeContainerInternal getAttributes() {
         return attributes;
+    }
+
+    @Override
+    public CapabilitiesMetadata getCapabilities() {
+        return capabilities;
     }
 
     private static class SingleArtifactSet implements ResolvedArtifactSet, ResolvedArtifactSet.Artifacts {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -57,7 +57,6 @@ import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -161,9 +160,9 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     private static CapabilitiesMetadata withImplicitCapability(VariantResolveMetadata variant, ModuleVersionIdentifier identifier) {
         CapabilitiesMetadata capabilities = variant.getCapabilities();
         if (capabilities.getCapabilities().isEmpty()) {
-            return ImmutableCapabilities.of(Collections.singleton(ImmutableCapability.defaultCapabilityForComponent(identifier)));
+            return ImmutableCapabilities.of(ImmutableCapability.defaultCapabilityForComponent(identifier));
         } else {
-            return capabilities;
+            return ImmutableCapabilities.copyAsImmutable(capabilities.getCapabilities());
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.DefaultResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectArtifactResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.specs.ExcludeSpec;
@@ -39,6 +40,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
+import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -55,6 +57,7 @@ import org.gradle.internal.resolve.result.DefaultBuildableArtifactResolveResult;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,7 +155,16 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
             identifier = null;
         }
 
-        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), variantAttributes, variant.getCapabilities(), resolvedArtifacts.build());
+        return ArtifactBackedResolvedVariant.create(identifier, variant.asDescribable(), variantAttributes, withImplicitCapability(variant, ownerId), resolvedArtifacts.build());
+    }
+
+    private static CapabilitiesMetadata withImplicitCapability(VariantResolveMetadata variant, ModuleVersionIdentifier identifier) {
+        CapabilitiesMetadata capabilities = variant.getCapabilities();
+        if (capabilities.getCapabilities().isEmpty()) {
+            return ImmutableCapabilities.of(Collections.singleton(ImmutableCapability.defaultCapabilityForComponent(identifier)));
+        } else {
+            return capabilities;
+        }
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.DefaultResolvableArtifact;
 import org.gradle.api.internal.artifacts.transform.AbstractTransformedArtifactSet;
 import org.gradle.api.internal.artifacts.transform.ExtraExecutionGraphDependenciesResolverFactory;
@@ -38,6 +39,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
@@ -248,6 +250,11 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public AttributeContainerInternal getAttributes() {
             return variantAttributes;
+        }
+
+        @Override
+        public CapabilitiesMetadata getCapabilities() {
+            return ImmutableCapabilities.EMPTY;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -269,7 +269,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
                                                Transformation transformation,
                                                ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver,
                                                CalculatedValueContainerFactory calculatedValueContainerFactory) {
-            super(delegate.getComponentId(), delegate, attributes, transformation, dependenciesResolver, calculatedValueContainerFactory);
+            super(delegate.getComponentId(), delegate, attributes, Collections.emptyList(), transformation, dependenciesResolver, calculatedValueContainerFactory);
             this.delegate = delegate;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariant.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Action;
 import org.gradle.api.attributes.HasAttributes;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.VariantResolveMetadata;
@@ -38,4 +39,6 @@ public interface ResolvedVariant extends HasAttributes {
     AttributeContainerInternal getAttributes();
 
     ResolvedArtifactSet getArtifacts();
+
+    CapabilitiesMetadata getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -78,7 +78,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         this.id = id;
         this.componentIdentifier = componentIdentifier;
         this.resolver = resolver;
-        this.implicitCapability = new ImmutableCapability(id.getGroup(), id.getName(), id.getVersion());
+        this.implicitCapability = ImmutableCapability.defaultCapabilityForComponent(id);
         this.hashCode = 31 * id.hashCode() ^ resultId.hashCode();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformedVariantFactory.java
@@ -79,7 +79,7 @@ public class DefaultTransformedVariantFactory implements TransformedVariantFacto
     }
 
     private TransformedExternalArtifactSet doCreateExternal(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, VariantDefinition variantDefinition, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
-        return new TransformedExternalArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), variantDefinition.getTargetAttributes(), variantDefinition.getTransformation(), dependenciesResolverFactory, calculatedValueContainerFactory);
+        return new TransformedExternalArtifactSet(componentIdentifier, sourceVariant.getArtifacts(), variantDefinition.getTargetAttributes(), sourceVariant.getCapabilities().getCapabilities(), variantDefinition.getTransformation(), dependenciesResolverFactory, calculatedValueContainerFactory);
     }
 
     private TransformedProjectArtifactSet doCreateProject(ComponentIdentifier componentIdentifier, ResolvedVariant sourceVariant, VariantDefinition variantDefinition, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
@@ -89,7 +89,7 @@ public class DefaultTransformedVariantFactory implements TransformedVariantFacto
         } else {
             sourceArtifacts = sourceVariant.getArtifacts();
         }
-        return new TransformedProjectArtifactSet(componentIdentifier, sourceArtifacts, variantDefinition, dependenciesResolverFactory, transformationNodeFactory);
+        return new TransformedProjectArtifactSet(componentIdentifier, sourceArtifacts, variantDefinition, sourceVariant.getCapabilities().getCapabilities(), dependenciesResolverFactory, transformationNodeFactory);
     }
 
     private interface Factory {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformedExternalArtifactSet.java
@@ -18,10 +18,13 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.model.CalculatedValueContainer;
 import org.gradle.internal.model.CalculatedValueContainerFactory;
+
+import java.util.List;
 
 /**
  * An artifact set containing transformed external artifacts.
@@ -31,11 +34,12 @@ public class TransformedExternalArtifactSet extends AbstractTransformedArtifactS
         ComponentIdentifier componentIdentifier,
         ResolvedArtifactSet delegate,
         ImmutableAttributes target,
+        List<? extends Capability> capabilities,
         Transformation transformation,
         ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory,
         CalculatedValueContainerFactory calculatedValueContainerFactory
     ) {
-        super(componentIdentifier, delegate, target, transformation, dependenciesResolverFactory, calculatedValueContainerFactory);
+        super(componentIdentifier, delegate, target, capabilities, transformation, dependenciesResolverFactory, calculatedValueContainerFactory);
     }
 
     public TransformedExternalArtifactSet(CalculatedValueContainer<ImmutableList<Artifacts>, AbstractTransformedArtifactSet.CalculateArtifacts> result) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapabilities.java
@@ -41,15 +41,41 @@ public class ImmutableCapabilities implements CapabilitiesMetadata {
         }
         if (capabilities.size() == 1) {
             Capability single = capabilities.stream().findAny().get();
-            if (single instanceof ShadowedCapability) {
-                return new ShadowedSingleImmutableCapabilities(single);
-            }
+            return of(single);
         }
         return new ImmutableCapabilities(ImmutableList.copyOf(capabilities));
     }
 
+    public static ImmutableCapabilities of(@Nullable Capability capability) {
+        if (capability == null) {
+            return EMPTY;
+        }
+        if (capability instanceof ShadowedCapability) {
+            return new ShadowedSingleImmutableCapabilities(capability);
+        }
+        return new ImmutableCapabilities(ImmutableList.of(capability));
+    }
+
     public ImmutableCapabilities(ImmutableList<? extends Capability> capabilities) {
         this.capabilities = capabilities;
+    }
+
+    public static ImmutableCapabilities copyAsImmutable(Collection<? extends Capability> capabilities) {
+        if (capabilities.isEmpty()) {
+            return ImmutableCapabilities.EMPTY;
+        }
+
+        ImmutableList.Builder<CapabilityInternal> builder = new ImmutableList.Builder<>();
+        for (Capability descriptor : capabilities) {
+            if (descriptor instanceof ImmutableCapability) {
+                builder.add((ImmutableCapability) descriptor);
+            } else if (descriptor instanceof ShadowedCapability) {
+                builder.add((ShadowedCapability) descriptor);
+            } else {
+                builder.add(new ImmutableCapability(descriptor.getGroup(), descriptor.getName(), descriptor.getVersion()));
+            }
+        }
+        return ImmutableCapabilities.of(builder.build());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ImmutableCapability.java
@@ -16,11 +16,16 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.capabilities.Capability;
 
 import javax.annotation.Nullable;
 
 public class ImmutableCapability implements CapabilityInternal {
+
+    public static ImmutableCapability defaultCapabilityForComponent(ModuleVersionIdentifier identifier) {
+        return new ImmutableCapability(identifier.getGroup(), identifier.getName(), identifier.getVersion());
+    }
 
     private final String group;
     private final String name;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
+import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
@@ -38,11 +39,16 @@ class DefaultArtifactSetTest extends Specification {
     def "returns empty set when component id does not match spec"() {
         def variant1 = Stub(VariantResolveMetadata)
         def variant2 = Stub(VariantResolveMetadata)
+        def ownerId = Stub(ModuleVersionIdentifier)
 
         given:
-        def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
-        def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
-        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, ownerId, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+
+        ownerId.group >> "group"
+        ownerId.name >> "name"
+        ownerId.version >> "1.0"
 
         expect:
         artifacts1.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
@@ -55,13 +61,17 @@ class DefaultArtifactSetTest extends Specification {
         def variant2 = Stub(VariantResolveMetadata)
         def resolvedVariant1 = Stub(ResolvedArtifactSet)
         def selector = Stub(VariantSelector)
+        def ownerId = Stub(ModuleVersionIdentifier)
 
         given:
-        def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
-        def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
-        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, null, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts1 = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts2 = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        def artifacts3 = DefaultArtifactSet.adHocVariant(componentId, ownerId, [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
 
         selector.select(_, _) >> resolvedVariant1
+        ownerId.group >> "group"
+        ownerId.name >> "name"
+        ownerId.version >> "1.0"
 
         expect:
         artifacts1.select({ true }, selector) == resolvedVariant1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -34,7 +34,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
     def result = ImmutableList.builder()
     CacheableInvocation<TransformationSubject> invocation = Mock(CacheableInvocation)
     def operationQueue = Mock(BuildOperationQueue)
-    def listener = new TransformingAsyncArtifactListener([new BoundTransformationStep(transformation, Stub(TransformUpstreamDependencies))], targetAttributes, result)
+    def listener = new TransformingAsyncArtifactListener([new BoundTransformationStep(transformation, Stub(TransformUpstreamDependencies))], targetAttributes, [], result)
     def file = new File("foo")
     def artifactFile = new File("foo-artifact")
     def artifactId = Stub(ComponentArtifactIdentifier)


### PR DESCRIPTION
This fixes a number of cases missed in #17393:
* Exposed capabilities are all of the same type
* The default capability is explicit in the `ResolvedVariantResult`
* Capabilities are carried over in transforms
* A `CapabilitiesCodec` has been added for configuration cache support