### PR TITLE
Make order of registered watchable directories consistent

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -67,11 +67,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run "hello", "--info"
         then:
         outputContains "Hello from original task!"
-
-        // roots discovered during build start up are not registered in a stable order
-        def watchable = determineWatchableHierarchies(output)
-        assert watchable == [ImmutableSet.of(testDirectory), ImmutableSet.of(testDirectory, file("buildSrc"))] ||
-            watchable == [ImmutableSet.of(file("buildSrc")), ImmutableSet.of(testDirectory, file("buildSrc"))]
+        assertWatchableHierarchies([ImmutableSet.of(testDirectory), ImmutableSet.of(testDirectory, file("buildSrc"))])
     }
 
     def "works with composite build"() {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -45,7 +45,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -57,7 +57,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     private final FileWatcherRegistryFactory watcherRegistryFactory;
     private final DaemonDocumentationIndex daemonDocumentationIndex;
     private final LocationsWrittenByCurrentBuild locationsWrittenByCurrentBuild;
-    private final Set<File> watchableHierarchies = new HashSet<>();
+    private final Set<File> watchableHierarchies = new LinkedHashSet<>();
 
     private FileWatcherRegistry watchRegistry;
     private Exception reasonForNotWatchingFiles;


### PR DESCRIPTION
The order was not consistent for watchable directories registered before starting to watch, since we used a `HashSet`. I changed this to use a `LinkedHashSet`.

This caused some flakiness in `WatchedDirectoriesFileSystemWatchingIntegrationTest`, after https://github.com/gradle/gradle/pull/18074 which causes `buildSrc` to be registered as well before we start watching.