### PR TITLE
Remove restrictions for aliases from versions and plugins for Version catalog

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
@@ -213,13 +213,13 @@ trait VersionCatalogErrorMessages {
             this
         }
 
-        ReservedAlias shouldNotEndWith(String forbidden) {
-            this.message = "It shouldn't end with '${forbidden}'"
+        ReservedAlias shouldNotContain(String forbidden) {
+            this.message = "Prefix for dependency shouldn't contain '${forbidden}'"
             this
         }
 
-        ReservedAlias reservedAliasSuffix(String... suffixes) {
-            this.solution = "Use a different alias which doesn't end with ${oxfordListOf(suffixes as List, 'or')}"
+        ReservedAlias reservedAliasPrefix(String... suffixes) {
+            this.solution = "Use a different alias which prefix doesn't contain ${oxfordListOf(suffixes as List, 'or')} (case insensitive)"
             this
         }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/catalog/problems/VersionCatalogErrorMessages.groovy
@@ -213,13 +213,13 @@ trait VersionCatalogErrorMessages {
             this
         }
 
-        ReservedAlias shouldNotContain(String forbidden) {
-            this.message = "Prefix for dependency shouldn't contain '${forbidden}'"
+        ReservedAlias shouldNotBeEqualTo(String forbidden) {
+            this.message = "Prefix for dependency shouldn't be equal to '${forbidden}'"
             this
         }
 
         ReservedAlias reservedAliasPrefix(String... suffixes) {
-            this.solution = "Use a different alias which prefix doesn't contain ${oxfordListOf(suffixes as List, 'or')} (case insensitive)"
+            this.solution = "Use a different alias which prefix is not equal to ${oxfordListOf(suffixes as List, 'or')}"
             this
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1738,6 +1738,44 @@ Second: 1.1"""
         ]
     }
 
+    @VersionCatalogProblemTestFor(
+        VersionCatalogProblemId.RESERVED_ALIAS_NAME
+    )
+    def "disallows aliases for dependency which have a prefix clash with reserved words"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    libs {
+                        alias("$reservedName").to("org:lib1:1.0")
+                    }
+                }
+            }
+        """
+
+        when:
+        fails "help"
+
+        then:
+        verifyContains(failure.error, reservedAlias {
+            inCatalog("libs")
+            alias(reservedName).shouldNotContain(prefix)
+            reservedAliasPrefix('bundle', 'bundles', 'dependency', 'dependencies', 'plugin', 'plugins', 'version', 'versions')
+        })
+
+        where:
+        reservedName          | prefix
+        "bundles"             | "bundles"
+        "versions"            | "versions"
+        "plugins"             | "plugins"
+        "findPlugin"          | "plugin"
+        "findVersion"         | "version"
+        "findDependency"      | "dependency"
+        "findBundle"          | "bundle"
+        "bundleAliases"       | "bundle"
+        "dependencyAliases"   | "dependency"
+        "dependenciesAliases" | "dependencies"
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/16768")
     def "the artifact notation doesn't require to set 'name'"() {
         settingsFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -1835,6 +1835,7 @@ Second: 1.1"""
                             prefer "1.1.0"
                             reject "1.0.5"
                         }
+                        alias("lib3").to("org", "test3").withoutVersion()
                         bundle("all", ["lib", "lib2"])
                         alias('greeter').toPluginId('com.acme.greeter').version('1.4')
                         alias('greeter2').toPluginId('com.acme.greeter2').version {
@@ -1860,6 +1861,9 @@ Second: 1.1"""
                     catalog.findDependency("lib2").ifPresent {
                         println("Found dependency: '\${it.get().toString()}'.")
                     }
+                    catalog.findDependency("lib3").ifPresent {
+                        println("Found dependency: '\${it.get().toString()}'.")
+                    }
                     catalog.findBundle("all").ifPresent {
                         println("Found bundle: '\${it.get().toString()}'.")
                     }
@@ -1880,65 +1884,7 @@ Second: 1.1"""
         outputContains "Found version: '1.5'."
         outputContains "Found dependency: 'org:test:1.0'."
         outputContains "Found dependency: 'org:test2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}'."
-        outputContains "Found bundle: '[org:test:1.0, org:test2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}]'."
-        outputContains "Found plugin: 'com.acme.greeter:1.4'."
-        outputContains "Found plugin: 'com.acme.greeter2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}'."
-    }
-
-    def "test aliases"() {
-        settingsFile << """
-            dependencyResolutionManagement {
-                versionCatalogs {
-                    libs {
-                        version("versions", "1.5")
-                        alias("plugins").to("org:test:1.0")
-                        alias("plugin").to("org", "test2").version {
-                            require "1.0.0"
-                            prefer "1.1.0"
-                            reject "1.0.5"
-                        }
-                        bundle("all", ["lib", "lib2"])
-                        alias('greeter').toPluginId('com.acme.greeter').version('1.4')
-                        alias('greeter2').toPluginId('com.acme.greeter2').version {
-                            require "1.0.0"
-                            prefer "1.1.0"
-                            reject "1.0.5"
-                        }
-                    }
-                }
-            }
-        """
-        buildFile << """
-            def catalog = project.extensions.getByType(VersionCatalogsExtension).named("libs")
-            tasks.register("printCatalog") {
-                doLast {
-                    catalog.findVersion("ver").ifPresent {
-                        println("Found version: '\${it.toString()}'.")
-                    }
-                    catalog.findDependency("lib").ifPresent {
-                        println("Found dependency: '\${it.get().toString()}'.")
-                    }
-                    catalog.findDependency("lib2").ifPresent {
-                        println("Found dependency: '\${it.get().toString()}'.")
-                    }
-                    catalog.findBundle("all").ifPresent {
-                        println("Found bundle: '\${it.get().toString()}'.")
-                    }
-                    catalog.findPlugin("greeter").ifPresent {
-                        println("Found plugin: '\${it.get().toString()}'.")
-                    }
-                    catalog.findPlugin("greeter2").ifPresent {
-                        println("Found plugin: '\${it.get().toString()}'.")
-                    }
-                }
-            }
-        """
-        when:
-        run 'printCatalog'
-        then:
-        outputContains "Found version: '1.5'."
-        outputContains "Found dependency: 'org:test:1.0'."
-        outputContains "Found dependency: 'org:test2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}'."
+        outputContains "Found dependency: 'org:test3'."
         outputContains "Found bundle: '[org:test:1.0, org:test2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}]'."
         outputContains "Found plugin: 'com.acme.greeter:1.4'."
         outputContains "Found plugin: 'com.acme.greeter2:{require 1.0.0; prefer 1.1.0; reject 1.0.5}'."

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMinimalDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMinimalDependency.java
@@ -72,6 +72,9 @@ public class DefaultMinimalDependency implements MinimalExternalModuleDependency
 
     @Override
     public String toString() {
-        return module + ":" + versionConstraint;
+        String versionConstraintAsString = versionConstraint.toString();
+        return versionConstraintAsString.isEmpty()
+            ? module.toString()
+            : module + ":" + versionConstraintAsString;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultPluginDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultPluginDependency.java
@@ -64,6 +64,9 @@ public class DefaultPluginDependency implements PluginDependency {
 
     @Override
     public String toString() {
-        return pluginId + ":" + versionConstraint;
+        String versionConstraintAsString = versionConstraint.toString();
+        return versionConstraintAsString.isEmpty()
+            ? pluginId
+            : pluginId + ":" + versionConstraintAsString;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
@@ -36,7 +36,8 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
             this.owner = owner;
         }
 
-        protected Provider<MinimalExternalModuleDependency> create(String alias) {
+        @Override
+        public Provider<MinimalExternalModuleDependency> create(String alias) {
             return owner.create(alias);
         }
 
@@ -49,7 +50,8 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         this.providers = providers;
     }
 
-    protected Provider<MinimalExternalModuleDependency> create(String alias) {
+    @Override
+    public Provider<MinimalExternalModuleDependency> create(String alias) {
         return providers.of(DependencyValueSource.class,
             spec -> spec.getParameters().getDependencyData().set(config.getDependencyData(alias)))
             .forUseAtConfigurationTime();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AbstractExternalDependencyFactory.java
@@ -17,15 +17,12 @@ package org.gradle.api.internal.catalog;
 
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
-import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.plugin.use.PluginDependency;
 
 import javax.inject.Inject;
-import java.util.List;
-import java.util.Optional;
 
 public abstract class AbstractExternalDependencyFactory implements ExternalModuleDependencyFactory {
     protected final DefaultVersionCatalog config;
@@ -43,50 +40,6 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
             return owner.create(alias);
         }
 
-        @Override
-        public Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
-            return owner.findDependency(alias);
-        }
-
-        @Override
-        public Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
-            return owner.findBundle(bundle);
-        }
-
-        @Override
-        public Optional<VersionConstraint> findVersion(String name) {
-            return owner.findVersion(name);
-        }
-
-        @Override
-        public Optional<Provider<PluginDependency>> findPlugin(String alias) {
-            return owner.findPlugin(alias);
-        }
-
-        @Override
-        public String getName() {
-            return owner.getName();
-        }
-
-        @Override
-        public List<String> getDependencyAliases() {
-            return owner.getDependencyAliases();
-        }
-
-        @Override
-        public List<String> getBundleAliases() {
-            return owner.getBundleAliases();
-        }
-
-        @Override
-        public List<String> getVersionAliases() {
-            return owner.getVersionAliases();
-        }
-
-        @Override
-        public List<String> getPluginAliases() {
-            return owner.getPluginAliases();
-        }
     }
 
     @Inject
@@ -100,63 +53,6 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
         return providers.of(DependencyValueSource.class,
             spec -> spec.getParameters().getDependencyData().set(config.getDependencyData(alias)))
             .forUseAtConfigurationTime();
-    }
-
-    @Override
-    public final Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
-        if (config.getDependencyAliases().contains(alias)) {
-            return Optional.of(create(alias));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
-        if (config.getBundleAliases().contains(bundle)) {
-            return Optional.of(new BundleFactory(providers, config).createBundle(bundle));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final Optional<VersionConstraint> findVersion(String name) {
-        if (config.getVersionAliases().contains(name)) {
-            return Optional.of(new VersionFactory(providers, config).findVersionConstraint(name));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<Provider<PluginDependency>> findPlugin(String alias) {
-        if (config.getPluginAliases().contains(alias)) {
-            return Optional.of(new PluginFactory(providers, config).createPlugin(alias));
-        }
-        return Optional.empty();
-    }
-
-    @Override
-    public final String getName() {
-        return config.getName();
-    }
-
-    @Override
-    public List<String> getDependencyAliases() {
-        return config.getDependencyAliases();
-    }
-
-    @Override
-    public List<String> getBundleAliases() {
-        return config.getBundleAliases();
-    }
-
-    @Override
-    public List<String> getVersionAliases() {
-        return config.getVersionAliases();
-    }
-
-    @Override
-    public List<String> getPluginAliases() {
-        return config.getPluginAliases();
     }
 
     public static class VersionFactory {
@@ -192,7 +88,7 @@ public abstract class AbstractExternalDependencyFactory implements ExternalModul
             return version.getPreferredVersion();
         }
 
-        private ImmutableVersionConstraint findVersionConstraint(String name) {
+        protected ImmutableVersionConstraint findVersionConstraint(String name) {
             return config.getVersion(name).getVersion();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.initialization.DependenciesAccessors;
 import org.gradle.internal.Cast;
@@ -210,6 +211,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
     @Override
     public void createExtensions(ProjectInternal project) {
         ExtensionContainer container = project.getExtensions();
+        ProviderFactory providerFactory = project.getProviders();
         try {
             if (!models.isEmpty()) {
                 ImmutableMap.Builder<String, VersionCatalog> catalogs = ImmutableMap.builderWithExpectedSize(models.size());
@@ -220,8 +222,8 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
                             factory = factories.computeIfAbsent(model.getName(), n -> loadFactory(classLoaderScope, ACCESSORS_PACKAGE + "." + ACCESSORS_CLASSNAME_PREFIX + StringUtils.capitalize(n)));
                         }
                         if (factory != null) {
-                            VersionCatalog catalog = container.create(model.getName(), factory, model);
-                            catalogs.put(catalog.getName(), catalog);
+                            container.create(model.getName(), factory, model);
+                            catalogs.put(model.getName(), new VersionCatalogView(model, providerFactory));
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -506,6 +506,7 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
 
     // public for injection
     public static class DefaultVersionCatalogsExtension implements VersionCatalogsExtension {
+
         private final Map<String, VersionCatalog> catalogs;
 
         @Inject

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultExternalDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultExternalDependencyFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.catalog;
+
+import org.gradle.api.provider.ProviderFactory;
+
+public class DefaultExternalDependencyFactory extends AbstractExternalDependencyFactory {
+
+    public DefaultExternalDependencyFactory(DefaultVersionCatalog config, ProviderFactory providers) {
+        super(config, providers);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java
@@ -61,6 +61,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang.StringUtils.split;
 import static org.gradle.api.internal.catalog.AliasNormalizer.normalize;
 import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuilder.buildProblem;
 import static org.gradle.api.internal.catalog.problems.DefaultCatalogProblemBuilder.maybeThrowError;
@@ -430,7 +431,7 @@ public class DefaultVersionCatalogBuilder implements VersionCatalogBuilderIntern
 
         private void validateAlias(AliasType type) {
             if (type == AliasType.LIBRARY) {
-                String[] parts = StringUtils.splitByCharacterTypeCamelCase(normalizedAlias.split("\\.")[0]);
+                String[] parts = StringUtils.splitByCharacterTypeCamelCase(split(normalizedAlias, '.')[0]);
                 for (String prefix : FORBIDDEN_LIBRARY_ALIAS_PREFIX) {
                     for (String part : parts) {
                         if (part.equalsIgnoreCase(prefix)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
@@ -21,7 +21,7 @@ import org.gradle.api.artifacts.VersionCatalog;
 import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.plugin.use.PluginDependency;
 
-public interface ExternalModuleDependencyFactory extends VersionCatalog {
+public interface ExternalModuleDependencyFactory {
 
     interface DependencyNotationSupplier extends ProviderConvertible<MinimalExternalModuleDependency> {
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/ExternalModuleDependencyFactory.java
@@ -17,11 +17,13 @@ package org.gradle.api.internal.catalog;
 
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
-import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.plugin.use.PluginDependency;
 
 public interface ExternalModuleDependencyFactory {
+
+    Provider<MinimalExternalModuleDependency> create(String alias);
 
     interface DependencyNotationSupplier extends ProviderConvertible<MinimalExternalModuleDependency> {
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
@@ -34,20 +34,20 @@ import java.util.Optional;
 public class VersionCatalogView implements VersionCatalog {
 
     private final DefaultVersionCatalog config;
-    private final ProviderFactory providers;
-    private final AbstractExternalDependencyFactory factory;
+    private final ProviderFactory providerFactory;
+    private final ExternalModuleDependencyFactory dependencyFactory;
 
     @Inject
     public VersionCatalogView(DefaultVersionCatalog config, ProviderFactory providerFactory) {
         this.config = config;
-        this.providers = providerFactory;
-        this.factory = new DefaultExternalDependencyFactory(config, providerFactory);
+        this.providerFactory = providerFactory;
+        this.dependencyFactory = new DefaultExternalDependencyFactory(config, providerFactory);
     }
 
     @Override
     public final Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
         if (config.getDependencyAliases().contains(alias)) {
-            return Optional.of(factory.create(alias));
+            return Optional.of(dependencyFactory.create(alias));
         }
         return Optional.empty();
     }
@@ -55,7 +55,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
         if (config.getBundleAliases().contains(bundle)) {
-            return Optional.of(new BundleFactory(providers, config).createBundle(bundle));
+            return Optional.of(new BundleFactory(providerFactory, config).createBundle(bundle));
         }
         return Optional.empty();
     }
@@ -63,7 +63,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public final Optional<VersionConstraint> findVersion(String name) {
         if (config.getVersionAliases().contains(name)) {
-            return Optional.of(new VersionFactory(providers, config).findVersionConstraint(name));
+            return Optional.of(new VersionFactory(providerFactory, config).findVersionConstraint(name));
         }
         return Optional.empty();
     }
@@ -71,7 +71,7 @@ public class VersionCatalogView implements VersionCatalog {
     @Override
     public Optional<Provider<PluginDependency>> findPlugin(String alias) {
         if (config.getPluginAliases().contains(alias)) {
-            return Optional.of(new PluginFactory(providers, config).createPlugin(alias));
+            return Optional.of(new PluginFactory(providerFactory, config).createPlugin(alias));
         }
         return Optional.empty();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/VersionCatalogView.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.catalog;
+
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle;
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.VersionCatalog;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.internal.catalog.AbstractExternalDependencyFactory.BundleFactory;
+import org.gradle.api.internal.catalog.AbstractExternalDependencyFactory.PluginFactory;
+import org.gradle.api.internal.catalog.AbstractExternalDependencyFactory.VersionFactory;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.plugin.use.PluginDependency;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+public class VersionCatalogView implements VersionCatalog {
+
+    private final DefaultVersionCatalog config;
+    private final ProviderFactory providers;
+    private final AbstractExternalDependencyFactory factory;
+
+    @Inject
+    public VersionCatalogView(DefaultVersionCatalog config, ProviderFactory providerFactory) {
+        this.config = config;
+        this.providers = providerFactory;
+        this.factory = new DefaultExternalDependencyFactory(config, providerFactory);
+    }
+
+    @Override
+    public final Optional<Provider<MinimalExternalModuleDependency>> findDependency(String alias) {
+        if (config.getDependencyAliases().contains(alias)) {
+            return Optional.of(factory.create(alias));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<Provider<ExternalModuleDependencyBundle>> findBundle(String bundle) {
+        if (config.getBundleAliases().contains(bundle)) {
+            return Optional.of(new BundleFactory(providers, config).createBundle(bundle));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public final Optional<VersionConstraint> findVersion(String name) {
+        if (config.getVersionAliases().contains(name)) {
+            return Optional.of(new VersionFactory(providers, config).findVersionConstraint(name));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Provider<PluginDependency>> findPlugin(String alias) {
+        if (config.getPluginAliases().contains(alias)) {
+            return Optional.of(new PluginFactory(providers, config).createPlugin(alias));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public final String getName() {
+        return config.getName();
+    }
+
+    @Override
+    public List<String> getDependencyAliases() {
+        return config.getDependencyAliases();
+    }
+
+    @Override
+    public List<String> getBundleAliases() {
+        return config.getBundleAliases();
+    }
+
+    @Override
+    public List<String> getVersionAliases() {
+        return config.getVersionAliases();
+    }
+
+    @Override
+    public List<String> getPluginAliases() {
+        return config.getPluginAliases();
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
@@ -87,21 +87,79 @@ class DefaultVersionCatalogBuilderTest extends Specification implements VersionC
         InvalidUserDataException ex = thrown()
         verify(ex.message, reservedAlias {
             inCatalog('libs')
-            alias(name).shouldNotEndWith(suffix)
-            reservedAliasSuffix('bundle', 'bundles', 'version', 'versions', 'plugin', 'plugins')
+            alias(name).shouldNotContain(prefix)
+            reservedAliasPrefix('bundle', 'bundles', 'dependency', 'dependencies', 'plugin', 'plugins', 'version', 'versions')
         })
 
         where:
-        name          | suffix
-        "bundles"     | "bundles"
-        "versions"    | "versions"
-        "plugins"     | "plugins"
-        "fooBundle"   | "bundle"
-        "fooVersion"  | "version"
-        "fooPlugin"   | "plugin"
-        "foo.plugin"  | "plugin"
-        "foo.bundle"  | "bundle"
-        "foo.version" | "version"
+        name                  | prefix
+        "bundles"             | "bundles"
+        "versions"            | "versions"
+        "plugins"             | "plugins"
+        "findPlugin"          | "plugin"
+        "findVersion"         | "version"
+        "findDependency"      | "dependency"
+        "findBundle"          | "bundle"
+        "bundleAliases"       | "bundle"
+        "dependencyAliases"   | "dependency"
+        "dependenciesAliases" | "dependencies"
+        "pluginAliases"       | "plugin"
+        "versionAliases"      | "version"
+        "myBundles"           | "bundles"
+        "bundles-my"          | "bundles"
+        "versions_my"         | "versions"
+        "plugins.my"          | "plugins"
+    }
+
+    @VersionCatalogProblemTestFor(
+        VersionCatalogProblemId.RESERVED_ALIAS_NAME
+    )
+    @Unroll
+    def "allows using #name as a dependency alias"() {
+        when:
+        builder.alias(name).to("org:foo:1.0")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        name << [
+            "my-bundles",
+            "my-versions",
+            "my-plugins",
+            "my-plugin",
+            "my-version",
+            "mplugins",
+            "theversion",
+            "theversions"
+        ]
+    }
+
+    @VersionCatalogProblemTestFor(
+        VersionCatalogProblemId.RESERVED_ALIAS_NAME
+    )
+    @Unroll
+    def "allows using #name for versions and plugins"() {
+        when:
+        builder.alias(name).toPluginId("org.foo").version("1.0")
+        builder.version(name, "1.0")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        name << [
+            "bundles",
+            "versions",
+            "plugins",
+            "bundleAliases",
+            "dependencyAliases",
+            "pluginAliases",
+            "versionAliases",
+            "bundles-my",
+            "versions_my",
+            "plugins.my"
+        ]
     }
 
     @VersionCatalogProblemTestFor(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilderTest.groovy
@@ -87,8 +87,8 @@ class DefaultVersionCatalogBuilderTest extends Specification implements VersionC
         InvalidUserDataException ex = thrown()
         verify(ex.message, reservedAlias {
             inCatalog('libs')
-            alias(name).shouldNotContain(prefix)
-            reservedAliasPrefix('bundle', 'bundles', 'dependency', 'dependencies', 'plugin', 'plugins', 'version', 'versions')
+            alias(name).shouldNotBeEqualTo(prefix)
+            reservedAliasPrefix('bundles', 'plugins', 'versions')
         })
 
         where:
@@ -96,16 +96,6 @@ class DefaultVersionCatalogBuilderTest extends Specification implements VersionC
         "bundles"             | "bundles"
         "versions"            | "versions"
         "plugins"             | "plugins"
-        "findPlugin"          | "plugin"
-        "findVersion"         | "version"
-        "findDependency"      | "dependency"
-        "findBundle"          | "bundle"
-        "bundleAliases"       | "bundle"
-        "dependencyAliases"   | "dependency"
-        "dependenciesAliases" | "dependencies"
-        "pluginAliases"       | "plugin"
-        "versionAliases"      | "version"
-        "myBundles"           | "bundles"
         "bundles-my"          | "bundles"
         "versions_my"         | "versions"
         "plugins.my"          | "plugins"
@@ -124,14 +114,21 @@ class DefaultVersionCatalogBuilderTest extends Specification implements VersionC
 
         where:
         name << [
+            "version",
+            "bundle",
+            "plugin",
             "my-bundles",
             "my-versions",
             "my-plugins",
+            "my-bundle",
             "my-plugin",
             "my-version",
-            "mplugins",
-            "theversion",
-            "theversions"
+            "myBundles",
+            "myPlugins",
+            "myVersions",
+            "bundlesOfMe",
+            "pluginsOfMe",
+            "versionsOfMe",
         ]
     }
 
@@ -152,10 +149,6 @@ class DefaultVersionCatalogBuilderTest extends Specification implements VersionC
             "bundles",
             "versions",
             "plugins",
-            "bundleAliases",
-            "dependencyAliases",
-            "pluginAliases",
-            "versionAliases",
             "bundles-my",
             "versions_my",
             "plugins.my"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -226,7 +226,6 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         }
 
         then:
-        println(sources.source)
         def libs = sources.compile()
         def foo = libs.foo.get()
         def bar = libs.bar.get()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -226,6 +226,7 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         }
 
         then:
+        println(sources.source)
         def libs = sources.compile()
         def foo = libs.foo.get()
         def bar = libs.bar.get()
@@ -257,8 +258,8 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         then:
         InvalidUserDataException ex = thrown()
         verify ex.message, reservedAlias {
-            alias(reservedName).shouldNotContain(prefix)
-            reservedAliasPrefix('bundle', 'bundles', 'dependency', 'dependencies', 'plugin', 'plugins', 'version', 'versions')
+            alias(reservedName).shouldNotBeEqualTo(prefix)
+            reservedAliasPrefix('bundles', 'plugins', 'versions')
         }
 
         where:
@@ -266,15 +267,6 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         "bundles"             | "bundles"
         "versions"            | "versions"
         "plugins"             | "plugins"
-        "findPlugin"          | "plugin"
-        "findVersion"         | "version"
-        "findDependency"      | "dependency"
-        "findBundle"          | "bundle"
-        "bundleAliases"       | "bundle"
-        "dependencyAliases"   | "dependency"
-        "dependenciesAliases" | "dependencies"
-        "pluginAliases"       | "plugin"
-        "versionAliases"      | "version"
     }
 
     @VersionCatalogProblemTestFor(

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -257,21 +257,24 @@ ${nameClash { noIntro().kind('bundles').inConflict('one.cool', 'oneCool').getter
         then:
         InvalidUserDataException ex = thrown()
         verify ex.message, reservedAlias {
-            alias(reservedName).shouldNotEndWith(suffix)
-            reservedAliasSuffix("bundle", "bundles", "version", "versions", "plugin", "plugins")
+            alias(reservedName).shouldNotContain(prefix)
+            reservedAliasPrefix('bundle', 'bundles', 'dependency', 'dependencies', 'plugin', 'plugins', 'version', 'versions')
         }
 
         where:
-        reservedName   | suffix
-        'versions'     | 'versions'
-        'bundles'      | 'bundles'
-        'plugins'      | 'plugins'
-        'someVersions' | 'versions'
-        'someBundles'  | 'bundles'
-        'somePlugins'  | 'plugins'
-        'some.version' | 'version'
-        'some.bundle'  | 'bundle'
-        'some.plugin'  | 'plugin'
+        reservedName          | prefix
+        "bundles"             | "bundles"
+        "versions"            | "versions"
+        "plugins"             | "plugins"
+        "findPlugin"          | "plugin"
+        "findVersion"         | "version"
+        "findDependency"      | "dependency"
+        "findBundle"          | "bundle"
+        "bundleAliases"       | "bundle"
+        "dependencyAliases"   | "dependency"
+        "dependenciesAliases" | "dependencies"
+        "pluginAliases"       | "plugin"
+        "versionAliases"      | "version"
     }
 
     @VersionCatalogProblemTestFor(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -345,7 +345,7 @@ class Interpreter(val host: Host) {
         }
 
     private
-    fun Any.getKotlinType(): KotlinType = when(this) {
+    fun Any.getKotlinType(): KotlinType = when (this) {
         is GeneratedSubclass -> KotlinType(this.publicType().kotlin)
         else -> KotlinType(this.javaClass.kotlin)
     }


### PR DESCRIPTION
(Updated)
Removed restrictions for plugins and versions since they are accessed with:
`libs.plugins.<name-of-plugin>` and `libs.versions.<name of version>`.

For dependencies:
We still apply restriction but we apply them only for first part of alias for:
- bundles
- versions
- plugins

So for example:
`plugins-my,  bundles-my` are forbidden. But `my-bundles` is allowed.

Also all camelCase cases works now without any issue.

I removed VersionCatalog interface from generated classes, so there is no more `findDependency&friends` on generated accessors. This is good for lifting restrictions, but my break some people's usages. But users can still access VersionCatalog API through VersionCatalogExtension.

----
I also have to update documentation, will do this after https://github.com/gradle/gradle/pull/18207 is merged. And since I added word `dependency` and `dependencies` I will add this to potential breaking changes

Fixes #18167 