### PR TITLE
Make jacoco plugin work on Turkish locale

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Extension for tasks that should run with a Jacoco agent to generate coverage execution data.
@@ -56,7 +57,7 @@ public class JacocoTaskExtension {
          * Gets type in format of agent argument.
          */
         public String getAsArg() {
-            return toString().toLowerCase().replaceAll("_", "");
+            return toString().toLowerCase(Locale.US).replaceAll("_", "");
         }
     }
 


### PR DESCRIPTION
Fixes #17600.

### Context

There's a comprehensive fix implemented in #17657, but there's a debate on how it needs to be implemented. This PR patches the reported problem but omits the implementation that prohibits further usages of the error-prone `toLowerCase()` and `toUppercase()` calls.