### PR TITLE
Suppress "Possible heap pollution" warnings

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -97,6 +97,7 @@ public interface HasMultipleValues<T> extends HasConfigurableValue {
      * @param elements The elements to add
      * @since 4.10
      */
+    @SuppressWarnings("varargs")
     void addAll(T... elements);
 
     /**


### PR DESCRIPTION
This is to test some functionality of gradle bot by fixing tiny issues in the code base.