### PR TITLE
Update SnapshotTaskInputsBuildOperationResult to convey new attributes, and do not visit empty directories when the strategy doesn't care

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -101,7 +101,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         result.actionClassLoaderHashes == null
         result.actionClassNames == null
         result.inputValueHashes == null
-        result.inputPropertiesLoadedByUnknownClassLoader == null
         result.outputPropertyNames == null
     }
 
@@ -122,7 +121,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         result.actionClassLoaderHashes != null
         result.actionClassNames != null
         result.inputValueHashes == null
-        result.inputPropertiesLoadedByUnknownClassLoader == null
         result.outputPropertyNames != null
     }
 
@@ -172,7 +170,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         result.actionClassLoaderHashes == null
         result.actionClassNames == null
         result.inputValueHashes == null
-        result.inputPropertiesLoadedByUnknownClassLoader == null
         result.outputPropertyNames == null
     }
 
@@ -207,7 +204,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         result.actionClassLoaderHashes == null
         result.actionClassNames == null
         result.inputValueHashes == null
-        result.inputPropertiesLoadedByUnknownClassLoader == null
         result.outputPropertyNames == null
     }
 
@@ -257,24 +253,24 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         with(aCompileJava.classpath) {
             hash != null
             roots.empty
-            normalization == "COMPILE_CLASSPATH"
+            attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava["options.sourcepath"] as Map<String, ?>) {
             hash != null
             roots.empty
-            normalization == "RELATIVE_PATH"
+            attributes == ['DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava["options.annotationProcessorPath"] as Map<String, ?>) {
             hash != null
             roots.empty
-            normalization == "CLASSPATH"
+            attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_CLASSPATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava.stableSources) {
             hash != null
-            normalization == "RELATIVE_PATH"
+            attributes == ['DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS']
             roots.size() == 1
             with(roots[0]) {
                 path == file("a/src/main/java").absolutePath
@@ -367,7 +363,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 path == file("inputFile").absolutePath
                 !containsKey("children")
             }
-            normalization == "RELATIVE_PATH"
+            attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
     }
 
@@ -399,7 +395,6 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         then:
         def result = operations.first(SnapshotTaskInputsBuildOperationType).result
         result.hash == null
-        result.inputPropertiesLoadedByUnknownClassLoader == null
         result.classLoaderHash == null
         result.actionClassLoaderHashes == null
         result.actionClassNames == null

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -225,6 +225,12 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 dir("empty") {
                     dir("empty")
                 }
+                dir("nonempty") {
+                    dir("nonempty") {
+                        dir("empty")
+                        file("Z.java") << "package nonempty.nonempty; class Z {}"
+                    }
+                }
             }
         }
 
