### PR TITLE
Add enum entries for Microsoft JDKs

### DIFF
--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmVendor.java
@@ -27,6 +27,7 @@ public interface JvmVendor {
         GRAAL_VM("graalvm community", "GraalVM Community"),
         HEWLETT_PACKARD("hewlett-packard", "HP-UX"),
         IBM("ibm", "IBM"),
+        MICROSOFT("microsoft", "Microsoft"),
         ORACLE("oracle", "Oracle"),
         SAP("sap se", "SAP SapMachine"),
         UNKNOWN("gradle", "Unknown Vendor");

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -43,6 +43,14 @@ public abstract class JvmVendorSpec {
 
     public static final JvmVendorSpec HEWLETT_PACKARD = matching(KnownJvmVendor.HEWLETT_PACKARD);
     public static final JvmVendorSpec IBM = matching(KnownJvmVendor.IBM);
+
+    /**
+     * A constant for using <a href="https://www.microsoft.com/openjdk">Microsoft OpenJDK</a> as the JVM vendor.
+     *
+     * @since 7.3
+     */
+    @Incubating
+    public static final JvmVendorSpec MICROSOFT = matching(KnownJvmVendor.MICROSOFT);
     public static final JvmVendorSpec ORACLE = matching(KnownJvmVendor.ORACLE);
     public static final JvmVendorSpec SAP = matching(KnownJvmVendor.SAP);
 


### PR DESCRIPTION
Microsoft publishes its own builds of OpenJDK:

- https://www.microsoft.com/openjdk
- https://docs.microsoft.com/en-us/java/openjdk/download

Adding these enum entries will allow type-safe configuration of the vendor filter as shown [here](https://docs.gradle.org/7.2/userguide/toolchains.html#sec:vendors).