### PR TITLE
When running tooling API build action defer configuration of each project until required by action

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -64,7 +64,7 @@ class DefaultNestedBuildTest extends Specification {
     }
 
     def "stops controller on stop"() {
-        sessionServices.add(new BuildModelParameters(false, false, false, false))
+        sessionServices.add(Stub(BuildModelParameters))
         def build = build()
 
         when:
@@ -76,7 +76,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "runs action and finishes build when model is not required by root build"() {
         given:
-        sessionServices.add(new BuildModelParameters(false, false, false, false))
+        sessionServices.add(new BuildModelParameters(false, false, false, false, false))
         def build = build()
 
         when:
@@ -97,7 +97,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "runs action but does not finish build when model is required by root build"() {
         given:
-        sessionServices.add(new BuildModelParameters(false, false, false, true))
+        sessionServices.add(new BuildModelParameters(false, false, false, true, false))
         def build = build()
 
         when:
@@ -118,7 +118,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "can have null result"() {
         given:
-        sessionServices.add(new BuildModelParameters(false, false, false, false))
+        sessionServices.add(Stub(BuildModelParameters))
         def build = build()
 
         when:

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/TestBuildTreeLifecycleControllerFactory.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.tooling.provider.model.UnknownModelException
 import org.gradle.tooling.provider.model.internal.ToolingModelBuilderLookup
 
+import java.util.function.Consumer
 import java.util.function.Function
 
 class TestBuildTreeLifecycleControllerFactory implements BuildTreeLifecycleControllerFactory {
@@ -89,7 +90,7 @@ class TestBuildTreeLifecycleControllerFactory implements BuildTreeLifecycleContr
         }
 
         @Override
-        GradleInternal getGradle() {
+        void beforeBuild(Consumer<? super GradleInternal> action) {
             throw new UnsupportedOperationException()
         }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForEachProjectInParallel.java
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/FetchCustomModelForEachProjectInParallel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated;
+
+import org.gradle.configurationcache.fixtures.SomeToolingModel;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchCustomModelForEachProjectInParallel implements BuildAction<List<SomeToolingModel>> {
+    @Override
+    public List<SomeToolingModel> execute(BuildController controller) {
+        List<FetchModelForProject> actions = new ArrayList<>();
+        GradleBuild buildModel = controller.getBuildModel();
+        for (BasicGradleProject project : buildModel.getProjects()) {
+            actions.add(new FetchModelForProject(project));
+        }
+        return controller.run(actions);
+    }
+
+    private static class FetchModelForProject implements BuildAction<SomeToolingModel> {
+        private final BasicGradleProject project;
+
+        public FetchModelForProject(BasicGradleProject project) {
+            this.project = project;
+        }
+
+        @Override
+        public SomeToolingModel execute(BuildController controller) {
+            return controller.findModel(project, SomeToolingModel.class);
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+
+class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.start()
+    }
+
+    def "projects are configured and models created in parallel when project scoped model is queried concurrently"() {
+        withSomeToolingModelBuilderPluginInBuildSrc("""
+            ${server.callFromBuildUsingExpression("'model-' + project.name")}
+        """)
+        settingsFile << """
+            include("a")
+            include("b")
+            rootProject.name = "root"
+        """
+        apply(testDirectory)
+        apply(file("a"))
+        apply(file("b"))
+
+        given:
+        server.expect("configure-root")
+        server.expectConcurrent("model-root", "configure-a", "configure-b")
+        server.expectConcurrent("model-a", "model-b")
+
+        when:
+        // TODO - get rid of usage of --parallel
+        executer.withArguments(ENABLE_CLI, "--parallel")
+        def model = runBuildAction(new FetchCustomModelForEachProjectInParallel())
+
+        then:
+        model.size() == 3
+        model[0].message == "It works from project :"
+        model[1].message == "It works from project :a"
+        model[2].message == "It works from project :b"
+    }
+
+    TestFile apply(TestFile dir) {
+        def buildFile = dir.file("build.gradle")
+        buildFile << """
+            ${server.callFromBuildUsingExpression("'configure-' + project.name")}
+            plugins.apply(my.MyPlugin)
+        """
+        return buildFile
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeLifecycleControllerFactory.kt
@@ -18,8 +18,8 @@ package org.gradle.configurationcache
 
 import org.gradle.composite.internal.IncludedBuildTaskGraph
 import org.gradle.configurationcache.extensions.get
-import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.build.BuildLifecycleController
+import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor
 import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
@@ -32,7 +32,7 @@ import org.gradle.internal.resources.ProjectLeaseRegistry
 
 
 class DefaultBuildTreeLifecycleControllerFactory(
-    private val startParameter: ConfigurationCacheStartParameter,
+    private val buildModelParameters: BuildModelParameters,
     private val cache: BuildTreeConfigurationCache,
     private val taskGraph: IncludedBuildTaskGraph,
     private val buildOperationExecutor: BuildOperationExecutor,
@@ -44,21 +44,21 @@ class DefaultBuildTreeLifecycleControllerFactory(
         val rootBuild = targetBuild.gradle.isRootBuild
 
         val defaultWorkPreparer = DefaultBuildTreeWorkPreparer(targetBuild, taskGraph)
-        val workPreparer = if (startParameter.isEnabled && rootBuild) {
+        val workPreparer = if (buildModelParameters.isConfigurationCache && rootBuild) {
             ConfigurationCacheAwareBuildTreeWorkPreparer(defaultWorkPreparer, cache)
         } else {
             defaultWorkPreparer
         }
 
-        val defaultModelCreator = DefaultBuildTreeModelCreator(targetBuild, buildOperationExecutor, projectLeaseRegistry)
-        val modelCreator = if (startParameter.isEnabled && rootBuild) {
+        val defaultModelCreator = DefaultBuildTreeModelCreator(buildModelParameters, targetBuild, buildOperationExecutor, projectLeaseRegistry)
+        val modelCreator = if (buildModelParameters.isConfigurationCache && rootBuild) {
             ConfigurationCacheAwareBuildTreeModelCreator(defaultModelCreator, cache)
         } else {
             defaultModelCreator
         }
 
         // Some temporary wiring: the cache implementation is still scoped to the root build rather than the build tree
-        if (startParameter.isEnabled && rootBuild) {
+        if (buildModelParameters.isConfigurationCache && rootBuild) {
             cache.attachRootBuild(targetBuild.gradle.services.get())
         }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -39,11 +39,12 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
 
         val isolatedProjects = startParameter.isolatedProjects.get()
         val modelParameters = if (requirements.isCreatesModel) {
-            // When creating a model, disable certain features - don't enable configure on demand and only enable configuration cache when isolated projects is enabled
-            BuildModelParameters(false, isolatedProjects, isolatedProjects, true)
+            // When creating a model, disable certain features - only enable configure on demand and configuration cache when isolated projects is enabled
+            BuildModelParameters(isolatedProjects, isolatedProjects, isolatedProjects, true)
         } else {
             val configurationCache = startParameter.configurationCache.get() || isolatedProjects
-            BuildModelParameters(startParameter.isConfigureOnDemand, configurationCache, isolatedProjects, false)
+            val configureOnDemand = startParameter.isConfigureOnDemand || isolatedProjects
+            BuildModelParameters(configureOnDemand, configurationCache, isolatedProjects, false)
         }
 
         if (!startParameter.isConfigurationCacheQuiet) {
@@ -52,6 +53,9 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
             } else if (modelParameters.isConfigurationCache) {
                 IncubationLogger.incubatingFeatureUsed("Configuration cache")
             }
+        }
+        if (!modelParameters.isIsolatedProjects && modelParameters.isConfigureOnDemand) {
+            IncubationLogger.incubatingFeatureUsed("Configuration on demand")
         }
 
         return BuildTreeModelControllerServices.Supplier { registration ->

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -38,13 +38,14 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         }
 
         val isolatedProjects = startParameter.isolatedProjects.get()
+        val parallelToolingActions = (isolatedProjects || requirements.startParameter.isParallelProjectExecutionEnabled) && !"false".equals(requirements.startParameter.systemPropertiesArgs.get("org.gradle.internal.tooling.parallel"), true)
         val modelParameters = if (requirements.isCreatesModel) {
             // When creating a model, disable certain features - only enable configure on demand and configuration cache when isolated projects is enabled
-            BuildModelParameters(isolatedProjects, isolatedProjects, isolatedProjects, true)
+            BuildModelParameters(isolatedProjects, isolatedProjects, isolatedProjects, true, parallelToolingActions)
         } else {
             val configurationCache = startParameter.configurationCache.get() || isolatedProjects
             val configureOnDemand = startParameter.isConfigureOnDemand || isolatedProjects
-            BuildModelParameters(configureOnDemand, configurationCache, isolatedProjects, false)
+            BuildModelParameters(configureOnDemand, configurationCache, isolatedProjects, false, parallelToolingActions)
         }
 
         if (!startParameter.isConfigurationCacheQuiet) {
@@ -70,7 +71,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         return BuildTreeModelControllerServices.Supplier { registration ->
             registration.add(BuildType::class.java, BuildType.TASKS)
             // Configuration cache is not supported for nested build trees
-            registration.add(BuildModelParameters::class.java, BuildModelParameters(startParameter.isConfigureOnDemand, false, false, true))
+            registration.add(BuildModelParameters::class.java, BuildModelParameters(startParameter.isConfigureOnDemand, false, false, true, false))
             registration.add(RunTasksRequirements::class.java, RunTasksRequirements(startParameter))
         }
     }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/ConfigurationCacheKeyTest.kt
@@ -101,7 +101,7 @@ class ConfigurationCacheKeyTest {
                     null,
                     null
                 ),
-                BuildModelParameters(false, true, false, false),
+                BuildModelParameters(false, true, false, false, false),
                 startParameter
             ),
             RunTasksRequirements(startParameter)

--- a/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/DefaultProjectsPreparer.java
@@ -21,7 +21,6 @@ import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.initialization.ProjectsEvaluatedNotifier;
 import org.gradle.internal.buildtree.BuildModelParameters;
 import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.util.internal.IncubationLogger;
 
 public class DefaultProjectsPreparer implements ProjectsPreparer {
     private final BuildOperationExecutor buildOperationExecutor;
@@ -44,7 +43,6 @@ public class DefaultProjectsPreparer implements ProjectsPreparer {
     @Override
     public void prepareProjects(GradleInternal gradle) {
         if (buildModelParameters.isConfigureOnDemand() && gradle.isRootBuild()) {
-            IncubationLogger.incubatingFeatureUsed("Configuration on demand");
             projectConfigurer.configure(gradle.getRootProject());
         } else {
             projectConfigurer.configureHierarchy(gradle.getRootProject());

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcUpdateFactory.java
@@ -16,13 +16,12 @@
 
 package org.gradle.initialization.buildsrc;
 
-import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
-import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -52,8 +51,7 @@ public class BuildSrcUpdateFactory {
 
     private Collection<File> build() {
         BuildSrcBuildListenerFactory.Listener listener = listenerFactory.create();
-        GradleInternal gradle = buildController.getGradle();
-        gradle.addListener(listener);
+        buildController.beforeBuild(gradle -> gradle.addListener(listener));
 
         buildController.scheduleAndRunTasks();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -25,12 +25,14 @@ public class BuildModelParameters {
     private final boolean configurationCache;
     private final boolean isolatedProjects;
     private final boolean requiresBuildModel;
+    private final boolean parallelToolingApiActions;
 
-    public BuildModelParameters(boolean configureOnDemand, boolean configurationCache, boolean isolatedProjects, boolean requiresBuildModel) {
+    public BuildModelParameters(boolean configureOnDemand, boolean configurationCache, boolean isolatedProjects, boolean requiresBuildModel, boolean parallelToolingApiActions) {
         this.configureOnDemand = configureOnDemand;
         this.configurationCache = configurationCache;
         this.isolatedProjects = isolatedProjects;
         this.requiresBuildModel = requiresBuildModel;
+        this.parallelToolingApiActions = parallelToolingApiActions;
     }
 
     /**
@@ -52,5 +54,12 @@ public class BuildModelParameters {
 
     public boolean isIsolatedProjects() {
         return isolatedProjects;
+    }
+
+    /**
+     * Force parallel tooling API actions? When true, always use parallel execution, when false use a default value.
+     */
+    public boolean isParallelToolingApiActions() {
+        return parallelToolingApiActions;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildTreeLifecycleController.java
@@ -20,17 +20,17 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.internal.build.BuildToolingModelAction;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
  * Controls the lifecycle of the build tree, allowing a single action to be run against the build tree.
  */
 public interface BuildTreeLifecycleController {
-
     /**
-     * @return The {@link org.gradle.api.internal.GradleInternal} object that represents the build invocation.
+     * Performs some setup of the mutable model, prior to any execution. Must be called prior to one of the other methods.
      */
-    GradleInternal getGradle();
+    void beforeBuild(Consumer<? super GradleInternal> action);
 
     /**
      * Runs the given action against an empty build model. Does not attempt to perform any configuration or run any tasks.

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ProblemReportingBuildActionRunner.java
@@ -33,11 +33,13 @@ import java.util.function.Consumer;
 public class ProblemReportingBuildActionRunner implements BuildActionRunner {
     private final BuildActionRunner delegate;
     private final ExceptionAnalyser exceptionAnalyser;
+    private final BuildLayout buildLayout;
     private final List<? extends ProblemReporter> reporters;
 
-    public ProblemReportingBuildActionRunner(BuildActionRunner delegate, ExceptionAnalyser exceptionAnalyser, List<? extends ProblemReporter> reporters) {
+    public ProblemReportingBuildActionRunner(BuildActionRunner delegate, ExceptionAnalyser exceptionAnalyser, BuildLayout buildLayout, List<? extends ProblemReporter> reporters) {
         this.delegate = delegate;
         this.exceptionAnalyser = exceptionAnalyser;
+        this.buildLayout = buildLayout;
         this.reporters = ImmutableList.sortedCopyOf(Comparator.comparing(ProblemReporter::getId), reporters);
     }
 
@@ -66,14 +68,14 @@ public class ProblemReportingBuildActionRunner implements BuildActionRunner {
 
     private RootProjectBuildDirCollectingListener getRootProjectBuildDirCollectingListener(BuildTreeLifecycleController buildController) {
         RootProjectBuildDirCollectingListener listener = new RootProjectBuildDirCollectingListener(
-            defaultRootBuildDirOf(buildController)
+            defaultRootBuildDirOf()
         );
-        buildController.getGradle().addBuildListener(listener);
+        buildController.beforeBuild(gradle -> gradle.addBuildListener(listener));
         return listener;
     }
 
-    private File defaultRootBuildDirOf(BuildTreeLifecycleController buildController) {
-        return new File(buildController.getGradle().getServices().get(BuildLayout.class).getRootDirectory(), "build");
+    private File defaultRootBuildDirOf() {
+        return new File(buildLayout.getRootDirectory(), "build");
     }
 
     private static class RootProjectBuildDirCollectingListener extends InternalBuildAdapter {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/StateTransitionControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/StateTransitionControllerTest.groovy
@@ -37,6 +37,19 @@ class StateTransitionControllerTest extends ConcurrentSpec {
         0 * _
     }
 
+    def "runs action and returns result for transition when in from state"() {
+        def action = Mock(Supplier)
+        def controller = new StateTransitionController(TestState.A)
+
+        when:
+        def result = controller.transition(TestState.A, TestState.B, action)
+
+        then:
+        result == "result"
+        1 * action.get() >> "result"
+        0 * _
+    }
+
     def "fails transition when already in to state"() {
         def action = Mock(Runnable)
         def controller = new StateTransitionController(TestState.A)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/TasksWithInputsAndOutputs.groovy
@@ -199,7 +199,7 @@ trait TasksWithInputsAndOutputs {
         """
     }
 
-    def taskTypeWithInputFileCollection() {
+    def taskTypeWithInputFileCollection(TestFile buildFile = getBuildFile()) {
         buildFile << """
             class InputFilesTask extends DefaultTask {
                 @InputFiles

--- a/subprojects/enterprise/src/test/groovy/org/gradle/internal/scan/config/LegacyGradleEnterprisePluginCheckInServiceTest.groovy
+++ b/subprojects/enterprise/src/test/groovy/org/gradle/internal/scan/config/LegacyGradleEnterprisePluginCheckInServiceTest.groovy
@@ -106,7 +106,7 @@ class LegacyGradleEnterprisePluginCheckInServiceTest extends Specification {
 
         new LegacyGradleEnterprisePluginCheckInService(
             gradle,
-            new BuildModelParameters(false, false, false, false),
+            Stub(BuildModelParameters),
             new GradleEnterprisePluginManager(),
             BuildType.TASKS
         )

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
@@ -16,26 +16,25 @@
 
 package org.gradle.launcher.exec;
 
-import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
-import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
+import org.gradle.internal.invocation.BuildAction;
 
 /**
  * An {@link BuildActionRunner} that notifies the GE plugin manager that the build has completed.
  */
 public class BuildCompletionNotifyingBuildActionRunner implements BuildActionRunner {
     private final BuildActionRunner delegate;
+    private final GradleEnterprisePluginManager gradleEnterprisePluginManager;
 
-    public BuildCompletionNotifyingBuildActionRunner(BuildActionRunner delegate) {
+    public BuildCompletionNotifyingBuildActionRunner(BuildActionRunner delegate, GradleEnterprisePluginManager gradleEnterprisePluginManager) {
         this.delegate = delegate;
+        this.gradleEnterprisePluginManager = gradleEnterprisePluginManager;
     }
 
     @Override
     public Result run(final BuildAction action, BuildTreeLifecycleController buildController) {
-        GradleEnterprisePluginManager gradleEnterprisePluginManager = buildController.getGradle().getServices()
-            .get(GradleEnterprisePluginManager.class);
-
         Result result;
         try {
             result = delegate.run(action, buildController);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -58,13 +58,13 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
 
     @Override
     public Result run(BuildAction action, BuildTreeLifecycleController buildController) {
-        StartParameter startParameter = buildController.getGradle().getStartParameter();
+        StartParameter startParameter = action.getStartParameter();
         TaskExecutionStatisticsEventAdapter taskStatisticsCollector = new TaskExecutionStatisticsEventAdapter();
         listenerManager.addListener(taskStatisticsCollector);
 
         BuildLogger buildLogger = new BuildLogger(Logging.getLogger(BuildLogger.class), styledTextOutputFactory, startParameter, buildRequestMetaData, buildStartedTime, clock, workValidationWarningReporter);
         // Register as a 'logger' to support this being replaced by build logic.
-        buildController.getGradle().useLogger(buildLogger);
+        buildController.beforeBuild(gradle -> gradle.useLogger(buildLogger));
 
         Result result = delegate.run(action, buildController);
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -17,12 +17,14 @@
 package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.execution.internal.TaskInputsListeners;
+import org.gradle.api.internal.changedetection.state.FileHasherStatistics;
 import org.gradle.deployment.internal.DeploymentRegistryInternal;
 import org.gradle.execution.WorkValidationWarningReporter;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.initialization.exception.ExceptionAnalyser;
+import org.gradle.initialization.layout.BuildLayout;
 import org.gradle.internal.build.BuildLayoutValidator;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.build.event.BuildEventListenerFactory;
@@ -33,7 +35,9 @@ import org.gradle.internal.buildtree.BuildTreeModelControllerServices;
 import org.gradle.internal.buildtree.ProblemReportingBuildActionRunner;
 import org.gradle.internal.classpath.CachedClasspathTransformer;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.file.StatStatistics;
 import org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory;
 import org.gradle.internal.filewatch.FileSystemChangeWaiterFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
@@ -42,6 +46,7 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.service.ServiceRegistration;
@@ -49,8 +54,10 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.session.BuildSessionActionExecutor;
+import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
+import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner;
 import org.gradle.launcher.exec.BuildExecuter;
@@ -194,13 +201,26 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                                                      ListenerManager listenerManager,
                                                      BuildStartedTime buildStartedTime,
                                                      BuildRequestMetaData buildRequestMetaData,
+                                                     GradleEnterprisePluginManager gradleEnterprisePluginManager,
+                                                     BuildLifecycleAwareVirtualFileSystem virtualFileSystem,
+                                                     StatStatistics.Collector statStatisticsCollector,
+                                                     FileHasherStatistics.Collector fileHasherStatisticsCollector,
+                                                     DirectorySnapshotterStatistics.Collector directorySnapshotterStatisticsCollector,
+                                                     BuildOperationRunner buildOperationRunner,
                                                      Clock clock,
+                                                     BuildLayout buildLayout,
                                                      ExceptionAnalyser exceptionAnalyser,
                                                      List<ProblemReporter> problemReporters) {
             return new RootBuildLifecycleBuildActionExecutor(
                 buildStateRegistry,
                 new BuildCompletionNotifyingBuildActionRunner(
-                    new FileSystemWatchingBuildActionRunner(eventEmitter,
+                    new FileSystemWatchingBuildActionRunner(
+                        eventEmitter,
+                        virtualFileSystem,
+                        statStatisticsCollector,
+                        fileHasherStatisticsCollector,
+                        directorySnapshotterStatisticsCollector,
+                        buildOperationRunner,
                         new BuildOutcomeReportingBuildActionRunner(
                             styledTextOutputFactory,
                             workValidationWarningReporter,
@@ -208,11 +228,13 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                             new ProblemReportingBuildActionRunner(
                                 new ChainingBuildActionRunner(buildActionRunners),
                                 exceptionAnalyser,
+                                buildLayout,
                                 problemReporters
                             ),
                             buildStartedTime,
                             buildRequestMetaData,
-                            clock))));
+                            clock)),
+                    gradleEnterprisePluginManager));
         }
     }
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionRequestActionRunner.java
@@ -18,9 +18,9 @@ package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.api.tasks.testing.TestExecutionException;
 import org.gradle.execution.BuildConfigurationActionExecuter;
-import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
+import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.operations.BuildOperationAncestryTracker;
 import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.tooling.internal.protocol.test.InternalTestExecutionException;
@@ -69,8 +69,10 @@ public class TestExecutionRequestActionRunner implements BuildActionRunner {
     }
 
     private void doRun(TestExecutionRequestAction action, BuildTreeLifecycleController buildController) {
-        TestExecutionBuildConfigurationAction testTasksConfigurationAction = new TestExecutionBuildConfigurationAction(action, buildController.getGradle());
-        buildController.getGradle().getServices().get(BuildConfigurationActionExecuter.class).setTaskSelectors(Collections.singletonList(testTasksConfigurationAction));
+        buildController.beforeBuild(gradle -> {
+            TestExecutionBuildConfigurationAction testTasksConfigurationAction = new TestExecutionBuildConfigurationAction(action, gradle);
+            gradle.getServices().get(BuildConfigurationActionExecuter.class).setTaskSelectors(Collections.singletonList(testTasksConfigurationAction));
+        });
         buildController.scheduleAndRunTasks();
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Continues #18074 so that when project isolation is enabled individual projects are not configured until required, where "required" means either tasks for that project need to be scheduled or a tooling model for that project is queried.

This means that when running tasks unnecessary projects are not configured, which combines with project isolation constraints to provide a reliable configuration on demand implementation whenever project isolation is enabled. Currently the root project is always configured when the state of any project is required, as this was the simplest option at this stage. This behaviour may change later.

This change also means that when tooling model actions are running in parallel and query the models for different projects, then those projects will be configured in parallel (including expensive steps like script compilation or plugin resolution). Currently this requires using `--parallel` in order to run the tooling model actions in parallel, but this should become the default when project isolation is enabled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
