### PR TITLE
Fix or ignore failing santaTracker smoke tests on release6x

### DIFF
--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -66,8 +66,8 @@ tasks {
 
     val santaTrackerKotlin by registering(RemoteProject::class) {
         remoteUri.set(santaGitUri)
-        // Pinned from branch agp-3.6.0
-        ref.set("3122343674246eaa56a5dd6365ea137edb021780")
+        // Pinned from branch main
+        ref.set("c26e2b8aa5c34758934009f1d5b0334f7fc2db5a")
     }
 
     val santaTrackerJava by registering(RemoteProject::class) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerJavaCachingSmokeTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE
@@ -42,6 +43,7 @@ class AndroidSantaTrackerJavaCachingSmokeTest extends AbstractAndroidSantaTracke
 
     @Unroll
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @Ignore("https://github.com/gradle/gradle-private/issues/3421")
     def "can cache Santa Tracker Java Android application (agp=#agpVersion)"() {
 
         // TODO remove after next 4.2 release

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.profiler.mutations.ApplyNonAbiChangeToJavaSourceFileMutator
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -39,6 +40,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
 
     @Unroll
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @Ignore("https://github.com/gradle/gradle-private/issues/3421")
     def "check deprecation warnings produced by building Santa Tracker Java (agp=#agpVersion)"() {
 
         given:
@@ -66,6 +68,7 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
 
     @Unroll
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_3_ITERATION_MATCHER, AGP_4_0_ITERATION_MATCHER])
+    @Ignore("https://github.com/gradle/gradle-private/issues/3421")
     def "incremental Java compilation works for Santa Tracker Java (agp=#agpVersion)"() {
 
         given:


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/3421