### PR TITLE
Remove special handling of `maxParallelForks` on AX41

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -129,6 +129,8 @@ fun BuildType.paramsForBuildToolBuild(buildJvm: Jvm = BuildToolBuildJvm, os: Os)
         if (os == Os.MACOS) {
             // Use fewer parallel forks on macOs, since the agents are not very powerful.
             param("maxParallelForks", "2")
+        } else {
+            param("maxParallelForks", "8")
         }
         if (os == Os.LINUX || os == Os.MACOS) {
             param("env.LC_ALL", "en_US.UTF-8")
@@ -181,7 +183,8 @@ fun functionalTestExtraParameters(buildScanTag: String, os: Os, testJvmVersion: 
     )
     return (listOf(
         "-PtestJavaVersion=$testJvmVersion",
-        "-PtestJavaVendor=$testJvmVendor") +
+        "-PtestJavaVendor=$testJvmVendor"
+    ) +
         listOf(buildScanTag(buildScanTag)) +
         buildScanValues.map { buildScanCustomValue(it.key, it.value) }
         ).filter { it.isNotBlank() }.joinToString(separator = " ")

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -22,6 +22,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.internal.os.OperatingSystem
 import java.io.ByteArrayOutputStream
+import java.net.InetAddress
 
 
 fun Project.testDistributionEnabled() = providers.systemProperty("enableTestDistribution").forUseAtConfigurationTime().orNull?.toBoolean() == true
@@ -93,6 +94,7 @@ object BuildEnvironment {
     const val BUILD_VCS_NUMBER = "BUILD_VCS_NUMBER"
 
     val isCiServer = CI_ENVIRONMENT_VARIABLE in System.getenv()
+    val isEc2Agent = InetAddress.getLocalHost().hostName.startsWith("ip-")
     val isIntelliJIDEA by lazy { System.getProperty("idea.version") != null }
     val isTravis = "TRAVIS" in System.getenv()
     val isJenkins = "JENKINS_HOME" in System.getenv()

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -298,7 +298,11 @@ val Project.maxTestDistributionPartitionSecond: Long?
     get() = providers.systemProperty("testDistributionPartitionSizeInSeconds").forUseAtConfigurationTime().orNull?.toLong()
 
 val Project.maxParallelForks: Int
-    get() = findProperty("maxParallelForks")?.toString()?.toInt() ?: 4
+    get() = if (BuildEnvironment.isEc2Agent) {
+        4
+    } else {
+        findProperty("maxParallelForks")?.toString()?.toInt() ?: 4
+    }
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -298,7 +298,7 @@ val Project.maxTestDistributionPartitionSecond: Long?
     get() = providers.systemProperty("testDistributionPartitionSizeInSeconds").forUseAtConfigurationTime().orNull?.toLong()
 
 val Project.maxParallelForks: Int
-    get() = (findProperty("maxParallelForks")?.toString()?.toInt() ?: 4) * (if (System.getenv("BUILD_AGENT_VARIANT") == "AX41") 2 else 1)
+    get() = findProperty("maxParallelForks")?.toString()?.toInt() ?: 4
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -17,6 +17,7 @@
 import com.gradle.scan.plugin.BuildScanExtension
 import gradlebuild.basics.BuildEnvironment.isCiServer
 import gradlebuild.basics.BuildEnvironment.isGhActions
+import gradlebuild.basics.BuildEnvironment.isEc2Agent
 import gradlebuild.basics.BuildEnvironment.isJenkins
 import gradlebuild.basics.BuildEnvironment.isTravis
 import gradlebuild.basics.kotlindsl.execAndGetStdout
@@ -38,7 +39,6 @@ import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperati
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.launcher.exec.RunBuildBuildOperationType
-import java.net.InetAddress
 import java.net.URLEncoder
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -167,15 +167,13 @@ fun extractCheckstyleAndCodenarcData() {
     }
 }
 
-fun isEc2Agent() = InetAddress.getLocalHost().hostName.startsWith("ip-")
-
 fun Project.extractCiData() {
     if (isCiServer) {
         buildScan {
             background {
                 setCompileAllScanSearch(execAndGetStdout("git", "rev-parse", "--verify", "HEAD"))
             }
-            if (isEc2Agent()) {
+            if (isEc2Agent) {
                 tag("EC2")
             }
             if (isGhActions) {


### PR DESCRIPTION
Because now we have unified build agents.