### PR TITLE
When running tooling API build action defer configuration of projects until required by action

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -19,6 +19,7 @@ package org.gradle.internal.build.event;
 import com.google.common.collect.ImmutableList;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
+import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.provider.Provider;
@@ -68,8 +69,10 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     private final List<Object> listeners = new ArrayList<>();
     private final ExecutorFactory executorFactory;
 
-    public DefaultBuildEventsListenerRegistry(BuildEventListenerFactory factory, ListenerManager listenerManager,
-                                              BuildOperationListenerManager buildOperationListenerManager, ExecutorFactory executorFactory) {
+    public DefaultBuildEventsListenerRegistry(
+        BuildEventListenerFactory factory, ListenerManager listenerManager,
+        BuildOperationListenerManager buildOperationListenerManager, ExecutorFactory executorFactory
+    ) {
         this.factory = factory;
         this.listenerManager = listenerManager;
         this.buildOperationListenerManager = buildOperationListenerManager;
@@ -237,7 +240,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         @Override
         public void buildFinished(BuildResult result) {
             // TODO - maybe make the registry a build scoped service
-            if (result.getGradle().getParent() != null) {
+            if (!((GradleInternal) result.getGradle()).isRootBuild()) {
                 // Stop only when the root build completes
                 return;
             }

--- a/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
+++ b/subprojects/build-events/src/test/groovy/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistryTest.groovy
@@ -46,7 +46,10 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
     def factory = new MockBuildEventListenerFactory()
     def listenerManager = new DefaultListenerManager(Scopes.Build)
     def buildOperationListenerManager = new DefaultBuildOperationListenerManager()
-    def buildResult = new BuildResult(Mock(GradleInternal), null)
+    def gradle = Stub(GradleInternal) {
+        isRootBuild() >> true
+    }
+    def buildResult = new BuildResult(gradle, null)
     def registry = new DefaultBuildEventsListenerRegistry(factory, listenerManager, buildOperationListenerManager, executorFactory)
 
     def cleanup() {
@@ -120,6 +123,9 @@ class DefaultBuildEventsListenerRegistryTest extends ConcurrentSpec {
 
         then:
         registry.subscriptions.size() == 1
+
+        cleanup:
+        signalBuildFinished()
     }
 
     def "listeners receive events concurrently"() {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -16,12 +16,16 @@
 
 package org.gradle.composite.internal;
 
+import org.gradle.StartParameter;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
+import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.initialization.BuildCancellationToken;
+import org.gradle.internal.Actions;
 import org.gradle.internal.build.BuildLifecycleControllerFactory;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.build.PublicBuildPath;
 import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.buildtree.BuildTreeState;
@@ -31,7 +35,12 @@ import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.session.CrossBuildSessionState;
+import org.gradle.plugin.management.internal.PluginRequests;
 import org.gradle.util.Path;
+
+import java.io.File;
+
+import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
 
 @ServiceScope(Scopes.BuildTree.class)
 public class BuildStateFactory {
@@ -43,13 +52,15 @@ public class BuildStateFactory {
     private final BuildCancellationToken buildCancellationToken;
     private final ProjectStateRegistry projectStateRegistry;
 
-    public BuildStateFactory(BuildTreeState buildTreeState,
-                             BuildLifecycleControllerFactory buildLifecycleControllerFactory,
-                             ListenerManager listenerManager,
-                             GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry,
-                             CrossBuildSessionState crossBuildSessionState,
-                             BuildCancellationToken buildCancellationToken,
-                             ProjectStateRegistry projectStateRegistry) {
+    public BuildStateFactory(
+        BuildTreeState buildTreeState,
+        BuildLifecycleControllerFactory buildLifecycleControllerFactory,
+        ListenerManager listenerManager,
+        GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry,
+        CrossBuildSessionState crossBuildSessionState,
+        BuildCancellationToken buildCancellationToken,
+        ProjectStateRegistry projectStateRegistry
+    ) {
         this.buildTreeState = buildTreeState;
         this.buildLifecycleControllerFactory = buildLifecycleControllerFactory;
         this.listenerManager = listenerManager;
@@ -64,13 +75,45 @@ public class BuildStateFactory {
     }
 
     public StandAloneNestedBuild createNestedBuild(BuildIdentifier buildIdentifier, Path identityPath, BuildDefinition buildDefinition, BuildState owner) {
-        return new DefaultNestedBuild(buildIdentifier, identityPath, buildDefinition, owner, buildTreeState, buildLifecycleControllerFactory, projectStateRegistry);
+        DefaultNestedBuild build = new DefaultNestedBuild(buildIdentifier, identityPath, buildDefinition, owner, buildTreeState, buildLifecycleControllerFactory, projectStateRegistry);
+        // Expose any contributions from the parent's settings
+        build.getMutableModel().setClassLoaderScope(() -> owner.getMutableModel().getSettings().getClassLoaderScope());
+        return build;
     }
 
-    public NestedBuildTree createNestedTree(BuildDefinition buildDefinition,
-                                            BuildIdentifier buildIdentifier,
-                                            Path identityPath,
-                                            BuildState owner) {
+    public NestedBuildTree createNestedTree(
+        BuildDefinition buildDefinition,
+        BuildIdentifier buildIdentifier,
+        Path identityPath,
+        BuildState owner
+    ) {
         return new DefaultNestedBuildTree(buildDefinition, buildIdentifier, identityPath, owner, userHomeDirServiceRegistry, crossBuildSessionState, buildCancellationToken);
+    }
+
+    public BuildDefinition buildDefinitionFor(File buildSrcDir, BuildState owner) {
+        PublicBuildPath publicBuildPath = owner.getMutableModel().getServices().get(PublicBuildPath.class);
+        StartParameterInternal buildSrcStartParameter = buildSrcStartParameterFor(buildSrcDir, owner.getMutableModel().getStartParameter());
+        BuildDefinition buildDefinition = BuildDefinition.fromStartParameterForBuild(
+            buildSrcStartParameter,
+            BUILD_SRC,
+            buildSrcDir,
+            PluginRequests.EMPTY,
+            Actions.doNothing(),
+            publicBuildPath,
+            true
+        );
+        @SuppressWarnings("deprecation")
+        File customBuildFile = buildSrcStartParameter.getBuildFile();
+        assert customBuildFile == null;
+        return buildDefinition;
+    }
+
+    private StartParameterInternal buildSrcStartParameterFor(File buildSrcDir, StartParameter containingBuildParameters) {
+        final StartParameterInternal buildSrcStartParameter = (StartParameterInternal) containingBuildParameters.newBuild();
+        buildSrcStartParameter.setCurrentDir(buildSrcDir);
+        buildSrcStartParameter.setProjectProperties(containingBuildParameters.getProjectProperties());
+        buildSrcStartParameter.doNotSearchUpwards();
+        buildSrcStartParameter.setProfile(containingBuildParameters.isProfile());
+        return buildSrcStartParameter;
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuild.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.TaskReference;
 import org.gradle.initialization.IncludedBuildSpec;
@@ -152,28 +151,13 @@ public class DefaultIncludedBuild extends AbstractCompositeParticipantBuildState
     }
 
     @Override
-    public Path getIdentityPathForProject(Path projectPath) {
+    public Path calculateIdentityPathForProject(Path projectPath) {
         return getIdentityPath().append(projectPath);
     }
 
     @Override
     public Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions() {
         return buildDefinition.getDependencySubstitutions();
-    }
-
-    @Override
-    public boolean hasInjectedSettingsPlugins() {
-        return !buildDefinition.getInjectedPluginRequests().isEmpty();
-    }
-
-    @Override
-    public SettingsInternal loadSettings() {
-        return buildLifecycleController.getLoadedSettings();
-    }
-
-    @Override
-    public SettingsInternal getLoadedSettings() {
-        return getGradle().getSettings();
     }
 
     @Override

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -19,7 +19,6 @@ package org.gradle.composite.internal;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.internal.build.AbstractBuildState;
@@ -52,7 +51,6 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     private final BuildDefinition buildDefinition;
     private final BuildLifecycleController buildLifecycleController;
     private final BuildTreeLifecycleController buildTreeLifecycleController;
-    private final BuildScopeServices buildScopeServices;
 
     DefaultNestedBuild(
         BuildIdentifier buildIdentifier,
@@ -69,7 +67,7 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         this.owner = owner;
         this.projectStateRegistry = projectStateRegistry;
 
-        buildScopeServices = new BuildScopeServices(buildTree.getServices());
+        BuildScopeServices buildScopeServices = new BuildScopeServices(buildTree.getServices());
         this.buildLifecycleController = buildLifecycleControllerFactory.newInstance(buildDefinition, this, owner, buildScopeServices);
 
         IncludedBuildTaskGraph taskGraph = buildScopeServices.get(IncludedBuildTaskGraph.class);
@@ -131,17 +129,12 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
     }
 
     @Override
-    public SettingsInternal getLoadedSettings() {
-        return buildLifecycleController.getGradle().getSettings();
-    }
-
-    @Override
     public Path getCurrentPrefixForProjectsInChildBuilds() {
         return owner.getCurrentPrefixForProjectsInChildBuilds().child(buildDefinition.getName());
     }
 
     @Override
-    public Path getIdentityPathForProject(Path projectPath) {
+    public Path calculateIdentityPathForProject(Path projectPath) {
         return buildLifecycleController.getGradle().getIdentityPath().append(projectPath);
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -20,7 +20,6 @@ import org.gradle.BuildResult;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -168,17 +167,12 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
     }
 
     @Override
-    public SettingsInternal getLoadedSettings() {
-        return buildLifecycleController.getGradle().getSettings();
-    }
-
-    @Override
     public Path getCurrentPrefixForProjectsInChildBuilds() {
         return Path.ROOT;
     }
 
     @Override
-    public Path getIdentityPathForProject(Path path) {
+    public Path calculateIdentityPathForProject(Path path) {
         return path;
     }
 

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/RootOfNestedBuildTree.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.initialization.RunNestedBuildBuildOperationType;
@@ -141,17 +140,12 @@ public class RootOfNestedBuildTree extends AbstractBuildState implements NestedR
     }
 
     @Override
-    public SettingsInternal getLoadedSettings() {
-        return buildLifecycleController.getGradle().getSettings();
-    }
-
-    @Override
     public Path getCurrentPrefixForProjectsInChildBuilds() {
         return owner.getCurrentPrefixForProjectsInChildBuilds().child(buildName);
     }
 
     @Override
-    public Path getIdentityPathForProject(Path projectPath) {
+    public Path calculateIdentityPathForProject(Path projectPath) {
         return buildLifecycleController.getGradle().getIdentityPath().append(projectPath);
     }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.composite.internal
 
-import org.gradle.api.GradleException
+
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
@@ -26,6 +26,7 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.initialization.exception.ExceptionAnalyser
+import org.gradle.initialization.layout.BuildLayout
 import org.gradle.internal.Actions
 import org.gradle.internal.build.BuildAddedListener
 import org.gradle.internal.build.BuildLifecycleController
@@ -34,6 +35,7 @@ import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.IncludedBuildFactory
 import org.gradle.internal.build.IncludedBuildState
+import org.gradle.internal.build.PublicBuildPath
 import org.gradle.internal.build.RootBuildState
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
@@ -41,10 +43,12 @@ import org.gradle.internal.buildtree.BuildTreeState
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry
 import org.gradle.internal.session.CrossBuildSessionState
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.plugin.management.internal.PluginRequests
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
 import org.junit.Rule
@@ -90,15 +94,13 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     def "can add a root build"() {
         def notifiedBuild
         def buildDefinition = Stub(BuildDefinition)
-        def gradleLauncher = Stub(BuildLifecycleController)
-        def gradle = Stub(GradleInternal)
+        def buildController = buildController()
 
         when:
         def rootBuild = registry.createRootBuild(buildDefinition)
 
         then:
-        _ * gradleLauncher.gradle >> gradle
-        1 * gradleLauncherFactory.newInstance(buildDefinition, _, null, _) >> gradleLauncher
+        1 * gradleLauncherFactory.newInstance(buildDefinition, _, null, _) >> buildController
         1 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
             notifiedBuild = addedBuild
         }
@@ -118,6 +120,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def buildIdentifier = new DefaultBuildIdentifier("b1")
         def idPath = Path.path(":b1")
         includedBuild.buildIdentifier >> buildIdentifier
+        includedBuild.buildRootDir >> dir
 
         given:
         registry.attachRootBuild(rootBuild())
@@ -138,22 +141,18 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     }
 
     def "can add multiple included builds"() {
-        def dir1 = tmpDir.createDir("b1")
-        def dir2 = tmpDir.createDir("b2")
-        def buildDefinition1 = build(dir1)
-        def buildDefinition2 = build(dir2)
-        def includedBuild1 = Stub(IncludedBuildState)
-        def includedBuild2 = Stub(IncludedBuildState)
+        def buildDefinition1 = build("b1")
+        def buildDefinition2 = build("b2")
+        def includedBuild1 = expectIncludedBuildAdded("b1", buildDefinition1)
+        def includedBuild2 = expectIncludedBuildAdded("b2", buildDefinition2)
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(new DefaultBuildIdentifier("b1"), Path.path(":b1"), buildDefinition1, false, _) >> includedBuild1
-        includedBuildFactory.createBuild(new DefaultBuildIdentifier("b2"), Path.path(":b2"), buildDefinition2, false, _) >> includedBuild2
 
-        expect:
         registry.addIncludedBuild(buildDefinition1)
         registry.addIncludedBuild(buildDefinition2)
 
+        expect:
         registry.includedBuilds as List == [includedBuild1, includedBuild2]
     }
 
@@ -165,23 +164,12 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def buildDefinition2 = build(dir2, "b2")
         def buildDefinition3 = build(dir3, "b3")
         def id1 = new DefaultBuildIdentifier("b1")
-        def id2 = new DefaultBuildIdentifier("b2")
-        def id3 = new DefaultBuildIdentifier("b3")
-        def idPath1 = Path.path(":b1")
-        def idPath2 = Path.path(":b2")
-        def idPath3 = Path.path(":b3")
-        def includedBuild1 = Stub(IncludedBuildState) { getBuildIdentifier() >> id1 }
-        def includedBuild2 = Stub(IncludedBuildState) { getBuildIdentifier() >> id2 }
-        def includedBuild3 = Stub(IncludedBuildState) { getBuildIdentifier() >> id3 }
-        includedBuild1.identityPath >> idPath1
-        includedBuild2.identityPath >> idPath2
-        includedBuild3.identityPath >> idPath3
+        def includedBuild1 = expectIncludedBuildAdded("b1", buildDefinition1)
+        def includedBuild2 = expectIncludedBuildAdded("b2", buildDefinition2)
+        def includedBuild3 = expectIncludedBuildAdded("b3", buildDefinition3)
 
         given:
         registry.attachRootBuild(rootBuild())
-        includedBuildFactory.createBuild(id1, idPath1, buildDefinition1, false, _) >> includedBuild1
-        includedBuildFactory.createBuild(id2, idPath2, buildDefinition2, false, _) >> includedBuild2
-        includedBuildFactory.createBuild(id3, idPath3, buildDefinition3, false, _) >> includedBuild3
 
         expect:
         registry.addIncludedBuild(buildDefinition1)
@@ -197,10 +185,11 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def dir = tmpDir.createDir("b1")
         def buildDefinition1 = build(dir)
         def buildDefinition2 = build(dir)
+        def includedBuild = expectIncludedBuildAdded("b1", buildDefinition1)
 
         given:
         registry.attachRootBuild(rootBuild())
-        def includedBuild = registry.addIncludedBuild(buildDefinition1)
+        registry.addIncludedBuild(buildDefinition1)
 
         expect:
         registry.addIncludedBuild(buildDefinition2) is includedBuild
@@ -210,6 +199,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         def dir = tmpDir.createDir("b1")
         def buildDefinition = build(dir)
         def includedBuild = Stub(IncludedBuildState)
+        includedBuild.buildRootDir >> dir
 
         given:
         registry.attachRootBuild(rootBuild())
@@ -226,70 +216,65 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         registry.includedBuilds as List == [includedBuild]
     }
 
-    def "can add a buildSrc nested build"() {
+    def "add buildSrc nested build when owner is registered"() {
         given:
-        def buildDefinition = Stub(BuildDefinition)
-        buildDefinition.name >> "buildSrc"
-        registry.attachRootBuild(rootBuild())
-        def owner = Stub(BuildState) { getIdentityPath() >> Path.ROOT }
-        def notifiedBuild
+        def rootDir = tmpDir.createDir("root")
+        rootDir.file("buildSrc/build.gradle").createFile()
+
+        def rootBuild = rootBuild(rootDir)
+        def notifiedBuilds = []
 
         when:
-        def nestedBuild = registry.addBuildSrcNestedBuild(buildDefinition, owner)
+        registry.attachRootBuild(rootBuild)
+
         then:
-        1 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
-            notifiedBuild = addedBuild
+        2 * buildAddedListener.buildAdded(_) >> { BuildState addedBuild ->
+            notifiedBuilds << addedBuild
         }
 
+        and:
+        def nestedBuild = registry.getBuildSrcNestedBuild(rootBuild)
+        nestedBuild != null
         nestedBuild.implicitBuild
         nestedBuild.buildIdentifier == new DefaultBuildIdentifier("buildSrc")
         nestedBuild.identityPath == Path.path(":buildSrc")
-        notifiedBuild.is(nestedBuild)
 
+        and:
+        notifiedBuilds == [rootBuild, nestedBuild]
+
+        and:
         registry.getBuild(nestedBuild.buildIdentifier).is(nestedBuild)
     }
 
-    def "cannot add multiple buildSrc nested builds with same name"() {
+    def "can add multiple buildSrc builds with different levels of nesting"() {
         given:
-        def buildDefinition = Stub(BuildDefinition)
-        buildDefinition.name >> "buildSrc"
-        registry.attachRootBuild(rootBuild())
-        def owner = Stub(BuildState) { getIdentityPath() >> Path.ROOT }
+        def rootDir = tmpDir.createDir("root")
+        rootDir.file("buildSrc/build.gradle").createFile()
 
-        when:
-        registry.addBuildSrcNestedBuild(buildDefinition, owner)
-        registry.addBuildSrcNestedBuild(buildDefinition, owner)
-
-        then:
-        thrown GradleException
-    }
-
-    def "can add multiple buildSrc nested builds with same name and different levels of nesting"() {
-        given:
-        def rootBuild = rootBuild()
+        def rootBuild = rootBuild(rootDir)
         registry.attachRootBuild(rootBuild)
 
-        def parent1Definition = Stub(BuildDefinition)
-        parent1Definition.name >> "parent"
-        def parent1 = registry.addIncludedBuild(parent1Definition)
+        def parentDir = rootDir.file("parent").createDir()
+        parentDir.file("buildSrc/build.gradle").createFile()
 
-        def buildDefinition = Stub(BuildDefinition)
-        buildDefinition.name >> "buildSrc"
-        buildDefinition.buildRootDir >> new File("d")
+        def parentDefinition = build(parentDir, "parent")
+        def parent = expectIncludedBuildAdded("parent", parentDefinition)
+
+        registry.addIncludedBuild(parentDefinition)
 
         expect:
-        def nestedBuild1 = registry.addBuildSrcNestedBuild(buildDefinition, rootBuild)
+        def nestedBuild1 = registry.getBuildSrcNestedBuild(rootBuild)
         nestedBuild1.buildIdentifier == new DefaultBuildIdentifier("buildSrc")
         nestedBuild1.identityPath == Path.path(":buildSrc")
 
-        def nestedBuild2 = registry.addBuildSrcNestedBuild(buildDefinition, parent1)
+        def nestedBuild2 = registry.getBuildSrcNestedBuild(parent)
         // Shows current behaviour, not necessarily desired behaviour
         nestedBuild2.buildIdentifier == new DefaultBuildIdentifier("buildSrc:1")
         nestedBuild2.identityPath == Path.path(":parent:buildSrc")
+    }
 
-        def nestedBuild3 = registry.addBuildSrcNestedBuild(buildDefinition, nestedBuild1)
-        nestedBuild3.buildIdentifier == new DefaultBuildIdentifier("buildSrc:2")
-        nestedBuild3.identityPath == Path.path(":buildSrc:buildSrc")
+    def build(String name) {
+        return build(tmpDir.createDir(name), name)
     }
 
     def build(File rootDir, String name = rootDir.name) {
@@ -304,16 +289,35 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         )
     }
 
-    RootBuildState rootBuild(String... projects) {
-        def gradleLauncher = Stub(BuildLifecycleController)
-        def parentGradle = Stub(GradleInternal)
+    IncludedBuildState expectIncludedBuildAdded(String name, BuildDefinition buildDefinition) {
+        def idPath = Path.path(":$name")
+        def buildIdentifier = new DefaultBuildIdentifier(name)
+
         def gradle = Stub(GradleInternal)
+        def services = Stub(ServiceRegistry)
+
+        def includedBuild = Stub(IncludedBuildState)
+        includedBuild.buildRootDir >> buildDefinition.buildRootDir
+        includedBuild.identityPath >> idPath
+        includedBuild.buildIdentifier >> buildIdentifier
+        includedBuild.mutableModel >> gradle
+
+        gradle.services >> services
+
+        services.get(PublicBuildPath) >> Stub(PublicBuildPath)
+
+        includedBuildFactory.createBuild(buildIdentifier, idPath, buildDefinition, false, _) >> includedBuild
+
+        return includedBuild
+    }
+
+    RootBuildState rootBuild(TestFile rootDir = tmpDir.createDir("root-dir")) {
         def settings = Stub(SettingsInternal)
+        def gradle = Stub(GradleInternal)
+        def buildController = buildController(settings, gradle)
         def build = Stub(RootBuildState)
 
-        gradleLauncherFactory.newInstance(_, _, _, _) >> gradleLauncher
-        gradleLauncher.gradle >> gradle
-        gradle.settings >> settings
+        gradleLauncherFactory.newInstance(_, _, _, _) >> buildController
         settings.rootProject >> Stub(ProjectDescriptor) {
             getName() >> "root"
         }
@@ -324,7 +328,32 @@ class DefaultIncludedBuildRegistryTest extends Specification {
         build.buildIdentifier >> DefaultBuildIdentifier.ROOT
         build.identityPath >> Path.ROOT
         build.loadedSettings >> settings
-        build.mutableModel >> parentGradle
+        build.mutableModel >> gradle
+        build.buildRootDir >> rootDir
         return build
     }
+
+    private BuildLifecycleController buildController() {
+        def settings = Stub(SettingsInternal)
+        def gradle = Stub(GradleInternal)
+        return buildController(settings, gradle)
+    }
+
+    private BuildLifecycleController buildController(SettingsInternal settings, GradleInternal gradle) {
+        def buildController = Stub(BuildLifecycleController)
+        def services = Stub(ServiceRegistry)
+        def buildLayout = Stub(BuildLayout)
+
+        _ * buildController.gradle >> gradle
+        if (settings != null) {
+            _ * gradle.settings >> settings
+        }
+        _ * gradle.services >> services
+        _ * services.get(BuildLayout) >> buildLayout
+        _ * buildLayout.rootDirectory >> tmpDir.file("root-dir")
+        _ * services.get(PublicBuildPath) >> Stub(PublicBuildPath)
+
+        return buildController
+    }
+
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
@@ -18,7 +18,9 @@ package org.gradle.composite.internal
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.build.BuildState
 import org.gradle.internal.build.BuildToolingModelAction
 import org.gradle.internal.build.BuildToolingModelController
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor
@@ -26,6 +28,8 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.operations.RunnableBuildOperation
+import org.gradle.tooling.provider.model.UnknownModelException
+import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup
 
 import java.util.function.Function
 
@@ -50,6 +54,21 @@ class TestBuildTreeLifecycleControllerFactory implements BuildTreeLifecycleContr
         @Override
         GradleInternal getConfiguredModel() {
             return targetBuild.configuredBuild
+        }
+
+        @Override
+        ToolingModelBuilderLookup.Builder locateBuilderForDefaultTarget(String modelName, boolean param) throws UnknownModelException {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        ToolingModelBuilderLookup.Builder locateBuilderForTarget(BuildState target, String modelName, boolean param) throws UnknownModelException {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        ToolingModelBuilderLookup.Builder locateBuilderForTarget(ProjectState target, String modelName, boolean param) throws UnknownModelException {
+            throw new UnsupportedOperationException()
         }
 
         @Override

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
@@ -47,11 +47,6 @@ class TestBuildTreeLifecycleControllerFactory implements BuildTreeLifecycleContr
         }
 
         @Override
-        GradleInternal getMutableModel() {
-            return targetBuild.gradle
-        }
-
-        @Override
         GradleInternal getConfiguredModel() {
             return targetBuild.configuredBuild
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDebugLogIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDebugLogIntegrationTest.groovy
@@ -45,21 +45,21 @@ class ConfigurationCacheDebugLogIntegrationTest extends AbstractConfigurationCac
         events.contains([profile: "fingerprint", type: "C", "frame": GradleEnvironment.name])
 
         and: "Gradle and Work Graph events are logged"
-        events.contains([profile: "root state", type: "O", frame: "Gradle"])
-        events.contains([profile: "root state", type: "O", frame: "Work Graph"])
+        events.contains([profile: "build ':' state", type: "O", frame: "Gradle"])
+        events.contains([profile: "build ':' state", type: "O", frame: "Work Graph"])
 
         and: "state frame events are logged"
-        events.contains([profile: "root state", type: "O", frame: ":ok"])
-        events.contains([profile: "root state", type: "C", frame: ":ok"])
-        events.contains([profile: "root state", type: "O", frame: ":sub:ok"])
-        events.contains([profile: "root state", type: "C", frame: ":sub:ok"])
+        events.contains([profile: "build ':' state", type: "O", frame: ":ok"])
+        events.contains([profile: "build ':' state", type: "C", frame: ":ok"])
+        events.contains([profile: "build ':' state", type: "O", frame: ":sub:ok"])
+        events.contains([profile: "build ':' state", type: "C", frame: ":sub:ok"])
 
         and: "task type frame follows task path frame follows LocalTaskNode frame"
         def firstTaskNodeIndex = events.findIndexOf { it.frame == LocalTaskNode.name }
         firstTaskNodeIndex > 0
-        events[firstTaskNodeIndex] == [profile: "root state", type: "O", frame: LocalTaskNode.name]
-        events[firstTaskNodeIndex + 1] == [profile: "root state", type: "O", frame: ":ok"]
-        events[firstTaskNodeIndex + 2] == [profile: "root state", type: "O", frame: DefaultTask.name]
+        events[firstTaskNodeIndex] == [profile: "build ':' state", type: "O", frame: LocalTaskNode.name]
+        events[firstTaskNodeIndex + 1] == [profile: "build ':' state", type: "O", frame: ":ok"]
+        events[firstTaskNodeIndex + 2] == [profile: "build ':' state", type: "O", frame: DefaultTask.name]
     }
 
     private Collection<Map<String, Object>> collectOutputEvents() {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache.isolated
 
 import org.gradle.configurationcache.fixtures.SomeToolingModel
+import org.gradle.tooling.model.GradleProject
 import org.gradle.tooling.model.gradle.GradleBuild
 
 class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
@@ -119,6 +120,9 @@ class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsola
             include("b")
             println("configuring build")
         """
+        buildFile << """
+            throw new RuntimeException("should not be called")
+        """
 
         when:
         executer.withArguments(ENABLE_CLI)
@@ -189,11 +193,10 @@ class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsola
 
         when:
         executer.withArguments(ENABLE_CLI)
-        def model3 = fetchModel(GradleBuild)
+        def model3 = fetchModel(GradleProject)
 
         then:
-        model3 instanceof GradleBuild
-        model3.projects.size() == 1
+        model3 instanceof GradleProject
 
         and:
         outputContains("Creating tooling model as no configuration cache is available for the requested model")
@@ -203,11 +206,10 @@ class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsola
 
         when:
         executer.withArguments(ENABLE_CLI)
-        def model4 = fetchModel(GradleBuild)
+        def model4 = fetchModel(GradleProject)
 
         then:
-        model4 instanceof GradleBuild
-        model4.projects.size() == 1
+        model4 instanceof GradleProject
 
         and:
         outputContains("Reusing configuration cache.")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheHost.kt
@@ -106,7 +106,7 @@ class ConfigurationCacheHost internal constructor(
         override fun registerProjects() {
             // Ensure projects are registered for look up e.g. by dependency resolution
             val projectRegistry = service<ProjectStateRegistry>()
-            projectRegistry.registerProjects(service<BuildState>())
+            projectRegistry.registerProjects(state, projectDescriptorRegistry)
             createRootProject()
         }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -108,7 +108,7 @@ class ConfigurationCacheIO internal constructor(
         action: suspend DefaultWriteContext.(ConfigurationCacheState) -> T
     ): T {
         val build = host.currentBuild
-        val (context, codecs) = writerContextFor(stateFile.outputStream(), build.gradle.rootProject.name + " state")
+        val (context, codecs) = writerContextFor(stateFile.outputStream(), build.gradle.owner.displayName.displayName + " state")
         return context.useToRun {
             runWriteOperation {
                 action(ConfigurationCacheState(codecs, stateFile))

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
@@ -28,13 +28,15 @@ import org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController
 import org.gradle.internal.buildtree.DefaultBuildTreeModelCreator
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkPreparer
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.resources.ProjectLeaseRegistry
 
 
 class DefaultBuildTreeLifecycleControllerFactory(
     private val startParameter: ConfigurationCacheStartParameter,
     private val cache: BuildTreeConfigurationCache,
     private val taskGraph: IncludedBuildTaskGraph,
-    private val buildOperationExecutor: BuildOperationExecutor
+    private val buildOperationExecutor: BuildOperationExecutor,
+    private val projectLeaseRegistry: ProjectLeaseRegistry
 ) : BuildTreeLifecycleControllerFactory {
     override fun createController(targetBuild: BuildLifecycleController, workExecutor: BuildTreeWorkExecutor, finishExecutor: BuildTreeFinishExecutor): BuildTreeLifecycleController {
         // Currently, apply the decoration only to the root build, as the cache implementation is still scoped to the root build
@@ -48,7 +50,7 @@ class DefaultBuildTreeLifecycleControllerFactory(
             defaultWorkPreparer
         }
 
-        val defaultModelCreator = DefaultBuildTreeModelCreator(targetBuild, buildOperationExecutor)
+        val defaultModelCreator = DefaultBuildTreeModelCreator(targetBuild, buildOperationExecutor, projectLeaseRegistry)
         val modelCreator = if (startParameter.isEnabled && rootBuild) {
             ConfigurationCacheAwareBuildTreeModelCreator(defaultModelCreator, cache)
         } else {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/GradleInternal.java
@@ -36,6 +36,7 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * An internal interface for Gradle that exposed objects and concepts that are not intended for public
@@ -121,7 +122,7 @@ public interface GradleInternal extends Gradle, PluginAwareInternal {
 
     ServiceRegistryFactory getServiceRegistryFactory();
 
-    void setClassLoaderScope(ClassLoaderScope classLoaderScope);
+    void setClassLoaderScope(Supplier<? extends ClassLoaderScope> classLoaderScope);
 
     ClassLoaderScope getClassLoaderScope();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/SettingsInternal.java
@@ -28,7 +28,6 @@ import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.management.DependencyResolutionManagementInternal;
 import org.gradle.internal.service.ServiceRegistry;
 
-import java.io.File;
 import java.util.List;
 
 public interface SettingsInternal extends Settings, PluginAwareInternal {
@@ -64,8 +63,6 @@ public interface SettingsInternal extends Settings, PluginAwareInternal {
      * Gradle runtime + this object's script's additions.
      */
     ClassLoaderScope getClassLoaderScope();
-
-    File getBuildSrcDir();
 
     ServiceRegistry getServices();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectState.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.project;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.DisplayName;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.resources.ResourceLock;
@@ -26,6 +27,8 @@ import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import java.io.File;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -34,6 +37,8 @@ import java.util.function.Function;
  */
 @ThreadSafe
 public interface ProjectState extends ModelContainer<ProjectInternal> {
+    DisplayName getDisplayName();
+
     /**
      * Returns the containing build of this project.
      */
@@ -44,6 +49,11 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
      */
     @Nullable
     ProjectState getParent();
+
+    /**
+     * Returns the direct children of this project, in public iteration order.
+     */
+    Set<ProjectState> getChildProjects();
 
     /**
      * Returns the name of this project (which may not necessarily be unique).
@@ -59,6 +69,11 @@ public interface ProjectState extends ModelContainer<ProjectInternal> {
      * Returns a path for this project within its containing build. These are not unique within a build tree.
      */
     Path getProjectPath();
+
+    /**
+     * Returns the project directory.
+     */
+    File getProjectDir();
 
     /**
      * Returns the identifier of the default component produced by this project.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -58,7 +58,7 @@ public interface ProjectStateRegistry {
     /**
      * Registers the projects of a build.
      */
-    void registerProjects(BuildState build);
+    void registerProjects(BuildState build, ProjectRegistry<DefaultProjectDescriptor> projectRegistry);
 
     /**
      * Registers a single project.

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -281,11 +281,6 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
     }
 
     @Override
-    public File getBuildSrcDir() {
-        return new File(getSettingsDir(), BUILD_SRC);
-    }
-
-    @Override
     public ServiceRegistry getServices() {
         return services;
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsAttachingSettingsLoader.java
@@ -19,7 +19,6 @@ package org.gradle.initialization;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.internal.build.BuildState;
 
 class SettingsAttachingSettingsLoader implements SettingsLoader {
     private final SettingsLoader delegate;
@@ -34,7 +33,7 @@ class SettingsAttachingSettingsLoader implements SettingsLoader {
     public SettingsInternal findAndLoadSettings(GradleInternal gradle) {
         SettingsInternal settings = delegate.findAndLoadSettings(gradle);
         gradle.setSettings(settings);
-        projectRegistry.registerProjects(gradle.getServices().get(BuildState.class));
+        projectRegistry.registerProjects(gradle.getOwner(), settings.getProjectRegistry());
         return settings;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildProjectRegistry.java
@@ -19,18 +19,32 @@ package org.gradle.internal.build;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 public interface BuildProjectRegistry {
+    /**
+     * Returns the root project of this build.
+     */
+    ProjectState getRootProject();
+
     /**
      * Returns all projects in this build, in public iteration order.
      */
     Set<? extends ProjectState> getAllProjects();
 
     /**
-     * Locates a project of this build.
+     * Locates a project of this build, failing if the project is not present.
      *
      * @param projectPath The path relative to the root project of this build.
      */
     ProjectState getProject(Path projectPath);
+
+    /**
+     * Locates a project of this build, returning null if the project is not present.
+     *
+     * @param projectPath The path relative to the root project of this build.
+     */
+    @Nullable
+    ProjectState findProject(Path projectPath);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -17,11 +17,11 @@
 package org.gradle.internal.build;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.initialization.IncludedBuildSpec;
+import org.gradle.internal.DisplayName;
 import org.gradle.util.Path;
 
 import java.io.File;
@@ -33,6 +33,8 @@ import java.util.function.Consumer;
  * Implementations are not yet entirely thread-safe, but should be.
  */
 public interface BuildState {
+    DisplayName getDisplayName();
+
     /**
      * Returns the identifier for this build. The identifier is fixed for the lifetime of the build.
      */
@@ -70,15 +72,21 @@ public interface BuildState {
     /**
      * Calculates the identity path for a project in this build.
      */
-    Path getIdentityPathForProject(Path projectPath) throws IllegalStateException;
+    Path calculateIdentityPathForProject(Path projectPath) throws IllegalStateException;
 
     /**
-     * Calculates the identifier for a project in this build.
+     * Loads the projects for this build so that {@link #getProjects()} can be used, if not already done.
+     * This includes running the settings script for the build.
      */
-    ProjectComponentIdentifier getIdentifierForProject(Path projectPath) throws IllegalStateException;
+    void ensureProjectsLoaded();
 
     /**
-     * Returns the projects of this build.
+     * Ensures all projects in this build are configured, if not already done.
+     */
+    void ensureProjectsConfigured();
+
+    /**
+     * Returns the projects of this build. Fails if the projects are not yet loaded for this build.
      */
     BuildProjectRegistry getProjects();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildStateRegistry.java
@@ -99,9 +99,10 @@ public interface BuildStateRegistry {
     IncludedBuildState addImplicitIncludedBuild(BuildDefinition buildDefinition);
 
     /**
-     * Creates a standalone nested build.
+     * Locates the buildSrc build for the given build, if present. Returns null if the given build does not have an associated buildSrc build.
      */
-    StandAloneNestedBuild addBuildSrcNestedBuild(BuildDefinition buildDefinition, BuildState owner);
+    @Nullable
+    StandAloneNestedBuild getBuildSrcNestedBuild(BuildState owner);
 
     /**
      * Creates a new standalone nested build tree.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
@@ -17,10 +17,16 @@
 package org.gradle.internal.build;
 
 import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.tooling.provider.model.UnknownModelException;
+import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 
 import java.util.Collection;
 
+/**
+ * Coordinates the building of tooling models.
+ */
 public interface BuildToolingModelController {
     /**
      * Returns the current state of the mutable model.
@@ -31,6 +37,12 @@ public interface BuildToolingModelController {
      * Returns the mutable model, configuring if necessary.
      */
     GradleInternal getConfiguredModel();
+
+    ToolingModelBuilderLookup.Builder locateBuilderForDefaultTarget(String modelName, boolean param) throws UnknownModelException;
+
+    ToolingModelBuilderLookup.Builder locateBuilderForTarget(BuildState target, String modelName, boolean param) throws UnknownModelException;
+
+    ToolingModelBuilderLookup.Builder locateBuilderForTarget(ProjectState target, String modelName, boolean param) throws UnknownModelException;
 
     boolean queryModelActionsRunInParallel();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildToolingModelController.java
@@ -29,11 +29,6 @@ import java.util.Collection;
  */
 public interface BuildToolingModelController {
     /**
-     * Returns the current state of the mutable model.
-     */
-    GradleInternal getMutableModel();
-
-    /**
      * Returns the mutable model, configuring if necessary.
      */
     GradleInternal getConfiguredModel();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildFactory.java
@@ -31,6 +31,6 @@ public interface IncludedBuildFactory {
      * This ensures that the required classloaders are created in the right order which is required for configuration cache
      */
     default void prepareBuild(IncludedBuildState includedBuild) {
-        includedBuild.loadSettings();
+        includedBuild.getLoadedSettings();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/IncludedBuildState.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.DependencySubstitutions;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 
 import java.io.File;
 
@@ -35,10 +34,6 @@ public interface IncludedBuildState extends NestedBuildState, CompositeBuildPart
     boolean isPluginBuild();
 
     Action<? super DependencySubstitutions> getRegisteredDependencySubstitutions();
-
-    boolean hasInjectedSettingsPlugins();
-
-    SettingsInternal loadSettings();
 
     GradleInternal getConfiguredBuild();
 

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -255,6 +255,9 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
 
     @Override
     public ProjectInternal getDefaultProject() {
+        if (defaultProject == null) {
+            throw new IllegalStateException("The default project is not yet available for " + this + ".");
+        }
         return defaultProject;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -70,6 +70,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 public abstract class DefaultGradle extends AbstractPluginAware implements GradleInternal {
 
@@ -86,7 +87,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     private final MutableActionSet<Project> rootProjectActions = new MutableActionSet<Project>();
     private boolean projectsLoaded;
     private Path identityPath;
-    private ClassLoaderScope classLoaderScope;
+    private Supplier<? extends ClassLoaderScope> classLoaderScope;
     private ClassLoaderScope baseProjectClassLoaderScope;
 
     public DefaultGradle(@Nullable BuildState parent, StartParameter startParameter, ServiceRegistryFactory parentRegistry) {
@@ -467,7 +468,7 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     }
 
     @Override
-    public void setClassLoaderScope(ClassLoaderScope classLoaderScope) {
+    public void setClassLoaderScope(Supplier<? extends ClassLoaderScope> classLoaderScope) {
         if (this.classLoaderScope != null) {
             throw new IllegalStateException("Class loader scope already used");
         }
@@ -477,60 +478,44 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     @Override
     public ClassLoaderScope getClassLoaderScope() {
         if (classLoaderScope == null) {
-            classLoaderScope = services.get(ClassLoaderScopeRegistry.class).getCoreAndPluginsScope();
+            classLoaderScope = () -> getClassLoaderScopeRegistry().getCoreAndPluginsScope();
         }
-        return classLoaderScope;
+        return classLoaderScope.get();
     }
+
+    @Inject
+    protected abstract ClassLoaderScopeRegistry getClassLoaderScopeRegistry();
 
     @Override
     @Inject
     public abstract ProjectRegistry<ProjectInternal> getProjectRegistry();
 
     @Inject
-    protected TextUriResourceLoader.Factory getResourceLoaderFactory() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract TextUriResourceLoader.Factory getResourceLoaderFactory();
 
     @Inject
-    protected ScriptHandlerFactory getScriptHandlerFactory() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract ScriptHandlerFactory getScriptHandlerFactory();
 
     @Inject
-    protected ScriptPluginFactory getScriptPluginFactory() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract ScriptPluginFactory getScriptPluginFactory();
 
     @Inject
-    protected FileResolver getFileResolver() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract FileResolver getFileResolver();
 
     @Inject
-    protected CurrentGradleInstallation getCurrentGradleInstallation() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract CurrentGradleInstallation getCurrentGradleInstallation();
 
     @Inject
-    protected ListenerManager getListenerManager() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract ListenerManager getListenerManager();
 
     @Inject
-    protected ListenerBuildOperationDecorator getListenerBuildOperationDecorator() {
-        throw new UnsupportedOperationException();
-    }
+    protected abstract ListenerBuildOperationDecorator getListenerBuildOperationDecorator();
 
     @Override
     @Inject
-    public PluginManagerInternal getPluginManager() {
-        throw new UnsupportedOperationException();
-    }
+    public abstract PluginManagerInternal getPluginManager();
 
     @Override
     @Inject
-    public PublicBuildPath getPublicBuildPath() {
-        throw new UnsupportedOperationException();
-    }
-
+    public abstract PublicBuildPath getPublicBuildPath();
 }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -21,10 +21,8 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier;
-import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.temp.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
@@ -236,6 +234,10 @@ public class ProjectBuilderImpl {
         }
 
         @Override
+        public void ensureProjectsLoaded() {
+        }
+
+        @Override
         public BuildWorkGraph getWorkGraph() {
             throw new UnsupportedOperationException();
         }
@@ -261,17 +263,12 @@ public class ProjectBuilderImpl {
         }
 
         @Override
-        public SettingsInternal getLoadedSettings() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public Path getCurrentPrefixForProjectsInChildBuilds() {
             return Path.ROOT;
         }
 
         @Override
-        public Path getIdentityPathForProject(Path projectPath) {
+        public Path calculateIdentityPathForProject(Path projectPath) {
             return projectPath;
         }
 
@@ -283,15 +280,6 @@ public class ProjectBuilderImpl {
         @Override
         public <T> T run(Function<? super BuildTreeLifecycleController, T> action) {
             throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ProjectComponentIdentifier getIdentifierForProject(Path projectPath) {
-            String name = projectPath.getName();
-            if (name == null) {
-                name = "root";
-            }
-            return new DefaultProjectComponentIdentifier(getBuildIdentifier(), projectPath, projectPath, name);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/BuildScopeModelBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/BuildScopeModelBuilder.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling.fixture;
+package org.gradle.tooling.provider.model.internal;
 
-import org.gradle.tooling.BuildAction;
-import org.gradle.tooling.BuildController;
+import org.gradle.internal.build.BuildState;
 
-public class ActionForwardsFailure implements BuildAction<String> {
-    @Override
-    public String execute(BuildController controller) {
-        controller.getBuildModel();
-        return "result";
-    }
+public interface BuildScopeModelBuilder {
+    /**
+     * Creates the model for the given target. The target build will not necessarily have been configured, and it is the builder's responsibility
+     * to transition the target into the appropriate state required to create the model.
+     */
+    Object create(BuildState target);
 }

--- a/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
+++ b/subprojects/core/src/main/java/org/gradle/tooling/provider/model/internal/ToolingModelBuilderLookup.java
@@ -16,9 +16,9 @@
 
 package org.gradle.tooling.provider.model.internal;
 
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
+import org.gradle.internal.build.BuildState;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.tooling.provider.model.ToolingModelBuilder;
@@ -32,14 +32,12 @@ public interface ToolingModelBuilderLookup {
     Registration find(String modelName);
 
     /**
-     * Locates a builder for a build-scoped model.
-     */
-    Builder locateForClientOperation(String modelName, boolean parameter, GradleInternal target) throws UnknownModelException;
-
-    /**
      * Locates a builder for a project-scoped model.
      */
-    Builder locateForClientOperation(String modelName, boolean parameter, ProjectInternal target) throws UnknownModelException;
+    Builder locateForClientOperation(String modelName, boolean parameter, ProjectState target) throws UnknownModelException;
+
+    @Nullable
+    Builder maybeLocateForBuildScope(String modelName, boolean parameter, BuildState target);
 
     interface Registration {
         ToolingModelBuilder getBuilder();

--- a/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.tooling.provider.model.internal
 
-import org.gradle.api.internal.GradleInternal
+
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.configuration.internal.UserCodeApplicationContext
+import org.gradle.internal.Describables
 import org.gradle.internal.Factory
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -68,43 +69,6 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         0 * _
     }
 
-    def "wraps model builder in build operation and lock and code application context for all projects when target is build instance"() {
-        def builder1 = Mock(ToolingModelBuilder)
-        def builder2 = Mock(ToolingModelBuilder)
-        def application = Mock(UserCodeApplicationContext.Application)
-        def gradle = Stub(GradleInternal)
-        def project = Stub(ProjectInternal)
-
-        when:
-        registry.register(builder1)
-        registry.register(builder2)
-
-        then:
-        userCodeApplicationContext.current() >> application
-        0 * _
-
-        when:
-        def actualBuilder = registry.locateForClientOperation("model", false, gradle)
-
-        then:
-        builder1.canBuild("model") >> false
-        builder2.canBuild("model") >> true
-        0 * _
-
-        when:
-        def result = actualBuilder.build(null)
-
-        then:
-        result == "result"
-
-        and:
-        1 * buildOperationExecutor.call(_) >> { CallableBuildOperation operation -> operation.call(Stub(BuildOperationContext)) }
-        1 * projectStateRegistry.withMutableStateOfAllProjects(_) >> { Factory factory -> factory.create() }
-        1 * application.reapply(_) >> { Supplier supplier -> supplier.get() }
-        1 * builder2.buildAll("model", project) >> "result"
-        0 * _
-    }
-
     def "wraps model builder in build operation and lock and code application context for project when target is project"() {
         def builder1 = Mock(ToolingModelBuilder)
         def builder2 = Mock(ToolingModelBuilder)
@@ -121,11 +85,13 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         0 * _
 
         when:
-        def actualBuilder = registry.locateForClientOperation("model", false, project)
+        def actualBuilder = registry.locateForClientOperation("model", false, projectState)
 
         then:
         builder1.canBuild("model") >> false
         builder2.canBuild("model") >> true
+        projectState.mutableModel >> project
+        projectState.displayName >> Describables.of("<project>")
 
         when:
         def result = actualBuilder.build(null)
@@ -135,7 +101,6 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
         and:
         1 * buildOperationExecutor.call(_) >> { CallableBuildOperation operation -> operation.call(Stub(BuildOperationContext)) }
-        1 * projectStateRegistry.stateFor(project) >> projectState
         1 * projectState.fromMutableState(_) >> { Function f -> f.apply(project) }
         1 * application.reapply(_) >> { Supplier supplier -> supplier.get() }
         1 * builder2.buildAll("model", project) >> "result"
@@ -181,7 +146,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
     def "fails when no parameterized builder is available for requested model"() {
         when:
-        registry.locateForClientOperation("model", true, Stub(ProjectInternal))
+        registry.locateForClientOperation("model", true, Stub(ProjectState))
 
         then:
         UnknownModelException e = thrown()
@@ -201,7 +166,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         builder2.canBuild("model") >> true
 
         when:
-        registry.locateForClientOperation("model", true, Stub(ProjectInternal))
+        registry.locateForClientOperation("model", true, Stub(ProjectState))
 
         then:
         UnknownModelException e = thrown()
@@ -210,17 +175,19 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
     def "wraps parameterized model builder in build operation and all project lock"() {
         def builder = Mock(ParameterizedToolingModelBuilder)
-        def gradle = Stub(GradleInternal)
         def project = Stub(ProjectInternal)
+        def projectState = Mock(ProjectState)
 
         given:
         registry.register(builder)
 
         and:
         builder.canBuild("model") >> true
+        projectState.mutableModel >> project
+        projectState.displayName >> Describables.of("<project>")
 
         expect:
-        def actualBuilder = registry.locateForClientOperation("model", true, gradle)
+        def actualBuilder = registry.locateForClientOperation("model", true, projectState)
 
         when:
         def result = actualBuilder.build("param")
@@ -230,7 +197,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
 
         and:
         1 * buildOperationExecutor.call(_) >> { CallableBuildOperation operation -> operation.call(Stub(BuildOperationContext)) }
-        1 * projectStateRegistry.withMutableStateOfAllProjects(_) >> { Factory factory -> factory.create() }
+        1 * projectState.fromMutableState(_) >> { Function factory -> factory.apply(project) }
         1 * builder.buildAll("model", "param", project) >> "result"
         0 * _
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -695,7 +695,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project 'depsub'.")
-        failure.assertHasCause("Project :doesnotexist not found.")
+        failure.assertHasCause("Project with path ':doesnotexist' not found in build ':'.")
     }
 
     void "replacing external module dependency with project dependency keeps the original configuration"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/MultiProjectProjectDependencyConflictResolutionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.internal.build.BuildState
 
 class MultiProjectProjectDependencyConflictResolutionIntegrationTest extends AbstractProjectDependencyConflictResolutionIntegrationSpec {
 
@@ -28,7 +27,7 @@ class MultiProjectProjectDependencyConflictResolutionIntegrationTest extends Abs
 
     @Override
     String getBuildId() {
-        "((${ProjectInternal.name}) project).getServices().get(${BuildState.name}.class).getBuildIdentifier()"
+        "((${ProjectInternal.name}) project).getOwner().getOwner().getBuildIdentifier()"
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactory.java
@@ -46,7 +46,7 @@ public class DefaultComponentIdentifierFactory implements ComponentIdentifierFac
 
     @Override
     public ProjectComponentSelector createProjectComponentSelector(String projectPath) {
-        return DefaultProjectComponentSelector.newSelector(currentBuild.getIdentifierForProject(Path.path(projectPath)));
+        return DefaultProjectComponentSelector.newSelector(currentBuild.getProjects().getProject(Path.path(projectPath)).getComponentIdentifier());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -327,7 +327,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
         }
 
         static ProjectComponentIdentifier identifierForProject(IncludedBuildState build, String notation) {
-            return build.getIdentifierForProject(Path.path(notation));
+            return build.getProjects().getProject(Path.path(notation)).getComponentIdentifier();
         }
     }
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractProjectDependencyConflictResolutionIntegrationSpec.groovy
@@ -183,7 +183,7 @@ abstract class AbstractProjectDependencyConflictResolutionIntegrationSpec extend
         def projectId(String projectName) {
             def buildId = $buildId
             def projectPath = $projectPath
-            return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).getIdentifierForProject(${Path.name}.path(projectPath))
+            return project.services.get(${BuildStateRegistry.name}).getBuild(buildId).projects.getProject(${Path.name}.path(projectPath)).componentIdentifier
         }
 """
     }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -114,7 +114,7 @@ Directory '$sub' does not contain a Gradle build.
 """
 
         and:
-        sub.file(".gradle").assertDoesNotExist()
+        sub.file(".gradle").assertIsDir()
         executer.gradleUserHomeDir.file(BuildScopeCacheDir.UNDEFINED_BUILD).assertDoesNotExist()
     }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -67,7 +67,11 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "hello", "--info"
         then:
         outputContains "Hello from original task!"
-        assertWatchableHierarchies([ImmutableSet.of(testDirectory), ImmutableSet.of(testDirectory, file("buildSrc"))])
+
+        // roots discovered during build start up are not registered in a stable order
+        def watchable = determineWatchableHierarchies(output)
+        assert watchable == [ImmutableSet.of(testDirectory), ImmutableSet.of(testDirectory, file("buildSrc"))] ||
+            watchable == [ImmutableSet.of(file("buildSrc")), ImmutableSet.of(testDirectory, file("buildSrc"))]
     }
 
     def "works with composite build"() {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildControllerFactory.java
@@ -19,23 +19,20 @@ package org.gradle.tooling.internal.provider.runner;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.BuildToolingModelController;
-import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
 @ServiceScope(Scopes.BuildTree.class)
 public class BuildControllerFactory {
     private final BuildCancellationToken buildCancellationToken;
-    private final ProjectLeaseRegistry projectLeaseRegistry;
     private final BuildStateRegistry buildStateRegistry;
 
-    public BuildControllerFactory(BuildCancellationToken buildCancellationToken, ProjectLeaseRegistry projectLeaseRegistry, BuildStateRegistry buildStateRegistry) {
+    public BuildControllerFactory(BuildCancellationToken buildCancellationToken, BuildStateRegistry buildStateRegistry) {
         this.buildCancellationToken = buildCancellationToken;
-        this.projectLeaseRegistry = projectLeaseRegistry;
         this.buildStateRegistry = buildStateRegistry;
     }
 
     public DefaultBuildController controllerFor(BuildToolingModelController controller) {
-        return new DefaultBuildController(controller, buildCancellationToken, projectLeaseRegistry, buildStateRegistry);
+        return new DefaultBuildController(controller, buildCancellationToken, buildStateRegistry);
     }
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildModelActionRunner.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.build.BuildToolingModelAction;
 import org.gradle.internal.build.BuildToolingModelController;
 import org.gradle.internal.buildtree.BuildActionRunner;
@@ -63,10 +62,6 @@ public class BuildModelActionRunner implements BuildActionRunner {
         }
     }
 
-    private static ToolingModelBuilderLookup getToolingModelBuilderRegistry(GradleInternal gradle) {
-        return gradle.getDefaultProject().getServices().get(ToolingModelBuilderLookup.class);
-    }
-
     private static class ModelCreateAction implements BuildToolingModelAction<Object> {
         private final BuildModelAction buildModelAction;
         private UnknownModelException modelLookupFailure;
@@ -83,11 +78,9 @@ public class BuildModelActionRunner implements BuildActionRunner {
         @Override
         public Object fromBuildModel(BuildToolingModelController controller) {
             String modelName = buildModelAction.getModelName();
-            GradleInternal gradle = controller.getConfiguredModel();
-            ToolingModelBuilderLookup builderRegistry = getToolingModelBuilderRegistry(gradle);
             ToolingModelBuilderLookup.Builder builder;
             try {
-                builder = builderRegistry.locateForClientOperation(modelName, false, gradle);
+                builder = controller.locateBuilderForDefaultTarget(modelName, false);
             } catch (UnknownModelException e) {
                 modelLookupFailure = e;
                 throw e;

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/DefaultBuildController.java
@@ -17,8 +17,7 @@
 package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.api.BuildCancelledException;
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.Try;
 import org.gradle.internal.build.BuildState;
@@ -29,7 +28,6 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.MultipleBuildOperationFailures;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.tooling.internal.adapter.ProtocolToModelAdapter;
 import org.gradle.tooling.internal.adapter.ViewBuilder;
 import org.gradle.tooling.internal.gradle.GradleBuildIdentity;
@@ -45,6 +43,7 @@ import org.gradle.tooling.provider.model.UnknownModelException;
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,18 +53,15 @@ import java.util.function.Supplier;
 class DefaultBuildController implements org.gradle.tooling.internal.protocol.InternalBuildController, InternalBuildControllerVersion2, InternalActionAwareBuildController {
     private final BuildToolingModelController controller;
     private final BuildCancellationToken cancellationToken;
-    private final ProjectLeaseRegistry projectLeaseRegistry;
     private final BuildStateRegistry buildStateRegistry;
 
     public DefaultBuildController(
         BuildToolingModelController controller,
         BuildCancellationToken cancellationToken,
-        ProjectLeaseRegistry projectLeaseRegistry,
         BuildStateRegistry buildStateRegistry
     ) {
         this.controller = controller;
         this.cancellationToken = cancellationToken;
-        this.projectLeaseRegistry = projectLeaseRegistry;
         this.buildStateRegistry = buildStateRegistry;
     }
 
@@ -92,7 +88,7 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
      * This is used by consumers 4.4 and later
      */
     @Override
-    public BuildResult<?> getModel(Object target, ModelIdentifier modelIdentifier, Object parameter)
+    public BuildResult<?> getModel(@Nullable Object target, ModelIdentifier modelIdentifier, Object parameter)
         throws BuildExceptionVersion1, InternalUnsupportedModelException {
         assertCanQuery();
         if (cancellationToken.isCancellationRequested()) {
@@ -113,7 +109,7 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
 
     @Override
     public boolean getCanQueryProjectModelInParallel(Class<?> modelType) {
-        return projectLeaseRegistry.getAllowsParallelExecution() && controller.queryModelActionsRunInParallel();
+        return controller.queryModelActionsRunInParallel();
     }
 
     @Override
@@ -150,16 +146,16 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
         return builder.build(internalParameter);
     }
 
-    private ModelTarget getTarget(Object target) {
+    private ModelTarget getTarget(@Nullable Object target) {
         if (target == null) {
-            return new BuildScopedModel(controller.getConfiguredModel());
+            return new DefaultTargetModel(controller);
         } else if (target instanceof GradleProjectIdentity) {
             GradleProjectIdentity projectIdentity = (GradleProjectIdentity) target;
             BuildState build = findBuild(projectIdentity);
-            return new ProjectScopedModel(findProject(build, projectIdentity));
+            return new ProjectScopedModel(controller, findProject(build, projectIdentity));
         } else if (target instanceof GradleBuildIdentity) {
             GradleBuildIdentity buildIdentity = (GradleBuildIdentity) target;
-            return new BuildScopedModel(findBuild(buildIdentity).getMutableModel());
+            return new BuildScopedModel(controller, findBuild(buildIdentity));
         } else {
             throw new IllegalArgumentException("Don't know how to build models for " + target);
         }
@@ -179,14 +175,13 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
         }
     }
 
-    private ProjectInternal findProject(BuildState build, GradleProjectIdentity projectIdentity) {
-        return build.getProjects().getProject(Path.path(projectIdentity.getProjectPath())).getMutableModel();
+    private ProjectState findProject(BuildState build, GradleProjectIdentity projectIdentity) {
+        return build.getProjects().getProject(Path.path(projectIdentity.getProjectPath()));
     }
 
     private ToolingModelBuilderLookup.Builder getToolingModelBuilder(ModelTarget modelTarget, boolean parameter, ModelIdentifier modelIdentifier) {
-        ToolingModelBuilderLookup modelBuilderRegistry = modelTarget.targetProject.getServices().get(ToolingModelBuilderLookup.class);
         try {
-            return modelTarget.locate(modelBuilderRegistry, parameter, modelIdentifier);
+            return modelTarget.locate(parameter, modelIdentifier);
         } catch (UnknownModelException e) {
             throw (InternalUnsupportedModelException) new InternalUnsupportedModelException().initCause(e);
         }
@@ -199,37 +194,49 @@ class DefaultBuildController implements org.gradle.tooling.internal.protocol.Int
     }
 
     private static abstract class ModelTarget {
-        final ProjectInternal targetProject;
-
-        protected ModelTarget(ProjectInternal targetProject) {
-            this.targetProject = targetProject;
-        }
-
-        abstract ToolingModelBuilderLookup.Builder locate(ToolingModelBuilderLookup lookup, boolean parameter, ModelIdentifier modelIdentifier);
+        abstract ToolingModelBuilderLookup.Builder locate(boolean parameter, ModelIdentifier modelIdentifier);
     }
 
     private static class ProjectScopedModel extends ModelTarget {
-        public ProjectScopedModel(ProjectInternal targetProject) {
-            super(targetProject);
+        private final BuildToolingModelController controller;
+        private final ProjectState target;
+
+        public ProjectScopedModel(BuildToolingModelController controller, ProjectState target) {
+            this.controller = controller;
+            this.target = target;
         }
 
         @Override
-        ToolingModelBuilderLookup.Builder locate(ToolingModelBuilderLookup lookup, boolean parameter, ModelIdentifier modelIdentifier) {
-            return lookup.locateForClientOperation(modelIdentifier.getName(), parameter, targetProject);
+        ToolingModelBuilderLookup.Builder locate(boolean parameter, ModelIdentifier modelIdentifier) {
+            return controller.locateBuilderForTarget(target, modelIdentifier.getName(), parameter);
         }
     }
 
     private static class BuildScopedModel extends ModelTarget {
-        private final GradleInternal targetBuild;
+        private final BuildToolingModelController controller;
+        private final BuildState target;
 
-        public BuildScopedModel(GradleInternal gradle) {
-            super(gradle.getDefaultProject());
-            this.targetBuild = gradle;
+        public BuildScopedModel(BuildToolingModelController controller, BuildState target) {
+            this.controller = controller;
+            this.target = target;
         }
 
         @Override
-        ToolingModelBuilderLookup.Builder locate(ToolingModelBuilderLookup lookup, boolean parameter, ModelIdentifier modelIdentifier) {
-            return lookup.locateForClientOperation(modelIdentifier.getName(), parameter, targetBuild);
+        ToolingModelBuilderLookup.Builder locate(boolean parameter, ModelIdentifier modelIdentifier) {
+            return controller.locateBuilderForTarget(target, modelIdentifier.getName(), parameter);
+        }
+    }
+
+    private static class DefaultTargetModel extends ModelTarget {
+        private final BuildToolingModelController controller;
+
+        public DefaultTargetModel(BuildToolingModelController controller) {
+            this.controller = controller;
+        }
+
+        @Override
+        ToolingModelBuilderLookup.Builder locate(boolean parameter, ModelIdentifier modelIdentifier) {
+            return controller.locateBuilderForDefaultTarget(modelIdentifier.getName(), parameter);
         }
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/CancellationSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/CancellationSpec.groovy
@@ -40,7 +40,14 @@ rootProject.name = 'cancelling'
 '''
     }
 
-    def setupCancelInConfigurationBuild() {
+    void setupCancelInSettingsBuild() {
+        settingsFile << waitForCancel()
+        buildFile << """
+throw new RuntimeException("should not run")
+"""
+    }
+
+    void setupCancelInConfigurationBuild() {
         settingsFile << '''
 include 'sub'
 rootProject.name = 'cancelling'

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionDiscardsConfigurationFailure.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionDiscardsConfigurationFailure.java
@@ -18,12 +18,13 @@ package org.gradle.integtests.tooling.fixture;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
 
-public class ActionDiscardsFailure implements BuildAction<String> {
+public class ActionDiscardsConfigurationFailure implements BuildAction<String> {
     @Override
     public String execute(BuildController controller) {
         try {
-            controller.getBuildModel();
+            controller.getModel(GradleProject.class);
             throw new IllegalStateException("should fail");
         } catch (Exception e) {
             // Ignore

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionQueriesModelThatRequiresConfigurationPhase.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionQueriesModelThatRequiresConfigurationPhase.java
@@ -18,11 +18,12 @@ package org.gradle.integtests.tooling.fixture;
 
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.GradleProject;
 
-public class FetchModelAction implements BuildAction<String> {
+public class ActionQueriesModelThatRequiresConfigurationPhase implements BuildAction<String> {
     @Override
     public String execute(BuildController controller) {
-        controller.getBuildModel();
+        controller.getModel(GradleProject.class);
         return "result";
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionQueriesModelThatRequiresOnlySettingsEvaluation.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/ActionQueriesModelThatRequiresOnlySettingsEvaluation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.fixture;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+
+public class ActionQueriesModelThatRequiresOnlySettingsEvaluation implements BuildAction<String> {
+    @Override
+    public String execute(BuildController controller) {
+        controller.getBuildModel();
+        return "result";
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiReceivingStandardStreamsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiReceivingStandardStreamsCrossVersionSpec.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.integtests.tooling.m5
 
-import org.gradle.integtests.tooling.fixture.FetchModelAction
+import org.gradle.integtests.tooling.fixture.ActionQueriesModelThatRequiresConfigurationPhase
 import org.gradle.integtests.tooling.fixture.ToolingApiLoggingSpecification
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.model.GradleProject
@@ -90,7 +90,7 @@ class ToolingApiReceivingStandardStreamsCrossVersionSpec extends ToolingApiLoggi
 
         when:
         withConnection { connection ->
-            def action = connection.action(new FetchModelAction())
+            def action = connection.action(new ActionQueriesModelThatRequiresConfigurationPhase())
             action.standardOutput = stdout
             action.standardError = stderr
             return action.run()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r41/BuildListenerCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r41/BuildListenerCrossVersionSpec.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.r18.FetchBuildEnvironment
 import org.gradle.tooling.ProjectConnection
-import org.gradle.tooling.model.gradle.GradleBuild
+import org.gradle.tooling.model.GradleProject
 
 @TargetGradleVersion(">=4.1")
 class BuildListenerCrossVersionSpec extends ToolingApiSpecification {
@@ -53,9 +53,9 @@ class BuildListenerCrossVersionSpec extends ToolingApiSpecification {
         when:
         withConnection {
             ProjectConnection connection ->
-                connection.model(GradleBuild)
-                .setStandardOutput(output)
-                .get()
+                connection.model(GradleProject)
+                    .setStandardOutput(output)
+                    .get()
         }
 
         then:

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/CancellationCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/CancellationCrossVersionSpec.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.tooling.r48
 
 import org.gradle.integtests.tooling.CancellationSpec
-import org.gradle.integtests.tooling.fixture.FetchModelAction
+import org.gradle.integtests.tooling.fixture.ActionQueriesModelThatRequiresConfigurationPhase
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.TestResultHandler
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
@@ -37,7 +37,7 @@ class CancellationCrossVersionSpec extends CancellationSpec {
         when:
         withConnection { ProjectConnection connection ->
             def action = connection.action()
-            action.projectsLoaded(new FetchModelAction(), Stub(IntermediateResultHandlerCollector))
+            action.projectsLoaded(new ActionQueriesModelThatRequiresConfigurationPhase(), Stub(IntermediateResultHandlerCollector))
             def build = action.build()
             build.withCancellationToken(cancel.token())
             collectOutputs(build)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.integtests.tooling.r48
 
-import org.gradle.integtests.tooling.fixture.ActionDiscardsFailure
-import org.gradle.integtests.tooling.fixture.ActionForwardsFailure
+import org.gradle.integtests.tooling.fixture.ActionDiscardsConfigurationFailure
+import org.gradle.integtests.tooling.fixture.ActionQueriesModelThatRequiresConfigurationPhase
 import org.gradle.integtests.tooling.fixture.ActionShouldNotBeCalled
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -210,7 +210,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         when:
         withConnection { connection ->
             def action = connection.action()
-                .projectsLoaded(new ActionForwardsFailure(), projectsLoadedHandler)
+                .projectsLoaded(new ActionQueriesModelThatRequiresConfigurationPhase(), projectsLoadedHandler)
                 .buildFinished(new ActionShouldNotBeCalled(), buildFinishedHandler)
                 .build()
             collectOutputs(action)
@@ -242,8 +242,8 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         when:
         withConnection { connection ->
             def action = connection.action()
-                .projectsLoaded(new ActionDiscardsFailure(), projectsLoadedHandler)
-                .buildFinished(new ActionForwardsFailure(), buildFinishedHandler)
+                .projectsLoaded(new ActionDiscardsConfigurationFailure(), projectsLoadedHandler)
+                .buildFinished(new ActionQueriesModelThatRequiresConfigurationPhase(), buildFinishedHandler)
                 .build()
             collectOutputs(action)
             action.run()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeferredConfigurationCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r73
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import spock.lang.Ignore
 
 @TargetGradleVersion(">=7.3")
 class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
@@ -70,7 +69,6 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         result.assertNotOutput(prefix)
     }
 
-    @Ignore
     def "runs settings scripts and does not configure projects when action queries GradleProject model"() {
         setupBuild()
 
@@ -90,7 +88,6 @@ class DeferredConfigurationCrossVersionSpec extends ToolingApiSpecification {
         result.assertNotOutput(rootProjectMessage)
     }
 
-    @Ignore
     @ToolingApiVersion(">=4.8")
     def "runs settings scripts and does not configure projects when phased action queries GradleProject model"() {
         setupBuild()


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Continuing from #18011 , separate out configuring the settings for a build from configuring the projects for a build, and defer both of these steps until the build action needs them. When a `GradleBuild` model is requested, only configure the settings for each build in the tree. When any other model is requested, also configure the projects of the build.

This is another step towards allowing projects to be individually configured when project isolation is enabled.

This PR also separates out the discovery of the `buildSrc` build for a given build in the tree from the building of the `buildSrc` outputs, so that the `GradleBuild` model can be constructed to include any `buildSrc` builds that may be present in the tree without needing to actually build them.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
