### PR TITLE
Document defaults for gradle properties in Build Enviroment page in the user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/multi_project_configuration_and_execution.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/multi-project/multi_project_configuration_and_execution.adoc
@@ -73,7 +73,7 @@ A very common way for projects to be coupled is by using <<sharing_build_logic_b
 It may not be immediately apparent, but using key Gradle features like the `allprojects` and `subprojects` keywords automatically cause your projects to be coupled.
 This is because these keywords are used in a `build.gradle` file, which defines a project.
 Often this is a “root project” that does nothing more than define common configuration, but as far as Gradle is concerned this root project is still a fully-fledged project, and by using `allprojects` that project is effectively coupled to all other projects.
-Coupling of the root project to subprojects does not impact 'configuration on demand', but using the `allprojects` and `subprojects` in any subproject's `build.gradle` file will have an impact.
+Coupling of the root project to subprojects does not impact <<#sec:configuration_on_demand,configuration on-demand>>, but using the `allprojects` and `subprojects` in any subproject's `build.gradle` file will have an impact.
 
 This means that using any form of shared build script logic or configuration injection (`allprojects`, `subprojects`, etc.) will cause your projects to be coupled.
 As we extend the concept of project decoupling and provide features that take advantage of decoupled projects, we will also introduce new features to help you to solve common use cases (like configuration injection) without causing your projects to be coupled.

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -47,43 +47,55 @@ The following properties can be used to configure the Gradle build environment:
 
 `org.gradle.caching=(true,false)`::
 When set to true, Gradle will reuse task outputs from any previous build, when possible, resulting is much faster builds. Learn more about <<build_cache.adoc#build_cache, using the build cache>>.
+_By default, the build cache is *not* enabled._
 
 `org.gradle.caching.debug=(true,false)`::
 When set to true, individual input property hashes and the build cache key for each task are logged on the console. Learn more about <<build_cache.adoc#sec:task_output_caching, task output caching>>.
+_Default is `false`._
 
 `org.gradle.configureondemand=(true,false)`::
 Enables incubating <<multi_project_configuration_and_execution.adoc#sec:configuration_on_demand, configuration on demand>>, where Gradle will attempt to configure only necessary projects.
+_Default is false._
 
 `org.gradle.console=(auto,plain,rich,verbose)`::
-Customize console output coloring or verbosity. Default depends on how Gradle is invoked. See <<command_line_interface.adoc#sec:command_line_logging, command-line logging>> for additional details.
+Customize console output coloring or verbosity.
+_Default depends on how Gradle is invoked. See <<command_line_interface.adoc#sec:command_line_logging, command-line logging>> for additional details._
 
 `org.gradle.daemon=(true,false)`::
-When set to `true` the <<gradle_daemon.adoc#gradle_daemon, Gradle Daemon>> is used to run the build. Default is `true`.
+When set to `true` the <<gradle_daemon.adoc#gradle_daemon, Gradle Daemon>> is used to run the build.
+_Default is `true`, builds will be run using the daemon._
 
 `org.gradle.daemon.idletimeout=(# of idle millis)`::
-Gradle Daemon will terminate itself after specified number of idle milliseconds. Default is `10800000` (3 hours).
+Gradle Daemon will terminate itself after specified number of idle milliseconds.
+_Default is `10800000` (3 hours)._
 
 `org.gradle.debug=(true,false)`::
-When set to `true`, Gradle will run the build with remote debugging enabled, listening on port 5005. Note that this is the equivalent of adding `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005` to the JVM command line and will suspend the virtual machine until a debugger is attached. Default is `false`.
+When set to `true`, Gradle will run the build with remote debugging enabled, listening on port 5005. Note that this is the equivalent of adding `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005` to the JVM command line and will suspend the virtual machine until a debugger is attached.
+_Default is `false`._
 
 `org.gradle.java.home=(path to JDK home)`::
