### PR TITLE
Fix warnings in `UpdateInitPluginTemplateVersionFile`

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
@@ -25,7 +25,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.util.PropertiesUtils
-import org.gradle.util.VersionNumber
+import org.gradle.util.internal.VersionNumber
 import org.gradle.work.DisableCachingByDefault
 import java.util.Properties
 


### PR DESCRIPTION
- Replace usages of deprecated `VersionNumber` class by internal class