### PR TITLE
Update SnapshotTaskInputsBuildOperationResult to convey new attributes, and do not traverse empty directories when the sensitivity ignores them

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -220,6 +220,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             dir("src/main/java") {
                 file("A.java") << "class A {}"
                 file("B.java") << "class B {}"
+                dir("emptydir")
                 dir("a") {
                     file("A.java") << "package a; class A {}"
                     dir("a") {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -259,23 +259,31 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             hash != null
             roots.empty
             normalization == "COMPILE_CLASSPATH"
+            directorySensitivity == "DEFAULT"
+            lineEndingSensitivity == "DEFAULT"
         }
 
         with(aCompileJava["options.sourcepath"] as Map<String, ?>) {
             hash != null
             roots.empty
             normalization == "RELATIVE_PATH"
+            directorySensitivity == "IGNORE_DIRECTORIES"
+            lineEndingSensitivity == "DEFAULT"
         }
 
         with(aCompileJava["options.annotationProcessorPath"] as Map<String, ?>) {
             hash != null
             roots.empty
             normalization == "CLASSPATH"
+            directorySensitivity == "DEFAULT"
+            lineEndingSensitivity == "DEFAULT"
         }
 
         with(aCompileJava.stableSources) {
             hash != null
             normalization == "RELATIVE_PATH"
+            directorySensitivity == "IGNORE_DIRECTORIES"
+            lineEndingSensitivity == "DEFAULT"
             roots.size() == 1
             with(roots[0]) {
                 path == file("a/src/main/java").absolutePath

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -75,6 +75,39 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         this.cachingState = cachingState;
     }
 
+    private static final String FINGERPRINTING_STRATEGY_PREFIX = "FINGERPRINTING_STRATEGY_";
+    private static final String DIRECTORY_SENSITIVITY_PREFIX = "DIRECTORY_SENSITIVITY_";
+    private static final String LINE_ENDING_SENSITIVITY_PREFIX = "LINE_ENDING_SENSITIVITY_";
+
+    enum PropertyAttribute {
+
+        FINGERPRINTING_STRATEGY_ABSOLUTE_PATH,
+        FINGERPRINTING_STRATEGY_NAME_ONLY,
+        FINGERPRINTING_STRATEGY_RELATIVE_PATH,
+        FINGERPRINTING_STRATEGY_IGNORED_PATH,
+        FINGERPRINTING_STRATEGY_CLASSPATH,
+        FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH,
+
+        DIRECTORY_SENSITIVITY_DEFAULT,
+        DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES,
+
+        LINE_ENDING_SENSITIVITY_DEFAULT,
+        LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS;
+
+        static PropertyAttribute fromFingerprintingStrategy(String fingerprintingStrategy) {
+            return PropertyAttribute.valueOf(FINGERPRINTING_STRATEGY_PREFIX + fingerprintingStrategy);
+        }
+
+        static PropertyAttribute fromDirectorySensitivity(DirectorySensitivity directorySensitivity) {
+            return PropertyAttribute.valueOf(DIRECTORY_SENSITIVITY_PREFIX + directorySensitivity.name());
+        }
+
+        static PropertyAttribute fromLineEndingSensitivity(LineEndingSensitivity lineEndingSensitivity) {
+            return PropertyAttribute.valueOf(LINE_ENDING_SENSITIVITY_PREFIX + lineEndingSensitivity.name());
+        }
+
+    }
+
     @Override
     public Map<String, byte[]> getInputValueHashesBytes() {
         return getBeforeExecutionState()
@@ -416,9 +449,9 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             public void preProperty(VisitState state) {
                 property = new Property(
                     HashCode.fromBytes(state.getPropertyHashBytes()).toString(),
-                    getAttributeMatching(state.getPropertyAttributes(), "FINGERPRINTING_STRATEGY_"),
-                    getAttributeMatching(state.getPropertyAttributes(), "DIRECTORY_SENSITIVITY_"),
-                    getAttributeMatching(state.getPropertyAttributes(), "LINE_ENDING_SENSITIVITY_")
+                    getAttributeMatching(state.getPropertyAttributes(), FINGERPRINTING_STRATEGY_PREFIX),
+                    getAttributeMatching(state.getPropertyAttributes(), DIRECTORY_SENSITIVITY_PREFIX),
+                    getAttributeMatching(state.getPropertyAttributes(), LINE_ENDING_SENSITIVITY_PREFIX)
                 );
                 fileProperties.put(state.getPropertyName(), property);
             }
@@ -491,32 +524,4 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         );
     }
 
-    enum PropertyAttribute {
-
-        FINGERPRINTING_STRATEGY_ABSOLUTE_PATH,
-        FINGERPRINTING_STRATEGY_NAME_ONLY,
-        FINGERPRINTING_STRATEGY_RELATIVE_PATH,
-        FINGERPRINTING_STRATEGY_IGNORED_PATH,
-        FINGERPRINTING_STRATEGY_CLASSPATH,
-        FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH,
-
-        DIRECTORY_SENSITIVITY_DEFAULT,
-        DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES,
-
-        LINE_ENDING_SENSITIVITY_DEFAULT,
-        LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS;
-
-        static PropertyAttribute fromFingerprintingStrategy(String fingerprintingStrategy) {
-            return PropertyAttribute.valueOf("FINGERPRINTING_STRATEGY_" + fingerprintingStrategy);
-        }
-
-        static PropertyAttribute fromDirectorySensitivity(DirectorySensitivity directorySensitivity) {
-            return PropertyAttribute.valueOf("DIRECTORY_SENSITIVITY_" + directorySensitivity.name());
-        }
-
-        static PropertyAttribute fromLineEndingSensitivity(LineEndingSensitivity lineEndingSensitivity) {
-            return PropertyAttribute.valueOf("LINE_ENDING_SENSITIVITY_" + lineEndingSensitivity);
-        }
-
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -342,11 +342,15 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             class Property {
                 private final String hash;
                 private final String normalization;
+                private final String directorySensitivity;
+                private final String lineEndingSensitivity;
                 private final List<Entry> roots = new ArrayList<>();
 
-                public Property(String hash, String normalization) {
+                public Property(String hash, String normalization, String directorySensitivity, String lineEndingSensitivity) {
                     this.hash = hash;
                     this.normalization = normalization;
+                    this.directorySensitivity = directorySensitivity;
+                    this.lineEndingSensitivity = lineEndingSensitivity;
                 }
 
                 public String getHash() {
@@ -355,6 +359,14 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
 
                 public String getNormalization() {
                     return normalization;
+                }
+
+                public String getDirectorySensitivity() {
+                    return directorySensitivity;
+                }
+
+                public String getLineEndingSensitivity() {
+                    return lineEndingSensitivity;
                 }
 
                 public Collection<Entry> getRoots() {
@@ -402,8 +414,19 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
 
             @Override
             public void preProperty(VisitState state) {
-                property = new Property(HashCode.fromBytes(state.getPropertyHashBytes()).toString(), state.getPropertyNormalizationStrategyName());
+                property = new Property(
+                    HashCode.fromBytes(state.getPropertyHashBytes()).toString(),
+                    getAttributeMatching(state.getPropertyAttributes(), "FINGERPRINTING_STRATEGY_"),
+                    getAttributeMatching(state.getPropertyAttributes(), "DIRECTORY_SENSITIVITY_"),
+                    getAttributeMatching(state.getPropertyAttributes(), "LINE_ENDING_SENSITIVITY_")
+                );
                 fileProperties.put(state.getPropertyName(), property);
+            }
+
+            private String getAttributeMatching(Set<String> propertyAttributes, String prefix) {
+                return propertyAttributes.stream()
+                    .filter(s -> s.startsWith(prefix)).findFirst().map(s -> s.substring(prefix.length()))
+                    .orElseThrow(() -> new IllegalStateException("Missing attribute starting with prefix " + prefix));
             }
 
             @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -159,6 +159,9 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         @Override
         public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
             if (snapshot.getType() == FileType.Directory) {
+                if (propertyAttributes.contains(PropertyAttribute.DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES) && ((DirectorySnapshot) snapshot).getChildren().isEmpty()) {
+                    return SnapshotVisitResult.SKIP_SUBTREE;
+                }
                 return SnapshotVisitResult.CONTINUE;
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -161,6 +161,8 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
              */
             String getPropertyNormalizationStrategyName();
 
+            Set<String> getPropertyAttributes();
+
             String getPath();
 
             String getName();

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -21,8 +21,10 @@ import com.google.common.collect.ImmutableMultimap
 import com.google.common.collect.Iterables
 import org.gradle.internal.execution.history.impl.SerializableFileCollectionFingerprint
 import org.gradle.internal.file.FileType
+import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
+import org.gradle.internal.fingerprint.LineEndingSensitivity
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.EmptyCurrentFileCollectionFingerprint
 import org.gradle.internal.hash.HashCode
@@ -275,7 +277,7 @@ class FingerprintCompareStrategyTest extends Specification {
             ]
             getRootHashes() >> ImmutableMultimap.of('/dir', HashCode.fromInt(456))
         }
-        def emptyFingerprint = new EmptyCurrentFileCollectionFingerprint("test")
+        def emptyFingerprint = new EmptyCurrentFileCollectionFingerprint("test", DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT)
         expect:
         changes(strategy, emptyFingerprint, fingerprint).toList() == [
             DefaultFileChange.removed("file1.txt", "test", FileType.RegularFile, "file1.txt"),
@@ -292,7 +294,7 @@ class FingerprintCompareStrategyTest extends Specification {
 
     def "comparing empty fingerprints produces empty (strategy: #strategy)"() {
         expect:
-        changes(strategy, new EmptyCurrentFileCollectionFingerprint("test"), new EmptyCurrentFileCollectionFingerprint("test"),).empty
+        changes(strategy, new EmptyCurrentFileCollectionFingerprint("test", DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT), new EmptyCurrentFileCollectionFingerprint("test", DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT),).empty
 
         where:
         strategy << ALL_STRATEGIES

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileSystemLocationSnapshotHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/CachingFileSystemLocationSnapshotHasher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.changedetection.state;
 
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
@@ -47,5 +48,10 @@ public class CachingFileSystemLocationSnapshotHasher implements FileSystemLocati
     @Override
     public HashCode hash(FileSystemLocationSnapshot snapshot) throws IOException {
         return resourceSnapshotterCacheService.hashFile(snapshot, delegate, delegateConfigurationHash);
+    }
+
+    @Override
+    public LineEndingSensitivity getLineEndingSensitivity() {
+        return LineEndingSensitivity.DEFAULT;
     }
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingFileSystemLocationSnapshotHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingFileSystemLocationSnapshotHasher.java
@@ -68,6 +68,11 @@ public class LineEndingNormalizingFileSystemLocationSnapshotHasher implements Fi
             .orElseGet(IoSupplier.wrap(() -> delegate.hash(snapshot)));
     }
 
+    @Override
+    public LineEndingSensitivity getLineEndingSensitivity() {
+        return LineEndingSensitivity.NORMALIZE_LINE_ENDINGS;
+    }
+
     private Optional<HashCode> hashContent(FileSystemLocationSnapshot snapshot) throws IOException {
         return snapshot.getType() == FileType.RegularFile ? hasher.hashContent(new File(snapshot.getAbsolutePath())) : Optional.empty();
     }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasher.java
@@ -56,6 +56,11 @@ public class LineEndingNormalizingResourceHasher implements ResourceHasher {
     }
 
     @Override
+    public LineEndingSensitivity lineEndingSensitivity() {
+        return LineEndingSensitivity.NORMALIZE_LINE_ENDINGS;
+    }
+
+    @Override
     public void appendConfigurationToHasher(Hasher hasher) {
         delegate.appendConfigurationToHasher(hasher);
         hasher.putString(getClass().getName());

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -83,13 +83,14 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
 
     private ClasspathFingerprintingStrategy(
         String identifier,
+        LineEndingSensitivity lineEndingSensitivity,
         NonJarFingerprintingStrategy nonZipFingerprintingStrategy,
         ResourceHasher classpathResourceHasher,
         ZipHasher zipHasher,
         ResourceSnapshotterCacheService cacheService,
         Interner<String> stringInterner
     ) {
-        super(identifier, DirectorySensitivity.DEFAULT, zipHasher);
+        super(identifier, DirectorySensitivity.DEFAULT, lineEndingSensitivity, zipHasher);
         this.nonZipFingerprintingStrategy = nonZipFingerprintingStrategy;
         this.classpathResourceHasher = classpathResourceHasher;
         this.cacheService = cacheService;
@@ -115,17 +116,17 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         resourceHasher = metaInfAwareClasspathResourceHasher(resourceHasher, manifestAttributeResourceEntryFilter);
         resourceHasher = ignoringResourceHasher(resourceHasher, classpathResourceFilter);
         ZipHasher zipHasher = new ZipHasher(resourceHasher);
-        return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner);
+        return new ClasspathFingerprintingStrategy(CLASSPATH_IDENTIFIER, lineEndingSensitivity, USE_FILE_HASH, resourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner) {
         ZipHasher zipHasher = new ZipHasher(classpathResourceHasher);
-        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
+        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, LineEndingSensitivity.DEFAULT, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     public static ClasspathFingerprintingStrategy compileClasspath(ResourceHasher classpathResourceHasher, ResourceSnapshotterCacheService cacheService, Interner<String> stringInterner, ZipHasher.HashingExceptionReporter hashingExceptionReporter) {
         ZipHasher zipHasher = new ZipHasher(classpathResourceHasher, hashingExceptionReporter);
-        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
+        return new ClasspathFingerprintingStrategy(COMPILE_CLASSPATH_IDENTIFIER, LineEndingSensitivity.DEFAULT, IGNORE, classpathResourceHasher, zipHasher, cacheService, stringInterner);
     }
 
     private static ResourceHasher ignoringResourceHasher(ResourceHasher delegate, ResourceFilter resourceFilter) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/CurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/CurrentFileCollectionFingerprint.java
@@ -38,6 +38,10 @@ public interface CurrentFileCollectionFingerprint extends FileCollectionFingerpr
      */
     String getStrategyIdentifier();
 
+    DirectorySensitivity getStrategyDirectorySensitivity();
+
+    LineEndingSensitivity getStrategyLineEndingSensitivity();
+
     /**
      * Returns the snapshot used to capture these fingerprints.
      */

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -47,6 +47,16 @@ public interface FingerprintingStrategy {
      */
     String getIdentifier();
 
+    /**
+     * UsedByScansPlugin
+     */
+    DirectorySensitivity getDirectorySensitivity();
+
+    /**
+     * UsedByScansPlugin
+     */
+    LineEndingSensitivity getLineEndingSensitivity();
+
     CurrentFileCollectionFingerprint getEmptyFingerprint();
 
     String normalizePath(FileSystemLocationSnapshot snapshot);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/FileSystemLocationSnapshotHasher.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/FileSystemLocationSnapshotHasher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.fingerprint.hashing;
 
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -30,11 +31,18 @@ public interface FileSystemLocationSnapshotHasher extends ConfigurableNormalizer
     @Nullable
     HashCode hash(FileSystemLocationSnapshot snapshot) throws IOException;
 
+    LineEndingSensitivity getLineEndingSensitivity();
+
     FileSystemLocationSnapshotHasher DEFAULT = new FileSystemLocationSnapshotHasher() {
         @Nullable
         @Override
         public HashCode hash(FileSystemLocationSnapshot snapshot) {
             return snapshot.getHash();
+        }
+
+        @Override
+        public LineEndingSensitivity getLineEndingSensitivity() {
+            return LineEndingSensitivity.DEFAULT;
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/ResourceHasher.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/hashing/ResourceHasher.java
@@ -16,8 +16,15 @@
 
 package org.gradle.internal.fingerprint.hashing;
 
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
+
 /**
  * Hashes resources (e.g., a class file in a jar or a class file in a directory)
  */
 public interface ResourceHasher extends ConfigurableNormalizer, RegularFileSnapshotContextHasher, ZipEntryContextHasher {
+
+    default LineEndingSensitivity lineEndingSensitivity() {
+        return LineEndingSensitivity.DEFAULT;
+    }
+
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -43,7 +43,7 @@ public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingSt
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public AbsolutePathFingerprintingStrategy(DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher.getLineEndingSensitivity(), normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
@@ -19,6 +19,7 @@ package org.gradle.internal.fingerprint.impl;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
 import org.gradle.internal.hash.HashCode;
@@ -34,16 +35,19 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
     private final String identifier;
     private final CurrentFileCollectionFingerprint emptyFingerprint;
     private final DirectorySensitivity directorySensitivity;
+    private final LineEndingSensitivity lineEndingSensitivity;
     private final HashCode configurationHash;
 
     public AbstractFingerprintingStrategy(
         String identifier,
         DirectorySensitivity directorySensitivity,
+        LineEndingSensitivity lineEndingSensitivity,
         ConfigurableNormalizer contentNormalizer
     ) {
         this.identifier = identifier;
-        this.emptyFingerprint = new EmptyCurrentFileCollectionFingerprint(identifier);
         this.directorySensitivity = directorySensitivity;
+        this.lineEndingSensitivity = lineEndingSensitivity;
+        this.emptyFingerprint = new EmptyCurrentFileCollectionFingerprint(identifier, directorySensitivity, lineEndingSensitivity);
         Hasher hasher = Hashing.newHasher();
         hasher.putString(getClass().getName());
         contentNormalizer.appendConfigurationToHasher(hasher);
@@ -53,6 +57,16 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
     @Override
     public String getIdentifier() {
         return identifier;
+    }
+
+    @Override
+    public DirectorySensitivity getDirectorySensitivity() {
+        return directorySensitivity;
+    }
+
+    @Override
+    public LineEndingSensitivity getLineEndingSensitivity() {
+        return lineEndingSensitivity;
     }
 
     @Override
@@ -73,10 +87,6 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
 
     private static String failedToNormalize(FileSystemLocationSnapshot snapshot) {
         return String.format("Failed to normalize content of '%s'.", snapshot.getAbsolutePath());
-    }
-
-    protected DirectorySensitivity getDirectorySensitivity() {
-        return directorySensitivity;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/DefaultCurrentFileCollectionFingerprint.java
@@ -19,10 +19,12 @@ package org.gradle.internal.fingerprint.impl;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterables;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
@@ -40,9 +42,11 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     private final FileSystemSnapshot roots;
     private final ImmutableMultimap<String, HashCode> rootHashes;
     private final HashCode strategyConfigurationHash;
+    private final DirectorySensitivity directorySensitivity;
+    private final LineEndingSensitivity lineEndingSensitivity;
     private HashCode hash;
 
-    public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy, @Nullable  FileCollectionFingerprint candidate) {
+    public static CurrentFileCollectionFingerprint from(FileSystemSnapshot roots, FingerprintingStrategy strategy, @Nullable FileCollectionFingerprint candidate) {
         if (roots == FileSystemSnapshot.EMPTY) {
             return strategy.getEmptyFingerprint();
         }
@@ -76,6 +80,8 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     ) {
         this.fingerprints = fingerprints;
         this.identifier = strategy.getIdentifier();
+        this.directorySensitivity = strategy.getDirectorySensitivity();
+        this.lineEndingSensitivity = strategy.getLineEndingSensitivity();
         this.hashingStrategy = strategy.getHashingStrategy();
         this.strategyConfigurationHash = strategy.getConfigurationHash();
         this.roots = roots;
@@ -116,6 +122,16 @@ public class DefaultCurrentFileCollectionFingerprint implements CurrentFileColle
     @Override
     public String getStrategyIdentifier() {
         return identifier;
+    }
+
+    @Override
+    public DirectorySensitivity getStrategyDirectorySensitivity() {
+        return directorySensitivity;
+    }
+
+    @Override
+    public LineEndingSensitivity getStrategyLineEndingSensitivity() {
+        return lineEndingSensitivity;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -18,9 +18,11 @@ package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMultimap;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
@@ -33,9 +35,13 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     private static final HashCode SIGNATURE = Hashing.signature(EmptyCurrentFileCollectionFingerprint.class);
 
     private final String identifier;
+    private final DirectorySensitivity directorySensitivity;
+    private final LineEndingSensitivity lineEndingSensitivity;
 
-    public EmptyCurrentFileCollectionFingerprint(String identifier) {
+    public EmptyCurrentFileCollectionFingerprint(String identifier, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity) {
         this.identifier = identifier;
+        this.directorySensitivity = directorySensitivity;
+        this.lineEndingSensitivity = lineEndingSensitivity;
     }
 
     @Override
@@ -71,6 +77,16 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     @Override
     public String getStrategyIdentifier() {
         return identifier;
+    }
+
+    @Override
+    public DirectorySensitivity getStrategyDirectorySensitivity() {
+        return directorySensitivity;
+    }
+
+    @Override
+    public LineEndingSensitivity getStrategyLineEndingSensitivity() {
+        return lineEndingSensitivity;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -45,7 +45,7 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public IgnoredPathFingerprintingStrategy(FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, DirectorySensitivity.DEFAULT, normalizedContentHasher);
+        super(IDENTIFIER, DirectorySensitivity.DEFAULT, normalizedContentHasher.getLineEndingSensitivity(), normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -43,7 +43,7 @@ public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrate
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public NameOnlyFingerprintingStrategy(DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher.getLineEndingSensitivity(), normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -45,7 +45,7 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public RelativePathFingerprintingStrategy(Interner<String> stringInterner, DirectorySensitivity directorySensitivity, FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, directorySensitivity, normalizedContentHasher);
+        super(IDENTIFIER, directorySensitivity, normalizedContentHasher.getLineEndingSensitivity(), normalizedContentHasher);
         this.stringInterner = stringInterner;
         this.normalizedContentHasher = normalizedContentHasher;
     }


### PR DESCRIPTION
- Expose DirectorySensitivity and LineEndingSensitivity to SnapshotTaskInputsBuildOperationResult
  - This is done by a lose Set<String>, built from the NormalizationStrategy, the DirectorySensitivity, the LineEndingSensitivity, in order to make the contract more stable for future changes
  We aggregate all those attributes in a single enum, declared by the build operation result, to ensure there are no duplicates coming from the various sources. Consumers (build scan plugin) have to know this logic to fetch the things they are interested in, from the aggregate enum
- Do not continue traversing empty directories when the sensitivity ignores directories
  - Return SKIP_SUBTREE when entering such a directory, to avoid pre/post-Visiting the directory