@@ -277,7 +283,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
             roots.size() == 1
             with(roots[0]) {
                 path == file("a/src/main/java").absolutePath
-                children.size() == 3
+                children.size() == 4
                 with(children[0]) {
                     path == "a"
                     children.size() == 2
@@ -301,6 +307,21 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 with(children[2]) {
                     path == "B.java"
                     hash != null
+                }
+                with(children[3]) {
+                    path == "nonempty"
+                    hash == null
+                    children.size() == 1
+                    with(children[0]) {
+                        path == "nonempty"
+                        hash == null
+                        children.size() == 1
+                        with(children[0]) {
+                            path == "Z.java"
+                            hash != null
+                            children == null
+                        }
+                    }
                 }
             }
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -262,23 +262,27 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         with(aCompileJava.classpath) {
             hash != null
             roots.empty
+            normalization == "COMPILE_CLASSPATH"
             attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava["options.sourcepath"] as Map<String, ?>) {
             hash != null
             roots.empty
+            normalization == "RELATIVE_PATH"
             attributes == ['DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava["options.annotationProcessorPath"] as Map<String, ?>) {
             hash != null
             roots.empty
+            normalization == "CLASSPATH"
             attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_CLASSPATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
 
         with(aCompileJava.stableSources) {
             hash != null
+            normalization == "RELATIVE_PATH"
             attributes == ['DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS']
             roots.size() == 1
             with(roots[0]) {
@@ -400,6 +404,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         def aFoo = result.inputFileProperties
         with(aFoo.src) {
             hash != null
+            normalization == "ABSOLUTE_PATH"
             attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_ABSOLUTE_PATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
             roots.size() == 1
             with(roots[0]) {
@@ -465,6 +470,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
                 path == file("inputFile").absolutePath
                 !containsKey("children")
             }
+            normalization == "RELATIVE_PATH"
             attributes == ['DIRECTORY_SENSITIVITY_DEFAULT', 'FINGERPRINTING_STRATEGY_RELATIVE_PATH', 'LINE_ENDING_SENSITIVITY_DEFAULT']
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -61,9 +61,9 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.Iterator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -86,7 +86,7 @@ import java.util.stream.Collectors;
  */
 public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInputsBuildOperationType.Result, CustomOperationTraceSerialization {
 
-    static final String FINGERPRINTING_STRATEGY_PREFIX = "FINGERPRINTING_STRATEGY_";
+    private static final String FINGERPRINTING_STRATEGY_PREFIX = "FINGERPRINTING_STRATEGY_";
     private static final String DIRECTORY_SENSITIVITY_PREFIX = "DIRECTORY_SENSITIVITY_";
     private static final String LINE_ENDING_SENSITIVITY_PREFIX = "LINE_ENDING_SENSITIVITY_";
     private static final Map<Class<? extends FileNormalizer>, String> FINGERPRINTING_STRATEGIES_BY_NORMALIZER = ImmutableMap.<Class<? extends FileNormalizer>, String>builder()
@@ -195,6 +195,15 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         @Override
         public Set<String> getPropertyAttributes() {
             return propertyAttributesByPropertyName.get(propertyName).stream().map(Enum::name).sorted().collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        @Override
+        @SuppressWarnings("deprecation")
+        public String getPropertyNormalizationStrategyName() {
+            String prefix = SnapshotTaskInputsBuildOperationResult.FINGERPRINTING_STRATEGY_PREFIX;
+            return getPropertyAttributes().stream()
+                .filter(s -> s.startsWith(prefix)).findFirst().map(s -> s.substring(prefix.length()))
+                .orElseThrow(() -> new IllegalStateException("Missing attribute starting with prefix " + prefix));
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -148,11 +148,11 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         @Override
         public Set<String> getPropertyAttributes() {
             InputFilePropertySpec propertySpec = propertySpec(propertyName);
-            return ImmutableSortedSet.<String>naturalOrder()
-                .add(FilePropertyAttribute.fromNormalizerClass(propertySpec.getNormalizer()).name())
-                .add(FilePropertyAttribute.from(propertySpec.getDirectorySensitivity()).name())
-                .add(FilePropertyAttribute.from(propertySpec.getLineEndingNormalization()).name())
-                .build();
+            return ImmutableSortedSet.of(
+                FilePropertyAttribute.fromNormalizerClass(propertySpec.getNormalizer()).name(),
+                FilePropertyAttribute.from(propertySpec.getDirectorySensitivity()).name(),
+                FilePropertyAttribute.from(propertySpec.getLineEndingNormalization()).name()
+            );
         }
 
         @Override
@@ -337,7 +337,6 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
     }
 
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
     public Object getCustomOperationTraceSerializableModel() {
         Map<String, Object> model = new TreeMap<>();
 
@@ -401,16 +400,22 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
 
             class Property {
                 private final String hash;
+                private final String normalization;
                 private final Set<String> attributes;
                 private final List<Entry> roots = new ArrayList<>();
 
-                public Property(String hash, Set<String> attributes) {
+                public Property(String hash, String normalization, Set<String> attributes) {
                     this.hash = hash;
+                    this.normalization = normalization;
                     this.attributes = attributes;
                 }
 
                 public String getHash() {
                     return hash;
+                }
+
+                public String getNormalization() {
+                    return normalization;
                 }
 
                 public Set<String> getAttributes() {
@@ -460,9 +465,10 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
                 }
             }
 
+            @SuppressWarnings("deprecation")
             @Override
             public void preProperty(VisitState state) {
-                property = new Property(HashCode.fromBytes(state.getPropertyHashBytes()).toString(), state.getPropertyAttributes());
+                property = new Property(HashCode.fromBytes(state.getPropertyHashBytes()).toString(), state.getPropertyNormalizationStrategyName(), state.getPropertyAttributes());
                 fileProperties.put(state.getPropertyName(), property);
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -531,8 +531,10 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
     @UsedByScanPlugin("The value names are used as part of build scan data and cannot be changed - new values can be added")
     enum FilePropertyAttribute {
 
-        // note: when adding new values, be sure to indicate which Gradle version started emitting the attribute via comment.
+        // When adding new values, be sure to comment which Gradle version started emitting the attribute.
+        // Additionally, indicate any other relevant constraints with regard to other attributes or changes.
 
+        // Every property has exactly one of the following
         FINGERPRINTING_STRATEGY_ABSOLUTE_PATH,
         FINGERPRINTING_STRATEGY_NAME_ONLY,
         FINGERPRINTING_STRATEGY_RELATIVE_PATH,
@@ -540,9 +542,11 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         FINGERPRINTING_STRATEGY_CLASSPATH,
         FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH,
 
+        // Every property has exactly one of the following
         DIRECTORY_SENSITIVITY_DEFAULT,
         DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES,
 
+        // Every property has exactly one of the following
         LINE_ENDING_SENSITIVITY_DEFAULT,
         LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -49,6 +49,7 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.operations.trace.CustomOperationTraceSerialization;
+import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
@@ -114,6 +115,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         this.propertyAttributesByPropertyName = ImmutableMap.copyOf(propertyAttributesByPropertyName);
     }
 
+    @UsedByScanPlugin("The enum value names are transmitted to the GE Gradle Enterprise plugin")
     enum PropertyAttribute {
 
         FINGERPRINTING_STRATEGY_ABSOLUTE_PATH,
@@ -132,7 +134,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         static PropertyAttribute fromNormalizerClass(Class<? extends FileNormalizer> normalizerClass) {
             String fingerprintingStrategy = FINGERPRINTING_STRATEGIES_BY_NORMALIZER.get(normalizerClass);
             if (fingerprintingStrategy == null) {
-                throw new IllegalStateException("Could not find a fingerprinting strategy for normalizer " + normalizerClass.getSimpleName());
+                throw new IllegalStateException("Could not find a fingerprinting strategy for normalizer: " + normalizerClass.getSimpleName());
             }
             return PropertyAttribute.valueOf(FINGERPRINTING_STRATEGY_PREFIX + fingerprintingStrategy);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -149,9 +149,9 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         public Set<String> getPropertyAttributes() {
             InputFilePropertySpec propertySpec = propertySpec(propertyName);
             return ImmutableSortedSet.<String>naturalOrder()
-                .add(PropertyAttribute.fromNormalizerClass(propertySpec.getNormalizer()).name())
-                .add(PropertyAttribute.from(propertySpec.getDirectorySensitivity()).name())
-                .add(PropertyAttribute.from(propertySpec.getLineEndingNormalization()).name())
+                .add(FilePropertyAttribute.fromNormalizerClass(propertySpec.getNormalizer()).name())
+                .add(FilePropertyAttribute.from(propertySpec.getDirectorySensitivity()).name())
+                .add(FilePropertyAttribute.from(propertySpec.getLineEndingNormalization()).name())
                 .build();
         }
 
@@ -529,7 +529,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
     }
 
     @UsedByScanPlugin("The value names are used as part of build scan data and cannot be changed - new values can be added")
-    enum PropertyAttribute {
+    enum FilePropertyAttribute {
 
         // note: when adding new values, be sure to indicate which Gradle version started emitting the attribute via comment.
 
@@ -546,7 +546,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         LINE_ENDING_SENSITIVITY_DEFAULT,
         LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS;
 
-        private static final Map<Class<? extends FileNormalizer>, PropertyAttribute> BY_NORMALIZER_CLASS = ImmutableMap.<Class<? extends FileNormalizer>, PropertyAttribute>builder()
+        private static final Map<Class<? extends FileNormalizer>, FilePropertyAttribute> BY_NORMALIZER_CLASS = ImmutableMap.<Class<? extends FileNormalizer>, FilePropertyAttribute>builder()
             .put(ClasspathNormalizer.class, FINGERPRINTING_STRATEGY_CLASSPATH)
             .put(CompileClasspathNormalizer.class, FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH)
             .put(AbsolutePathInputNormalizer.class, FINGERPRINTING_STRATEGY_ABSOLUTE_PATH)
@@ -555,18 +555,18 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             .put(IgnoredPathInputNormalizer.class, FINGERPRINTING_STRATEGY_IGNORED_PATH)
             .build();
 
-        private static final Map<DirectorySensitivity, PropertyAttribute> BY_DIRECTORY_SENSITIVITY = Maps.immutableEnumMap(ImmutableMap.<DirectorySensitivity, PropertyAttribute>builder()
+        private static final Map<DirectorySensitivity, FilePropertyAttribute> BY_DIRECTORY_SENSITIVITY = Maps.immutableEnumMap(ImmutableMap.<DirectorySensitivity, FilePropertyAttribute>builder()
             .put(DirectorySensitivity.DEFAULT, DIRECTORY_SENSITIVITY_DEFAULT)
             .put(DirectorySensitivity.IGNORE_DIRECTORIES, DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES)
             .build());
 
-        private static final Map<LineEndingSensitivity, PropertyAttribute> BY_LINE_ENDING_SENSITIVITY = Maps.immutableEnumMap(ImmutableMap.<LineEndingSensitivity, PropertyAttribute>builder()
+        private static final Map<LineEndingSensitivity, FilePropertyAttribute> BY_LINE_ENDING_SENSITIVITY = Maps.immutableEnumMap(ImmutableMap.<LineEndingSensitivity, FilePropertyAttribute>builder()
             .put(LineEndingSensitivity.DEFAULT, LINE_ENDING_SENSITIVITY_DEFAULT)
             .put(LineEndingSensitivity.NORMALIZE_LINE_ENDINGS, LINE_ENDING_SENSITIVITY_NORMALIZE_LINE_ENDINGS)
             .build());
 
-        private static <T> PropertyAttribute findFor(T value, Map<T, PropertyAttribute> mapping) {
-            PropertyAttribute attribute = mapping.get(value);
+        private static <T> FilePropertyAttribute findFor(T value, Map<T, FilePropertyAttribute> mapping) {
+            FilePropertyAttribute attribute = mapping.get(value);
             if (attribute == null) {
                 throw new IllegalStateException("Did not find property attribute mapping for '" + value + "' (from: " + mapping.keySet() + ")");
             }
@@ -574,15 +574,15 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             return attribute;
         }
 
-        static PropertyAttribute fromNormalizerClass(Class<? extends FileNormalizer> normalizerClass) {
+        static FilePropertyAttribute fromNormalizerClass(Class<? extends FileNormalizer> normalizerClass) {
             return findFor(normalizerClass, BY_NORMALIZER_CLASS);
         }
 
-        static PropertyAttribute from(DirectorySensitivity directorySensitivity) {
+        static FilePropertyAttribute from(DirectorySensitivity directorySensitivity) {
             return findFor(directorySensitivity, BY_DIRECTORY_SENSITIVITY);
         }
 
-        static PropertyAttribute from(LineEndingSensitivity lineEndingSensitivity) {
+        static FilePropertyAttribute from(LineEndingSensitivity lineEndingSensitivity) {
             return findFor(lineEndingSensitivity, BY_LINE_ENDING_SENSITIVITY);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -156,7 +156,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
         }
 
         @Override
-        @SuppressWarnings({"deprecation", "RedundantSuppression"})
+        @Deprecated
         public String getPropertyNormalizationStrategyName() {
             InputFilePropertySpec propertySpec = propertySpec(propertyName);
             Class<? extends FileNormalizer> normalizer = propertySpec.getNormalizer();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -172,12 +172,7 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
              * @deprecated Use {@link #getPropertyAttributes()} instead.
              */
             @Deprecated
-            default String getPropertyNormalizationStrategyName() {
-                String prefix = SnapshotTaskInputsBuildOperationResult.FINGERPRINTING_STRATEGY_PREFIX;
-                return getPropertyAttributes().stream()
-                    .filter(s -> s.startsWith(prefix)).findFirst().map(s -> s.substring(prefix.length()))
-                    .orElseThrow(() -> new IllegalStateException("Missing attribute starting with prefix " + prefix));
-            }
+            String getPropertyNormalizationStrategyName();
 
             /**
              * Returns a lexicographically sorted set of attributes for the currently visited location.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -43,8 +43,7 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
 
     @UsedByScanPlugin
     public interface Details {
-        SnapshotTaskInputsBuildOperationType.Details INSTANCE = new SnapshotTaskInputsBuildOperationType.Details() {
-        };
+        SnapshotTaskInputsBuildOperationType.Details INSTANCE = new SnapshotTaskInputsBuildOperationType.Details() {};
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -16,6 +16,12 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute;
+import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.IgnoredPathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.NameOnlyFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.RelativePathFingerprintingStrategy;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -164,20 +170,35 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             byte[] getPropertyHashBytes();
 
             /**
-             * Returns the single {@link #getPropertyAttributes()} with the "FINGERPRINTING_STRATEGY_" prefix for the currently visited location.
-             * <p>
+             * The “primary” attribute of the current properfy.
              *
-             * This is kept for backward compatibility with the Gradle Enterprise Gradle plugin.
+             * Used by Gradle Enterprise plugin <= 3.4, retained for backwards compatibility.
              *
-             * @deprecated Use {@link #getPropertyAttributes()} instead.
+             * Returns the name value of one of:
+             *
+             * <li>{@link FingerprintingStrategy#CLASSPATH_IDENTIFIER}</li>
+             * <li>{@link FingerprintingStrategy#COMPILE_CLASSPATH_IDENTIFIER}</li>
+             * <li>{@link AbsolutePathFingerprintingStrategy#IDENTIFIER}</li>
+             * <li>{@link RelativePathFingerprintingStrategy#IDENTIFIER}</li>
+             * <li>{@link NameOnlyFingerprintingStrategy#IDENTIFIER}</li>
+             * <li>{@link IgnoredPathFingerprintingStrategy#IDENTIFIER}</li>
+             *
+             * @deprecated since 7.3, superseded by {@link #getPropertyAttributes()}
              */
             @Deprecated
             String getPropertyNormalizationStrategyName();
 
             /**
-             * Returns a lexicographically sorted set of attributes for the currently visited location.
-             * <p>
-             * For now, attributes are the 'fingerprinting strategy', the 'directory sensitivity', and the 'line ending sensitivity'.
+             * A description of how the current property was fingerprinted.
+             *
+             * Returns one or more of the values of {@link PropertyAttribute}, sorted.
+             *
+             * This interface does not constrain the compatibility of values.
+             * In practice however, such constraints do exist but are managed informally.
+             * For example, consumers can assume that both {@link PropertyAttribute#DIRECTORY_SENSITIVITY_DEFAULT}
+             * and {@link PropertyAttribute#DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES} will not be present.
+             * This loose approach is used to allow the various types of normalization supported by Gradle to evolve,
+             * and their usage to be conveyed here without changing this interface.
              *
              * @since 7.3
              */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -170,9 +170,9 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             byte[] getPropertyHashBytes();
 
             /**
-             * The “primary” attribute of the current properfy.
+             * The “primary” attribute of the current property.
              *
-             * Used by Gradle Enterprise plugin <= 3.4, retained for backwards compatibility.
+             * Used by Gradle Enterprise plugin < 3.8, retained for backwards compatibility.
              *
              * Returns the name value of one of:
              *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
-import org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute;
+import org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
 import org.gradle.internal.fingerprint.impl.IgnoredPathFingerprintingStrategy;
@@ -191,12 +191,12 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
             /**
              * A description of how the current property was fingerprinted.
              *
-             * Returns one or more of the values of {@link PropertyAttribute}, sorted.
+             * Returns one or more of the values of {@link FilePropertyAttribute}, sorted.
              *
              * This interface does not constrain the compatibility of values.
              * In practice however, such constraints do exist but are managed informally.
-             * For example, consumers can assume that both {@link PropertyAttribute#DIRECTORY_SENSITIVITY_DEFAULT}
-             * and {@link PropertyAttribute#DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES} will not be present.
+             * For example, consumers can assume that both {@link FilePropertyAttribute#DIRECTORY_SENSITIVITY_DEFAULT}
+             * and {@link FilePropertyAttribute#DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES} will not be present.
              * This loose approach is used to allow the various types of normalization supported by Gradle to evolve,
              * and their usage to be conveyed here without changing this interface.
              *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -85,6 +85,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -454,14 +455,14 @@ public class TaskExecution implements UnitOfWork {
     @Override
     public void markLegacySnapshottingInputsFinished(CachingState cachingState) {
         context.removeSnapshotTaskInputsBuildOperationContext()
-            .ifPresent(operation -> operation.setResult(new SnapshotTaskInputsBuildOperationResult(cachingState)));
+            .ifPresent(operation -> operation.setResult(new SnapshotTaskInputsBuildOperationResult(cachingState, context.getTaskProperties().getInputFileProperties())));
     }
 
     @Override
     public void ensureLegacySnapshottingInputsClosed() {
         // If the operation hasn't finished normally (because of a shortcut or an error), we close it without a cache key
         context.removeSnapshotTaskInputsBuildOperationContext()
-            .ifPresent(operation -> operation.setResult(new SnapshotTaskInputsBuildOperationResult(CachingState.NOT_DETERMINED)));
+            .ifPresent(operation -> operation.setResult(new SnapshotTaskInputsBuildOperationResult(CachingState.NOT_DETERMINED, Collections.emptySet())));
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -56,7 +56,14 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Specification
 
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.*
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_ABSOLUTE_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_CLASSPATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_IGNORED_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_NAME_ONLY
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_RELATIVE_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.from
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.fromNormalizerClass
 import static org.gradle.internal.fingerprint.DirectorySensitivity.DEFAULT
 import static org.gradle.internal.fingerprint.DirectorySensitivity.IGNORE_DIRECTORIES
 import static org.gradle.internal.fingerprint.LineEndingSensitivity.NORMALIZE_LINE_ENDINGS
@@ -99,7 +106,6 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
 
         then:
         def t = thrown(IllegalStateException)
-        t.message == 'Could not find a fingerprinting strategy for normalizer: OutputNormalizer'
     }
 
     @Requires(TestPrecondition.NOT_WINDOWS)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -56,14 +56,14 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Specification
 
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_ABSOLUTE_PATH
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_CLASSPATH
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_IGNORED_PATH
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_NAME_ONLY
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.FINGERPRINTING_STRATEGY_RELATIVE_PATH
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.from
-import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.fromNormalizerClass
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_ABSOLUTE_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_CLASSPATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_IGNORED_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_NAME_ONLY
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.FINGERPRINTING_STRATEGY_RELATIVE_PATH
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.from
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute.fromNormalizerClass
 import static org.gradle.internal.fingerprint.DirectorySensitivity.DEFAULT
 import static org.gradle.internal.fingerprint.DirectorySensitivity.IGNORE_DIRECTORIES
 import static org.gradle.internal.fingerprint.LineEndingSensitivity.NORMALIZE_LINE_ENDINGS
@@ -86,7 +86,7 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         directorySensitivity << DirectorySensitivity.values()
     }
 
-    def "can convert normalizer class into a PropertyAttribute"(Class<? extends FileNormalizer> normalizerClass, SnapshotTaskInputsBuildOperationResult.PropertyAttribute expectedPropertyAttribute) {
+    def "can convert normalizer class into a PropertyAttribute"(Class<? extends FileNormalizer> normalizerClass, SnapshotTaskInputsBuildOperationResult.FilePropertyAttribute expectedPropertyAttribute) {
         expect:
         fromNormalizerClass(normalizerClass) == expectedPropertyAttribute
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -52,6 +52,8 @@ import org.gradle.internal.fingerprint.RelativePathInputNormalizer
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.TestSnapshotFixture
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import spock.lang.Specification
 
 import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.*
@@ -100,6 +102,7 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         t.message == 'Could not find a fingerprinting strategy for normalizer: OutputNormalizer'
     }
 
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "properly visits structure when ignoring directories"() {
         given:
         def visitor = Mock(SnapshotTaskInputsBuildOperationType.Result.InputFilePropertyVisitor)
@@ -164,6 +167,7 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         0 * visitor._
     }
 
+    @Requires(TestPrecondition.NOT_WINDOWS)
     def "properly visits structure when not ignoring directories"() {
         given:
         def visitor = Mock(SnapshotTaskInputsBuildOperationType.Result.InputFilePropertyVisitor)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -65,7 +65,7 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
 
     def "can convert line ending sensitivity into a PropertyAttribute"(LineEndingSensitivity lineEndingSensitivity) {
         expect:
-        fromLineEndingSensitivity(lineEndingSensitivity)
+        from(lineEndingSensitivity)
 
         where:
         lineEndingSensitivity << LineEndingSensitivity.values()
@@ -73,7 +73,7 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
 
     def "can convert directory sensitivity into a PropertyAttribute"(DirectorySensitivity directorySensitivity) {
         expect:
-        fromDirectorySensitivity(directorySensitivity)
+        from(directorySensitivity)
 
         where:
         directorySensitivity << DirectorySensitivity.values()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks
+
+import org.gradle.api.tasks.ClasspathNormalizer
+import org.gradle.api.tasks.CompileClasspathNormalizer
+import org.gradle.api.tasks.FileNormalizer
+import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
+import org.gradle.internal.fingerprint.DirectorySensitivity
+import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer
+import org.gradle.internal.fingerprint.LineEndingSensitivity
+import org.gradle.internal.fingerprint.NameOnlyInputNormalizer
+import org.gradle.internal.fingerprint.OutputNormalizer
+import org.gradle.internal.fingerprint.RelativePathInputNormalizer
+import org.gradle.internal.snapshot.TestSnapshotFixture
+import spock.lang.Specification
+
+import static org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationResult.PropertyAttribute.*
+
+class SnapshotTaskInputsBuildOperationResultTest extends Specification implements TestSnapshotFixture {
+
+    def "can convert line ending sensitivity into a PropertyAttribute"(LineEndingSensitivity lineEndingSensitivity) {
+        expect:
+        fromLineEndingSensitivity(lineEndingSensitivity)
+
+        where:
+        lineEndingSensitivity << LineEndingSensitivity.values()
+    }
+
+    def "can convert directory sensitivity into a PropertyAttribute"(DirectorySensitivity directorySensitivity) {
+        expect:
+        fromDirectorySensitivity(directorySensitivity)
+
+        where:
+        directorySensitivity << DirectorySensitivity.values()
+    }
+
+    def "can convert normalizer class into a PropertyAttribute"(Class<? extends FileNormalizer> normalizerClass, SnapshotTaskInputsBuildOperationResult.PropertyAttribute expectedPropertyAttribute) {
+        expect:
+        fromNormalizerClass(normalizerClass) == expectedPropertyAttribute
+
+        where:
+        normalizerClass             | expectedPropertyAttribute
+        ClasspathNormalizer         | FINGERPRINTING_STRATEGY_CLASSPATH
+        CompileClasspathNormalizer  | FINGERPRINTING_STRATEGY_COMPILE_CLASSPATH
+        AbsolutePathInputNormalizer | FINGERPRINTING_STRATEGY_ABSOLUTE_PATH
+        RelativePathInputNormalizer | FINGERPRINTING_STRATEGY_RELATIVE_PATH
+        NameOnlyInputNormalizer     | FINGERPRINTING_STRATEGY_NAME_ONLY
+        IgnoredPathInputNormalizer  | FINGERPRINTING_STRATEGY_IGNORED_PATH
+    }
+
+    def "throws when converting an unsupported normalizer class into a PropertyAttribute"() {
+        when:
+        fromNormalizerClass(OutputNormalizer)
+
+        then:
+        def t = thrown(IllegalStateException)
+        t.message == 'Could not find a fingerprinting strategy for normalizer: OutputNormalizer'
+    }
+
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -41,9 +41,6 @@ public interface FingerprintingStrategy {
      */
     FingerprintHashingStrategy getHashingStrategy();
 
-    /**
-     * Names are expected as part of org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType.Result.VisitState.getPropertyNormalizationStrategyName().
-     */
     String getIdentifier();
 
     CurrentFileCollectionFingerprint getEmptyFingerprint();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -42,7 +42,6 @@ public interface FingerprintingStrategy {
     FingerprintHashingStrategy getHashingStrategy();
 
     /**
-     * UsedByScansPlugin
      * Names are expected as part of org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType.Result.VisitState.getPropertyNormalizationStrategyName().
      */
     String getIdentifier();


### PR DESCRIPTION
This supersedes #18270

- Expose DirectorySensitivity and LineEndingSensitivity to SnapshotTaskInputsBuildOperationResult from the task input prop spec
This is done by a lose Set, built from the NormalizationStrategy, the DirectorySensitivity, the LineEndingSensitivity, in order to make the contract more stable for future changes
We aggregate all those attributes in a single enum, declared by the build operation result, to ensure there are no duplicates coming from the various sources. Consumers (build scan plugin) have to know this logic to fetch the things they are interested in, from the aggregate enum

- Do not continue call pre/postDirectory visitor callbacks when we don't have fingerprints for directories (meaning the used strategy doesn't care).
  Keep them in a pending list and apply them in proper order if we eventually have sth in the directory structure