### PR TITLE
 Reconfigure CI mirroring

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/jvm/argumentproviders/CiEnvironmentProvider.kt
@@ -49,7 +49,7 @@ class CiEnvironmentProvider(private val test: Test) : CommandLineArgumentProvide
     private
     fun collectMirrorUrls(): Map<String, String> =
         // expected env var format: repo1_id:repo1_url,repo2_id:repo2_url,...
-        System.getenv("REPO_MIRROR_GRDEV_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
+        System.getenv("REPO_MIRROR_URLS")?.ifBlank { null }?.split(',')?.associate { nameToUrl ->
             val (name, url) = nameToUrl.split(':', limit = 2)
             name to url
         } ?: emptyMap()

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -44,7 +44,7 @@ val propagatedEnvironmentVariables = listOf(
     "LOCALAPPDATA",
 
     // Used by Gradle test infrastructure
-    "REPO_MIRROR_URL",
+    "REPO_MIRROR_URLS",
 
     // Used to find local java installations
     "SDKMAN_CANDIDATES_DIR",

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -25,14 +25,14 @@ val originalUrls: Map<String, String> = mapOf(
     "mavencentral" to "https://repo.maven.apache.org/maven2/",
     "google" to "https://dl.google.com/dl/android/maven2/",
     "gradle" to "https://repo.gradle.org/gradle/repo",
-    "gradleplugins" to "https://plugins.gradle.org/m2",
+    "gradle-prod-plugins" to "https://plugins.gradle.org/m2",
     "gradlejavascript" to "https://repo.gradle.org/gradle/javascript-public",
     "gradle-public" to "https://repo.gradle.org/gradle/public",
-    "gradle-enterprise-plugin-rc" to "https://repo.gradle.org/gradle/enterprise-libs-release-candidates"
+    "gradle-enterprise-rc" to "https://repo.gradle.org/gradle/enterprise-libs-release-candidates"
 )
 
 val mirrorUrls: Map<String, String> =
-    providers.environmentVariable("REPO_MIRROR_GRDEV_URLS").forUseAtConfigurationTime().orNull
+    providers.environmentVariable("REPO_MIRROR_URLS").forUseAtConfigurationTime().orNull
         ?.ifBlank { null }
         ?.split(',')
         ?.associate { nameToUrl ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -58,7 +58,7 @@ class RepoScriptBlockUtil {
         RESTLET('https://maven.restlet.com', System.getProperty('org.gradle.integtest.mirrors.restlet'), 'maven'),
         GRADLE('https://repo.gradle.org/gradle/repo', System.getProperty('org.gradle.integtest.mirrors.gradle'), 'maven'),
         JBOSS('https://repository.jboss.org/maven2/', System.getProperty('org.gradle.integtest.mirrors.jboss'), 'maven'),
-        GRADLE_PLUGIN("https://plugins.gradle.org/m2", System.getProperty('org.gradle.integtest.mirrors.gradleplugins'), 'maven'),
+        GRADLE_PLUGIN("https://plugins.gradle.org/m2", System.getProperty('org.gradle.integtest.mirrors.gradle-prod-plugins'), 'maven'),
         GRADLE_LIB_RELEASES('https://repo.gradle.org/gradle/libs-releases', System.getProperty('org.gradle.integtest.mirrors.gradle'), 'maven'),
         GRADLE_LIB_MILESTONES('https://repo.gradle.org/gradle/libs-milestones', System.getProperty('org.gradle.integtest.mirrors.gradle'), 'maven'),
         GRADLE_LIB_SNAPSHOTS('https://repo.gradle.org/gradle/libs-snapshots', System.getProperty('org.gradle.integtest.mirrors.gradle'), 'maven'),


### PR DESCRIPTION
Use the reconfigured env var REPO_MIRROR_URLS instead of the
intermediate REPO_MIRROR_GRDEV_URLS and make sure it is propagated to
test processes. Some of the mapping keys where also changes in the CI
configuration to make them more consistent.