-Specifies the Java home for the Gradle build process. The value can be set to either a `jdk` or `jre` location, however, depending on what your build does, using a JDK is safer. A reasonable default is derived from your environment (`JAVA_HOME` or the path to `java`) if the setting is unspecified. This does not affect the version of Java used to launch the Gradle client VM (<<#sec:gradle_environment_variables, see Environment variables>>).
+Specifies the Java home for the Gradle build process. The value can be set to either a `jdk` or `jre` location, however, depending on what your build does, using a JDK is safer. This does not affect the version of Java used to launch the Gradle client VM (<<#sec:gradle_environment_variables, see Environment variables>>).
+_A reasonable default is derived from your environment (`JAVA_HOME` or the path to `java`) if the setting is unspecified._
 
 `org.gradle.jvmargs=(JVM arguments)`::
 Specifies the JVM arguments used for the Gradle Daemon. The setting is particularly useful for <<#sec:configuring_jvm_memory,configuring JVM memory settings>> for build performance. This does not affect the JVM settings for the Gradle client VM.
+_The default is `-Xmx512m "-XX:MaxMetaspaceSize=256m"`._
 
 `org.gradle.logging.level=(quiet,warn,lifecycle,info,debug)`::
-When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level. The values are not case sensitive. The `lifecycle` level is the default. See <<logging.adoc#sec:choosing_a_log_level,Choosing a log level>>.
+When set to quiet, warn, lifecycle, info, or debug, Gradle will use this log level. The values are not case sensitive. See <<logging.adoc#sec:choosing_a_log_level,Choosing a log level>>.
+_The `lifecycle` level is the default._
 
 `org.gradle.parallel=(true,false)`::
 When configured, Gradle will fork up to `org.gradle.workers.max` JVMs to execute projects in parallel. To learn more about parallel task execution, see <<performance.adoc#parallel_execution,the section on Gradle build performance>>.
+_Default is `false`._
 
 `org.gradle.priority=(low,normal)`::
-Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Default is `normal`. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.
+Specifies the scheduling priority for the Gradle daemon and all processes launched by it. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.
+_Default is `normal`._
 
 `org.gradle.vfs.verbose=(true,false)`::
 Configures verbose logging when <<gradle_daemon.adoc#sec:daemon_watch_fs,watching the file system>>.
-_Default is off_.
+_Default is `false`._
 
 `org.gradle.vfs.watch=(true,false)`::
 Toggles <<gradle_daemon.adoc#sec:daemon_watch_fs,watching the file system>>.
@@ -92,9 +104,11 @@ _Enabled by default on operating systems where Gradle supports this feature._
 
 `org.gradle.warning.mode=(all,fail,summary,none)`::
 When set to `all`, `summary` or `none`, Gradle will use different warning type display. See <<command_line_interface.adoc#sec:command_line_logging,Command-line logging options>> for details.
+_Default is `summary`._
 
 `org.gradle.workers.max=(max # of worker processes)`::
-When configured, Gradle will use a maximum of the given number of workers. Default is number of CPU processors. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.
+When configured, Gradle will use a maximum of the given number of workers. See also <<command_line_interface.adoc#sec:command_line_performance, performance command-line options>>.
+_Default is number of CPU processors._
 
 The following example demonstrates usage of various properties.
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -55,7 +55,7 @@ _Default is `false`._
 
 `org.gradle.configureondemand=(true,false)`::
 Enables incubating <<multi_project_configuration_and_execution.adoc#sec:configuration_on_demand, configuration on demand>>, where Gradle will attempt to configure only necessary projects.
-_Default is false._
+_Default is `false`._
 
 `org.gradle.console=(auto,plain,rich,verbose)`::
 Customize console output coloring or verbosity.

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -186,7 +186,7 @@ project.tasks.register('copyFiles', Copy) { Task t ->
 ----
 
 You can see how this example uses the `register()` and `getByName()` methods, which are available on all Gradle “domain object containers”, like tasks, configurations, dependencies, extensions, etc.
-Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#https://docs.gradle.org/current/dsl/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:create(java.lang.String,%20java.lang.Class)[create] method that takes a task type.
+Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:create(java.lang.String,%20java.lang.Class)[create] method that takes a task type.
 
 If you do decide to use static compilation, using an IDE can quickly show errors due to unrecognised types, properties, and methods.
 You’ll also get auto-completion, which is always handy.

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -186,7 +186,7 @@ project.tasks.register('copyFiles', Copy) { Task t ->
 ----
 
 You can see how this example uses the `register()` and `getByName()` methods, which are available on all Gradle “domain object containers”, like tasks, configurations, dependencies, extensions, etc.
-Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:create(java.lang.String,%20java.lang.Class)[create] method that takes a task type.
+Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:create(java.lang.String,%20java.lang.Class)[create] method that takes a task type.
 
 If you do decide to use static compilation, using an IDE can quickly show errors due to unrecognised types, properties, and methods.
 You’ll also get auto-completion, which is always handy.

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -186,7 +186,7 @@ project.tasks.register('copyFiles', Copy) { Task t ->
 ----
 
 You can see how this example uses the `register()` and `getByName()` methods, which are available on all Gradle “domain object containers”, like tasks, configurations, dependencies, extensions, etc.
-Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the `create()` method above that takes a task type.
+Some collections have dedicated types, `TaskContainer` being one of them, that have useful extra methods like the link:{groovyDslPath}/org.gradle.api.tasks.TaskContainer.html#https://docs.gradle.org/current/dsl/org.gradle.api.tasks.TaskContainer.html#org.gradle.api.tasks.TaskContainer:create(java.lang.String,%20java.lang.Class)[create] method that takes a task type.
 
 If you do decide to use static compilation, using an IDE can quickly show errors due to unrecognised types, properties, and methods.
 You’ll also get auto-completion, which is always handy.


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Addresses https://github.com/gradle/gradle/issues/15203 by adding defaults directly to properties page.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
