### PR TITLE
Automatically normalize aliases for find* methods in VersionCatalog API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -37,24 +37,36 @@ import java.util.Optional;
 public interface VersionCatalog extends Named {
     /**
      * Returns the dependency provider for the corresponding alias.
+     * <p>
+     * Note: Alias will be automatically normalized: '-', '_' and '.' will be replaced with '.'
+     * </p>
      * @param alias the alias of the dependency
      */
     Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias);
 
     /**
      * Returns the dependency provider for the corresponding bundle.
+     * <p>
+     * Note: Bundle will be automatically normalized: '-', '_' and '.' will be replaced with '.'
+     * </p>
      * @param bundle the alias of the bundle
      */
     Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle);
 
     /**
      * Returns the version constraint with the corresponding name in the catalog.
+     * <p>
+     * Note: Name will be automatically normalized: '-', '_' and '.' will be replaced with '.'
+     * </p>
      * @param name the name of the version
      */
     Optional<VersionConstraint> findVersion(String name);
 
     /**
      * Returns the plugin dependency provider for the requested alias.
+     * <p>
+     * Note: Alias will be automatically normalized: '-', '_' and '.' will be replaced with '.'
+     * </p>
      * @param alias the alias of the plugin
      *
      * @since 7.2

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
@@ -17,17 +17,12 @@ package org.gradle.api.internal.catalog;
 
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
-import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.plugin.use.PluginDependency;
 
 import javax.inject.Inject;
-import java.util.List;
-import java.util.Optional;
-
-import static org.gradle.api.internal.catalog.AliasNormalizer.normalize;
 
 public abstract class AbstractExternalDependencyFactory implements ExternalModuleDependencyFactory {
     protected final DefaultVersionCatalog config;
@@ -60,63 +55,6 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         return providers.of(DependencyValueSource.class,
             spec -> spec.getParameters().getDependencyData().set(config.getDependencyData(alias)))
             .forUseAtConfigurationTime();
-    }
-
-    @Override
-    public final Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
-        if (config.getDependencyAliases().contains(alias)) {
-            return Optional.of(create(alias));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
-        if (config.getBundleAliases().contains(bundle)) {
-            return Optional.of(new BundleFactory(providers, config).createBundle(bundle));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final Optional<VersionConstraint> findVersion(String name) {
-        if (config.getVersionAliases().contains(name)) {
-            return Optional.of(new VersionFactory(providers, config).findVersionConstraint(name));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Provider<PluginDependency>> findPlugin(String alias) {
-        if (config.getPluginAliases().contains(alias)) {
-            return Optional.of(new PluginFactory(providers, config).createPlugin(alias));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final String getName() {
-        return config.getName();
-    }
-
-    @Override
-    public List<String> getDependencyAliases() {
-        return config.getDependencyAliases();
-    }
-
-    @Override
-    public List<String> getBundleAliases() {
-        return config.getBundleAliases();
-    }
-
-    @Override
-    public List<String> getVersionAliases() {
-        return config.getVersionAliases();
-    }
-
-    @Override
-    public List<String> getPluginAliases() {
-        return config.getPluginAliases();
     }
 
     public static class VersionFactory {
@@ -152,7 +90,7 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
             return version.getPreferredVersion();
         }
 
-        private ImmutableVersionConstraint findVersionConstraint(String name) {
+        protected ImmutableVersionConstraint findVersionConstraint(String name) {
             return config.getVersion(name).getVersion();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
@@ -31,6 +31,8 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static org.gradle.api.internal.catalog.AliasNormalizer.normalize;
+
 public class VersionCatalogView implements VersionCatalog {
 
     private final DefaultVersionCatalog config;
@@ -46,32 +48,36 @@ public class VersionCatalogView implements VersionCatalog {
 
     @Override
     public final Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
-        if (config.getDependencyAliases().contains(alias)) {
-            return Optional.of(dependencyFactory.create(alias));
+        String normalizedAlias = normalize(alias);
+        if (config.getDependencyAliases().contains(normalizedAlias)) {
+            return Optional.of(dependencyFactory.create(normalizedAlias));
         }
         return Optional.empty();
     }
 
     @Override
     public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
-        if (config.getBundleAliases().contains(bundle)) {
-            return Optional.of(new BundleFactory(providerFactory, config).createBundle(bundle));
+        String normalizedBundle = normalize(bundle);
+        if (config.getBundleAliases().contains(normalizedBundle)) {
+            return Optional.of(new BundleFactory(providerFactory, config).createBundle(normalizedBundle));
         }
         return Optional.empty();
     }
 
     @Override
     public final Optional<VersionConstraint> findVersion(String name) {
-        if (config.getVersionAliases().contains(name)) {
-            return Optional.of(new VersionFactory(providerFactory, config).findVersionConstraint(name));
+        String normalizedName = normalize(name);
+        if (config.getVersionAliases().contains(normalizedName)) {
+            return Optional.of(new VersionFactory(providerFactory, config).findVersionConstraint(normalizedName));
         }
         return Optional.empty();
     }
 
     @Override
     public Optional<Provider<PluginDependency>> findPlugin(String alias) {
-        if (config.getPluginAliases().contains(alias)) {
-            return Optional.of(new PluginFactory(providerFactory, config).createPlugin(alias));
+        String normalizedAlias = normalize(alias);
+        if (config.getPluginAliases().contains(normalizedAlias)) {
+            return Optional.of(new PluginFactory(providerFactory, config).createPlugin(normalizedAlias));
         }
         return Optional.empty();
     }

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -62,7 +62,7 @@ For example:
 - but `this.#is.not!`
 
 Then type safe accessors are generated for _each subgroup_.
-For example, given the following aliases in version catalog named `libs`:
+For example, given the following aliases in a version catalog named `libs`:
 
 `guava`, `groovy-core`, `groovy-xml`, `groovy-json`, `androidx.awesome.lib`
 
@@ -74,7 +74,7 @@ We would generate the following type-safe accessors:
 - `libs.groovy.json`
 - `libs.androidx.awesome.lib`
 
-Where prefix `libs` comes from version catalog name.
+Where the `libs` prefix comes from the version catalog name.
 
 In case you want to avoid the generation of a subgroup accessor, we recommend relying on case to differentiate.
 For example the aliases `groovyCore`, `groovyJson` and `groovyXml` would be mapped to the `libs.groovyCore`, `libs.groovyJson` and `libs.groovyXml` accessors respectively.
@@ -249,7 +249,7 @@ Dependency declaration can either be declared as a simple string, in which case 
 
 [NOTE]
 ====
-For aliases same rules apply as described in <<platforms.adoc#sub:mapping-aliases-to-accessors, aliases and their mapping to type safe accessors>> section.
+For aliases, the rules described in the section <<platforms.adoc#sub:mapping-aliases-to-accessors, aliases and their mapping to type safe accessors>> apply as well.
 ====
 
 .Different dependency notations
@@ -288,14 +288,14 @@ See the https://toml.io[TOML specification] for details.
 [[sub:programmatic-access-to-catalog]]
 === Programmatic access to catalog
 
-You can also access version catalog programmatically with version catalog extension and version catalog API:
+You can also access version catalog programmatically with the version catalog extension and API:
 
 ====
 include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",files="build.gradle[tags=programmatic_access]"]
 include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="build.gradle.kts[tags=programmatic_access]"]
 ====
 
-Check link:{javadocPath}/org/gradle/api/artifacts/VersionCatalog.html[version catalog API] for all supported methods.
+Check the link:{javadocPath}/org/gradle/api/artifacts/VersionCatalog.html[version catalog API] for all supported methods.
 
 [[sec:sharing-catalogs]]
 == Sharing catalogs

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -47,9 +47,9 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",fil
 include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="settings.gradle.kts[tags=simple_catalog]"]
 ====
 
-[NOTE]
-.Mapping of aliases to type-safe accessors
-====
+[[sub:mapping-aliases-to-accessors]]
+==== Aliases and their mapping to type safe accessors
+
 Aliases must consist of a series of identifiers separated by a dash (`-`, recommended), an underscore (`_`) or a dot (`.`).
 Identifiers themselves must consist of ascii characters, preferably lowercase, eventually followed by numbers.
 
@@ -62,7 +62,7 @@ For example:
 - but `this.#is.not!`
 
 Then type safe accessors are generated for _each subgroup_.
-For example, given the following aliases:
+For example, given the following aliases in version catalog named `libs`:
 
 `guava`, `groovy-core`, `groovy-xml`, `groovy-json`, `androidx.awesome.lib`
 
@@ -74,17 +74,36 @@ We would generate the following type-safe accessors:
 - `libs.groovy.json`
 - `libs.androidx.awesome.lib`
 
-In case you want to avoid the generation of a subgroup accessor, we recommend to rely on case to differentiate.
+Where prefix `libs` comes from version catalog name.
+
+In case you want to avoid the generation of a subgroup accessor, we recommend relying on case to differentiate.
 For example the aliases `groovyCore`, `groovyJson` and `groovyXml` would be mapped to the `libs.groovyCore`, `libs.groovyJson` and `libs.groovyXml` accessors respectively.
 
 When declaring aliases, it's worth noting that any of the `-`, `_` and `.` characters can be used as separators, but the generated catalog will have all normalized to `.`:
 for example `foo-bar` as an alias is converted to `foo.bar` automatically.
+
+[WARNING]
+====
+Some keywords are reserved, so they cannot be used as an alias. Next words cannot be used as an alias:
+
+- extensions
+- class
+- convention
+
+Additional to that next words cannot be used as a suffix of an alias:
+
+- bundles
+- versions
+- version
+- bundle
+- plugin
+- plugins
 ====
 
 [[sec:common-version-numbers]]
 ==== Dependencies with same version numbers
 
-In the example above, we can see that we declare 3 aliases for various components of the `groovy` library and that all of them share the same version number.
+In the first example in <<platforms.adoc#sub:version-catalog-declaration, declaring a version catalog>>, we can see that we declare 3 aliases for various components of the `groovy` library and that all of them share the same version number.
 
 Instead of repeating the same version number, we can declare a version and reference it:
 
@@ -228,6 +247,11 @@ Supported members of a version declaration are:
 
 Dependency declaration can either be declared as a simple string, in which case they are interpreted as `group:artifact:version` coordinates, or separating the version declaration from the group and name:
 
+[NOTE]
+====
+For aliases same rules apply as described in <<platforms.adoc#sub:mapping-aliases-to-accessors, aliases and their mapping to type safe accessors>> section.
+====
+
 .Different dependency notations
 ----
 include::{snippetsPath}/dependencyManagement/catalogs-toml/groovy/gradle/test-libs.versions.toml[]
@@ -260,6 +284,18 @@ or
 
 See the https://toml.io[TOML specification] for details.
 ====
+
+[[sub:programmatic-access-to-catalog]]
+=== Programmatic access to catalog
+
+You can also access version catalog programmatically with version catalog extension and version catalog API:
+
+====
+include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",files="build.gradle[tags=programmatic_access]"]
+include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="build.gradle.kts[tags=programmatic_access]"]
+====
+
+Check link:{javadocPath}/org/gradle/api/artifacts/VersionCatalog.html[version catalog API] for all supported methods.
 
 [[sec:sharing-catalogs]]
 == Sharing catalogs
@@ -417,7 +453,10 @@ include::sample[dir="snippets/dependencyManagement/managingTransitiveDependencie
 
 Because platforms and catalogs both talk about dependency versions and can both be used to share dependency versions in a project, there might be a confusion regarding what to use and if one is preferable to the other.
 
-The answer is that you should always use catalogs and _maybe_ use platforms in addition.
+In short, you should:
+
+- use catalogs to only define dependencies and their versions for projects and to generate type-safe accessors
+- use platform to apply versions to dependency graph and to affect dependency resolution
 
 A catalog helps with centralizing the dependency versions and is only, as it name implies, a catalog of dependencies you can pick from.
 We recommend using it to declare the coordinates of your dependencies, in all cases.

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -90,14 +90,13 @@ Some keywords are reserved, so they cannot be used as an alias. Next words canno
 - class
 - convention
 
-Additional to that next words cannot be used as a suffix of an alias:
+Additional to that next words cannot be used as a first subgroup of an alias for dependencies (for bundles, versions and plugins this restriction doesn't apply):
 
 - bundles
 - versions
-- version
-- bundle
-- plugin
 - plugins
+
+So for example for dependencies an alias `versions-dependency` is not valid, but `versionsDependency` or `dependency-versions` are valid.
 ====
 
 [[sec:common-version-numbers]]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/build.gradle
@@ -57,3 +57,12 @@ dependencies {
     implementation libs.bundles.groovy
 }
 // end::use_dependency_bundle[]
+
+// tag::programmatic_access[]
+def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
+dependencies {
+    versionCatalog.findDependency("groovy-json").ifPresent {
+        implementation(it)
+    }
+}
+// end::programmatic_access[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/build.gradle.kts
@@ -56,3 +56,13 @@ dependencies {
     implementation(libs.bundles.groovy)
 }
 // end::use_dependency_bundle[]
+
+// tag::programmatic_access[]
+val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+dependencies {
+    versionCatalog.findDependency("groovy-json").ifPresent {
+        implementation(it)
+    }
+}
+// end::programmatic_access[]
+


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #18050

I figured to make it more user friendly, we can just automatically normalize aliases. 