### PR TITLE
Inject credentials via environment variables

### DIFF
--- a/subprojects/build-scan-performance/build.gradle.kts
+++ b/subprojects/build-scan-performance/build.gradle.kts
@@ -57,8 +57,8 @@ tasks.withType<gradlebuild.performance.tasks.PerformanceTest>().configureEach {
     systemProperties["incomingArtifactDir"] = "$rootDir/incoming/"
 
     environment("GRADLE_INTERNAL_REPO_URL", System.getenv("GRADLE_INTERNAL_REPO_URL"))
-    environment("ORG_GRADLE_PROJECT_gradleInternalRepositoryUsername", System.getenv("GRADLE_INTERNAL_REPO_USERNAME"))
-    environment("ORG_GRADLE_PROJECT_gradleInternalRepositoryPassword", System.getenv("GRADLE_INTERNAL_REPO_PASSWORD"))
+    environment("GRADLE_INTERNAL_REPO_USERNAME", System.getenv("GRADLE_INTERNAL_REPO_USERNAME"))
+    environment("GRADLE_INTERNAL_REPO_PASSWORD", System.getenv("GRADLE_INTERNAL_REPO_PASSWORD"))
 
     reportGeneratorClass.set("org.gradle.performance.results.BuildScanReportGenerator")
 }

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -185,6 +185,10 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
                             maven {
                                 name 'gradleInternalRepository'
                                 url '${System.getenv("GRADLE_INTERNAL_REPO_URL")}/enterprise-libs-snapshots-local/'
+                                credentials {
+                                    username = System.getenv("GRADLE_INTERNAL_REPO_USERNAME")
+                                    password = System.getenv("GRADLE_INTERNAL_REPO_PASSWORD")
+                                }
                                 authentication {
                                     basic(BasicAuthentication)
                                 }


### PR DESCRIPTION
Credentials can't be injected via project properties into settings scripts.
In order to access the credentials here, we're now injecting them directly
as environment variables.