### PR TITLE
Adjust version catalog documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/version_catalog_problems.adoc
@@ -25,7 +25,7 @@ To fix this problem, if you need more entries, it's probably best to split the c
 == Use of a reserved alias name
 
 This error indicates that you chose an alias which is a reserved name.
-Typically this happens if you choose an alias which ends with `version` or `bundle`, as it may clash with generated accessors.
+Typically this happens if you choose an alias which ends with `version`, `bundle`, or `plugin`, as it may clash with generated accessors.
 
 To fix this problem, you must choose a different alias.
 


### PR DESCRIPTION
Gradle 7.2 adds support for declaring plugin version in the version catalog. The implementation now lists `plugin` as a reserved keyword, but the documentation doesn't mention it.

The PR targets the release branch, although an RC version has already been published. This is a documentation-only PR so should be fine to merge it without publishing a new RC.