### PR TITLE
Remove ellipses from documentation titles

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -118,7 +118,7 @@
             <li><a href="../userguide/what_is_gradle.html">What is Gradle?</a></li>
             <li><a href="../userguide/getting_started.html">Getting Started</a></li>
             <li><a href="../userguide/installation.html">Installing Gradle</a></li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle...</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>
                 <ul id="upgrading-gradle">
                     <li><a href="../userguide/upgrading_version_7.html">version 7.X to 8.0</a></li>
                     <li><a href="../userguide/upgrading_version_6.html">version 6.X to 7.0</a></li>
@@ -127,7 +127,7 @@
                     <li><a href="../userguide/feature_lifecycle.html">Gradle's Feature Lifecycle</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#migrating-to-gradle" aria-expanded="false" aria-controls="migrating-to-gradle">Migrating to Gradle...</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#migrating-to-gradle" aria-expanded="false" aria-controls="migrating-to-gradle">Migrating to Gradle</a>
                 <ul id="migrating-to-gradle">
                     <li><a href="../userguide/migrating_from_maven.html">from Maven</a></li>
                     <li><a href="../userguide/migrating_from_ant.html">from Ant</a></li>


### PR DESCRIPTION
They look weird and inconsistent with all the other top-level titles that do not have ellipses.

![image](https://user-images.githubusercontent.com/495366/127631634-8cacae2d-2a78-4bd0-a34d-817a0df9cd04.png)
