### PR TITLE
Use isolated user home for TAPI running on Gradle 2.14

### DIFF
--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientJdkCompatibilityTest.groovy
@@ -238,6 +238,7 @@ abstract class ToolingApiClientJdkCompatibilityTest extends AbstractIntegrationS
         Assume.assumeTrue(tapiClientCompilerJdk && gradleDaemonJdk)
 
         if (gradleDaemonJdkVersion == JavaVersion.VERSION_1_6 && gradleVersion == "2.14.1") {
+            executer.requireOwnGradleUserHomeDir()
             executer.expectDeprecationWarning("Support for running Gradle using Java 6 has been deprecated and will be removed in Gradle 3.0")
         }
 


### PR DESCRIPTION
We had some TAPI tests failing when 2.14 daemon try to initialize
cache dierectory:

```
Caused by: org.gradle.api.UncheckedIOException: java.io.IOException:
Unable to delete file:
C:\tcagent1\work\e67123fb5b9af0ac\intTestHomeDir\distributions-full\caches\jars-1\kok9qhooqr6gfa8j2ilgdi07kmm5e43\gradle-tooling-api-7.3.jar
	at org.gradle.util.GFileUtils.forceDelete(GFileUtils.java:208)
	at
org.gradle.cache.internal.DefaultPersistentDirectoryCache$Initializer.initialize(DefaultPersistentDirectoryCache.java:93)
	at
org.gradle.cache.internal.DefaultCacheAccess$4.run(DefaultCacheAccess.java:353)
```

Let's use isolated user home for this old test.
