### PR TITLE
Fix functional tests generated by build-init to be rerunnable 

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
@@ -17,8 +17,10 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
+
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.lang.Unroll
 
 
@@ -43,6 +45,31 @@ class GroovyGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec 
 
         when:
         run("build")
+
+        then:
+        assertTestPassed("some.thing.SomeThingPluginTest", "plugin registers task")
+        assertFunctionalTestPassed("some.thing.SomeThingPluginFunctionalTest", "can run task")
+
+        where:
+        scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18206")
+    @Unroll
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs builds in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    def "re-running check succeeds"() {
+        given:
+        run('init', '--type', 'groovy-gradle-plugin', '--dsl', scriptDsl.id)
+
+        when:
+        run('check')
+
+        then:
+        assertTestPassed("some.thing.SomeThingPluginTest", "plugin registers task")
+        assertFunctionalTestPassed("some.thing.SomeThingPluginFunctionalTest", "can run task")
+
+        when:
+        run('check', '--rerun-tasks')
 
         then:
         assertTestPassed("some.thing.SomeThingPluginTest", "plugin registers task")

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaGradlePluginInitIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.buildinit.plugins
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 import spock.lang.Unroll
 
 
@@ -43,6 +44,31 @@ class JavaGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec {
 
         when:
         run("build")
+
+        then:
+        assertTestPassed("some.thing.SomeThingPluginTest", "pluginRegistersATask")
+        assertFunctionalTestPassed("some.thing.SomeThingPluginFunctionalTest", "canRunTask")
+
+        where:
+        scriptDsl << ScriptDslFixture.SCRIPT_DSLS
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18206")
+    @Unroll
+    @IgnoreIf({ GradleContextualExecuter.embedded }) // This test runs a build that itself runs builds in a test worker with 'gradleApi()' dependency, which needs to pick up Gradle modules from a real distribution
+    def "re-running check succeeds"() {
+        given:
+        run('init', '--type', 'java-gradle-plugin', '--dsl', scriptDsl.id)
+
+        when:
+        run('check')
+
+        then:
+        assertTestPassed("some.thing.SomeThingPluginTest", "pluginRegistersATask")
+        assertFunctionalTestPassed("some.thing.SomeThingPluginFunctionalTest", "canRunTask")
+
+        when:
+        run('check', '--rerun-tasks')
 
         then:
         assertTestPassed("some.thing.SomeThingPluginTest", "pluginRegistersATask")

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
@@ -23,8 +23,8 @@ class ${className.javaIdentifier} extends Specification {
 
     def "can run task"() {
         given:
-        getSettingsFile() << ""
-        getBuildFile() << """
+        settingsFile << ""
+        buildFile << """
 plugins {
     id('${pluginId.value}')
 }

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
@@ -3,30 +3,32 @@
  */
 ${packageDecl.statement}
 import spock.lang.Specification
+import spock.lang.TempDir
 import org.gradle.testkit.runner.GradleRunner
 
 /**
  * A simple functional test for the '${pluginId.value}' plugin.
  */
 class ${className.javaIdentifier} extends Specification {
+    @TempDir
+    private File projectDir
+
+    private getBuildFile() {
+        new File(projectDir, "build.gradle")
+    }
+
+    private getSettingsFile() {
+        new File(projectDir, "settings.gradle")
+    }
+
     def "can run task"() {
         given:
-        def projectDir = new File("build/functionalTest")
-        projectDir.mkdirs()
-
-        def settingsFile = new File(projectDir, "settings.gradle")
-        if (!settingsFile.exists()) {
-            settingsFile << ""
-        }
-
-        def buildFile = new File(projectDir, "build.gradle")
-        if (!buildFile.exists()) {
-            buildFile << """
-            plugins {
-                id('${pluginId.value}')
-            }
+        getSettingsFile() << ""
+        getBuildFile() << """
+plugins {
+    id('${pluginId.value}')
+}
 """
-        }
 
         when:
         def runner = GradleRunner.create()

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/groovy/spock/PluginFunctionalTest.groovy.template
@@ -13,12 +13,20 @@ class ${className.javaIdentifier} extends Specification {
         given:
         def projectDir = new File("build/functionalTest")
         projectDir.mkdirs()
-        new File(projectDir, "settings.gradle") << ""
-        new File(projectDir, "build.gradle") << """
+
+        def settingsFile = new File(projectDir, "settings.gradle")
+        if (!settingsFile.exists()) {
+            settingsFile << ""
+        }
+
+        def buildFile = new File(projectDir, "build.gradle")
+        if (!buildFile.exists()) {
+            buildFile << """
             plugins {
                 id('${pluginId.value}')
             }
-        """
+"""
+        }
 
         when:
         def runner = GradleRunner.create()

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
@@ -10,29 +10,30 @@ import java.nio.file.Files;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A simple functional test for the '${pluginId.value}' plugin.
  */
 class ${className.javaIdentifier} {
+    @TempDir
+    File projectDir;
+
+    private File getBuildFile() {
+        return new File(projectDir, "build.gradle");
+    }
+
+    private File getSettingsFile() {
+        return new File(projectDir, "settings.gradle");
+    }
+
     @Test void canRunTask() throws IOException {
-        // Setup the test build
-        File projectDir = new File("build/functionalTest");
-        Files.createDirectories(projectDir.toPath());
-
-        File settingsFile = new File(projectDir, "settings.gradle");
-        if (!settingsFile.exists()) {
-            writeString(settingsFile, "");
-        }
-
-        File buildFile = new File(projectDir, "build.gradle");
-        if (!buildFile.exists()) {
-            writeString(buildFile,
-                "plugins {" +
-                "  id('${pluginId.value}')" +
-                "}");
-        }
+        writeString(getSettingsFile(), "");
+        writeString(getBuildFile(),
+            "plugins {" +
+            "  id('${pluginId.value}')" +
+            "}");
 
         // Run the build
         GradleRunner runner = GradleRunner.create();

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/java/junit/PluginFunctionalTest.java.template
@@ -20,11 +20,19 @@ class ${className.javaIdentifier} {
         // Setup the test build
         File projectDir = new File("build/functionalTest");
         Files.createDirectories(projectDir.toPath());
-        writeString(new File(projectDir, "settings.gradle"), "");
-        writeString(new File(projectDir, "build.gradle"),
-            "plugins {" +
-            "  id('${pluginId.value}')" +
-            "}");
+
+        File settingsFile = new File(projectDir, "settings.gradle");
+        if (!settingsFile.exists()) {
+            writeString(settingsFile, "");
+        }
+
+        File buildFile = new File(projectDir, "build.gradle");
+        if (!buildFile.exists()) {
+            writeString(buildFile,
+                "plugins {" +
+                "  id('${pluginId.value}')" +
+                "}");
+        }
 
         // Run the build
         GradleRunner runner = GradleRunner.create();

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
@@ -14,10 +14,11 @@ import org.junit.rules.TemporaryFolder
  * A simple functional test for the '${pluginId.value}' plugin.
  */
 class ${className.javaIdentifier} {
-    @get:Rule val projectDir = TemporaryFolder()
+    @get:Rule val tempFolder = TemporaryFolder()
 
-    private fun getBuildFile() = projectDir.resolve("build.gradle")
-    private fun getSettingsFile() = projectDir.resolve("settings.gradle")
+    private fun getProjectDir() = tempFolder.root
+    private fun getBuildFile() = getProjectDir().resolve("build.gradle")
+    private fun getSettingsFile() = getProjectDir().resolve("settings.gradle")
 
     @Test fun `can run task`() {
         // Setup the test build
@@ -33,7 +34,7 @@ plugins {
         runner.forwardOutput()
         runner.withPluginClasspath()
         runner.withArguments("greeting")
-        runner.withProjectDir(projectDir)
+        runner.withProjectDir(getProjectDir())
         val result = runner.build();
 
         // Verify the result

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
@@ -3,6 +3,7 @@
  */
 ${packageDecl.statement}
 import java.io.File
+import java.nio.file.Files
 import org.gradle.testkit.runner.GradleRunner
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -11,16 +12,19 @@ import kotlin.test.assertTrue
  * A simple functional test for the '${pluginId.value}' plugin.
  */
 class ${className.javaIdentifier} {
+    private val projectDir = Files.createTempDirectory("functionalTest").toFile()
+
+    private fun getBuildFile() = projectDir.resolve("build.gradle")
+    private fun getSettingsFile() = projectDir.resolve("settings.gradle")
+
     @Test fun `can run task`() {
         // Setup the test build
-        val projectDir = File("build/functionalTest")
-        projectDir.mkdirs()
-        projectDir.resolve("settings.gradle").writeText("")
-        projectDir.resolve("build.gradle").writeText("""
-            plugins {
-                id('${pluginId.value}')
-            }
-        """)
+        getSettingsFile().writeText("")
+        getBuildFile().writeText("""
+plugins {
+    id('${pluginId.value}')
+}
+""")
 
         // Run the build
         val runner = GradleRunner.create()

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/plugin/kotlin/kotlintest/PluginFunctionalTest.kt.template
@@ -4,15 +4,17 @@
 ${packageDecl.statement}
 import java.io.File
 import java.nio.file.Files
-import org.gradle.testkit.runner.GradleRunner
-import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.test.Test
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 
 /**
  * A simple functional test for the '${pluginId.value}' plugin.
  */
 class ${className.javaIdentifier} {
-    private val projectDir = Files.createTempDirectory("functionalTest").toFile()
+    @get:Rule val projectDir = TemporaryFolder()
 
     private fun getBuildFile() = projectDir.resolve("build.gradle")
     private fun getSettingsFile() = projectDir.resolve("settings.gradle")


### PR DESCRIPTION
Ensure that when gradle plugin projects are setup via the build-init plugin, the generated functional tests are rerunnable using "gradle check --rerun-tasks".

Previously, the way build scripts were applied in the Spock and JUnit templates would result in duplicate plugin application blocks which would fail to run.

<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/18206.

### Context
This will reduce a potential point of confusion for new plugin authors.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
