### PR TITLE
Add Copy. ignoreExistingContentInDestinationDir()

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -280,7 +280,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec {
             task copy(type: Copy) {
                 from '${input.name}'
                 into '${outputDirectory.name}'
-                doNotTrackDestinationDir()
+                doNotTrackOutput()
             }
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -288,7 +288,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec {
         executer.expectDeprecationWarning("Cannot access a file in the destination directory (see --info log for details). " +
             "Copying to a directory which contains unreadable content has been deprecated. " +
             "This will fail with an error in Gradle 8.0. " +
-            "Use the method Copy.doNotTrackOutput().")
+            "Use the method Copy.ignoreExistingContentInDestinationDir().")
         succeeds "copy", "--info"
         then:
         outputDirectory.list().contains input.name
@@ -296,7 +296,7 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec {
         outputContains(expectedError(unreadableOutput))
 
         when:
-        buildFile << "copy.doNotTrackOutput()"
+        buildFile << "copy.ignoreExistingContentInDestinationDir()"
         succeeds "copy"
         then:
         executedAndNotSkipped(":copy")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -295,13 +295,6 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("Cannot access output property 'destinationDir' of task ':copy'")
         outputContains(expectedError(unreadableOutput))
 
-        when:
-        buildFile << "copy.ignoreExistingContentInDestinationDir()"
-        succeeds "copy"
-        then:
-        executedAndNotSkipped(":copy")
-        outputDirectory.list().contains input.name
-
         cleanup:
         unreadableOutput.makeReadable()
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -231,24 +231,17 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec {
             task copy(type: Copy) {
                 from '${input.name}'
                 into '${outputDirectory.name}'
+                doNotTrackDestinationDir()
             }
         """
 
         when:
-        executer.expectDeprecationWarning("Cannot access output property 'destinationDir' of task ':copy' (see --info log for details). " +
-            "Accessing unreadable inputs or outputs has been deprecated. " +
-            "This will fail with an error in Gradle 8.0. " +
-            "Declare the property as untracked.")
         run "copy"
         then:
         outputDirectory.list().contains input.name
         executedAndNotSkipped(":copy")
 
         when:
-        executer.expectDeprecationWarning("Cannot access output property 'destinationDir' of task ':copy' (see --info log for details). " +
-            "Accessing unreadable inputs or outputs has been deprecated. " +
-            "This will fail with an error in Gradle 8.0. " +
-            "Declare the property as untracked.")
         run "copy"
         then:
         outputDirectory.list().contains input.name

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -231,7 +231,7 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec {
             task copy(type: Copy) {
                 from '${input.name}'
                 into '${outputDirectory.name}'
-                doNotTrackDestinationDir()
+                doNotTrackOutput()
             }
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -245,7 +245,10 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec {
         executedAndNotSkipped(":copy")
 
         when:
-        buildFile << "copy.ignoreExistingContentInDestinationDir()"
+        executer.expectDeprecationWarning("Cannot access a file in the destination directory (see --info log for details). " +
+            "Copying to a directory which contains unreadable content has been deprecated. " +
+            "This will fail with an error in Gradle 8.0. " +
+            "Use the method Copy.ignoreExistingContentInDestinationDir().")
         run "copy"
         then:
         outputDirectory.list().contains input.name

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -238,14 +238,14 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec {
         executer.expectDeprecationWarning("Cannot access a file in the destination directory (see --info log for details). " +
             "Copying to a directory which contains unreadable content has been deprecated. " +
             "This will fail with an error in Gradle 8.0. " +
-            "Use the method Copy.doNotTrackOutput().")
+            "Use the method Copy.ignoreExistingContentInDestinationDir().")
         run "copy"
         then:
         outputDirectory.list().contains input.name
         executedAndNotSkipped(":copy")
 
         when:
-        buildFile << "copy.doNotTrackOutput()"
+        buildFile << "copy.ignoreExistingContentInDestinationDir()"
         run "copy"
         then:
         outputDirectory.list().contains input.name

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -43,6 +43,7 @@ import org.gradle.api.internal.tasks.properties.InputPropertySpec;
 import org.gradle.api.internal.tasks.properties.OutputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.StopActionException;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.internal.UncheckedException;
@@ -369,13 +370,24 @@ public class TaskExecution implements UnitOfWork {
             throw UncheckedException.throwAsUncheckedException(cause);
         }
         LOGGER.info("Cannot access {} property '{}' of {}", propertyType, propertyName, getDisplayName(), cause);
-        DeprecationLogger.deprecateAction(String.format("Cannot access %s property '%s' of %s (see --info log for details). Accessing unreadable inputs or outputs",
-                propertyType, propertyName, getDisplayName()))
-            .withAdvice("Declare the property as untracked.")
-            .willBecomeAnErrorInGradle8()
-            // TODO: Document
-            .undocumented()
-            .nagUser();
+        boolean isDestinationOfCopy = propertyName.equals("destinationDir") && task instanceof Copy;
+        if (isDestinationOfCopy) {
+            DeprecationLogger.deprecateAction("Cannot access a file in the destination directory (see --info log for details). Copying to a directory which contains unreadable content")
+                .withAdvice("Use the method Copy.doNotTrackOutput().")
+                .willBecomeAnErrorInGradle8()
+                // TODO: Document
+                .undocumented()
+                .nagUser();
+        } else {
+            DeprecationLogger.deprecateAction(String.format("Cannot access %s property '%s' of %s (see --info log for details). Accessing unreadable inputs or outputs",
+                    propertyType, propertyName, getDisplayName()))
+                .withAdvice("Declare the property as untracked.")
+                .willBecomeAnErrorInGradle8()
+                // TODO: Document
+                .undocumented()
+                .nagUser();
+
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -373,7 +373,7 @@ public class TaskExecution implements UnitOfWork {
         boolean isDestinationOfCopy = propertyName.equals("destinationDir") && task instanceof Copy;
         if (isDestinationOfCopy) {
             DeprecationLogger.deprecateAction("Cannot access a file in the destination directory (see --info log for details). Copying to a directory which contains unreadable content")
-                .withAdvice("Use the method Copy.doNotTrackOutput().")
+                .withAdvice("Use the method Copy.ignoreExistingContentInDestinationDir().")
                 .willBecomeAnErrorInGradle8()
                 // TODO: Document
                 .undocumented()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -46,6 +46,7 @@ import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.StopActionException;
 import org.gradle.api.tasks.StopExecutionException;
+import org.gradle.api.tasks.Sync;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.event.ListenerManager;
@@ -370,10 +371,17 @@ public class TaskExecution implements UnitOfWork {
             throw UncheckedException.throwAsUncheckedException(cause);
         }
         LOGGER.info("Cannot access {} property '{}' of {}", propertyType, propertyName, getDisplayName(), cause);
-        boolean isDestinationOfCopy = propertyName.equals("destinationDir") && task instanceof Copy;
-        if (isDestinationOfCopy) {
+        boolean isDestinationDir = propertyName.equals("destinationDir");
+        if (isDestinationDir && task instanceof Copy) {
             DeprecationLogger.deprecateAction("Cannot access a file in the destination directory (see --info log for details). Copying to a directory which contains unreadable content")
                 .withAdvice("Use the method Copy.ignoreExistingContentInDestinationDir().")
+                .willBecomeAnErrorInGradle8()
+                // TODO: Document
+                .undocumented()
+                .nagUser();
+        } else if (isDestinationDir && task instanceof Sync) {
+            DeprecationLogger.deprecateAction("Cannot access a file in the destination directory (see --info log for details). Syncing to a directory which contains unreadable content")
+                .withAdvice("Use a Copy task with Copy.ignoreExistingContentInDestinationDir() instead.")
                 .willBecomeAnErrorInGradle8()
                 // TODO: Document
                 .undocumented()

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
@@ -92,16 +92,17 @@ public class Copy extends AbstractCopyTask {
 
     /**
      * Force Gradle to ignore content in the destination directory.
+     * <p>
      * This can be useful if the destination directory contains unreadable content, or special files like named pipes that Gradle cannot snapshot.
      * It can also be useful when copying to a location not exclusively owned by the build, for example to a common installation directory.
      * In the latter case calling this method will prevent Gradle from trying to snapshot a potentially large amount of content (that might also contain unreadable files).
-     * Copy tasks with untracked outputs are never up-to-date.
+     * Copy tasks which ignore content in the destination directory are never up-to-date.
      *
      * @see Untracked
      * @since 7.3
      */
     @Incubating
-    public void doNotTrackOutput() {
+    public void ignoreExistingContentInDestinationDir() {
         getOutputs()
             .dir((Callable<File>) this::getDestinationDir)
             .withPropertyName("untrackedDestinationDir")

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.internal.file.copy.CopyAction;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
@@ -24,6 +25,7 @@ import org.gradle.api.internal.file.copy.FileCopyAction;
 import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
+import java.util.concurrent.Callable;
 
 /**
  * Copies files into a destination directory. This task can also rename and filter files as it copies. The task
@@ -86,6 +88,23 @@ public class Copy extends AbstractCopyTask {
     @Override
     public DestinationRootCopySpec getRootSpec() {
         return (DestinationRootCopySpec) super.getRootSpec();
+    }
+
+    /**
+     * Uses {@link Untracked} for {@link #getDestinationDir()}.
+     * <p>
+     * This causes the task to ignore already existing files in the destination directory.
+     * You should use this if the destination directory contains unrelated unreadable files.
+     * </p>
+     *
+     * @since 7.3
+     */
+    @Incubating
+    public void doNotTrackDestinationDir() {
+        getOutputs()
+            .dir((Callable<File>) this::getDestinationDir)
+            .withPropertyName("untrackedDestinationDir")
+            .untracked();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
@@ -98,11 +98,10 @@ public class Copy extends AbstractCopyTask {
      * Copy tasks with untracked outputs are never up-to-date.
      *
      * @see Untracked
-     *
      * @since 7.3
      */
     @Incubating
-    public void doNotTrackOutputs() {
+    public void doNotTrackOutput() {
         getOutputs()
             .dir((Callable<File>) this::getDestinationDir)
             .withPropertyName("untrackedDestinationDir")

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/Copy.java
@@ -91,16 +91,18 @@ public class Copy extends AbstractCopyTask {
     }
 
     /**
-     * Uses {@link Untracked} for {@link #getDestinationDir()}.
-     * <p>
-     * This causes the task to ignore already existing files in the destination directory.
-     * You should use this if the destination directory contains unrelated unreadable files.
-     * </p>
+     * Force Gradle to ignore content in the destination directory.
+     * This can be useful if the destination directory contains unreadable content, or special files like named pipes that Gradle cannot snapshot.
+     * It can also be useful when copying to a location not exclusively owned by the build, for example to a common installation directory.
+     * In the latter case calling this method will prevent Gradle from trying to snapshot a potentially large amount of content (that might also contain unreadable files).
+     * Copy tasks with untracked outputs are never up-to-date.
+     *
+     * @see Untracked
      *
      * @since 7.3
      */
     @Incubating
-    public void doNotTrackDestinationDir() {
+    public void doNotTrackOutputs() {
         getOutputs()
             .dir((Callable<File>) this::getDestinationDir)
             .withPropertyName("untrackedDestinationDir")

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
@@ -22,6 +22,9 @@
                     <td>Name</td>
                 </tr>
             </thead>
+            <tr>
+                <td>doNotTrackDestinationDir</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
@@ -23,7 +23,7 @@
                 </tr>
             </thead>
             <tr>
-                <td>doNotTrackOutput</td>
+                <td>ignoreExistingContentInDestinationDir</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.Copy.xml
@@ -23,7 +23,7 @@
                 </tr>
             </thead>
             <tr>
-                <td>doNotTrackDestinationDir</td>
+                <td>doNotTrackOutput</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -755,6 +755,20 @@ include::sample[dir="snippets/files/sync/kotlin",files="build.gradle.kts[tags=co
 
 You can also perform the same function in your own tasks with the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:sync(org.gradle.api.Action)[Project.sync(org.gradle.api.Action)] method.
 
+[[sec:copy_deploy]]
+=== Deploying single files into application servers
+
+When working with application servers, you can use a `Copy` task to deploy the application archive (e.g. a WAR file).
+Since you are deploying a single file, the destination directory of the `Copy` is the whole deployment directory.
+The deployment directory sometimes does contain unreadable files like named pipes, so Gradle may have problems doing up-to-date checks.
+In order to support this use-case, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackDestinationDir()[Copy.doNotTrackDestinationDir()].
+
+.Using Copy to deploy a WAR file
+====
+include::sample[dir="snippets/files/deployWarWithCopy/groovy",files="build.gradle"]
+include::sample[dir="snippets/files/deployWarWithCopy/kotlin",files="build.gradle.kts"]
+====
+
 [[sec:archives]]
 == Archive creation in depth
 

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -773,9 +773,9 @@ include::sample[dir="snippets/files/deployWarWithCopy/kotlin",files="build.gradl
 === Installing executables
 
 When you are building a standalone executable, you may want to install this file on your system, so it ends up in your path.
-You can use a `Copy` to install the executable into shared directories like `/usr/local/bin`.
+You can use a `Copy` task to install the executable into shared directories like `/usr/local/bin`.
 The installation directory probably contains many other executables, some of which may even be unreadable by Gradle.
-To support the unreadable files in `Copy`'s destination directory and to avoid doing possible expensive up-to-date checks, you should use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:ignoreExistingContentInDestinationDir()[Copy.ignoreExistingContentInDestinationDir()].
+To support the unreadable files in the `Copy` task's destination directory and to avoid time consuming up-to-date checks, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:ignoreExistingContentInDestinationDir()[Copy.ignoreExistingContentInDestinationDir()].
 
 .Using Copy to install an executable
 ====

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -761,7 +761,7 @@ You can also perform the same function in your own tasks with the link:{groovyDs
 When working with application servers, you can use a `Copy` task to deploy the application archive (e.g. a WAR file).
 Since you are deploying a single file, the destination directory of the `Copy` is the whole deployment directory.
 The deployment directory sometimes does contain unreadable files like named pipes, so Gradle may have problems doing up-to-date checks.
-In order to support this use-case, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackDestinationDir()[Copy.doNotTrackDestinationDir()].
+In order to support this use-case, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackOutput()[Copy.doNotTrackOutput()].
 
 .Using Copy to deploy a WAR file
 ====

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -761,7 +761,7 @@ You can also perform the same function in your own tasks with the link:{groovyDs
 When working with application servers, you can use a `Copy` task to deploy the application archive (e.g. a WAR file).
 Since you are deploying a single file, the destination directory of the `Copy` is the whole deployment directory.
 The deployment directory sometimes does contain unreadable files like named pipes, so Gradle may have problems doing up-to-date checks.
-In order to support this use-case, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackOutput()[Copy.doNotTrackOutput()].
+In order to support this use-case, you can use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:ignoreExistingContentInDestinationDir()[Copy.ignoreExistingContentInDestinationDir()].
 
 .Using Copy to deploy a WAR file
 ====
@@ -775,7 +775,7 @@ include::sample[dir="snippets/files/deployWarWithCopy/kotlin",files="build.gradl
 When you are building a standalone executable, you may want to install this file on your system, so it ends up in your path.
 You can use a `Copy` to install the executable into shared directories like `/usr/local/bin`.
 The installation directory probably contains many other executables, some of which may even be unreadable by Gradle.
-To support the unreadable files in `Copy`'s destination directory and to avoid doing possible expensive up-to-date checks, you should use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackOutput()[Copy.doNotTrackOutput()].
+To support the unreadable files in `Copy`'s destination directory and to avoid doing possible expensive up-to-date checks, you should use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:ignoreExistingContentInDestinationDir()[Copy.ignoreExistingContentInDestinationDir()].
 
 .Using Copy to install an executable
 ====

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -769,6 +769,20 @@ include::sample[dir="snippets/files/deployWarWithCopy/groovy",files="build.gradl
 include::sample[dir="snippets/files/deployWarWithCopy/kotlin",files="build.gradle.kts"]
 ====
 
+[[sec:install_executable]]
+=== Installing executables
+
+When you are building a standalone executable, you may want to install this file on your system, so it ends up in your path.
+You can use a `Copy` to install the executable into shared directories like `/usr/local/bin`.
+The installation directory probably contains many other executables, some of which may even be unreadable by Gradle.
+To support the unreadable files in `Copy`'s destination directory and to avoid doing possible expensive up-to-date checks, you should use link:{groovyDslPath}/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:doNotTrackOutput()[Copy.doNotTrackOutput()].
+
+.Using Copy to install an executable
+====
+include::sample[dir="snippets/files/installExecutable/groovy",files="build.gradle"]
+include::sample[dir="snippets/files/installExecutable/kotlin",files="build.gradle.kts"]
+====
+
 [[sec:archives]]
 == Archive creation in depth
 

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'war'
+}
+
+tasks.register("deployToTomcat", Copy) {
+    from war
+    into layout.projectDirectory.dir('tomcat/webapps')
+    doNotTrackDestinationDir()
+}

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
@@ -5,5 +5,5 @@ plugins {
 tasks.register("deployToTomcat", Copy) {
     from war
     into layout.projectDirectory.dir('tomcat/webapps')
-    doNotTrackDestinationDir()
+    doNotTrackOutput()
 }

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/build.gradle
@@ -5,5 +5,5 @@ plugins {
 tasks.register("deployToTomcat", Copy) {
     from war
     into layout.projectDirectory.dir('tomcat/webapps')
-    doNotTrackOutput()
+    ignoreExistingContentInDestinationDir()
 }

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'deployWarWithCopy'

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    war
+}
+
+tasks.register<Copy>("deployToTomcat") {
+    from(tasks.war)
+    into(layout.projectDirectory.dir("tomcat/webapps"))
+    doNotTrackDestinationDir()
+}

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 tasks.register<Copy>("deployToTomcat") {
     from(tasks.war)
     into(layout.projectDirectory.dir("tomcat/webapps"))
-    doNotTrackDestinationDir()
+    doNotTrackOutput()
 }

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 tasks.register<Copy>("deployToTomcat") {
     from(tasks.war)
     into(layout.projectDirectory.dir("tomcat/webapps"))
-    doNotTrackOutput()
+    ignoreExistingContentInDestinationDir()
 }

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "deployWarWithCopy"

--- a/subprojects/docs/src/snippets/files/deployWarWithCopy/tests/deployWarWithCopy.sample.conf
+++ b/subprojects/docs/src/snippets/files/deployWarWithCopy/tests/deployWarWithCopy.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: deployToTomcat

--- a/subprojects/docs/src/snippets/files/installExecutable/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/installExecutable/groovy/build.gradle
@@ -1,0 +1,5 @@
+tasks.register("installExecutable", Copy) {
+    from "build/my-binary"
+    into "/usr/local/bin"
+    doNotTrackOutput()
+}

--- a/subprojects/docs/src/snippets/files/installExecutable/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/installExecutable/groovy/build.gradle
@@ -1,5 +1,5 @@
 tasks.register("installExecutable", Copy) {
     from "build/my-binary"
     into "/usr/local/bin"
-    doNotTrackOutput()
+    ignoreExistingContentInDestinationDir()
 }

--- a/subprojects/docs/src/snippets/files/installExecutable/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/files/installExecutable/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'installExecutable'

--- a/subprojects/docs/src/snippets/files/installExecutable/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/installExecutable/kotlin/build.gradle.kts
@@ -1,5 +1,5 @@
 tasks.register<Copy>("installExecutable") {
     from("build/my-binary")
     into("/usr/local/bin")
-    doNotTrackOutput()
+    ignoreExistingContentInDestinationDir()
 }

--- a/subprojects/docs/src/snippets/files/installExecutable/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/installExecutable/kotlin/build.gradle.kts
@@ -1,0 +1,5 @@
+tasks.register<Copy>("installExecutable") {
+    from("build/my-binary")
+    into("/usr/local/bin")
+    doNotTrackOutput()
+}

--- a/subprojects/docs/src/snippets/files/installExecutable/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/files/installExecutable/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "installExecutable"

--- a/subprojects/docs/src/snippets/files/installExecutable/tests/installExecutable.sample.conf
+++ b/subprojects/docs/src/snippets/files/installExecutable/tests/installExecutable.sample.conf
@@ -1,0 +1,2 @@
+executable: gradle
+args: help


### PR DESCRIPTION
Allows the `Copy` task to mark its output as untracked. To continue supporting use-cases as https://github.com/gradle/gradle/issues/9576.

Fixes #18159.