### PR TITLE
Use decorating instantiator for polymorphic domain object collections

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -777,18 +777,26 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
     def "plugin can create ExtensiblePolymorphicDomainObjectContainer instances using named managed types"() {
         given:
         buildFile """
-            interface BaseThing extends Named { }
+            interface BaseThing extends Named { 
+                Property<Integer> getValue()
+            }
             interface ThingA extends BaseThing { }
             interface ThingB extends BaseThing { }
 
             def container = project.objects.polymorphicDomainObjectContainer(BaseThing)
             container.registerBinding(ThingA, ThingA)
             container.registerBinding(ThingB, ThingB)
-            container.register("a", ThingA) { }
-            container.register("b", ThingB) { }
+            container.register("a", ThingA) { 
+                value = 0
+            }
+            container.register("b", ThingB) { 
+                value = 1
+            }
             assert container.size() == 2
             assert container[0] instanceof ThingA
+            assert container[0].value.get() == 0
             assert container[1] instanceof ThingB
+            assert container[1].value.get() == 1
         """
 
         expect:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -30,14 +30,26 @@ import java.util.Set;
 public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorphicDomainObjectContainer<T>
     implements ExtensiblePolymorphicDomainObjectContainer<T> {
     protected final DefaultPolymorphicNamedEntityInstantiator<T> namedEntityInstantiator;
+    private final Instantiator elementInstantiator;
 
+    // NOTE: This constructor exists for backwards compatibility
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
-        super(type, instantiator, namer, callbackDecorator);
-        namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<T>(type, "this container");
+        this(type, instantiator, instantiator, namer, callbackDecorator);
     }
 
+    // NOTE: This constructor exists for backwards compatibility
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {
-        this(type, instantiator, Named.Namer.forType(type), callbackDecorator);
+        this(type, instantiator, instantiator, Named.Namer.forType(type), callbackDecorator);
+    }
+
+    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator callbackDecorator) {
+        this(type, instantiator, elementInstantiator, Named.Namer.forType(type), callbackDecorator);
+    }
+
+    private DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Instantiator elementInstantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
+        super(type, instantiator, namer, callbackDecorator);
+        this.namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<T>(type, "this container");
+        this.elementInstantiator = elementInstantiator;
     }
 
     @Override
@@ -92,8 +104,8 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
 
             @Override
             public U create(String name) {
-                return named ? getInstantiator().newInstance(implementationType, name)
-                    : getInstantiator().newInstance(implementationType);
+                return named ? elementInstantiator.newInstance(implementationType, name)
+                    : elementInstantiator.newInstance(implementationType);
             }
         });
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiator.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.gradle.internal.Cast.uncheckedCast;
-
 public class DefaultPolymorphicNamedEntityInstantiator<T> implements PolymorphicNamedEntityInstantiator<T> {
     private final Map<Class<? extends T>, NamedDomainObjectFactory<? extends T>> factories = Maps.newHashMap();
     private final Class<? extends T> baseType;
@@ -68,7 +66,7 @@ public class DefaultPolymorphicNamedEntityInstantiator<T> implements Polymorphic
             String message = String.format("Cannot register a factory for type %s because it is not a subtype of container element type %s.", type.getSimpleName(), baseType.getSimpleName());
             throw new IllegalArgumentException(message);
         }
