### PR TITLE
List HttpClient in NOTICE file

### DIFF
--- a/subprojects/distributions-full/src/toplevel/NOTICE
+++ b/subprojects/distributions-full/src/toplevel/NOTICE
@@ -13,6 +13,7 @@ Groovy (http://groovy-lang.org)
 SLF4J (http://www.slf4j.org)
 JUnit (http://www.junit.org)
 JCIFS (http://jcifs.samba.org)
+HttpClient (https://hc.apache.org/httpcomponents-client-4.5.x/)
 
 For licenses, see the LICENSE file.
 


### PR DESCRIPTION
The `NTLMSchemeFactory` class contains an implementation that was copied from the Apache HttpClient library, but it is not listed in the NOTICE file. 