### PR TITLE
Disable incremental Kotlin compiler when running on Java 17

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradlePropertiesLoader.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.initialization;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.properties.GradleProperties;
@@ -59,6 +60,11 @@ public class DefaultGradlePropertiesLoader implements IGradlePropertiesLoader {
         overrideProperties.putAll(getEnvProjectProperties(envProperties));
         overrideProperties.putAll(getSystemProjectProperties(systemProperties));
         overrideProperties.putAll(startParameter.getProjectProperties());
+
+        // workaround https://youtrack.jetbrains.com/issue/KT-47152 - should be fixed in Kotlin 1.5.30
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+            overrideProperties.put("kotlin.incremental", "false");
+        }
 
         return new DefaultGradleProperties(defaultProperties, overrideProperties);
     }


### PR DESCRIPTION
This is a workaround to https://youtrack.jetbrains.com/issue/KT-47152
The fix is planned in Kotlin 1.5.30.

If the fix lands before Java 17, then it would be preferable to
upgrade.

On the other hand, I was able to work around this issue in a smoke
test by adding the required JVM arguments to the Kotlin compiler daemon
here: https://github.com/gradle/gradle/pull/17763/commits/3fd0d2113ca2ff1487187d71bc2d62d105cbe073

At the same time, I am not able to apply such a workaround within
Gradle as was done previously with `--illegal-access=permit`:
https://github.com/gradle/gradle/pull/17781/files#diff-66f4b61ab1b7cbf83f68849143ddd9934681ab75a5a68f26c6a51df7ad5c3f88
I do not understand why setting the same JVM args as in above
smoke test in this place does not seem to do the trick here.
Figuring this out instead,would be a better approach than
disabling incremental Kotlin compiler on Java 17.
