### PR TITLE
Remove restriction on subgroups for version catalog for platform, enforcedPlatform, testFixtures and variantOf

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -603,6 +604,21 @@ public interface DependencyHandler extends ExtensionAware {
     Provider<MinimalExternalModuleDependency> variantOf(Provider<MinimalExternalModuleDependency> dependencyProvider, Action<? super ExternalModuleDependencyVariantSpec> variantSpec);
 
     /**
+     * Allows fine-tuning what variant to select for the target dependency. This can be used to
+     * specify a classifier, for example.
+     *
+     * @param dependencyProviderConvertible the dependency provider convertible that returns the dependency provider
+     * @param variantSpec the variant specification
+     * @return a new dependency provider targeting the configured variant
+     * @since 7.3
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> variantOf(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible,
+                                                                Action<? super ExternalModuleDependencyVariantSpec> variantSpec) {
+        return variantOf(dependencyProviderConvertible.asProvider(), variantSpec);
+    }
+
+    /**
      * Configures this dependency provider to select the platform variant of the target component
      * @param dependencyProvider the dependency provider
      * @return a new dependency provider targeting the platform variant of the component
@@ -611,6 +627,17 @@ public interface DependencyHandler extends ExtensionAware {
     @Incubating
     default Provider<MinimalExternalModuleDependency> platform(Provider<MinimalExternalModuleDependency> dependencyProvider) {
         return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::platform);
+    }
+
+    /**
+     * Configures this dependency provider to select the platform variant of the target component
+     * @param dependencyProviderConvertible the dependency provider convertible that returns the dependency provider
+     * @return a new dependency provider targeting the platform variant of the component
+     * @since 7.3
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> platform(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
+        return platform(dependencyProviderConvertible.asProvider());
     }
 
     /**
@@ -623,6 +650,17 @@ public interface DependencyHandler extends ExtensionAware {
     Provider<MinimalExternalModuleDependency> enforcedPlatform(Provider<MinimalExternalModuleDependency> dependencyProvider);
 
     /**
+     * Configures this dependency provider to select the enforced-platform variant of the target component
+     * @param dependencyProviderConvertible the dependency provider convertible that returns the dependency provider
+     * @return a new dependency provider targeting the enforced-platform variant of the component
+     * @since 7.3
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> enforcedPlatform(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
+        return enforcedPlatform(dependencyProviderConvertible.asProvider());
+    }
+
+    /**
      * Configures this dependency provider to select the test fixtures of the target component
      * @param dependencyProvider the dependency provider
      * @return a new dependency provider targeting the test fixtures of the component
@@ -631,6 +669,17 @@ public interface DependencyHandler extends ExtensionAware {
     @Incubating
     default Provider<MinimalExternalModuleDependency> testFixtures(Provider<MinimalExternalModuleDependency> dependencyProvider) {
         return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::testFixtures);
+    }
+
+    /**
+     * Configures this dependency provider to select the test fixtures of the target component
+     * @param dependencyProviderConvertible the dependency provider convertible that returns the dependency provider
+     * @return a new dependency provider targeting the test fixtures of the component
+     * @since 7.3
+     */
+    @Incubating
+    default Provider<MinimalExternalModuleDependency> testFixtures(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
+        return testFixtures(dependencyProviderConvertible.asProvider());
     }
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -903,7 +903,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         ]
     }
 
