### PR TITLE
Let configuration cache preserve iteration order of HashMap instances

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CollectionCodecs.kt
@@ -64,8 +64,11 @@ fun <T : MutableCollection<Any?>> collectionCodec(factory: (Int) -> T) = codec(
 )
 
 
+/**
+ * Decodes HashMap instances as LinkedHashMap to preserve original iteration order.
+ */
 internal
-val hashMapCodec: Codec<HashMap<Any?, Any?>> = mapCodec { HashMap<Any?, Any?>(it) }
+val hashMapCodec: Codec<HashMap<Any?, Any?>> = mapCodec { LinkedHashMap<Any?, Any?>(it) }
 
 
 internal


### PR DESCRIPTION
by deserializing into LinkedHashMap
the same way we already do for HashSet using LinkedHashSet
