### PR TITLE
Toolchains: support custom path for auto-download location.

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -253,6 +253,16 @@ In order to disable auto-provisioning, you can use the `org.gradle.java.installa
 * Either start gradle using `-Porg.gradle.java.installations.auto-download=false`
 * Or put `org.gradle.java.installations.auto-download=false` into a `gradle.properties` file.
 
+[[sub:configure_auto_provision_location]]
+=== How to configure auto provisioning location
+
+By default, Gradle will auto provision JDKs inside `$GRADLE_HOME/jdks` directory. There might be scenarios where this is not desired.
+
+In order to configure a custom auto-provisioning location, you can use the `org.gradle.java.installations.auto-download-location` Gradle property:
+
+* Either start gradle using `-Porg.gradle.java.installations.auto-download-location=/custom/path/jdks`
+* Or put `org.gradle.java.installations.auto-download-location=/custom/path/jdks` into a `gradle.properties` file.
+
 [[sec:custom_loc]]
 == Custom Toolchain locations
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplierTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/AutoInstalledInstallationSupplierTest.groovy
@@ -132,7 +132,7 @@ class AutoInstalledInstallationSupplierTest extends Specification {
     }
 
     private JdkCacheDirectory newCacheDirProvider(javaHomes) {
-        new JdkCacheDirectory(Mock(GradleUserHomeDirProvider), Mock(FileOperations), Mock(FileLockManager)) {
+        new JdkCacheDirectory(Mock(GradleUserHomeDirProvider), Mock(FileOperations), Mock(FileLockManager), createProviderFactory()) {
             @Override
             Set<File> listJavaHomes() {
                 return javaHomes
@@ -144,6 +144,7 @@ class AutoInstalledInstallationSupplierTest extends Specification {
         def providerFactory = Mock(ProviderFactory)
         providerFactory.gradleProperty("org.gradle.java.installations.auto-detect") >> Providers.ofNullable(null)
         providerFactory.gradleProperty("org.gradle.java.installations.auto-download") >> Providers.ofNullable(null)
+        providerFactory.gradleProperty("org.gradle.java.installations.auto-download-location") >> Providers.ofNullable(null)
         providerFactory
     }
 


### PR DESCRIPTION
Resolves #17946

Signed-off-by: Roberto Perez Alcolea <rperezalcolea@netflix.com>

### Context
When using the auto download mechanism to provision a JDK, Gradle will download and store them under `$GRADLE_HOME/jdks`. 

While this is great, it would be ideal to allow users to configure the download location. 

Scenarios that this could potentially help:

* Shared infrastructure: For example, running multiple builds at the same time on Jenkins where each executor has its own `GRADLE_HOME`, results in multiple JDK downloads (when necessary). By having a well known location outside the `GRADLE_HOME`, existing downloads could be re-used.
* Users that for some reason have to wipe their `GRADLE_HOME` in between runs
* It might be common to run against different `GRADLE_HOME` for verifying/triaging issues and on this case, it might be better if JDKs don't have to be downloaded again

This allows users to set a `org.gradle.java.installations.auto-download-location` property

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
