### PR TITLE
Fail the build if input property can't be resolved

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -432,6 +432,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/17962")
     def "execution fails when a nested property throws an exception"() {
         buildFile << """
             class TaskWithFailingNestedInput extends DefaultTask {
@@ -459,7 +460,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
 
         expect:
         fails "myTask"
-        failure.assertHasDescription("Execution failed for task ':myTask'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':myTask'.")
         failure.assertHasCause("BOOM")
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
@@ -101,8 +101,7 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
 
         @Override
         public TaskDependencyContainer getTaskDependencies() {
-            // Ignore
-            return TaskDependencyContainer.EMPTY;
+            throw UncheckedException.throwAsUncheckedException(exception);
         }
 
         @Override

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishHttpIntegTest.groovy
@@ -599,7 +599,7 @@ credentials {
 
         then:
         notExecuted(':jar', ':publishIvyPublicationToIvyRepository')
-        failure.assertHasDescription("Credentials required for this build could not be resolved.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':publishIvyPublicationToIvyRepository'.")
         failure.assertHasCause("The following Gradle properties are missing for 'ivy' credentials:")
         failure.assertHasErrorOutput("- ivyUsername")
         failure.assertHasErrorOutput("- ivyPassword")

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftMissingToolchainIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftMissingToolchainIntegrationTest.groovy
@@ -45,7 +45,7 @@ class SwiftMissingToolchainIntegrationTest extends AbstractIntegrationSpec imple
         fails("assemble")
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileDebugSwift'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':linkDebug'.")
         failure.assertHasCause("""No tool chain is available to build Swift for host operating system '${osName}' architecture '${archName}':
   - Tool chain 'swiftc' (Swift Compiler):
       - Could not find Swift compiler 'swiftc'. Searched in:

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadIntegrationTest.groovy
@@ -44,7 +44,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
             .assertHasCause("Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any, implementation=vendor-specific}")
             .assertHasCause("Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.")
@@ -76,7 +76,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
             .assertHasCause("No compatible toolchains found for request filter: {languageVersion=14, vendor=any, implementation=vendor-specific} (auto-detect false, auto-download false)")
     }
@@ -107,7 +107,7 @@ class JavaToolchainDownloadIntegrationTest extends AbstractIntegrationSpec {
             .runWithFailure()
 
         then:
-        failure.assertHasDescription("Execution failed for task ':compileJava'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':compileJava'.")
             .assertHasCause("Failed to calculate the value of task ':compileJava' property 'javaCompiler'")
             .assertHasCause('Unable to download toolchain matching these requirements: {languageVersion=99, vendor=any, implementation=vendor-specific}')
             .assertThatCause(CoreMatchers.startsWith('Attempting to download a JDK from an insecure URI http://example.com'))


### PR DESCRIPTION
and that property can contribute to dependencies.

Fixes #17962.