### PR TITLE
Add full compile classpath of a sourceset to PMD's auxclasspath

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginAuxclasspathIntegrationTest.groovy
@@ -112,6 +112,22 @@ class PmdPluginAuxclasspathIntegrationTest extends AbstractPmdPluginVersionInteg
             assertContents(containsText("auxclasspath configured"))
     }
 
+    def "auxclasspath configured for test sourceset of rule-using project"() {
+        Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
+
+        given:
+        setupRuleUsingProject(classExtendingJunit(), JUNIT_IMPL_DEPENDENCY)
+
+        file("rule-using/src/test/java/org/gradle/ruleusing/Class2.java") << testClass()
+
+        expect:
+        fails ":rule-using:pmdTest"
+
+        file("rule-using/build/reports/pmd/test.xml").
+            assertContents(containsClass("org.gradle.ruleusing.Class2")).
+            assertContents(containsText("auxclasspath configured"))
+    }
+
     def "auxclasspath not configured properly for rule-using project"() {
         Assume.assumeTrue(supportsAuxclasspath() && fileLockingIssuesSolved())
 
@@ -226,6 +242,13 @@ project("rule-using") {
         """
             package org.gradle.ruleusing;
             public class Class1 extends junit.framework.TestCase { }
+        """
+    }
+
+    private static testClass() {
+        """
+            package org.gradle.ruleusing;
+            public class Class2 extends Class1 { }
         """
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.quality;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.ConventionMapping;
@@ -184,6 +185,13 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         // This is important to get transitive implementation dependencies. PMD may load referenced classes for analysis so it expects the classpath to be "closed" world.
         getJvmPluginServices().configureAsRuntimeClasspath(pmdAuxClasspath);
 
-        taskMapping.map("classpath", () -> sourceSet.getOutput().plus(pmdAuxClasspath));
+        // We have to explicitly add compileClasspath here because it may contain classes that aren't part of the compileClasspathConfiguration. In particular, compile
+        // classpath of the test sourceSet contains output of the main sourceSet.
+        taskMapping.map("classpath", () -> {
+            // It is important to subtract compileClasspath and not pmdAuxClasspath here because these configurations are resolved differently (as a compile and as a
+            // runtime classpath). Compile and runtime entries for the same dependency may resolve to different files (e.g. compiled classes directory vs. jar).
+            FileCollection nonConfigurationClasspathEntries = sourceSet.getCompileClasspath().minus(compileClasspath);
+            return sourceSet.getOutput().plus(nonConfigurationClasspathEntries).plus(pmdAuxClasspath);
+        });
     }
 }


### PR DESCRIPTION
The compile classpath of the sourceset doesn't entirely consist of the
compileClasspath configuration. It may also include other things; for
example the compile classpath of the test source set contains outputs
of the compilation of the main source set. These things are crucial
for the PMD analysis too.

This CL adds all non-configuration-originated entries of the compile
classpath to the PMD aux classpath.

<!--- The issue this PR addresses -->
Fixes #17893 
