### PR TITLE
Issue: 17964: Run exclude before and after dependencySubstitution to exclude rewritten dependencies

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -434,7 +434,6 @@ public class NodeState implements DependencyGraphNode {
         try {
             collectAncestorsStrictVersions(incomingEdges);
             for (DependencyState dependencyState : dependencies(resolutionFilter)) {
-                dependencyState = maybeSubstitute(dependencyState, resolveState.getDependencySubstitutionApplicator());
                 PendingDependenciesVisitor.PendingState pendingState = pendingDepsVisitor.maybeAddAsPendingDependency(this, dependencyState);
                 if (dependencyState.getDependency().isConstraint()) {
                     registerActivatingConstraint(dependencyState);
@@ -507,6 +506,11 @@ public class NodeState implements DependencyGraphNode {
         }
         List<DependencyState> tmp = Lists.newArrayListWithCapacity(from.size());
         for (DependencyState dependencyState : from) {
+            if (isExcluded(spec, dependencyState)) {
+                continue;
+            }
+            dependencyState = maybeSubstitute(dependencyState, resolveState.getDependencySubstitutionApplicator());
+
             if (!isExcluded(spec, dependencyState)) {
                 tmp.add(dependencyState);
             }


### PR DESCRIPTION
Apply the exclude spec before and after dependency substitution to
ensure that redirected dependency will be excluded correctly.

Signed-off-by: Attix Zhang <attix.zhang.cs@gmail.com>

<!--- The issue this PR addresses -->
Fixes #17964 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
