### PR TITLE
Invalidate the VFS for untracked task outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedPropertiesIntegrationTest.groovy
@@ -38,7 +38,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                 abstract RegularFileProperty getOutputFile()
                 @TaskAction
                 void doStuff() {
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile.text = inputFile.get().asFile.text
                 }
             }
@@ -100,7 +99,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                     .withPropertyName("outputFile")
                     ${(properties == "outputs" ? ".untracked()" : "")}
                 doLast {
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile.text = inputFile.text
                 }
             }
@@ -136,7 +134,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                 abstract RegularFileProperty getOutputFile()
                 @TaskAction
                 void doStuff() {
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile.text = inputFile.get().asFile.text
                 }
             }
@@ -386,7 +383,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                 outputs.file(outputFile)
                     .withPropertyName("outputFile")
                 doLast {
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile.text = inputFile.text
                 }
             }
@@ -430,7 +426,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
 
                 static void writeFile(DirectoryProperty dir) {
                     def outputFile = dir.file("output.txt").get().asFile
-                    outputFile.parentFile.mkdirs()
                     outputFile.text = "Produced file"
                 }
             }
@@ -585,7 +580,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                 void execute() {
                     def unreadableDir = inputDir.get().dir("unreadable").asFile
                     assert !unreadableDir.canRead()
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile << "Executed"
                 }
             }
@@ -608,7 +602,6 @@ class UntrackedPropertiesIntegrationTest extends AbstractIntegrationSpec impleme
                     assert changes != null
                     def unreadableDir = inputDir.get().dir("unreadable").asFile
                     assert !unreadableDir.canRead()
-                    outputFile.get().asFile.parentFile.mkdirs()
                     outputFile.get().asFile << "Executed"
                 }
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -36,7 +36,6 @@ import org.gradle.api.internal.tasks.InputChangesAwareTaskAction;
 import org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult;
 import org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
-import org.gradle.api.internal.tasks.properties.ContentTracking;
 import org.gradle.api.internal.tasks.properties.InputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.InputParameterUtils;
 import org.gradle.api.internal.tasks.properties.InputPropertySpec;
@@ -309,10 +308,6 @@ public class TaskExecution implements UnitOfWork {
             visitor.visitInputProperty(inputProperty.getPropertyName(), () -> InputParameterUtils.prepareInputParameterValue(inputProperty, task));
         }
         for (InputFilePropertySpec inputFileProperty : inputFileProperties) {
-            if (inputFileProperty.getContentTracking() == ContentTracking.UNTRACKED) {
-                // Not visiting untracked inputs
-                continue;
-            }
             Object value = inputFileProperty.getValue();
             // SkipWhenEmpty implies incremental.
             // If this file property is empty, then we clean up the previously generated outputs.
@@ -337,10 +332,6 @@ public class TaskExecution implements UnitOfWork {
     public void visitOutputs(File workspace, OutputVisitor visitor) {
         TaskProperties taskProperties = context.getTaskProperties();
         for (OutputFilePropertySpec property : taskProperties.getOutputFileProperties()) {
-            if (property.getContentTracking() == ContentTracking.UNTRACKED) {
-                // Not visiting untracked outputs
-                continue;
-            }
             File outputFile = property.getOutputFile();
             if (outputFile != null) {
                 visitor.visitOutputProperty(property.getPropertyName(), property.getOutputType(), outputFile, property.getPropertyFiles());


### PR DESCRIPTION
We did hide untracked task inputs and outputs completely from the execution engine.
We actually don't have to, since the problematic parts is the snapshotting of
both outputs and inputs. And we don't do this any more as soon as we detect any
untracked input or output.

Whether we pass the untracked input or not doesn't make any difference - we
don't do anything apart from fingerprinting with the input anyway. For the
outputs, the story is different. Especially the step where we invalidate the VFS
for an output location before the task start executing is something we also
should do for untracked inputs.

Passing the untracked outputs to the execution engine causes the following:
- We create the output directories.
- We invalidate the VFS for the outputs before starting task execution.