### PR TITLE
Refine error message when build scan performance test failed

### DIFF
--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -127,8 +127,12 @@ class BuildScanPluginPerformanceTest extends AbstractBuildScanPluginPerformanceT
         void afterBuild(BuildContext context, Throwable t) {
             assert !new File(projectDir, 'error.log').exists()
             def buildCacheDirectory = new TestFile(projectDir, 'local-build-cache')
-            def cacheEntries = buildCacheDirectory.listFiles().sort()
-            cacheEntries.eachWithIndex { TestFile entry, int i ->
+            def cacheEntries = buildCacheDirectory.listFiles()
+            if (cacheEntries == null) {
+                throw new IllegalStateException("Cache dir doesn't exist, did the build succeed? Please check the build log.")
+            }
+
+            cacheEntries.sort().eachWithIndex { TestFile entry, int i ->
                 if (i % 2 == 0) {
                     entry.delete()
                 }


### PR DESCRIPTION
Previously, if the build scan performance test fails to start,
there will be an NPE thrown, hiding the real problem. Now
we refine the error message to point people to the real failure.
