### PR TITLE
Use task to promote final backport release

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -70,7 +70,7 @@ abstract class PublishRelease(
 
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
-    task = "promoteFinalRelease",
+    task = "promoteFinalBackportRelease",
     requiredConfirmationCode = "final",
     init = {
         id("Promotion_FinalRelease")


### PR DESCRIPTION
So we don't set the default version on SDKMan