### PR TITLE
Fixes for some flaky tests

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiSpec.groovy
@@ -16,16 +16,14 @@
 
 package org.gradle.configurationcache.fixtures
 
+import groovy.transform.SelfType
 import org.apache.tools.ant.util.TeeOutputStream
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.integtests.fixtures.executer.ExecutionFailure
-import org.gradle.integtests.fixtures.executer.ExecutionResult
-import org.gradle.integtests.fixtures.executer.GradleExecuter
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionFailure
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.internal.Pair
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildActionExecuter
 import org.gradle.tooling.provider.model.ToolingModelBuilder
@@ -33,20 +31,11 @@ import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 
 import javax.inject.Inject
 
+@SelfType(AbstractIntegrationSpec)
 trait ToolingApiSpec {
-    abstract GradleExecuter getExecuter()
-
-    abstract TestFile getBuildFile()
-
     ToolingApiBackedGradleExecuter getToolingApiExecutor() {
         return (ToolingApiBackedGradleExecuter) getExecuter()
     }
-
-    abstract void setResult(ExecutionResult executionResult)
-
-    abstract void setFailure(ExecutionFailure executionFailure)
-
-    abstract TestFile file(Object... path)
 
     void withSomeToolingModelBuilderPluginInBuildSrc(String content = "") {
         file("buildSrc/src/main/groovy/my/MyModel.groovy") << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
 
 class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
@@ -31,7 +30,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         fails(*tasks)
 
         then:
-        isEmpty(testDirectory)
+        testDirectory.assertIsEmptyDir()
         failure.assertHasDescription("Directory '$testDirectory' does not contain a Gradle build.")
         failure.assertHasResolutions(
             "Run gradle init to create a new Gradle build in this directory.",
@@ -85,7 +84,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         fails("build")
 
         then:
-        isEmpty(dir)
+        dir.assertIsEmptyDir()
         failure.assertHasDescription("Execution failed for task ':build'.")
         failure.assertHasCause("Directory '$dir' does not contain a Gradle build.")
     }
@@ -98,7 +97,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         fails("tasks")
 
         then:
-        isEmpty(testDirectory)
+        testDirectory.assertIsEmptyDir()
         failure.assertHasDescription("Directory '$testDirectory' does not contain a Gradle build.")
     }
 
@@ -181,14 +180,9 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
         succeeds(flag)
 
         then:
-        isEmpty(testDirectory)
+        testDirectory.assertIsEmptyDir()
 
         where:
         flag << ["--version", "--help", "-h", "-?", "--help"]
-    }
-
-    void isEmpty(TestFile dir) {
-        dir.assertIsDir()
-        assert dir.listFiles().size() == 0
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -23,11 +23,7 @@ import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.watch.vfs.WatchMode;
 
-import javax.annotation.Nullable;
 import java.io.File;
-import java.util.List;
-
-import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
 
 public class StartParameterInternal extends StartParameter {
     private WatchMode watchFileSystemMode = WatchMode.DEFAULT;
@@ -184,17 +180,5 @@ public class StartParameterInternal extends StartParameter {
 
     public void setConfigurationCacheQuiet(boolean configurationCacheQuiet) {
         this.configurationCacheQuiet = configurationCacheQuiet;
-    }
-
-    /**
-     * The following special behavior wrt. how the build root is discovered, is implemented:
-     * - If the current folder is called 'buildSrc', we do not search upwards for a settings file
-     * - If the build runs the 'init' task, we do not search upwards for a settings file
-     *
-     * This has an influence on deciding which 'gradle.properties' to load (in the launcher) and which 'settings.gradle(.kts)' to use (in the daemon)
-     */
-    public static boolean useLocationAsProjectRoot(@Nullable File potentialProjectLocation, List<String> requestedTaskNames) {
-        return requestedTaskNames.contains("init")
-            || potentialProjectLocation != null && potentialProjectLocation.getName().equals(BUILD_SRC);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/BuildScopeCacheDir.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/BuildScopeCacheDir.java
@@ -17,12 +17,15 @@
 package org.gradle.cache.internal;
 
 import org.gradle.StartParameter;
+import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleUserHomeDirProvider;
 import org.gradle.initialization.layout.BuildLayout;
 
 import java.io.File;
 
 public class BuildScopeCacheDir {
+    public static final String UNDEFINED_BUILD = "undefined-build";
+
     private final File cacheDir;
 
     public BuildScopeCacheDir(
@@ -32,8 +35,8 @@ public class BuildScopeCacheDir {
     ) {
         if (startParameter.getProjectCacheDir() != null) {
             cacheDir = startParameter.getProjectCacheDir();
-        } else if (buildLayout.isBuildDefinitionMissing()) {
-            cacheDir = new File(userHomeDirProvider.getGradleUserHomeDirectory(), "undefined-build");
+        } else if (!buildLayout.getRootDirectory().getName().equals(SettingsInternal.BUILD_SRC) && buildLayout.isBuildDefinitionMissing()) {
+            cacheDir = new File(userHomeDirProvider.getGradleUserHomeDirectory(), UNDEFINED_BUILD);
         } else {
             cacheDir = new File(buildLayout.getRootDirectory(), ".gradle");
         }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -57,7 +57,7 @@ BUILD SUCCESSFUL"""
 
         and:
         // Directory is still empty
-        testDirectory.list().size() == 0
+        testDirectory.assertIsEmptyDir()
 
         and:
         // Uses a directory under the user home for those things that happen to need a cache directory
@@ -87,7 +87,7 @@ Directory '$sub' does not contain a Gradle build.
 
         and:
         // Directory is still empty
-        sub.list().size() == 0
+        sub.assertIsEmptyDir()
     }
 
     def "shows help message when run in users home directory"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -316,11 +316,28 @@ class AbstractIntegrationSpec extends Specification {
     }
 
     void assertNoDefinedBuild(TestFile testDirectory) {
-        testDirectory.file(".gradle").assertDoesNotExist()
+        def file = findBuildDefinition(testDirectory)
+        if (file != null) {
+            throw new AssertionError("""Found unexpected build definition $file visible to test directory $testDirectory
+tmpdir = ${System.getProperty("java.io.tmpdir")}""")
+        }
+    }
+
+    private TestFile findBuildDefinition(TestFile testDirectory) {
+        def buildFile = testDirectory.file(".gradle")
+        if (buildFile.exists()) {
+            return buildFile
+        }
         def currentDirectory = testDirectory
         for (; ;) {
-            currentDirectory.file(settingsFileName).assertDoesNotExist()
-            currentDirectory.file(settingsKotlinFileName).assertDoesNotExist()
+            def settingsFile = currentDirectory.file(settingsFileName)
+            if (settingsFile.exists()) {
+                return settingsFile
+            }
+            settingsFile = currentDirectory.file(settingsKotlinFileName)
+            if (settingsFile.exists()) {
+                return settingsFile
+            }
             currentDirectory = currentDirectory.parentFile
             if (currentDirectory == null) {
                 break


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

The incorrect build scoped caches directory was being used for `buildSrc` builds with no build or settings files, and this was causing tests to interfere with each other.

Also fix a problem in the test fixtures when attempting to create a test directory that is not embedded under the build tool build, and add some additional trace to hunt down further test flakiness.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
