### PR TITLE
Update TD plugin to released version 2.2

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.6.4")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.1.1") // Sync with `settings.gradle.kts`
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.19.1")
         api("com.gradle.publish:plugin-publish-plugin:0.14.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("com.gradle.enterprise").version("3.6.4")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
-    id("com.gradle.enterprise.test-distribution").version("2.1.1") // Sync with `build-logic/build-platform/build.gradle.kts`
+    id("com.gradle.enterprise.test-distribution").version("2.2") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("gradlebuild.internal.testfiltering")
     id("com.gradle.internal.test-selection").version("0.6.4-rc-1")
 }


### PR DESCRIPTION
See title.

Verify and merge only when `ge.gradle.org` is updated to 2021.3.