### PR TITLE
Don't lose task dependencies when zipping against provider with no dependencies

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -149,7 +149,7 @@ public interface ValueSupplier {
 
         @Override
         public boolean isKnown() {
-            return left.isKnown() && right.isKnown();
+            return left.isKnown() || right.isKnown();
         }
 
         @Override


### PR DESCRIPTION
Fixes #17534