### PR TITLE
Re-split quick cross version tests

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -78,8 +78,8 @@ data class CIBuildModel(
                 SpecificBuild.SmokeTestsMinJavaVersion
             ),
             functionalTests = listOf(
-                TestCoverage(5, TestType.quickFeedbackCrossVersion, Os.LINUX, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size),
-                TestCoverage(6, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size)
+                TestCoverage(5, TestType.quickFeedbackCrossVersion, Os.LINUX, JvmCategory.MIN_VERSION, QUICK_CROSS_VERSION_BUCKETS.size),
+                TestCoverage(6, TestType.quickFeedbackCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, QUICK_CROSS_VERSION_BUCKETS.size)
             ),
             performanceTests = listOf(
                 PerformanceTestCoverage(6, PerformanceTestType.per_commit, Os.WINDOWS, numberOfBuckets = 5, failsStage = false),
@@ -95,14 +95,14 @@ data class CIBuildModel(
                 TestCoverage(8, TestType.soak, Os.LINUX, JvmCategory.MAX_VERSION, 1),
                 TestCoverage(9, TestType.soak, Os.WINDOWS, JvmCategory.MIN_VERSION, 1),
                 TestCoverage(35, TestType.soak, Os.MACOS, JvmCategory.MIN_VERSION, 1),
-                TestCoverage(10, TestType.allVersionsCrossVersion, Os.LINUX, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size),
-                TestCoverage(11, TestType.allVersionsCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size),
+                TestCoverage(10, TestType.allVersionsCrossVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
+                TestCoverage(11, TestType.allVersionsCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(12, TestType.noDaemon, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(13, TestType.noDaemon, Os.WINDOWS, JvmCategory.MAX_VERSION),
                 TestCoverage(14, TestType.platform, Os.MACOS, JvmCategory.MIN_VERSION, expectedBucketNumber = 20),
                 TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
-                TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.LINUX, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size),
-                TestCoverage(34, TestType.allVersionsIntegMultiVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, CROSS_VERSION_BUCKETS.size)
+                TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
+                TestCoverage(34, TestType.allVersionsIntegMultiVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size)
             ),
             performanceTests = listOf(
                 PerformanceTestCoverage(2, PerformanceTestType.per_day, Os.LINUX, numberOfBuckets = 30, oldUuid = "PerformanceTestSlowLinux")

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -11,7 +11,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import java.io.File
 
 /**
- * QuickCrossVersionTest only tests the last major version.
+ * QuickCrossVersionTest only tests the last minor for each major version in the range.
  */
 val QUICK_CROSS_VERSION_BUCKETS = listOf(
     listOf("0.0", "3.0"), // 0.0 <= version < 3.0

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -10,7 +10,25 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import java.io.File
 
-val CROSS_VERSION_BUCKETS = listOf(
+/**
+ * QuickCrossVersionTest only tests the last major version.
+ */
+val QUICK_CROSS_VERSION_BUCKETS = listOf(
+    listOf("0.0", "3.0"), // 0.0 <= version < 3.0
+    listOf("3.0", "4.0"), // 3.0 <= version < 4.0
+    listOf("4.0", "5.0"), // 4.0 <= version < 5.0
+    listOf("5.0", "6.0"), // 5.0 <=version < 6.0
+    listOf("6.0", "7.0"), // 6.0 <=version < 7.0
+    listOf("7.0", "8.0"), // 7.0 <=version < 8.0
+    listOf("8.0", "9.0"), // 8.0 <=version < 9.0
+    listOf("9.0", "10.0"), // 9.0 <=version < 10.0
+    listOf("10.0", "11.0"), // 10.0 <=version < 11.0
+    listOf("11.0", "12.0"), // 11.0 <=version < 12.0
+    listOf("12.0", "13.0"), // 12.0 <=version < 13.0
+    listOf("13.0", "99.0") // 13.0 <=version < 99.0
+)
+
+val ALL_CROSS_VERSION_BUCKETS = listOf(
     listOf("0.0", "2.8"), // 0.0 <= version < 2.8
     listOf("2.8", "3.3"), // 2.8 <= version < 3.3
     listOf("3.3", "4.1"), // 3.3 <= version < 4.1
@@ -32,19 +50,23 @@ interface FunctionalTestBucketProvider {
 }
 
 class DefaultFunctionalTestBucketProvider(val model: CIBuildModel, testBucketsJson: File) : FunctionalTestBucketProvider {
-    private val crossVersionTestBucketProvider = CrossVersionTestBucketProvider(model)
+    private val allCrossVersionTestBucketProvider = CrossVersionTestBucketProvider(ALL_CROSS_VERSION_BUCKETS, model)
+    private val quickCrossVersionTestBucketProvider = CrossVersionTestBucketProvider(QUICK_CROSS_VERSION_BUCKETS, model)
     private val functionalTestBucketProvider = StatisticBasedFunctionalTestBucketProvider(model, testBucketsJson)
     override fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage): List<FunctionalTest> {
-        return if (testCoverage.testType in listOf(TestType.quickFeedbackCrossVersion, TestType.allVersionsCrossVersion)) {
-            crossVersionTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
-        } else {
-            functionalTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
+        return when {
+            testCoverage.testType == TestType.quickFeedbackCrossVersion -> quickCrossVersionTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
+            testCoverage.testType == TestType.allVersionsCrossVersion -> allCrossVersionTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
+            else -> functionalTestBucketProvider.createFunctionalTestsFor(stage, testCoverage)
         }
     }
 }
 
-class CrossVersionTestBucketProvider(private val model: CIBuildModel) : FunctionalTestBucketProvider {
-    private val buckets: List<BuildTypeBucket> = CROSS_VERSION_BUCKETS.map { GradleVersionRangeCrossVersionTestBucket(it[0], it[1]) }
+class CrossVersionTestBucketProvider(
+    crossVersionBuckets: List<List<String>>,
+    private val model: CIBuildModel
+) : FunctionalTestBucketProvider {
+    private val buckets: List<BuildTypeBucket> = crossVersionBuckets.map { GradleVersionRangeCrossVersionTestBucket(it[0], it[1]) }
 
     // For quickFeedbackCrossVersion and allVersionsCrossVersion, the buckets are split by Gradle version
     // By default, split them by CROSS_VERSION_BUCKETS


### PR DESCRIPTION
Quick cross version tests only test last version in each major version,
so we need to re-split them to make sure they're distributed evenly.
