### PR TITLE
Simplify uber-jar documentation snippet

### DIFF
--- a/subprojects/docs/src/snippets/files/archivesWithJavaPlugin/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/archivesWithJavaPlugin/groovy/build.gradle
@@ -17,8 +17,6 @@ tasks.register('uberJar', Jar) {
     archiveClassifier = 'uber'
 
     from sourceSets.main.output
-
-    dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
     }

--- a/subprojects/docs/src/snippets/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
@@ -17,8 +17,6 @@ tasks.register<Jar>("uberJar") {
     archiveClassifier.set("uber")
 
     from(sourceSets.main.get().output)
-
-    dependsOn(configurations.runtimeClasspath)
     from({
         configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
     })


### PR DESCRIPTION
`dependsOn configurations.runtimeClasspath` is implicit when this configuration is used in `from`.