### PR TITLE
Fix build scan performance test credentials

### DIFF
--- a/subprojects/build-scan-performance/build.gradle.kts
+++ b/subprojects/build-scan-performance/build.gradle.kts
@@ -56,8 +56,9 @@ subprojects {
 tasks.withType<gradlebuild.performance.tasks.PerformanceTest>().configureEach {
     systemProperties["incomingArtifactDir"] = "$rootDir/incoming/"
 
-    environment("ARTIFACTORY_USERNAME", System.getenv("ARTIFACTORY_USERNAME"))
-    environment("ARTIFACTORY_PASSWORD", System.getenv("ARTIFACTORY_PASSWORD"))
+    environment("GRADLE_INTERNAL_REPO_URL", System.getenv("GRADLE_INTERNAL_REPO_URL"))
+    environment("ORG_GRADLE_PROJECT_gradleInternalRepositoryUsername", System.getenv("GRADLE_INTERNAL_REPO_USERNAME"))
+    environment("ORG_GRADLE_PROJECT_gradleInternalRepositoryPassword", System.getenv("GRADLE_INTERNAL_REPO_PASSWORD"))
 
     reportGeneratorClass.set("org.gradle.performance.results.BuildScanReportGenerator")
 }

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -183,11 +183,8 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
                     buildscript {
                         repositories {
                             maven {
-                                url 'https://repo.gradle.org/gradle/enterprise-libs-snapshots-local/'
-                                credentials {
-                                    username = System.getenv("ARTIFACTORY_USERNAME")
-                                    password = System.getenv("ARTIFACTORY_PASSWORD")
-                                }
+                                name 'gradleInternalRepository'
+                                url '${System.getenv("GRADLE_INTERNAL_REPO_URL")}/enterprise-snapshots-local/'
                                 authentication {
                                     basic(BasicAuthentication)
                                 }


### PR DESCRIPTION
Forwards the URL to the new internal repository from the build
environment into the test VMs environment. Credentials are also
forwarded but no longer written to the test build's setting script.
Instead they are set as project properties.
