### PR TITLE
Move artifactType attribute to the public API

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -24,12 +24,12 @@ import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.artifacts.transform.VariantTransform
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.capabilities.CapabilitiesMetadata
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.LocalFileDependencyBackedArtifactSet
@@ -108,7 +108,7 @@ class LocalFileDependencyBackedArtifactSetCodec(
             // Do not write this if it will not be used
             // TODO - simplify extracting the mappings
             // TODO - deduplicate this data, as the mapping is project scoped and almost always the same across all projects of a given type
-            val matchingOnArtifactFormat = value.selector.requestedAttributes.keySet().contains(ARTIFACT_FORMAT)
+            val matchingOnArtifactFormat = value.selector.requestedAttributes.keySet().contains(ARTIFACT_TYPE_ATTRIBUTE)
             writeBoolean(matchingOnArtifactFormat)
             val mappings = mutableMapOf<ImmutableAttributes, MappingSpec>()
             value.artifactTypeRegistry.visitArtifactTypes { sourceAttributes ->

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/type/ArtifactTypeDefinition.java
@@ -16,7 +16,9 @@
 
 package org.gradle.api.artifacts.type;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasAttributes;
 
@@ -28,6 +30,14 @@ import java.util.Set;
  * @since 4.0
  */
 public interface ArtifactTypeDefinition extends HasAttributes, Named {
+    /**
+     * The attribute that represents the type of the artifact.
+     *
+     * @since 7.3
+     */
+    @Incubating
+    Attribute<String> ARTIFACT_TYPE_ATTRIBUTE = Attribute.of("artifactType", String.class);
+
     /**
      * Represents a JAR file.
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ArtifactAttributes.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/ArtifactAttributes.java
@@ -15,8 +15,13 @@
  */
 package org.gradle.api.internal.artifacts;
 
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 
 public abstract class ArtifactAttributes {
-    public static final Attribute<String> ARTIFACT_FORMAT = Attribute.of("artifactType", String.class);
+    /**
+     * @deprecated use public {@link ArtifactTypeDefinition#ARTIFACT_TYPE_ATTRIBUTE} instead.
+     */
+    @Deprecated
+    public static final Attribute<String> ARTIFACT_FORMAT = ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -68,7 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;
 
 public abstract class DefaultDependencyHandler implements DependencyHandler, MethodMixIn {
@@ -315,7 +315,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     }
 
     private void configureSchema() {
-        attributesSchema.attribute(ARTIFACT_FORMAT);
+        attributesSchema.attribute(ARTIFACT_TYPE_ATTRIBUTE);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistry.java
@@ -20,7 +20,6 @@ import com.google.common.io.Files;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -34,7 +33,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 
 public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
     private final Instantiator instantiator;
@@ -57,7 +56,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
         if (artifactTypeDefinitions != null) {
             for (ArtifactTypeDefinition artifactTypeDefinition : artifactTypeDefinitions) {
                 ImmutableAttributes attributes = ((AttributeContainerInternal) artifactTypeDefinition.getAttributes()).asImmutable();
-                attributes = attributesFactory.concat(attributesFactory.of(ARTIFACT_FORMAT, artifactTypeDefinition.getName()), attributes);
+                attributes = attributesFactory.concat(attributesFactory.of(ARTIFACT_TYPE_ATTRIBUTE, artifactTypeDefinition.getName()), attributes);
                 if (seen.add(attributes)) {
                     action.accept(attributes);
                 }
@@ -66,7 +65,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
 
         for (ArtifactTransformRegistration transform : transformRegistry.getTransforms()) {
             AttributeContainerInternal sourceAttributes = transform.getFrom();
-            String format = sourceAttributes.getAttribute(ARTIFACT_FORMAT);
+            String format = sourceAttributes.getAttribute(ARTIFACT_TYPE_ATTRIBUTE);
             // Some format that is not already registered
             if (format != null) {
                 ImmutableAttributes attributes = sourceAttributes.asImmutable();
@@ -89,13 +88,13 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
     public ImmutableAttributes mapAttributesFor(File file) {
         ImmutableAttributes attributes = ImmutableAttributes.EMPTY;
         if (file.isDirectory()) {
-            attributes = attributesFactory.of(ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
+            attributes = attributesFactory.of(ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
         } else {
             String extension = Files.getFileExtension(file.getName());
             if (artifactTypeDefinitions != null) {
                 attributes = applyForExtension(attributes, extension);
             }
-            attributes = attributesFactory.concat(attributesFactory.of(ARTIFACT_FORMAT, extension), attributes);
+            attributes = attributesFactory.concat(attributesFactory.of(ARTIFACT_TYPE_ATTRIBUTE, extension), attributes);
         }
         return attributes;
     }
@@ -120,7 +119,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
         }
 
         // Add artifact format as an implicit attribute when all artifacts have the same format
-        if (!attributes.contains(ArtifactAttributes.ARTIFACT_FORMAT)) {
+        if (!attributes.contains(ARTIFACT_TYPE_ATTRIBUTE)) {
             String format = null;
             for (ComponentArtifactMetadata artifact : artifacts) {
                 String candidateFormat = artifact.getName().getType();
@@ -132,7 +131,7 @@ public class DefaultArtifactTypeRegistry implements ArtifactTypeRegistry {
                 }
             }
             if (format != null) {
-                attributes = attributesFactory.concat(attributes.asImmutable(), ArtifactAttributes.ARTIFACT_FORMAT, format);
+                attributes = attributesFactory.concat(attributes.asImmutable(), ARTIFACT_TYPE_ATTRIBUTE, format);
             }
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
-import static org.gradle.api.internal.artifacts.ArtifactAttributes.ARTIFACT_FORMAT
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
 import static org.gradle.util.internal.TextUtil.toPlatformLineSeparators
 
 class DefaultArtifactTransformsTest extends Specification {
@@ -217,7 +217,7 @@ Found the following transforms:
 
     private static AttributeContainerInternal typeAttributes(String artifactType) {
         def attributeContainer = new DefaultMutableAttributeContainer(AttributeTestUtil.attributesFactory())
-        attributeContainer.attribute(ARTIFACT_FORMAT, artifactType)
+        attributeContainer.attribute(ARTIFACT_TYPE_ATTRIBUTE, artifactType)
         attributeContainer.asImmutable()
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/type/DefaultArtifactTypeRegistryTest.groovy
@@ -20,7 +20,6 @@ package org.gradle.api.internal.artifacts.type
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.artifacts.ArtifactAttributes
 import org.gradle.api.internal.artifacts.VariantTransformRegistry
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.model.ComponentArtifactMetadata
@@ -142,7 +141,7 @@ class DefaultArtifactTypeRegistryTest extends Specification {
 
     def "maps only artifactType attribute for arbitrary files when no extensions are registered"() {
         expect:
-        registry.mapAttributesFor(artifactFile).getAttribute(ArtifactAttributes.ARTIFACT_FORMAT) == type
+        registry.mapAttributesFor(artifactFile).getAttribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE) == type
 
         where:
         artifactFile    | type

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -96,7 +95,7 @@ public class DefaultCppBinary extends DefaultNativeBinary implements CppBinary {
 
         ArtifactView includeDirs = includePathConfiguration.getIncoming().artifactView(viewConfiguration -> {
            viewConfiguration.attributes(attributeContainer -> {
-               attributeContainer.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
+               attributeContainer.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
            });
         });
         includePath = componentHeaderDirs.plus(includeDirs.getFiles());

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -25,7 +25,6 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -75,11 +74,11 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         apiElements.extendsFrom(dependencies.getApiDependencies());
         apiElements.setCanBeResolved(false);
         apiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
-        apiElements.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.DIRECTORY_TYPE);
+        apiElements.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE);
 
         AttributeContainer publicationAttributes = immutableAttributesFactory.mutable();
         publicationAttributes.attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
-        publicationAttributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE);
+        publicationAttributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.ZIP_TYPE);
         mainVariant = new MainLibraryVariant("api", apiUsage, apiElements, publicationAttributes, objectFactory);
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
@@ -37,7 +38,6 @@ import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.artifacts.transform.UnzipTransform;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
@@ -441,9 +441,9 @@ public class NativeBasePlugin implements Plugin<Project> {
 
     private void addHeaderZipTransform(DependencyHandler dependencyHandler, ObjectFactory objects) {
         dependencyHandler.registerTransform(UnzipTransform.class, variantTransform -> {
-            variantTransform.getFrom().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ZIP_TYPE);
+            variantTransform.getFrom().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ZIP_TYPE);
             variantTransform.getFrom().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API));
-            variantTransform.getTo().attribute(ArtifactAttributes.ARTIFACT_FORMAT, DIRECTORY_TYPE);
+            variantTransform.getTo().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE);
             variantTransform.getTo().attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.C_PLUS_PLUS_API));
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -33,7 +33,6 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.component.BuildableJavaComponent;
@@ -345,7 +344,7 @@ public class JavaPlugin implements Plugin<Project> {
 
         // Configure an implicit variant
         publications.getArtifacts().add(jarArtifact);
-        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE);
+        publications.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE);
     }
 
     private void addRuntimeVariants(Configuration configuration, PublishArtifact jarArtifact, final SourceSet sourceSet, final Provider<ProcessResources> processResources) {
@@ -353,7 +352,7 @@ public class JavaPlugin implements Plugin<Project> {
 
         // Configure an implicit variant
         publications.getArtifacts().add(jarArtifact);
-        publications.getAttributes().attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.JAR_TYPE);
+        publications.getAttributes().attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE);
 
         // Define some additional variants
         jvmServices.configureClassesDirectoryVariant(sourceSet.getRuntimeElementsConfigurationName(), sourceSet);


### PR DESCRIPTION
This attribute is required for some transforms and everyone had to
use internal one or define their own.

There are plugins in the wild that use the internal attribute so it
isn't removed in this PR as it would be breaking change.

Fixes #15223.