### PR TITLE
Use consistent failure conditions for build stages

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -161,8 +161,8 @@ fun Dependencies.compileAllDependency(compileAllId: String) {
     // Compile All has to succeed before anything else is started
     dependency(RelativeId(compileAllId)) {
         snapshot {
-            onDependencyFailure = FailureAction.CANCEL
-            onDependencyCancel = FailureAction.CANCEL
+            onDependencyFailure = FailureAction.FAIL_TO_START
+            onDependencyCancel = FailureAction.FAIL_TO_START
         }
     }
     // Get the build receipt from sanity check to reuse the timestamp

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -217,8 +217,8 @@ fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, notQuick
         buildType.dependencies {
             dependency(RelativeId(stageTriggerId(model, StageNames.QUICK_FEEDBACK_LINUX_ONLY))) {
                 snapshot {
-                    onDependencyFailure = FailureAction.CANCEL
-                    onDependencyCancel = FailureAction.CANCEL
+                    onDependencyFailure = FailureAction.FAIL_TO_START
+                    onDependencyCancel = FailureAction.FAIL_TO_START
                 }
             }
         }

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -60,7 +60,8 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, stagePro
         if (!stage.runsIndependent && prevStage != null) {
             dependency(RelativeId(stageTriggerId(model, prevStage))) {
                 snapshot {
-                    onDependencyFailure = FailureAction.ADD_PROBLEM
+                    onDependencyFailure = FailureAction.FAIL_TO_START
+                    onDependencyCancel = FailureAction.FAIL_TO_START
                 }
             }
         }
@@ -82,6 +83,9 @@ fun <T : BaseGradleBuildType> Dependencies.snapshotDependencies(buildTypes: Iter
                 if (!buildType.failStage) {
                     onDependencyFailure = FailureAction.IGNORE
                     onDependencyCancel = FailureAction.IGNORE
+                } else {
+                    onDependencyFailure = FailureAction.ADD_PROBLEM
+                    onDependencyCancel = FailureAction.ADD_PROBLEM
                 }
                 snapshotConfig(buildType)
             }

--- a/.teamcity/src/main/kotlin/configurations/StagePasses.kt
+++ b/.teamcity/src/main/kotlin/configurations/StagePasses.kt
@@ -85,7 +85,7 @@ fun <T : BaseGradleBuildType> Dependencies.snapshotDependencies(buildTypes: Iter
                     onDependencyCancel = FailureAction.IGNORE
                 } else {
                     onDependencyFailure = FailureAction.ADD_PROBLEM
-                    onDependencyCancel = FailureAction.ADD_PROBLEM
+                    onDependencyCancel = FailureAction.FAIL_TO_START
                 }
                 snapshotConfig(buildType)
             }

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -151,8 +151,8 @@ private fun FunctionalTestProject.addDependencyForAllBuildTypes(dependency: IdOw
         functionalTestBuildType.dependencies {
             dependency(dependency) {
                 snapshot {
-                    onDependencyFailure = FailureAction.CANCEL
-                    onDependencyCancel = FailureAction.CANCEL
+                    onDependencyFailure = FailureAction.FAIL_TO_START
+                    onDependencyCancel = FailureAction.FAIL_TO_START
                 }
             }
         }


### PR DESCRIPTION
The idea is that when a build in a stage fails, then the stage fails as well
(add a problem). And a stage fails which is a dependency of the current stage,
then the stage failed to start. For composited builds which group a test
coverage, those should also fail (add a problem), when one of their build fails.
If a dependency of an actual build (not-composite) fails, then the build also
failed to start.

Finally, when a dependency of any build failed to start, the current build
failed to start.