-        if(factories.containsKey(type)){
+        if (factories.containsKey(type)) {
             throw new GradleException(String.format("Cannot register a factory for type %s because a factory for this type is already registered.", type.getSimpleName()));
         }
         factories.put(type, factory);
@@ -77,16 +75,5 @@ public class DefaultPolymorphicNamedEntityInstantiator<T> implements Polymorphic
     @Override
     public Set<? extends Class<? extends T>> getCreatableTypes() {
         return ImmutableSet.copyOf(factories.keySet());
-    }
-
-    public void copyFactoriesFrom(DefaultPolymorphicNamedEntityInstantiator<T> source) {
-        for (Class<? extends T> languageType : source.factories.keySet()) {
-            copyFactory(source, languageType);
-        }
-    }
-
-    <U extends T> void copyFactory(DefaultPolymorphicNamedEntityInstantiator<T> source, Class<U> type) {
-        NamedDomainObjectFactory<U> factory = uncheckedCast(source.factories.get(type));
-        registerFactory(type, factory);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -85,7 +85,8 @@ public class DefaultDomainObjectCollectionFactory implements DomainObjectCollect
     @Override
     public <T> ExtensiblePolymorphicDomainObjectContainer<T> newPolymorphicDomainObjectContainer(Class<T> elementType) {
         Instantiator instantiator = instantiatorFactory.decorateLenient();
-        return Cast.uncheckedCast(instantiator.newInstance(DefaultPolymorphicDomainObjectContainer.class, elementType, instantiator, collectionCallbackActionDecorator));
+        Instantiator elementInstantiator = instantiatorFactory.decorateLenient(servicesToInject);
+        return Cast.uncheckedCast(instantiator.newInstance(DefaultPolymorphicDomainObjectContainer.class, elementType, instantiator, elementInstantiator, collectionCallbackActionDecorator));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationContainer.java
@@ -25,7 +25,7 @@ import org.gradle.internal.reflect.Instantiator;
 public class DefaultAuthenticationContainer extends DefaultPolymorphicDomainObjectContainer<Authentication> implements AuthenticationContainer {
 
     public DefaultAuthenticationContainer(Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {
-        super(Authentication.class, instantiator, callbackDecorator);
+        super(Authentication.class, instantiator, instantiator, callbackDecorator);
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -29,7 +29,11 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     def barney = new DefaultPerson(name: "barney")
     def agedBarney = new DefaultAgeAwarePerson(name: "barney", age: 42)
 
-    def container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, TestUtil.instantiatorFactory().decorateLenient(), callbackActionDecorator)
+    def container = createContainer()
+
+    private DefaultPolymorphicDomainObjectContainer<Person> createContainer() {
+        new DefaultPolymorphicDomainObjectContainer<Person>(Person, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.instantiatorFactory().decorateLenient(), callbackActionDecorator)
+    }
 
     boolean supportsBuildOperations = true
 
@@ -143,7 +147,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     }
 
     def "throws meaningful exception if it doesn't support creating domain objects without specifying a type"() {
-        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)
+        container = createContainer()
 
         when:
         container.create("fred")
@@ -237,7 +241,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     }
 
     def "throws meaningful exception if it doesn't support creating domain objects with the specified type"() {
-        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)
+        container = createContainer()
 
         when:
         container.create("fred", Person)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiatorTest.groovy
@@ -92,17 +92,4 @@ class DefaultPolymorphicNamedEntityInstantiatorTest extends Specification {
         GradleException e = thrown()
         e.message == "Cannot register a factory for type TestType because a factory for this type is already registered."
     }
-
-    def "copying factories from a different instantiator"() {
-        given:
-        def source = new DefaultPolymorphicNamedEntityInstantiator<Base>(Base, null)
-        def factoryTypes = [TestType, AnotherTestType] as Set
-        factoryTypes.each { source.registerFactory(it, {}) }
-
-        when:
-        instantiator.copyFactoriesFrom(source)
-
-        then:
-        instantiator.creatableTypes == factoryTypes
-    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/TypedDomainObjectContainerWrapperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/TypedDomainObjectContainerWrapperTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class TypedDomainObjectContainerWrapperTest extends Specification {
 
-    DefaultPolymorphicDomainObjectContainer<Type> parent = new DefaultPolymorphicDomainObjectContainer<Type>(Type, TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)
+    DefaultPolymorphicDomainObjectContainer<Type> parent = new DefaultPolymorphicDomainObjectContainer<Type>(Type, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)
 
     def setup() {
         parent.add(type("typeOne"))

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultPlatformContainer.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultPlatformContainer.java
@@ -25,7 +25,7 @@ import org.gradle.platform.base.PlatformContainer;
 public class DefaultPlatformContainer extends DefaultPolymorphicDomainObjectContainer<Platform> implements PlatformContainer {
 
     public DefaultPlatformContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        super(Platform.class, instantiator, collectionCallbackActionDecorator);
+        super(Platform.class, instantiator, instantiator, collectionCallbackActionDecorator);
     }
 
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
@@ -38,7 +38,7 @@ public class DefaultNativeToolChainRegistry extends DefaultPolymorphicDomainObje
     private final List<NativeToolChainInternal> searchOrder = new ArrayList<NativeToolChainInternal>();
 
     public DefaultNativeToolChainRegistry(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        super(NativeToolChain.class, instantiator, collectionCallbackActionDecorator);
+        super(NativeToolChain.class, instantiator, instantiator, collectionCallbackActionDecorator);
         whenObjectAdded(new Action<NativeToolChain>() {
             @Override
             public void execute(NativeToolChain toolChain) {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationContainer.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationContainer.java
@@ -25,7 +25,7 @@ import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultPublicationContainer extends DefaultPolymorphicDomainObjectContainer<Publication> implements PublicationContainer {
     public DefaultPublicationContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        super(Publication.class, instantiator, collectionCallbackActionDecorator);
+        super(Publication.class, instantiator, instantiator, collectionCallbackActionDecorator);
     }
 
     @Override


### PR DESCRIPTION
This makes polymorphic containers behave the same way as named domain object containers when using registerBinding.