-    def "can use the generated extension to select the test fixtures of a dependency"() {
+    def "can use the generated extension to select the test fixtures of a dependency with and without sub-accessors"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
@@ -911,35 +911,41 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         alias("myLib").to("org.gradle.test", "lib").version {
                             require "1.1"
                         }
+                        alias("myLib-subgroup").to("org.gradle.test", "lib.subgroup").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
         """
-        def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
-            .withModuleMetadata()
-            .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar']) {
-                capability('org.gradle.test', 'lib-test-fixtures', '1.1')
-                artifact("lib-1.1-test-fixtures.jar")
-            }
-            .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar']) {
-                capability('org.gradle.test', 'lib-test-fixtures', '1.1')
-                artifact("lib-1.1-test-fixtures.jar")
-            }
-            .publish()
+        def publishLib = { String artifactId ->
+            def lib = mavenHttpRepo.module("org.gradle.test", artifactId, "1.1")
+                .withModuleMetadata()
+                .variant("testFixturesApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.libraryelements': 'jar']) {
+                    capability('org.gradle.test', "$artifactId-test-fixtures", '1.1')
+                    artifact("$artifactId-1.1-test-fixtures.jar")
+                }
+                .variant("testFixturesRuntimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar']) {
+                    capability('org.gradle.test', "$artifactId-test-fixtures", '1.1')
+                    artifact("$artifactId-1.1-test-fixtures.jar")
+                }
+                .publish()
+            lib.pom.expectGet()
+            lib.moduleMetadata.expectGet()
+            lib.getArtifact(classifier: 'test-fixtures').expectGet()
+        }
+        publishLib("lib")
+        publishLib("lib.subgroup")
         buildFile << """
             apply plugin: 'java-library'
 
             dependencies {
                 implementation(testFixtures(libs.myLib))
+                implementation(testFixtures(libs.myLib.subgroup))
             }
         """
 
         when:
-        lib.pom.expectGet()
-        lib.moduleMetadata.expectGet()
-        lib.getArtifact(classifier: 'test-fixtures').expectGet()
-
-        then:
         run ':checkDeps'
 
         then:
@@ -952,11 +958,18 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         'org.gradle.libraryelements': 'jar'])
                     artifact(classifier: 'test-fixtures')
                 }
+                module('org.gradle.test:lib.subgroup:1.1') {
+                    variant('testFixturesRuntimeElements', [
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-runtime',
+                        'org.gradle.libraryelements': 'jar'])
+                    artifact(classifier: 'test-fixtures')
+                }
             }
         }
     }
 
-    def "can use the generated extension to select the platform variant of a dependency"() {
+    def "can use the generated extension to select the platform variant of a dependency with and without sub-accessors"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
@@ -964,12 +977,19 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         alias("myLib").to("org.gradle.test", "lib").version {
                             require "1.1"
                         }
+                        alias("myLib-subgroup").to("org.gradle.test", "lib.subgroup").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
         """
-        def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
+        mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
             .publish()
+            .pom.expectGet()
+        mavenHttpRepo.module("org.gradle.test", "lib.subgroup", "1.1")
+            .publish()
+            .pom.expectGet()
         buildFile << """
             apply plugin: 'java-library'
 
@@ -979,9 +999,6 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         """
 
         when:
-        lib.pom.expectGet()
-
-        then:
         run ':checkDeps'
 
         then:
@@ -994,12 +1011,19 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         'org.gradle.category': 'platform'])
                     noArtifacts()
                 }
+                module('org.gradle.test:lib.subgroup:1.1') {
+                    variant('platform-runtime', [
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-runtime',
+                        'org.gradle.category': 'platform'])
+                    noArtifacts()
+                }
             }
         }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/17849")
