### PR TITLE
Capture project input normalization rules in configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedProjectState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CachedProjectState.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.configurationcache.serialization.DefaultReadContext
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal
+import java.lang.IllegalArgumentException
+
+
+/**
+ * The configuration data of the project stored in the configuration cache.
+ */
+internal
+class CachedProjectState(
+    private val path: String,
+    private val normalizationState: InputNormalizationHandlerInternal.CachedState
+) {
+    companion object {
+        fun DefaultReadContext.configureProjectFromCachedState(state: CachedProjectState) {
+            val project = getProject(state.path)
+            state.apply {
+                project.normalization.configureFromCachedState(normalizationState)
+            }
+        }
+
+        fun Project.computeCachedState(): CachedProjectState? {
+            if (this !is ProjectInternal) {
+                throw IllegalArgumentException("Cannot compute cached state for project '$path'")
+            }
+            val normalizationState = normalization.computeCachedState() ?: return null
+            return CachedProjectState(path, normalizationState)
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -85,6 +85,7 @@ import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.registry.ModelRegistry
 import org.gradle.normalization.InputNormalizationHandler
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import org.gradle.process.JavaExecSpec
@@ -715,7 +716,7 @@ class ProblemReportingCrossProjectModelAccess(
             return delegate.components
         }
 
-        override fun getNormalization(): InputNormalizationHandler {
+        override fun getNormalization(): InputNormalizationHandlerInternal {
             onAccess()
             return delegate.normalization
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.normalization
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
@@ -29,8 +28,6 @@ import java.util.jar.Manifest
 
 @Unroll
 class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractIntegrationSpec {
-
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore files on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withFilesIgnored()
 
@@ -85,7 +82,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'nested in dir jars' | 'ignoredResourceInNestedInDirJar' | 'notIgnoredResourceInNestedInDirJar' | Api.ANNOTATION
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore manifest attributes in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestAttributesIgnored()
@@ -113,7 +109,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore entire manifest in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestIgnored()
@@ -141,7 +136,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Unroll
     def "can ignore all meta-inf files in #tree on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withAllMetaInfIgnored()
@@ -170,7 +164,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'directory' | 'manifestInDirectory'
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore manifest properties on runtime classpath"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME).withManifestPropertiesIgnored()
 
@@ -191,7 +184,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         skipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can configure ignore rules per project (using runtime API: #api)"() {
         def projectWithIgnores = new ProjectWithRuntimeClasspathNormalization('a', api).withFilesIgnored()
         def projectWithoutIgnores = new ProjectWithRuntimeClasspathNormalization('b', api)
@@ -247,7 +239,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'ignore property'           | "properties { ignoreProperty 'timestamp' }"               | Api.ANNOTATION
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties on runtime classpath in #tree (using runtime API: #api)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(api).withPropertiesIgnored()
 
@@ -287,7 +278,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         'nested in dir jars' | 'propertiesFileInNestedInDirJar' | Api.ANNOTATION
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties in selected files"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME_TOO): 'this should not actually be ignored'])
@@ -324,7 +314,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can ignore properties in selected files defined in multiple rules"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME_TOO): 'this should not actually be ignored'])
@@ -409,7 +398,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     def "can add rules to the default properties rule"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
         def notIgnoredPropertiesFile = new PropertiesResource(project.root.file('classpath/dirEntry/bar.properties'), [(IGNORE_ME): 'this should not actually be ignored'])
@@ -472,7 +460,6 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         executedAndNotSkipped(project.customTask)
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization - see https://github.com/gradle/gradle/issues/13706")
     @Issue('https://github.com/gradle/gradle/issues/16144')
     def "changing normalization configuration rules changes build cache key (#description)"() {
         def project = new ProjectWithRuntimeClasspathNormalization(Api.RUNTIME)
@@ -483,7 +470,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         project.buildFile << """
             normalization {
                 runtimeClasspath {
-                    if (project.hasProperty('${enableFilterFlag}')) {
+                    if (providers.gradleProperty('${enableFilterFlag}').forUseAtConfigurationTime().present) {
                         ${normalizationRule}
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -121,6 +121,7 @@ import org.gradle.model.internal.manage.schema.ModelSchemaStore;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.type.ModelType;
 import org.gradle.normalization.InputNormalizationHandler;
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.process.ExecResult;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
@@ -1403,7 +1404,7 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Inject
     @Override
-    public abstract InputNormalizationHandler getNormalization();
+    public abstract InputNormalizationHandlerInternal getNormalization();
 
     @Override
     public void normalization(Action<? super InputNormalizationHandler> configuration) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -45,6 +45,7 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.ServiceRegistryFactory;
 import org.gradle.model.internal.registry.ModelRegistry;
 import org.gradle.model.internal.registry.ModelRegistryScope;
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 import org.gradle.util.Path;
 
 import javax.annotation.Nullable;
@@ -169,6 +170,9 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
      * Returns the {@link ProjectState} that manages the state of this instance.
      */
     ProjectState getOwner();
+
+    @Override
+    InputNormalizationHandlerInternal getNormalization();
 
     @Override
     ScriptHandlerInternal getBuildscript();

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultInputNormalizationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/DefaultInputNormalizationHandler.java
@@ -35,4 +35,31 @@ public class DefaultInputNormalizationHandler implements InputNormalizationHandl
     public void runtimeClasspath(Action<? super RuntimeClasspathNormalization> configuration) {
         configuration.execute(getRuntimeClasspath());
     }
+
+    @Override
+    public CachedState computeCachedState() {
+        RuntimeClasspathNormalizationInternal.CachedState runtimeClasspathState = runtimeClasspathNormalization.computeCachedState();
+        if (runtimeClasspathState == null) {
+            return null;
+        }
+        return new DefaultCachedState(runtimeClasspathState);
+    }
+
+    @Override
+    public void configureFromCachedState(CachedState state) {
+        runtimeClasspathNormalization.configureFromCachedState(state.getRuntimeClasspathState());
+    }
+
+    private static class DefaultCachedState implements CachedState {
+        private final RuntimeClasspathNormalizationInternal.CachedState runtimeClasspathState;
+
+        public DefaultCachedState(RuntimeClasspathNormalizationInternal.CachedState runtimeClasspathState) {
+            this.runtimeClasspathState = runtimeClasspathState;
+        }
+
+        @Override
+        public RuntimeClasspathNormalizationInternal.CachedState getRuntimeClasspathState() {
+            return runtimeClasspathState;
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/InputNormalizationHandlerInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/InputNormalizationHandlerInternal.java
@@ -18,7 +18,33 @@ package org.gradle.normalization.internal;
 
 import org.gradle.normalization.InputNormalizationHandler;
 
+import javax.annotation.Nullable;
+
 public interface InputNormalizationHandlerInternal extends InputNormalizationHandler {
     @Override
     RuntimeClasspathNormalizationInternal getRuntimeClasspath();
+
+    /**
+     * Returns the configuration of input normalization in a configuration-cache friendly form.
+     * Input normalization cannot be further configured after this call.
+     *
+     * @return the configuration of input normalization or {@code null} if there is no user-defined state.
+     */
+    @Nullable
+    CachedState computeCachedState();
+
+    /**
+     * Configures input normalization from cached state data.
+     */
+    void configureFromCachedState(CachedState state);
+
+    /**
+     * The opaque representation of the input normalization state, intended to be serialized in the configuration cache.
+     */
+    interface CachedState {
+        /**
+         * @return the configuration of runtime classpath normalization
+         */
+        RuntimeClasspathNormalizationInternal.CachedState getRuntimeClasspathState();
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/normalization/internal/RuntimeClasspathNormalizationInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/normalization/internal/RuntimeClasspathNormalizationInternal.java
@@ -20,12 +20,33 @@ import org.gradle.api.internal.changedetection.state.ResourceEntryFilter;
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.normalization.RuntimeClasspathNormalization;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public interface RuntimeClasspathNormalizationInternal extends RuntimeClasspathNormalization {
-     ResourceFilter getClasspathResourceFilter();
+    ResourceFilter getClasspathResourceFilter();
 
-     ResourceEntryFilter getManifestAttributeResourceEntryFilter();
+    ResourceEntryFilter getManifestAttributeResourceEntryFilter();
 
-     Map<String, ResourceEntryFilter> getPropertiesFileFilters();
+    Map<String, ResourceEntryFilter> getPropertiesFileFilters();
+
+    /**
+     * Returns the configuration of runtime classpath normalization in a configuration-cache friendly form.
+     * The normalization cannot be further configured after this call.
+     *
+     * @return the configuration of input normalization or {@code null} if there is no user-defined state.
+     */
+    @Nullable
+    CachedState computeCachedState();
+
+    /**
+     * Configures input normalization from cached state data.
+     */
+    void configureFromCachedState(CachedState state);
+
+    /**
+     * The opaque representation of the runtime classpath normalization state, intended to be serialized in the configuration cache.
+     */
+    interface CachedState {
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -92,7 +92,7 @@ import org.gradle.internal.service.scopes.ServiceRegistryFactory
 import org.gradle.model.internal.manage.instance.ManagedProxyFactory
 import org.gradle.model.internal.manage.schema.ModelSchemaStore
 import org.gradle.model.internal.registry.ModelRegistry
-import org.gradle.normalization.InputNormalizationHandler
+import org.gradle.normalization.internal.InputNormalizationHandlerInternal
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Path
 import org.gradle.util.TestClosure
@@ -147,7 +147,7 @@ class DefaultProjectTest extends Specification {
     LoggingManagerInternal loggingManagerMock = Stub(LoggingManagerInternal)
     Instantiator instantiatorMock = Stub(Instantiator)
     SoftwareComponentContainer softwareComponentsMock = Stub(SoftwareComponentContainer)
-    InputNormalizationHandler inputNormalizationHandler = Stub(InputNormalizationHandler)
+    InputNormalizationHandlerInternal inputNormalizationHandler = Stub(InputNormalizationHandlerInternal)
     ProjectConfigurationActionContainer configureActions = Stub(ProjectConfigurationActionContainer)
     PluginManagerInternal pluginManager = Stub(PluginManagerInternal)
     PluginContainer pluginContainer = Stub(PluginContainer)
@@ -195,7 +195,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) ComponentMetadataHandler) >> moduleHandlerMock
         serviceRegistryMock.get((Type) ConfigurationTargetIdentifier) >> configurationTargetIdentifier
         serviceRegistryMock.get((Type) SoftwareComponentContainer) >> softwareComponentsMock
-        serviceRegistryMock.get((Type) InputNormalizationHandler) >> inputNormalizationHandler
+        serviceRegistryMock.get((Type) InputNormalizationHandlerInternal) >> inputNormalizationHandler
         serviceRegistryMock.get(ProjectEvaluator) >> projectEvaluator
         serviceRegistryMock.getFactory(AntBuilder) >> antBuilderFactoryMock
         serviceRegistryMock.get((Type) ScriptHandlerInternal) >> scriptHandlerMock

--- a/subprojects/core/src/test/groovy/org/gradle/normalization/internal/DefaultRuntimeClasspathNormalizationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/normalization/internal/DefaultRuntimeClasspathNormalizationTest.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.normalization.internal
+
+import org.gradle.api.GradleException
+import org.gradle.api.internal.changedetection.state.PropertiesFileFilter
+import spock.lang.Specification
+
+import java.util.function.Supplier
+
+class DefaultRuntimeClasspathNormalizationTest extends Specification {
+    def "default normalization has no cached state"() {
+        when:
+        def normalization = new DefaultRuntimeClasspathNormalization()
+        then:
+        normalization.computeCachedState() == null
+    }
+
+    def "file ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.ignore(ignoredPattern)
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        restoredNormalization.classpathResourceFilter.shouldBeIgnored(ignoredFilePathSegments)
+        !restoredNormalization.classpathResourceFilter.shouldBeIgnored(asPathFactory("notIgnored.file"))
+
+        where:
+        ignoredPattern | ignoredFilePathSegments
+        "some.file"    | asPathFactory("some.file")
+        "**/some.*"    | asPathFactory("dir", "some.file")
+    }
+
+    def "property ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.properties {
+            it.ignoreProperty("ignored.in.all")
+        }
+        originalNormalization.properties("some.properties") {
+            it.ignoreProperty("ignored.in.some")
+        }
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        restoredNormalization.getPropertiesFileFilters()[PropertiesFileFilter.ALL_PROPERTIES].shouldBeIgnored("ignored.in.all")
+        !restoredNormalization.getPropertiesFileFilters()[PropertiesFileFilter.ALL_PROPERTIES].shouldBeIgnored("not.ignored")
+        restoredNormalization.getPropertiesFileFilters()["some.properties"].shouldBeIgnored("ignored.in.some")
+        !restoredNormalization.getPropertiesFileFilters()["some.properties"].shouldBeIgnored("not.ignored")
+    }
+
+    def "metainf complete ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.metaInf {
+            it.ignoreCompletely()
+        }
+
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        restoredNormalization.classpathResourceFilter.shouldBeIgnored(asPathFactory("META-INF", "some.resource"))
+    }
+
+    def "metainf manifest ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.metaInf {
+            it.ignoreManifest()
+        }
+
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        !restoredNormalization.classpathResourceFilter.shouldBeIgnored(asPathFactory("META-INF", "some.resource"))
+        restoredNormalization.classpathResourceFilter.shouldBeIgnored(asPathFactory("META-INF", "MANIFEST.MF"))
+    }
+
+    def "metainf manifest attributes ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.metaInf {
+            it.ignoreAttribute("Ignored-Attribute")
+        }
+
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        // All clients of ResourceEntryFilter are expected to convert an attribute name to lowercase
+        !restoredNormalization.manifestAttributeResourceEntryFilter.shouldBeIgnored("non-ignored-attribute")
+        restoredNormalization.manifestAttributeResourceEntryFilter.shouldBeIgnored("ignored-attribute")
+    }
+
+    def "metainf ignores can be restored from the cached state"() {
+        given:
+        def originalNormalization = new DefaultRuntimeClasspathNormalization()
+        originalNormalization.metaInf {
+            it.ignoreProperty("ignored.property")
+        }
+
+
+        when:
+        def restoredNormalization = new DefaultRuntimeClasspathNormalization()
+        restoredNormalization.configureFromCachedState(originalNormalization.computeCachedState())
+
+        then:
+        restoredNormalization.propertiesFileFilters["META-INF/**/*.properties"].shouldBeIgnored("ignored.property")
+        !restoredNormalization.propertiesFileFilters["META-INF/**/*.properties"].shouldBeIgnored("non.ignored.property")
+        !restoredNormalization.getPropertiesFileFilters()[PropertiesFileFilter.ALL_PROPERTIES].shouldBeIgnored("ignored.property")
+    }
+
+    def "exception is thrown if ignore added after caching"() {
+        given:
+        def normalization = new DefaultRuntimeClasspathNormalization()
+
+        when:
+        normalization.computeCachedState()
+        normalization.ignore("some.file")
+
+        then:
+        thrown(GradleException.class)
+    }
+
+    def "exception is thrown if property ignore added after caching"() {
+        given:
+        def normalization = new DefaultRuntimeClasspathNormalization()
+
+        when:
+        normalization.computeCachedState()
+        normalization.properties {
+            it.ignoreProperty("some.property")
+        }
+
+        then:
+        thrown(IllegalStateException.class)
+    }
+
+    def "exception is thrown if manifest attribute ignore added after caching"() {
+        given:
+        def normalization = new DefaultRuntimeClasspathNormalization()
+
+        when:
+        normalization.computeCachedState()
+        normalization.metaInf {
+            it.ignoreAttribute("Some-Attribute")
+        }
+
+        then:
+        thrown(GradleException.class)
+    }
+
+    private static Supplier<String[]> asPathFactory(String... segments) {
+        return () -> segments
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 import java.util.regex.Pattern
@@ -1208,7 +1207,6 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         annotation << ["Classpath", "CompileClasspath"]
     }
 
-    @ToBeFixedForConfigurationCache(because = "classpath normalization configuration is not serialized")
     def "honors runtime classpath normalization for input artifact"() {
         settingsFile << "include 'a', 'b', 'c'"
         setupBuildWithColorTransformAction {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildCrossVersionTestConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildCrossVersionTestConfigurationCacheSmokeTest.groovy
@@ -41,6 +41,6 @@ class GradleBuildCrossVersionTestConfigurationCacheSmokeTest extends AbstractGra
 
         then:
         assertConfigurationCacheStateLoaded()
-        result.task(":configuration-cache:embeddedCrossVersionTest").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:embeddedCrossVersionTest").outcome == TaskOutcome.FROM_CACHE
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIntegTestConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildIntegTestConfigurationCacheSmokeTest.groovy
@@ -41,7 +41,7 @@ class GradleBuildIntegTestConfigurationCacheSmokeTest extends AbstractGradleBuil
 
         then:
         assertConfigurationCacheStateLoaded()
-        result.task(":configuration-cache:embeddedIntegTest").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:embeddedIntegTest").outcome == TaskOutcome.FROM_CACHE
         assertTestClassExecutedIn "subprojects/configuration-cache", "org.gradle.configurationcache.ConfigurationCacheDebugLogIntegrationTest"
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
@@ -59,16 +59,16 @@ class GradleBuildSanityCheckConfigurationCacheSmokeTest extends AbstractGradleBu
         then:
         assertConfigurationCacheStateLoaded()
         result.task(":configuration-cache:runKtlintCheckOverMainSourceSet").outcome == TaskOutcome.FROM_CACHE
-        result.task(":configuration-cache:validatePlugins").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:validatePlugins").outcome == TaskOutcome.FROM_CACHE
         result.task(":configuration-cache:codenarcIntegTest").outcome == TaskOutcome.FROM_CACHE
-        result.task(":configuration-cache:checkstyleIntegTestGroovy").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:checkstyleIntegTestGroovy").outcome == TaskOutcome.FROM_CACHE
         result.task(":configuration-cache:classycleIntegTest").outcome == TaskOutcome.FROM_CACHE
-        result.task(":configuration-cache:codeQuality").outcome == TaskOutcome.SUCCESS
+        result.task(":configuration-cache:codeQuality").outcome == TaskOutcome.UP_TO_DATE
         result.task(":docs:checkstyleApi").outcome == TaskOutcome.FROM_CACHE
         result.task(":internal-build-reports:allIncubationReportsZip").outcome == TaskOutcome.SUCCESS
         result.task(":architecture-test:checkBinaryCompatibility").outcome == TaskOutcome.SUCCESS
-        result.task(":docs:javadocAll").outcome == TaskOutcome.SUCCESS
-        result.task(":architecture-test:test").outcome == TaskOutcome.SUCCESS
+        result.task(":docs:javadocAll").outcome == TaskOutcome.FROM_CACHE
+        result.task(":architecture-test:test").outcome == TaskOutcome.FROM_CACHE
         result.task(":tooling-api:toolingApiShadedJar").outcome == TaskOutcome.SUCCESS
         result.task(":performance:verifyPerformanceScenarioDefinitions").outcome == TaskOutcome.SUCCESS
         result.task(":checkSubprojectsInfo").outcome == TaskOutcome.SUCCESS

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTestConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSmokeTestConfigurationCacheSmokeTest.groovy
@@ -41,6 +41,6 @@ class GradleBuildSmokeTestConfigurationCacheSmokeTest extends AbstractGradleBuil
 
         then:
         assertConfigurationCacheStateLoaded()
-        result.task(":smoke-test:smokeTest").outcome == TaskOutcome.SUCCESS
+        result.task(":smoke-test:smokeTest").outcome == TaskOutcome.FROM_CACHE
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSoakTestConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSoakTestConfigurationCacheSmokeTest.groovy
@@ -41,6 +41,6 @@ class GradleBuildSoakTestConfigurationCacheSmokeTest extends AbstractGradleBuild
 
         then:
         assertConfigurationCacheStateLoaded()
-        result.task(":soak:forkingIntegTest").outcome == TaskOutcome.SUCCESS
+        result.task(":soak:forkingIntegTest").outcome == TaskOutcome.FROM_CACHE
     }
 }


### PR DESCRIPTION
The configuration cache stores an intermediate form of the normalization
rules: not the compiled patterns but Strings used as inputs. The
balance between complexity and (potential) performance improvements of
storing compiled patterns seems fine at this point.

The CachedProjectState may be extended later to store other
project-level configuration parameters which aren't captured as task
inputs.

Fixes #13706