### PR TITLE
Remove restriction on subgroups in version catalogs for plugins

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
@@ -21,7 +21,7 @@ import org.gradle.api.NonExtensible;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
- * An object that can be transformed to {@link Provider<T>}.
+ * An object that can be converted to a {@link Provider}.
  *
  * @param <T> Type of value represented by provider
  * @since 7.3
@@ -32,7 +32,7 @@ import org.gradle.internal.HasInternalProtocol;
 public interface ProviderConvertible<T> {
 
     /**
-     * Returns a new {@link Provider<T>} from this object.
+     * Returns a {@link Provider} from this object.
      */
     Provider<T> asProvider();
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider;
+
+import org.gradle.api.NonExtensible;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * An object that can be transformed to {@link Provider<T>}.
+ *
+ * @param <T> Type of value represented by provider
+ * @since 7.3
+ */
+@HasInternalProtocol
+@NonExtensible
+public interface ProviderConvertible<T> {
+
+    /**
+     * Returns a new {@link Provider<T>} from this object.
+     */
+    Provider<T> asProvider();
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.provider;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.internal.HasInternalProtocol;
 
@@ -25,6 +26,7 @@ import org.gradle.internal.HasInternalProtocol;
  * @param <T> Type of value represented by provider
  * @since 7.3
  */
+@Incubating
 @HasInternalProtocol
 @NonExtensible
 public interface ProviderConvertible<T> {

--- a/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/plugin/use/PluginDependenciesSpec.java
@@ -18,6 +18,7 @@ package org.gradle.plugin.use;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 
 /**
  * The DSL for declaring plugins to use in a script.
@@ -138,5 +139,17 @@ public interface PluginDependenciesSpec {
      */
     @Incubating
     PluginDependencySpec alias(Provider<PluginDependency> notation);
+
+    /**
+     * Adds a plugin dependency using a notation coming from a version catalog.
+     * The resulting dependency spec can be refined with a version overriding
+     * what the version catalog provides.
+     * @param notation the plugin reference
+     * @return a mutable plugin dependency specification  that can be used to further refine the dependency
+     *
+     * @since 7.3
+     */
+    @Incubating
+    PluginDependencySpec alias(ProviderConvertible<PluginDependency> notation);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/use/internal/PluginRequestCollector.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.groovy.scripts.ScriptSource;
 import org.gradle.internal.exceptions.LocationAwareException;
 import org.gradle.plugin.internal.InvalidPluginIdException;
@@ -121,8 +122,13 @@ public class PluginRequestCollector {
         @Override
         public PluginDependencySpec alias(Provider<PluginDependency> notation) {
             PluginDependency pluginDependency = notation.get();
-            // For now we use the _requested version_ when a plugin comes from a catalog
+            // For now we use the _required version_ when a plugin comes from a catalog
             return id(pluginDependency.getPluginId()).version(pluginDependency.getVersion().getRequiredVersion());
+        }
+
+        @Override
+        public PluginDependencySpec alias(ProviderConvertible<PluginDependency> notation) {
+            return alias(notation.asProvider());
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginDslSupport.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PluginDslSupport.groovy
@@ -25,6 +25,10 @@ trait PluginDslSupport {
         withPlugins([:], [(alias): null])
     }
 
+    void withPluginAliases(List<String> aliases = []) {
+        withPlugins([:], aliases.collectEntries { [it, null] })
+    }
+
     void withPluginsBlockContents(String block) {
         def text = buildFile.text
         int idx = text.indexOf('allprojects')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsGroovyDSLIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsGroovyDSLIntegrationTest.groovy
@@ -191,16 +191,12 @@ dependencyResolutionManagement {
         String pluginVersion = '1.5'
         String firstLevelTask = 'greet'
         String firstLevelPluginId = 'com.acme.greeter'
+        String secondLevelPluginTask = 'greet-second'
+        String secondLevelPluginId = 'com.acme.greeter.second'
         new PluginBuilder(file("greeter"))
             .addPluginWithPrintlnTask(firstLevelTask, 'Hello from first plugin!', firstLevelPluginId, "FirstPlugin")
-            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
-            .allowAll()
-
-        String secondLevelPluginTask = 'greet-second'
-        String secondLevelPluginId = 'com.acme.greeter2'
-        new PluginBuilder(file("greeter-second"))
             .addPluginWithPrintlnTask(secondLevelPluginTask, 'Hello from second plugin!', secondLevelPluginId, "SecondPlugin")
-            .publishAs("some", "artifact2", pluginVersion, pluginPortal, executer)
+            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
             .allowAll()
 
         file("settings.gradle") << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
@@ -234,4 +234,96 @@ dependencyResolutionManagement {
         outputContains message
 
     }
+
+    def "can apply a plugin alias that has sub-accessors"() {
+        String pluginVersion = '1.5'
+        String firstLevelTask = 'greet'
+        String firstLevelPluginId = 'com.acme.greeter'
+        new PluginBuilder(file("greeter"))
+            .addPluginWithPrintlnTask(firstLevelTask, 'Hello from first plugin!', firstLevelPluginId, "FirstPlugin")
+            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
+            .allowAll()
+
+        String secondLevelPluginTask = 'greet-second'
+        String secondLevelPluginId = 'com.acme.greeter2'
+        new PluginBuilder(file("greeter-second"))
+            .addPluginWithPrintlnTask(secondLevelPluginTask, 'Hello from second plugin!', secondLevelPluginId, "SecondPlugin")
+            .publishAs("some", "artifact2", pluginVersion, pluginPortal, executer)
+            .allowAll()
+
+        // We use the Groovy DSL for settings because that's not what we want to
+        // test and the setup would be more complicated with Kotlin
+        settingsFile << """
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            alias("greeter").toPluginId("$firstLevelPluginId").version("$pluginVersion")
+            alias("greeter-second").toPluginId("$secondLevelPluginId").version("$pluginVersion")
+        }
+    }
+}"""
+        buildFile.renameTo(file('fixture.gradle'))
+        buildKotlinFile << """
+            plugins {
+                alias(libs.plugins.greeter)
+                alias(libs.plugins.greeter.second)
+            }
+        """
+
+        when:
+        succeeds(firstLevelTask, secondLevelPluginTask)
+
+        then:
+        outputContains 'Hello from first plugin!'
+        outputContains 'Hello from second plugin!'
+    }
+
+    def "can apply a plugin via buildscript that has sub-accessors"() {
+        String pluginVersion = '1.5'
+        String firstPluginId = 'com.acme.greeter'
+        new PluginBuilder(file("greeter"))
+            .addPluginWithPrintlnTask('greet', 'Hello from first plugin!', firstPluginId, "FirstPlugin")
+            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
+            .allowAll()
+        String secondPluginId = 'com.acme.greeter2'
+        new PluginBuilder(file("greeter-second"))
+            .addPluginWithPrintlnTask('greet2', 'Hello from second plugin!', secondPluginId, "SecondPlugin")
+            .publishAs("some", "artifact2", pluginVersion, pluginPortal, executer)
+            .allowAll()
+
+        // We use the Groovy DSL for settings because that's not what we want to
+        // test and the setup would be more complicated with Kotlin
+        file("settings.gradle") << """
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            alias('greeter').to('some', 'artifact').version('1.5')
+            alias('greeter-second').to('some', 'artifact2').version('1.5')
+        }
+    }
+}"""
+        buildFile.renameTo(file('fixture.gradle'))
+        buildKotlinFile << """
+            buildscript {
+                repositories {
+                    maven {
+                        url = uri("${pluginPortal.uri}")
+                    }
+                }
+                dependencies {
+                    classpath(libs.greeter)
+                    classpath(libs.greeter.second)
+                }
+            }
+            apply<org.gradle.test.FirstPlugin>()
+            apply<org.gradle.test.SecondPlugin>()
+        """
+
+        when:
+        succeeds('greet', 'greet2')
+
+        then:
+        outputContains 'Hello from first plugin!'
+        outputContains 'Hello from second plugin!'
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
@@ -239,16 +239,12 @@ dependencyResolutionManagement {
         String pluginVersion = '1.5'
         String firstLevelTask = 'greet'
         String firstLevelPluginId = 'com.acme.greeter'
+        String secondLevelPluginTask = 'greet-second'
+        String secondLevelPluginId = 'com.acme.greeter.second'
         new PluginBuilder(file("greeter"))
             .addPluginWithPrintlnTask(firstLevelTask, 'Hello from first plugin!', firstLevelPluginId, "FirstPlugin")
-            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
-            .allowAll()
-
-        String secondLevelPluginTask = 'greet-second'
-        String secondLevelPluginId = 'com.acme.greeter2'
-        new PluginBuilder(file("greeter-second"))
             .addPluginWithPrintlnTask(secondLevelPluginTask, 'Hello from second plugin!', secondLevelPluginId, "SecondPlugin")
-            .publishAs("some", "artifact2", pluginVersion, pluginPortal, executer)
+            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
             .allowAll()
 
         // We use the Groovy DSL for settings because that's not what we want to

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
@@ -192,49 +192,6 @@ dependencyResolutionManagement {
         outputContains message
     }
 
-    def "can apply a plugin declared in a catalog via buildscript"() {
-        String taskName = 'greet'
-        String message = 'Hello from plugin!'
-        String pluginId = 'com.acme.greeter'
-        String pluginVersion = '1.5'
-        def plugin = new PluginBuilder(file("greeter"))
-            .addPluginWithPrintlnTask(taskName, message, pluginId)
-            .publishAs("some", "artifact", pluginVersion, pluginPortal, executer)
-
-        // We use the Groovy DSL for settings because that's not what we want to
-        // test and the setup would be more complicated with Kotlin
-        file("settings.gradle") << """
-dependencyResolutionManagement {
-    versionCatalogs {
-        libs {
-            alias('greeter').to('some', 'artifact').version('1.5')
-        }
-    }
-}"""
-        buildFile.renameTo(file('fixture.gradle'))
-        buildKotlinFile << """
-            buildscript {
-                repositories {
-                    maven {
-                        url = uri("${pluginPortal.uri}")
-                    }
-                }
-                dependencies {
-                    classpath(libs.greeter)
-                }
-            }
-            apply<org.gradle.test.TestPlugin>()
-        """
-
-        when:
-        plugin.pluginModule.allowAll()
-        succeeds taskName
-
-        then:
-        outputContains message
-
-    }
-
     def "can apply a plugin alias that has sub-accessors"() {
         String pluginVersion = '1.5'
         String firstLevelTask = 'greet'
@@ -274,7 +231,7 @@ dependencyResolutionManagement {
         outputContains 'Hello from second plugin!'
     }
 
-    def "can apply a plugin via buildscript that has sub-accessors"() {
+    def "can apply a plugin via buildscript and also sub-accessor plugin"() {
         String pluginVersion = '1.5'
         String firstPluginId = 'com.acme.greeter'
         new PluginBuilder(file("greeter"))

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -51,6 +51,7 @@ import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
@@ -174,8 +175,8 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
                 .nagUser();
             return doAddConfiguration(configuration, (Configuration) dependencyNotation);
         }
-        if (dependencyNotation instanceof ExternalModuleDependencyFactory.ProviderConvertible<?>) {
-            return doAddProvider(configuration, ((ExternalModuleDependencyFactory.ProviderConvertible<?>) dependencyNotation).asProvider(), configureClosure);
+        if (dependencyNotation instanceof ProviderConvertible<?>) {
+            return doAddProvider(configuration, ((ProviderConvertible<?>) dependencyNotation).asProvider(), configureClosure);
         }
         if (dependencyNotation instanceof Provider<?>) {
             return doAddProvider(configuration, (Provider<?>) dependencyNotation, configureClosure);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -46,7 +46,6 @@ import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependencyVariant;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.api.internal.catalog.DependencyBundleValueSource;
-import org.gradle.api.internal.catalog.ExternalModuleDependencyFactory;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
@@ -18,13 +18,10 @@ package org.gradle.api.internal.catalog;
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
 import org.gradle.api.artifacts.VersionCatalog;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.plugin.use.PluginDependency;
 
 public interface ExternalModuleDependencyFactory extends VersionCatalog {
-    interface ProviderConvertible<T> {
-        Provider<T> asProvider();
-    }
 
     interface DependencyNotationSupplier extends ProviderConvertible<MinimalExternalModuleDependency> {
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/PluginDependenciesSpecScope.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.Incubating
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependency
 import org.gradle.plugin.use.PluginDependencySpec
@@ -40,6 +41,9 @@ class PluginDependenciesSpecScope internal constructor(
         plugins.id(id)
 
     override fun alias(notation: Provider<PluginDependency>) =
+        plugins.alias(notation)
+
+    override fun alias(notation: ProviderConvertible<PluginDependency>) =
         plugins.alias(notation)
 }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledProjectScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/PrecompiledProjectScript.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl.precompile
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.delegates.ProjectDelegate
 import org.gradle.plugin.use.PluginDependenciesSpec
@@ -60,6 +61,10 @@ open class PrecompiledProjectScript(
                 override fun alias(notation: Provider<PluginDependency>): PluginDependencySpec {
                     project.pluginManager.apply(notation.get().pluginId)
                     return NullPluginDependencySpec
+                }
+
+                override fun alias(notation: ProviderConvertible<PluginDependency>): PluginDependencySpec {
+                    return alias(notation.asProvider())
                 }
             }
         )

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
@@ -193,7 +193,6 @@ open class PrecompiledProjectScript(
                 override fun alias(notation: ProviderConvertible<PluginDependency>): PluginDependencySpec {
                     return alias(notation.asProvider())
                 }
-
             }
         )
     }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/precompile/v1/PrecompiledScriptTemplates.kt
@@ -26,6 +26,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.logging.LoggingManager
 import org.gradle.api.plugins.PluginAware
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver
 import org.gradle.kotlin.dsl.support.DefaultKotlinScript
@@ -111,6 +112,10 @@ open class PrecompiledSettingsScript(
                     pluginManager.apply(notation.get().pluginId)
                     return NullPluginDependencySpec
                 }
+
+                override fun alias(notation: ProviderConvertible<PluginDependency>): PluginDependencySpec {
+                    return alias(notation.asProvider())
+                }
             }
         )
     }
@@ -184,6 +189,11 @@ open class PrecompiledProjectScript(
                     pluginManager.apply(notation.get().pluginId)
                     return NullPluginDependencySpec
                 }
+
+                override fun alias(notation: ProviderConvertible<PluginDependency>): PluginDependencySpec {
+                    return alias(notation.asProvider())
+                }
+
             }
         )
     }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginManagementSpec.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/DefaultPluginManagementSpec.java
@@ -22,6 +22,7 @@ import org.gradle.api.initialization.ConfigurableIncludedPluginBuild;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Actions;
 import org.gradle.internal.build.BuildIncluder;
@@ -115,6 +116,11 @@ public class DefaultPluginManagementSpec implements PluginManagementSpecInternal
         public PluginDependencySpec alias(Provider<PluginDependency> notation) {
             PluginDependency pluginDependency = notation.get();
             return id(pluginDependency.getPluginId()).version(pluginDependency.getVersion().getRequiredVersion());
+        }
+
+        @Override
+        public PluginDependencySpec alias(ProviderConvertible<PluginDependency> notation) {
+            return alias(notation.asProvider());
         }
     }
 


### PR DESCRIPTION
This removes a restriction on subgroups in version catalogs for plugins. Fix for libraries was already applied before but for plugins this did not work.

This means, that:
```
plugins {
    alias(libs.plugins.greeter)
    alias(libs.plugins.greeter.second)
}
```
now works.

Note that I had to move `ProviderConvertible<T>` to public API.

Fixes #18142

