### PR TITLE
Fix native compiler metadata detection on non-english locales

### DIFF
--- a/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
+++ b/platforms/native/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
@@ -44,6 +44,7 @@ public abstract class AbstractMetadataProvider<T extends CompilerMetadata> imple
     @Override
     public SearchResult<T> getCompilerMetaData(List<File> path, Action<? super CompilerExecSpec> configureAction) {
         DefaultCompilerExecSpec execSpec = new DefaultCompilerExecSpec();
+        execSpec.environment("LC_MESSAGES", "C");
         configureAction.execute(execSpec);
 
         List<String> allArgs = ImmutableList.<String>builder().addAll(execSpec.args).addAll(compilerArgs()).build();


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #15803

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Users with non-English locales are able to use native toolchains. View #15803 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

I did not add an integration test because I do not know how to run a test with a specific environment variable and how to make sure the non english locale is available on the system. Without this PR some tests fail on my machine because I'm using a german locale. With this PR all tests are passing.