### PR TITLE
Revert changes done to build-init in  #17803

### DIFF
--- a/subprojects/build-init/build.gradle.kts
+++ b/subprojects/build-init/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation(project(":resources"))
     implementation(project(":workers"))
     implementation(project(":wrapper"))
-    implementation(project(":persistent-cache"))
 
     implementation(libs.groovy)
     implementation(libs.groovyTemplates)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -365,29 +365,21 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         when:
         useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
         def dotGradleDir = targetDir.file('.gradle')
+        dotGradleDir.mkdirs()
+        def gradlePropertiesFile = dotGradleDir.file("gradle.properties").touch()
+        gradlePropertiesFile << """
+            foo=bar
+        """
+        def snapshot = gradlePropertiesFile.snapshot()
         executer.withGradleUserHomeDir(dotGradleDir)
+        executer.withArguments("--project-cache-dir", dotGradleDir.path)
 
         then:
         succeeds "init"
         targetDir.file("gradlew").assertIsFile()
         targetDir.file("settings.gradle").assertIsFile()
         targetDir.file("build.gradle").assertIsFile()
-    }
-
-    def "skips init task if user home directory and project cache directory are the same"() {
-        when:
-        useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
-        def dotGradleDir = targetDir.file('.gradle')
-        dotGradleDir.mkdirs()
-        executer.withGradleUserHomeDir(dotGradleDir)
-        executer.withArguments("--project-cache-dir", dotGradleDir.path)
-
-        then:
-        succeeds "init"
-        result.assertTaskSkipped ":init"
-        result.assertTaskNotExecuted ":wrapper"
-        outputContains("Gradle user home directory '$dotGradleDir' overlaps with the project cache directory")
-        targetDir.list().toList() == ['.gradle']
+        targetDir.file(".gradle/gradle.properties").assertHasNotChangedSince(snapshot)
     }
 
     def "can create build in user home directory when user home directory has custom name"() {
@@ -402,6 +394,7 @@ class BuildInitPluginIntegrationTest extends AbstractInitIntegrationSpec {
         targetDir.file("gradlew").assertIsFile()
         targetDir.file("settings.gradle").assertIsFile()
         targetDir.file("build.gradle").assertIsFile()
+        targetDir.file(".gradle").assertDoesNotExist()
     }
 
     private ExecutionResult runInitWith(BuildInitDsl dsl) {


### PR DESCRIPTION
#17853 makes the checks added by #17803 obsolete. It's ok now to run `gradle init` in the user home directory, because it won't butcher the `.gradle` cache any longer.

This PR removes said obsolete checks added by #17803, but leaves and adjusts some tests.
