### PR TITLE
Compile everything in compileAllProduction

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -18,7 +18,6 @@ import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistribu
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
-import gradlebuild.basics.testing.TestType
 import gradlebuild.filterEnvironmentVariables
 import gradlebuild.jvm.argumentproviders.CiEnvironmentProvider
 import gradlebuild.jvm.extension.UnitTestAndCompileExtension
@@ -150,16 +149,12 @@ fun addCompileAllTask() {
     tasks.register("compileAllProduction") {
         description = "Compile all production source code, usually only main and testFixtures."
         val compileTasks = project.tasks.matching {
-            (it is JavaCompile || it is GroovyCompile) && !it.isTestCompile()
+            // Currently, we compile everything since the Groovy compiler is not deterministic enough.
+            (it is JavaCompile || it is GroovyCompile)
         }
         dependsOn(compileTasks)
     }
 }
-
-val testCompileTasks
-    get() = TestType.values().map { "compile${it.prefix.capitalize()}Test" } + listOf("compileTestGroovy", "compileTestKotlin")
-
-fun Task.isTestCompile() = testCompileTasks.any { name.startsWith(it) }
 
 fun configureJarTasks() {
     tasks.withType<Jar>().configureEach {


### PR DESCRIPTION
Groovy compilation seems to be non-deterministic, so
not compiling the Groovy test sources up-front causes
some cache misses later on :(