### PR TITLE
Parameters having opposite value

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/attributeMatching/kotlin/build.gradle.kts
@@ -33,8 +33,8 @@ configurations {
     }
     // A configuration meant for consumers that need the implementation of this component
     create("exposedRuntime") {
-        isCanBeResolved = false
-        isCanBeConsumed = true
+        isCanBeResolved = true
+        isCanBeConsumed = false
     }
 }
 // end::setup-configurations[]


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Documentation fix:
- The exposed configuration is meant to be resolved, in comparison to the one above, which showcases exactly the opposite.

### Context
This avoid confusion when understanding "consumers" and "producers" for gradle configurations.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
