### PR TITLE
Add Maven Relocation section to "Maven Publish Plugin" userguide

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -7,6 +7,7 @@ We would like to thank the following community members for their contributions t
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 -->
+[Marcono1234](https://github.com/Marcono1234)
 
 ## Upgrade instructions
 

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/component_capabilities.adoc
@@ -63,6 +63,7 @@ By adding this rule, we will make sure that Gradle _will_ detect conflicts and p
 
 See the <<dependency_capability_conflict.adoc#sub:selecting-between-candidates, capabilities section of the documentation>> to figure out how to fix capability conflicts.
 
+[[sec:declaring-additional-capabilities-for-a-local-component]]
 == Declaring additional capabilities for a local component
 
 All components have an _implicit capability_ corresponding to the same GAV coordinates as the component.

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -15,7 +15,7 @@
 [[publishing_maven]]
 = Maven Publish Plugin
 
-The Maven Publish Plugin provides the ability to publish build artifacts to an http://maven.apache.org/[Apache Maven] repository.
+The Maven Publish Plugin provides the ability to publish build artifacts to an https://maven.apache.org/[Apache Maven] repository.
 A module published to a Maven repository can be consumed by Maven, Gradle (see <<declaring_dependencies.adoc#declaring-dependencies,Declaring Dependencies>>) and other tools that understand the Maven repository format.
 You can learn about the fundamentals of publishing in <<publishing_setup.adoc#publishing_overview,Publishing Overview>>.
 
@@ -187,6 +187,54 @@ include::sample[dir="snippets/maven-publish/javaProject/kotlin",files="build.gra
 For integration with a local Maven installation, it is sometimes useful to publish the module into the Maven local repository (typically at _$USER_HOME/.m2/repository_), along with its POM file and other metadata. In Maven parlance, this is referred to as 'installing' the module.
 
 The Maven Publish Plugin makes this easy to do by automatically creating a link:{javadocPath}/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.html[PublishToMavenLocal] task for each link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPublication.html[MavenPublication] in the `publishing.publications` container. The task name follows the pattern of `publish__PubName__PublicationToMavenLocal`. Each of these tasks is wired into the `publishToMavenLocal` aggregate task. You do not need to have `mavenLocal()` in your `publishing.repositories` section.
+
+[[publishing_maven:relocation]]
+== Publishing Maven relocation information
+
+When a project changes the `groupId` or `artifactId` (the _coordinates_) of an artifact it publishes, it is important to let users know where the new artifact can be found. Maven can help with that through the _relocation_ feature. The way this works is that a project publishes an additional artifact under the old coordinates consisting only of a minimal _relocation POM_; that POM file specifies where the new artifact can be found. Maven repository browsers and build tools can then inform the user that the coordinates of an artifact have changed.
+
+For this, a project adds an additional `MavenPublication` specifying a link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPomRelocation[MavenPomRelocation]:
+
+.Specifying a relocation POM
+====
+include::sample[dir="snippets/maven-publish/specify-relocation/groovy/library",files="build.gradle[tags=specify-relocation]"]
+include::sample[dir="snippets/maven-publish/specify-relocation/kotlin/library",files="build.gradle.kts[tags=specify-relocation]"]
+====
+
+[TIP]
+====
+Only the property which has changed needs to be specified under `relocation`, that is `artifactId` and / or `groupId`. All other properties are optional.
+
+Specifying the `version` can be useful when the new artifact has a different version, for example because version numbering has started at 1.0.0 again.
+A custom `message` allows explaining why the artifact coordinates have changed.
+====
+
+The relocation POM should be created for what would be the next version of the old artifact. For example when the artifact coordinates of `com.example:lib:1.0.0` are changed and the artifact with the new coordinates continues version numbering and is published as `com.new-example:lib:2.0.0`, then the relocation POM should specify a relocation from `com.example:lib:**2.0.0**` to `**com.new-example**:lib:2.0.0`.
+
+A relocation POM only has to be published once, the build file configuration for it should be removed again once it has been published.
+
+Note that a relocation POM is not suitable for all situations; when an artifact has been split into two or more separate artifacts then a relocation POM might not be helpful.
+
+[[publishing_maven:retroactive_relocation]]
+=== Retroactively publishing relocation information
+
+It is possible to publish relocation information retroactively after the coordinates of an artifact have changed in the past, and no relocation information was published back then.
+
+The same recommendations as described above apply. To ease migration for users, it is important to pay attention to the `version` specified in the relocation POM. The relocation POM should allow the user to move to the new artifact in one step, and then allow them to update to the latest version in a separate step. For example when for the coordinates of `com.new-example:lib:5.0.0` were changed in version 2.0.0, then ideally the relocation POM should be published for the old coordinates `com.example:lib:**2.0.0**` relocating to `com.new-example:lib:**2.0.0**`. The user can then switch from `com.example:lib` to `com.new-example` and then separately update from version 2.0.0 to 5.0.0, handling breaking changes (if any) step by step.
+
+When relocation information is published retroactively, it is not necessary to wait for next regular release of the project, it can be published in the meantime. As mentioned above, the relocation information should then be removed again from the build file once the relocation POM has been published.
+
+[[publishing_maven:relocation_duplicate_dependencies]]
+=== Avoiding duplicate dependencies
+
+When only the coordinates of the artifact have changed, but package names of the classes inside the artifact have remained the same, dependency conflicts can occur. A project might (transitively) depend on the old artifact but at the same time also have a dependency on the new artifact which both contain the same classes, potentially with incompatible changes.
+
+To detect such conflicting duplicate dependencies, <<dependency_capability_conflict.adoc#sub:declaring-component-capabilities,capabilities>> can be published as part of the <<publishing_gradle_module_metadata.adoc#sec:understanding-gradle-module-md,Gradle Module Metadata>>.
+
+[[publishing_maven:relocation_dry_run]]
+=== Performing a dry run
+
+To verify that relocation information works as expected before publishing it to a remote repository, it can first be <<#publishing_maven:install,published to the local Maven repository>>. Then a local test Gradle or Maven project can be created which has the relocation artifact as dependency.
 
 [[publishing_maven:complete_example]]
 == Complete example

--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -201,15 +201,15 @@ include::sample[dir="snippets/maven-publish/specify-relocation/groovy/library",f
 include::sample[dir="snippets/maven-publish/specify-relocation/kotlin/library",files="build.gradle.kts[tags=specify-relocation]"]
 ====
 
-[TIP]
-====
 Only the property which has changed needs to be specified under `relocation`, that is `artifactId` and / or `groupId`. All other properties are optional.
 
+[TIP]
+====
 Specifying the `version` can be useful when the new artifact has a different version, for example because version numbering has started at 1.0.0 again.
 A custom `message` allows explaining why the artifact coordinates have changed.
 ====
 
-The relocation POM should be created for what would be the next version of the old artifact. For example when the artifact coordinates of `com.example:lib:1.0.0` are changed and the artifact with the new coordinates continues version numbering and is published as `com.new-example:lib:2.0.0`, then the relocation POM should specify a relocation from `com.example:lib:**2.0.0**` to `**com.new-example**:lib:2.0.0`.
+The relocation POM should be created for what would be the next version of the old artifact. For example when the artifact coordinates of `com.example:lib:1.0.0` are changed and the artifact with the new coordinates continues version numbering and is published as `com.new-example:lib:2.0.0`, then the relocation POM should specify a relocation from `com.example:lib:2.0.0` to `com.new-example:lib:2.0.0`.
 
 A relocation POM only has to be published once, the build file configuration for it should be removed again once it has been published.
 
@@ -220,7 +220,7 @@ Note that a relocation POM is not suitable for all situations; when an artifact 
 
 It is possible to publish relocation information retroactively after the coordinates of an artifact have changed in the past, and no relocation information was published back then.
 
-The same recommendations as described above apply. To ease migration for users, it is important to pay attention to the `version` specified in the relocation POM. The relocation POM should allow the user to move to the new artifact in one step, and then allow them to update to the latest version in a separate step. For example when for the coordinates of `com.new-example:lib:5.0.0` were changed in version 2.0.0, then ideally the relocation POM should be published for the old coordinates `com.example:lib:**2.0.0**` relocating to `com.new-example:lib:**2.0.0**`. The user can then switch from `com.example:lib` to `com.new-example` and then separately update from version 2.0.0 to 5.0.0, handling breaking changes (if any) step by step.
+The same recommendations as described above apply. To ease migration for users, it is important to pay attention to the `version` specified in the relocation POM. The relocation POM should allow the user to move to the new artifact in one step, and then allow them to update to the latest version in a separate step. For example when for the coordinates of `com.new-example:lib:5.0.0` were changed in version 2.0.0, then ideally the relocation POM should be published for the old coordinates `com.example:lib:2.0.0` relocating to `com.new-example:lib:2.0.0`. The user can then switch from `com.example:lib` to `com.new-example` and then separately update from version 2.0.0 to 5.0.0, handling breaking changes (if any) step by step.
 
 When relocation information is published retroactively, it is not necessary to wait for next regular release of the project, it can be published in the meantime. As mentioned above, the relocation information should then be removed again from the build file once the relocation POM has been published.
 
@@ -229,7 +229,7 @@ When relocation information is published retroactively, it is not necessary to w
 
 When only the coordinates of the artifact have changed, but package names of the classes inside the artifact have remained the same, dependency conflicts can occur. A project might (transitively) depend on the old artifact but at the same time also have a dependency on the new artifact which both contain the same classes, potentially with incompatible changes.
 
-To detect such conflicting duplicate dependencies, <<dependency_capability_conflict.adoc#sub:declaring-component-capabilities,capabilities>> can be published as part of the <<publishing_gradle_module_metadata.adoc#sec:understanding-gradle-module-md,Gradle Module Metadata>>.
+To detect such conflicting duplicate dependencies, <<dependency_capability_conflict.adoc#sub:declaring-component-capabilities,capabilities>> can be published as part of the <<publishing_gradle_module_metadata.adoc#sec:understanding-gradle-module-md,Gradle Module Metadata>>.  For an example using a <<java_library_plugin.adoc#java_library_plugin,Java Library>> project, see <<component_capabilities.adoc#sec:declaring-additional-capabilities-for-a-local-component,declaring additional capabilities for a local component>>.
 
 [[publishing_maven:relocation_dry_run]]
 === Performing a dry run

--- a/subprojects/docs/src/snippets/maven-publish/specify-relocation/groovy/library/build.gradle
+++ b/subprojects/docs/src/snippets/maven-publish/specify-relocation/groovy/library/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+}
+
+publishing {
+    repositories {
+        maven {
+            url = "${rootProject.buildDir}/repo" // change to point to your repo, e.g. http://my.org/repo
+        }
+    }
+}
+
+dependencies {
+    api 'org.slf4j:slf4j-api:1.7.10'
+}
+
+// tag::specify-relocation[]
+publishing {
+    publications {
+        // ... artifact publications
+
+        // Specify relocation POM
+        relocation(MavenPublication) {
+            pom {
+                // Old artifact coordinates
+                groupId = "com.example"
+                artifactId = "lib"
+                version = "2.0.0"
+
+                distributionManagement {
+                    relocation {
+                        // New artifact coordinates
+                        groupId = "com.new-example"
+                        artifactId = "lib"
+                        version = "2.0.0"
+                        message = "groupId has been changed"
+                    }
+                }
+            }
+        }
+    }
+}
+// end::specify-relocation[]

--- a/subprojects/docs/src/snippets/maven-publish/specify-relocation/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/maven-publish/specify-relocation/groovy/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'maven-specify-relocation'
+include 'library'

--- a/subprojects/docs/src/snippets/maven-publish/specify-relocation/kotlin/library/build.gradle.kts
+++ b/subprojects/docs/src/snippets/maven-publish/specify-relocation/kotlin/library/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("java-library")
+    id("maven-publish")
+}
+
+repositories {
+    mavenCentral()
+}
+
+publishing {
+    repositories {
+        maven {
+            url = uri("${rootProject.buildDir}/repo") // change to point to your repo, e.g. http://my.org/repo
+        }
+    }
+}
+
+dependencies {
+    api("org.slf4j:slf4j-api:1.7.10")
+}
+
+// tag::specify-relocation[]
+publishing {
+    publications {
+        // ... artifact publications
+
+        // Specify relocation POM
+        create<MavenPublication>("relocation") {
+            pom {
+                // Old artifact coordinates
+                groupId = "com.example"
+                artifactId = "lib"
+                version = "2.0.0"
+
+                distributionManagement {
+                    relocation {
+                        // New artifact coordinates
+                        groupId.set("com.new-example")
+                        artifactId.set("lib")
+                        version.set("2.0.0")
+                        message.set("groupId has been changed")
+                    }
+                }
+            }
+        }
+    }
+}
+// end::specify-relocation[]

--- a/subprojects/docs/src/snippets/maven-publish/specify-relocation/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/maven-publish/specify-relocation/kotlin/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "maven-specify-relocation"
+include("library")

--- a/subprojects/docs/src/snippets/maven-publish/specify-relocation/tests/publish-specify-relocation.sample.conf
+++ b/subprojects/docs/src/snippets/maven-publish/specify-relocation/tests/publish-specify-relocation.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: publish


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #17772

### Context
See #17772

Note that I am not that familiar with Maven Relocation, but tried to describe it as good as possible. Maybe these changes are a little bit verbose for a feature which might not be used that often. Feedback is appreciated!

There are a few open questions which is why I have marked this pull request as Draft for now.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <subproject>:quickTest`
`./gradlew docs:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
