### PR TITLE
Fix corner case of selector removal

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -320,7 +320,7 @@ class ModuleResolveState implements CandidateModule {
         for (SelectorState selectorState : selectors) {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
         }
-        if (!alreadyReused && selectors.size() != 0) {
+        if (!alreadyReused && selectors.size() != 0 && selected != null) {
             maybeUpdateSelection();
         }
     }


### PR DESCRIPTION
When a selector is removed, Gradle will attempt to reselect a different
version for a given module. This should however not happen when the
module has effectively no selection, as is the case when the target of a
replacement or capability conflict.