### PR TITLE
Fix performance at scale of IterationOrderRetainingSetElementSource#add

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -17,13 +17,14 @@
 package org.gradle.api.internal.collections;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.Iterators;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 public class IterationOrderRetainingSetElementSource<T> extends AbstractIterationOrderRetainingElementSource<T> {
     private final Spec<ValuePointer<T>> noDuplicates = new Spec<ValuePointer<T>>() {
@@ -32,6 +33,12 @@ public class IterationOrderRetainingSetElementSource<T> extends AbstractIteratio
             return !pointer.getElement().isDuplicate(pointer.getIndex());
         }
     };
+
+    /**
+     * Tracks the subset of values added with add() (without a Provider), allowing us to filter out duplicates
+     * from that subset in constant time.
+     */
+    private final Set<T> nonProvidedValues = new HashSet<>();
 
     @Override
     public Iterator<T> iterator() {
@@ -47,7 +54,7 @@ public class IterationOrderRetainingSetElementSource<T> extends AbstractIteratio
     @Override
     public boolean add(T element) {
         modCount++;
-        if (!Iterators.contains(iteratorNoFlush(), element)) {
+        if (nonProvidedValues.add(element)) {
             getInserted().add(new Element<T>(element));
             return true;
         } else {
@@ -70,6 +77,12 @@ public class IterationOrderRetainingSetElementSource<T> extends AbstractIteratio
                 markDuplicates(value);
             }
         }
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        nonProvidedValues.remove(o);
+        return super.remove(o);
     }
 
     private void markDuplicates(T value) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -85,6 +85,12 @@ public class IterationOrderRetainingSetElementSource<T> extends AbstractIteratio
         return super.remove(o);
     }
 
+    @Override
+    public void clear() {
+        nonProvidedValues.clear();
+        super.clear();
+    }
+
     private void markDuplicates(T value) {
         boolean seen = false;
         for (Element<T> element : getInserted()) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
@@ -90,6 +90,31 @@ class IterationOrderRetainingSetElementSourceTest extends AbstractIterationOrder
         source.iterator().collect() == ["b", "a"]
     }
 
+    def "can re-add an ordinary value after clear"() {
+        when:
+        source.add("a")
+        source.add("b")
+        source.clear()
+
+        then:
+        source.iterator().collect() == []
+
+        when:
+        source.add("a")
+        source.add("b")
+
+        then:
+        source.iterator().collect() == ["a", "b"]
+
+        when:
+        source.clear()
+        source.add("b")
+        source.add("a")
+
+        then:
+        source.iterator().collect() == ["b", "a"]
+    }
+
     def "duplicates are handled when values change"() {
         def provider1 = setProvider("foo", "bar", "baz")
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -17,10 +17,12 @@ We would like to thank the following community members for their contributions t
 [Roland Weisleder](https://github.com/rweisleder),
 [Konstantin Gribov](https://github.com/grossws),
 [aSemy](https://github.com/aSemy),
-[Rene Groeschke](https://github.com/breskeby)
+[Rene Groeschke](https://github.com/breskeby),
 [Jonathan Leitschuh](https://github.com/JLLeitschuh),
-[Jamie Tanna](https://github.com/jamietanna)
-[Xin Wang](https://github.com/scaventz)
+[Jamie Tanna](https://github.com/jamietanna),
+[Xin Wang](https://github.com/scaventz),
+[Alex Landau](https://github.com/AlexLandau)
+
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)


### PR DESCRIPTION
Fixes #16998

### Context
This `add` method was taking time linear in the size of the collection
rather than constant time, causing performance issues at scale.

There is a slight semantic change here: Previously, if an element was
submitted using `add`, it could be rejected if it matched an element
from a provider, but only if the provider had been realized. This
means the outcome of the iterator could have changed based on the
timing of this realization, and was also different from what the
behavior would be if the element were added through a provider.

Now, if provider and non-provider versions of the same value are
added, they will generally both be accepted into the collection
at `add` time (with a return value of true), and at iteration
time, only one of them will be returned.

I don't have a test for the performance characteristics (I don't know how I'd make such a test non-flakey), but I have tested it manually with https://github.com/AlexLandau/gradle-linear-iorses-add-repro.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