-    def "can use the generated extension to select the enforced-platform variant of a dependency"() {
+    def "can use the generated extension to select the enforced-platform variant of a dependency with and without sub-accessors"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
@@ -1007,24 +1031,29 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         alias("myLib").to("org.gradle.test", "lib").version {
                             require "1.1"
                         }
+                        alias("myLib-subgroup").to("org.gradle.test", "lib.subgroup").version {
+                            require "1.1"
+                        }
                     }
                 }
             }
         """
-        def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
+        mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
             .publish()
+            .pom.expectGet()
+        mavenHttpRepo.module("org.gradle.test", "lib.subgroup", "1.1")
+            .publish()
+            .pom.expectGet()
         buildFile << """
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(enforcedPlatform(libs.myLib))
+                implementation(enforcedPlatform(libs.lib))
+                implementation(enforcedPlatform(libs.lib.subgroup))
             }
         """
 
         when:
-        lib.pom.expectGet()
-
-        then:
         run ':checkDeps'
 
         then:
@@ -1037,16 +1066,26 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         'org.gradle.category': 'enforced-platform'])
                     noArtifacts()
                 }
+                module('org.gradle.test:lib.subgroup:1.1') {
+                    variant('enforced-platform-runtime', [
+                        'org.gradle.status': 'release',
+                        'org.gradle.usage': 'java-runtime',
+                        'org.gradle.category': 'enforced-platform'])
+                    noArtifacts()
+                }
             }
         }
     }
 
-    def "can use the generated extension to select a classified dependency"() {
+    def "can use the generated extension to select a classified dependency with and without sub-accessors"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
                     libs {
                         alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
+                        alias("myLib-subgroup").to("org.gradle.test", "lib.subgroup").version {
                             require "1.1"
                         }
                     }
@@ -1055,22 +1094,25 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
             .publish()
-
         lib.getArtifactFile(classifier: 'test-fixtures').bytes = []
+        lib.pom.expectGet()
+        lib.getArtifact(classifier: 'test-fixtures').expectGet()
+        def libSubgroup = mavenHttpRepo.module("org.gradle.test", "lib.subgroup", "1.1")
+            .publish()
+        libSubgroup.getArtifactFile(classifier: 'test-fixtures').bytes = []
+        libSubgroup.pom.expectGet()
+        libSubgroup.getArtifact(classifier: 'test-fixtures').expectGet()
 
         buildFile << """
             apply plugin: 'java-library'
 
             dependencies {
                 implementation(variantOf(libs.myLib) { classifier('test-fixtures') })
+                implementation(variantOf(libs.myLib.subgroup) { classifier('test-fixtures') })
             }
         """
 
         when:
-        lib.pom.expectGet()
-        lib.getArtifact(classifier: 'test-fixtures').expectGet()
-
-        then:
         run ':checkDeps'
 
         then:
@@ -1079,16 +1121,22 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                 module('org.gradle.test:lib:1.1') {
                     artifact(classifier: 'test-fixtures')
                 }
+                module('org.gradle.test:lib.subgroup:1.1') {
+                    artifact(classifier: 'test-fixtures')
+                }
             }
         }
     }
 
-    def "can use the generated extension to select an artifact with different type"() {
+    def "can use the generated extension to select an artifact with different type with and without sub-accessors"() {
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
                     libs {
                         alias("myLib").to("org.gradle.test", "lib").version {
+                            require "1.1"
+                        }
+                        alias("myLib-subgroup").to("org.gradle.test", "lib.subgroup").version {
                             require "1.1"
                         }
                     }
@@ -1097,28 +1145,35 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         """
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.1")
             .publish()
-
         lib.getArtifactFile(type: 'txt').bytes = "test".bytes
+        lib.pom.expectGet()
+        lib.getArtifact(type: 'txt').expectGet()
+        def libSubgroup = mavenHttpRepo.module("org.gradle.test", "lib.subgroup", "1.1")
+            .publish()
+        libSubgroup.getArtifactFile(type: 'txt').bytes = "test".bytes
+        libSubgroup.pom.expectGet()
+        libSubgroup.getArtifact(type: 'txt').expectGet()
+
 
         buildFile << """
             apply plugin: 'java-library'
 
             dependencies {
                 implementation(variantOf(libs.myLib) { artifactType('txt') })
+                implementation(variantOf(libs.myLib.subgroup) { artifactType('txt') })
             }
         """
 
         when:
-        lib.pom.expectGet()
-        lib.getArtifact(type: 'txt').expectGet()
-
-        then:
         run ':checkDeps'
 
         then:
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.gradle.test:lib:1.1') {
+                    artifact(type: 'txt')
+                }
+                module('org.gradle.test:lib.subgroup:1.1') {
                     artifact(type: 'txt')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -995,6 +995,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
 
             dependencies {
                 implementation(platform(libs.myLib))
+                implementation(platform(libs.myLib.subgroup))
             }
         """
 
@@ -1048,8 +1049,8 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             apply plugin: 'java-library'
 
             dependencies {
-                implementation(enforcedPlatform(libs.lib))
-                implementation(enforcedPlatform(libs.lib.subgroup))
+                implementation(enforcedPlatform(libs.myLib))
+                implementation(enforcedPlatform(libs.myLib.subgroup))
             }
         """
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #18229

I found another bug with sub-accessors. Looks like platform, enforcedPlatform, testFixtures and variantOf do not work currently.

Few more methods added to DependencyHandler.
