### PR TITLE
Persist variant capabilities for the elements of an ArtifactCollection to the configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -39,10 +39,12 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         remoteRepo.module("group", "lib1", "6500").publish().allowAll()
 
         settingsFile << """
+            rootProject.name = 'root'
             include 'a', 'b'"""
 
         buildFile << """
             subprojects {
+                group = 'test'
                 configurations { create("default") }
                 task producer(type: FileProducer) {
                     content = providers.gradleProperty("\${project.name}Content").orElse("content")
@@ -138,6 +140,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [a.thing, b.thing, a.out, b.out, lib1-6500.jar]")
         outputContains("artifacts = [a.thing, b.thing, a.out (project :a), b.out (project :b), lib1-6500.jar (group:lib1:6500)]")
         outputContains("variants = [{artifactType=thing}, {artifactType=thing}, {artifactType=out}, {artifactType=out}, {artifactType=jar, org.gradle.status=release}]")
+        outputContains("variant capabilities = [[], [], [capability group='test', name='a', version='unspecified'], [capability group='test', name='b', version='unspecified'], [capability group='group', name='lib1', version='6500']]")
 
         when:
         configurationCacheRun(":resolve", "-PaContent=changed")
@@ -153,6 +156,7 @@ class ConfigurationCacheDependencyResolutionIntegrationTest extends AbstractConf
         outputContains("files = [a.thing, b.thing, a.out, b.out, lib1-6500.jar]")
         outputContains("artifacts = [a.thing, b.thing, a.out (project :a), b.out (project :b), lib1-6500.jar (group:lib1:6500)]")
         outputContains("variants = [{artifactType=thing}, {artifactType=thing}, {artifactType=out}, {artifactType=out}, {artifactType=jar, org.gradle.status=release}]")
+        outputContains("variant capabilities = [[], [], [capability group='test', name='a', version='unspecified'], [capability group='test', name='b', version='unspecified'], [capability group='group', name='lib1', version='6500']]")
     }
 
     def "task input property can include mapped configuration elements that contain project dependencies"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ArtifactCollectionCodec.kt
@@ -80,6 +80,7 @@ private
 class FixedFileArtifactSpec(
     val id: ComponentArtifactIdentifier,
     val variantAttributes: AttributeContainer,
+    val capabilities: List<Capability>,
     val variantDisplayName: DisplayName,
     val file: File
 )
@@ -111,8 +112,8 @@ class CollectingArtifactVisitor : ArtifactVisitor {
         failures.add(failure)
     }
 
-    override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, capabilities: MutableList<out Capability>, artifact: ResolvableArtifact) {
-        elements.add(FixedFileArtifactSpec(artifact.id, variantAttributes, variantName, artifact.file))
+    override fun visitArtifact(variantName: DisplayName, variantAttributes: AttributeContainer, capabilities: List<Capability>, artifact: ResolvableArtifact) {
+        elements.add(FixedFileArtifactSpec(artifact.id, variantAttributes, capabilities, variantName, artifact.file))
     }
 
     override fun endVisitCollection(source: FileCollectionInternal.Source) {
@@ -163,7 +164,7 @@ class FixedArtifactCollection(
                         DefaultResolvedArtifactResult(
                             element.id,
                             element.variantAttributes,
-                            emptyList(),
+                            element.capabilities,
                             element.variantDisplayName,
                             Artifact::class.java,
                             element.file

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -243,6 +243,7 @@ trait TasksWithInputsAndOutputs {
                     println("artifacts = \${collection.artifacts.id}")
                     println("components = \${collection.artifacts.id.componentIdentifier}")
                     println("variants = \${collection.artifacts.variant.attributes}")
+                    println("variant capabilities = \${collection.artifacts.variant.capabilities}")
                     println("files = \${collection.artifactFiles.files.name}")
                 }
             }


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
