### PR TITLE
Try replacing IgnoreIf with Requires for tests that cannot run embedded

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
@@ -27,8 +29,9 @@ class GroovyGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec 
     @Override
     String subprojectName() { 'plugin' }
 
+    // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     @Unroll
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'groovy-gradle-plugin', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
@@ -17,12 +17,9 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
-
 
 class GroovyGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec {
 

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -18,10 +18,8 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaApplicationInitIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.buildinit.plugins
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -228,7 +230,7 @@ class JavaApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
 
 
     @Issue("https://github.com/gradle/gradle/issues/17383")
-    @IgnoreIf({ GradleContextualExecuter.embedded })
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "command line works with different locale"() {
         setup:
         executer.withCommandLineGradleOpts('-Duser.language=tr', '-Duser.country=TR')

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
@@ -17,12 +17,9 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
-
 
 class JavaGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec {
 

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
@@ -27,8 +29,9 @@ class JavaGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec {
     @Override
     String subprojectName() { 'plugin' }
 
+    // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     @Unroll
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-gradle-plugin', '--dsl', scriptDsl.id)

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinGradlePluginInitIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinGradlePluginInitIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.buildinit.plugins
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
@@ -38,8 +40,9 @@ class KotlinGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec 
         dslFixtureFor(KOTLIN).assertGradleFilesGenerated()
     }
 
+    // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     @Unroll
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs a build in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'kotlin-gradle-plugin', '--dsl', scriptDsl.id)

--- a/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
+++ b/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -43,7 +44,7 @@ class ProjectBuilderCrossVersionIntegrationTest extends MultiVersionIntegrationS
     }
 
     // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
-    @IgnoreIf({ GradleContextualExecuter.embedded })
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "can apply plugin using ProjectBuilder in a test running with Gradle version under development"() {
         writeSourceFiles()
         expect:

--- a/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
+++ b/subprojects/core/src/crossVersionTest/groovy/org/gradle/testfixtures/ProjectBuilderCrossVersionIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.testfixtures
 
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetVersions
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -17,15 +17,12 @@
 package org.gradle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.nativeintegration.jansi.JansiStorageLocator
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
-
 // needs to run a distribution from scratch to not have native services on the classpath already
 @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
 class NativeServicesIntegrationTest extends AbstractIntegrationSpec {

--- a/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/NativeServicesIntegrationTest.groovy
@@ -20,11 +20,14 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.nativeintegration.jansi.JansiStorageLocator
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
-@IgnoreIf({ GradleContextualExecuter.embedded }) // needs to run a distribution from scratch to not have native services on the classpath already
+// needs to run a distribution from scratch to not have native services on the classpath already
+@Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
 class NativeServicesIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -21,6 +21,8 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.GradleVersion
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -81,7 +83,8 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-3068")
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
+    // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "can use gradleApi in test"() {
         given:
         file("src/test/groovy/org/acme/ProjectBuilderTest.groovy") << """
@@ -113,7 +116,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
         succeeds("test")
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Gradle API JAR is not generated when running embedded
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "generated Gradle API JAR in custom Gradle user home is reused across multiple invocations"() {
         requireOwnGradleUserHomeDir()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.GradleVersion
@@ -27,7 +26,6 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.util.internal.TextUtil.normaliseFileSeparators
-
 // TODO: This needs a better home - Possibly in the test kit package in the future
 @Issue("https://github.com/gradle/gradle-private/issues/3247")
 @IgnoreIf({ OperatingSystem.current().macOsX && JavaVersion.current() == JavaVersion.VERSION_1_8})

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
@@ -19,9 +19,12 @@ package org.gradle.cache.internal
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.GradleVersion
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 
-@IgnoreIf({ GradleContextualExecuter.embedded }) // tests a real Gradle distribution
+// tests a real Gradle distribution
+@Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
 class WrapperDistributionCleanupActionIntegrationTest extends AbstractIntegrationSpec {
 
     def "reads Gradle version from actual distribution"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/cache/internal/WrapperDistributionCleanupActionIntegrationTest.groovy
@@ -17,11 +17,9 @@
 package org.gradle.cache.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.GradleVersion
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 
 // tests a real Gradle distribution
 @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.initialization
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
@@ -26,7 +28,7 @@ class DistributionPropertiesLoaderIntegrationTest extends AbstractIntegrationSpe
 
     @Issue('https://github.com/gradle/gradle/issues/11173')
     @ToBeFixedForConfigurationCache(because = "undeclared system properties")
-    @IgnoreIf({ GradleContextualExecuter.embedded })
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "System properties defined in gradle.properties are available in buildSrc and in included builds"() {
         given:
         settingsFile << '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/DistributionPropertiesLoaderIntegrationTest.groovy
@@ -18,10 +18,8 @@ package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 class DistributionPropertiesLoaderIntegrationTest extends AbstractIntegrationSpec {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
@@ -17,12 +17,10 @@
 package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Issue
 import spock.lang.Unroll
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.initialization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -82,7 +84,8 @@ task printSystemProp {
         outputContains('mySystemProp=commandline')
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // needs to run Gradle from command line
+    // needs to run Gradle from command line
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "build property set on command line takes precedence over jvm args"() {
         when:
         executer.withEnvironmentVars 'GRADLE_OPTS': '-Dorg.gradle.configureondemand=true'
@@ -111,7 +114,8 @@ task assertCodDisabled {
         succeeds ':assertCodDisabled'
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // needs to run Gradle from command line
+    // needs to run Gradle from command line
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "system property set on command line takes precedence over jvm args"() {
         given:
         executer.withEnvironmentVars 'GRADLE_OPTS': '-DmySystemProp=jvmarg'
@@ -176,7 +180,7 @@ task printSystemProp {
         outputContains("myProp=fromEnv2")
     }
 
-    @IgnoreIf({ GradleContextualExecuter.embedded })
+    @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
     def "properties can be distributed as part of a custom Gradle installation"() {
         given:
         requireIsolatedGradleDistribution()

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
@@ -16,14 +16,11 @@
 
 package org.gradle.testfixtures
 
-
 import org.gradle.api.internal.tasks.testing.worker.TestWorker
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.internal.TextUtil
-import spock.lang.IgnoreIf
 
 // this requires a full distribution
 @Requires(TestPrecondition.INSTALLED_DISTRIBUTION)

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
@@ -20,10 +20,13 @@ package org.gradle.testfixtures
 import org.gradle.api.internal.tasks.testing.worker.TestWorker
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.gradle.util.internal.TextUtil
 import spock.lang.IgnoreIf
 
-@IgnoreIf({ GradleContextualExecuter.isEmbedded()}) // this requires a full distribution
+// this requires a full distribution
+@Requires(TestPrecondition.INSTALLED_DISTRIBUTION)
 class ProjectBuilderEndUserIntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -165,13 +165,17 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     }),
     MSBUILD({
         // Simplistic approach at detecting MSBuild by assuming Windows imply MSBuild is present
-        WINDOWS.fulfilled && "embedded" != System.getProperty("org.gradle.integtest.executer")
+        // To test with MSBuild, we need to have an installed Gradle distribution
+        WINDOWS.fulfilled && INSTALLED_DISTRIBUTION.fulfilled
     }),
     SUPPORTS_TARGETING_JAVA6({ !JDK12_OR_LATER.fulfilled }),
     // Currently mac agents are not that strong so we avoid running high-concurrency tests on them
     HIGH_PERFORMANCE(NOT_MAC_OS_X),
     NOT_EC2_AGENT({
         !InetAddress.getLocalHost().getHostName().startsWith("ip-")
+    }),
+    INSTALLED_DISTRIBUTION({
+        "embedded" != System.getProperty("org.gradle.integtest.executer")
     })
 
     /**


### PR DESCRIPTION
Some tests require a full distribution to work. We previously disabled
these tests with a IgnoreIf annotation and a check against the contextual
executer.

This change introduces a TestPrecondition that will cause the test
to be skipped when the embedded executer is used.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
