### PR TITLE
Correct checksum type in documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -268,7 +268,7 @@ See <<sec:troubleshooting-verification,troubleshooting dependency verification>>
 === What checksums are verified?
 
 If a dependency verification metadata file declares more than one checksum for a dependency, Gradle will verify _all of them_ and fail if _any of them fails_.
-For example, the following configuration would check both the `md5` and `sha256` checksums:
+For example, the following configuration would check both the `md5` and `sha1` checksums:
 
 [source,xml]
 ----


### PR DESCRIPTION
### Context

From the following two paragraphs, I deduce that `sha1` was intended to be used in the changed place.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
