### PR TITLE
Fix regression when selecting constructors

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
@@ -129,8 +129,8 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
         failure.assertHasCause("""Multiple constructors for parameters ['a', 'b']:
-  1. candidate: Thing(String, String, ObjectFactory)
-  2. best match: Thing(String, String, ProjectLayout)""")
+  1. candidate: Thing(String, String, ProjectLayout)
+  2. best match: Thing(String, String, ObjectFactory)""")
     }
 
     def "fails when too many construction parameters provided"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ObjectExtensionInstantiationIntegrationTest.groovy
@@ -128,7 +128,9 @@ class ObjectExtensionInstantiationIntegrationTest extends AbstractIntegrationSpe
         expect:
         fails()
         failure.assertHasCause("Could not create an instance of type Thing.")
-        failure.assertHasCause("Multiple constructors of type Thing match parameters: ['a', 'b']")
+        failure.assertHasCause("""Multiple constructors for parameters ['a', 'b']:
+  1. candidate: Thing(String, String, ObjectFactory)
+  2. best match: Thing(String, String, ProjectLayout)""")
     }
 
     def "fails when too many construction parameters provided"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -37,7 +37,12 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 public class OutputScrapingExecutionResult implements ExecutionResult {
-    static final Pattern STACK_TRACE_ELEMENT = Pattern.compile("\\s+(at\\s+)?([\\w.$_]+/)?[\\w.$_]+\\.[\\w$_ =+'-<>]+\\(.+?\\)(\\x1B\\[0K)?");
+    // This monster is to find lines in our logs that look like stack traces
+    // We want to match lines that contain just packages and classes:
+    // at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:145)
+    // and with module names:
+    // at java.base/java.lang.Thread.dumpStack(Thread.java:1383)
+    static final Pattern STACK_TRACE_ELEMENT = Pattern.compile("\\s+(at\\s+)?([\\w.$_]+/)?[a-zA-Z_][\\w.$]+\\.[\\w$_ =+'-<>]+\\(.+?\\)(\\x1B\\[0K)?");
     private static final String TASK_PREFIX = "> Task ";
 
     //for example: ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a'

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.integtests.fixtures.executer
 
 import spock.lang.Unroll
 
+import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.STACK_TRACE_ELEMENT
+
 class OutputScrapingExecutionResultTest extends AbstractExecutionResultTest {
     def "can have empty output"() {
         def result = OutputScrapingExecutionResult.from("", "")
@@ -48,6 +50,38 @@ class OutputScrapingExecutionResultTest extends AbstractExecutionResultTest {
         result.output == output
         result.normalizedOutput == output
         result.error == error
+    }
+
+    def "finds stack traces when present"() {
+        def output = '''
+* What went wrong:
+A problem occurred evaluating root project '4j0h2'.
+org.gradle.api.GradleScriptException: A problem occurred evaluating root project '4j0h2'.
+	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)
+	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.lambda$apply$0(DefaultScriptPluginFactory.java:133)
+	at org.gradle.configuration.ProjectScriptTarget.addConfiguration(ProjectScriptTarget.java:79)
+	at org.gradle.configuration.DefaultScriptPluginFactory$ScriptPluginImpl.apply(DefaultScriptPluginFactory.java:136)
+	at org.gradle.configuration.BuildOperationScriptPlugin$1.run(BuildOperationScriptPlugin.java:65)
+	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
+'''
+        def matches = output.readLines().grep(line -> STACK_TRACE_ELEMENT.matcher(line).matches())
+        expect:
+        matches.size() == 6
+        matches[0] == '\tat org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:93)'
+    }
+
+    def "does not find things that might look like stack traces"() {
+        def output = """
+* What went wrong:
+A problem occurred evaluating root project '4j0h2'.
+> Could not create an instance of type Thing.
+   > Multiple constructors for parameters ['a', 'b']:
+       1. candidate: Thing(String, String, ProjectLayout)
+       2. best match: Thing(String, String, ObjectFactory)
+"""
+        def matches = output.readLines().grep(line -> STACK_TRACE_ELEMENT.matcher(line).matches())
+        expect:
+        matches.empty
     }
 
     def "can assert build output is present in main content"() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/text/TreeFormatter.java
@@ -200,6 +200,26 @@ public class TreeFormatter implements DiagnosticsVisitor {
         return this;
     }
 
+    /**
+     * Appends some user provided values to the current node.
+     */
+    public TreeFormatter appendTypes(Type... types) {
+        // Implementation is currently dumb, can be made smarter
+        append("(");
+        for (int i = 0; i < types.length; i++) {
+            Type type = types[i];
+            if (type == null) {
+                throw new IllegalStateException("type cannot be null");
+            }
+            if (i > 0) {
+                append(", ");
+            }
+            appendType(type);
+        }
+        append(")");
+        return this;
+    }
+
     public TreeFormatter startNumberedChildren() {
         startChildren();
         prefixer = new NumberedPrefixer();

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/text/TreeFormatterTest.groovy
@@ -412,6 +412,34 @@ Some thing.''')
         formatter.toString() == toPlatformLineSeparators("thing []")
     }
 
+    def "can append array of types"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendTypes(Class, Number, String)
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing (Class, Number, String)")
+    }
+
+    def "can append empty array of types"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendTypes()
+
+        then:
+        formatter.toString() == toPlatformLineSeparators("thing ()")
+    }
+
+    def "cannot append array of types with null"() {
+        when:
+        formatter.node("thing ")
+        formatter.appendTypes(Class, Number, null)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'type cannot be null'
+    }
+
     def "cannot append after children started"() {
         when:
         formatter.node("Root")

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -76,7 +76,6 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -438,12 +437,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     builder.add(new GeneratedConstructorImpl(constructor));
                 }
             }
-            this.constructors = Ordering.from(new Comparator<GeneratedConstructor>() {
-                @Override
-                public int compare(GeneratedConstructor o1, GeneratedConstructor o2) {
-                    return Integer.compare(o1.getParameterTypes().length, o2.getParameterTypes().length);
-                }
-            }).sortedCopy(builder.build());
+            this.constructors = Ordering.from(new ConstructorComparator()).sortedCopy(builder.build());
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/AbstractClassGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
@@ -75,6 +76,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -428,6 +430,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             this.outerType = outerType;
             this.injectedServices = injectedServices;
             this.annotationsTriggeringServiceInjection = annotationsTriggeringServiceInjection;
+
             ImmutableList.Builder<GeneratedConstructor<Object>> builder = ImmutableList.builderWithExpectedSize(generatedClass.getDeclaredConstructors().length);
             for (final Constructor<?> constructor : generatedClass.getDeclaredConstructors()) {
                 if (!constructor.isSynthetic()) {
@@ -435,7 +438,12 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     builder.add(new GeneratedConstructorImpl(constructor));
                 }
             }
-            this.constructors = builder.build();
+            this.constructors = Ordering.from(new Comparator<GeneratedConstructor>() {
+                @Override
+                public int compare(GeneratedConstructor o1, GeneratedConstructor o2) {
+                    return Integer.compare(o1.getParameterTypes().length, o2.getParameterTypes().length);
+                }
+            }).sortedCopy(builder.build());
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ConstructorComparator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ConstructorComparator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation.generator;
+
+import java.util.Comparator;
+
+/**
+ * Sorts GeneratedConstructors based on the number of parameters.
+ *
+ * When two constructors have the same number of parameters, we settle on a stable sort by looking at the names of the
+ * types of the parameters.
+ *
+ */
+public class ConstructorComparator implements Comparator<ClassGenerator.GeneratedConstructor<?>> {
+    @Override
+    public int compare(ClassGenerator.GeneratedConstructor<?> o1, ClassGenerator.GeneratedConstructor<?> o2) {
+        int parameterSort = Integer.compare(o1.getParameterTypes().length, o2.getParameterTypes().length);
+        if (parameterSort == 0) {
+            // Both constructors have the same number of parameters
+            // Create a stable sort based on the names of all the parameters
+            long lhs = 0;
+            for (Class<?> paramType : o1.getParameterTypes()) {
+                lhs += paramType.getCanonicalName().hashCode();
+            }
+            long rhs=0;
+            for (Class<?> paramType : o2.getParameterTypes()) {
+                rhs += paramType.getCanonicalName().hashCode();
+            }
+            return Long.compare(lhs, rhs);
+        }
+        return parameterSort;
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
@@ -118,7 +118,6 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
                     formatter.appendType(type);
                     formatter.appendTypes(match.getParameterTypes());
                     formatter.endChildren();
-                    System.out.println(constructors);
                     throw new IllegalArgumentException(formatter.toString());
                 }
             }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/ParamsMatchingConstructorSelector.java
@@ -56,11 +56,16 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
         }
 
         ClassGenerator.GeneratedConstructor<?> match = null;
+        // NOTE: this relies on the constructors being in a predictable order
+        // sorted by the number of parameters the constructor requires
         for (ClassGenerator.GeneratedConstructor<?> constructor : constructors) {
             Class<?>[] parameterTypes = constructor.getParameterTypes();
+            // The candidate constructor has fewer parameters than the number of
+            // parameters we were given. This can't be the constructor
             if (parameterTypes.length < params.length) {
                 continue;
             }
+
             int fromParam = 0;
             int toParam = 0;
             for (; fromParam < params.length; fromParam++) {
@@ -80,16 +85,40 @@ class ParamsMatchingConstructorSelector implements ConstructorSelector {
                 }
                 toParam++;
             }
+            // The current candidate's parameter types matched the given parameter types
+            // There may be more parameters to the constructor than were given because
+            // we can inject additional services
             if (fromParam == params.length) {
-                if (match == null || parameterTypes.length < match.getParameterTypes().length) {
-                    // Choose the shortest match
+                if (match == null) {
+                    // We had no previous match, so choose this candidate
+                    match = constructor;
+                } else if (parameterTypes.length < match.getParameterTypes().length) {
+                    // We had a previous match, if this candidate has fewer parameters, choose it as the best match
                     match = constructor;
                 } else if (parameterTypes.length == match.getParameterTypes().length) {
+                    // We have a previous match with the same number of parameters as this candidate.
+                    // This means for the given parameters, we've found two constructors that could be used
+                    // Given constructors C1 and C2.
+                    // C1(A, B, C, D)
+                    // C2(A, B, X, D)
+                    // C1 and C2 both accept the parameters A, B and D, but
+                    // C1 accepts a parameter of type C at position 2 and
+                    // C2 accepts a parameter of type X at position 2.
+                    // This will trigger this check because we cannot tell which is the "better"
+                    // constructor assuming that the other parameter could be injected.
+
                     TreeFormatter formatter = new TreeFormatter();
-                    formatter.node("Multiple constructors of type ");
-                    formatter.appendType(type);
-                    formatter.append(" match parameters: ");
+                    formatter.node("Multiple constructors for parameters ");
                     formatter.appendValues(params);
+                    formatter.startNumberedChildren();
+                    formatter.node("candidate: ");
+                    formatter.appendType(type);
+                    formatter.appendTypes(parameterTypes);
+                    formatter.node("best match: ");
+                    formatter.appendType(type);
+                    formatter.appendTypes(match.getParameterTypes());
+                    formatter.endChildren();
+                    System.out.println(constructors);
                     throw new IllegalArgumentException(formatter.toString());
                 }
             }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/AbstractClassGeneratorSpec.groovy
@@ -80,4 +80,33 @@ abstract class AbstractClassGeneratorSpec extends Specification {
             return instantiator.newInstanceWithDisplayName(clazz, displayName, args)
         }
     }
+
+
+    static class ManyConstructors {
+        // the exact order of these constructors as they are returned by the JDK is undefined
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4) {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8, int p9) {}
+        ManyConstructors(int p0, int p1, int p2) {}
+        ManyConstructors() {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5, int p6, boolean p7) {}
+        ManyConstructors(int p0, int p1) {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5, int p6) {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5) {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7, int p8) {}
+        ManyConstructors(int p0, int p1, boolean p2) {}
+        ManyConstructors(int p0, int p1, int p2, int p3, int p4, int p5, int p6, int p7) {}
+        ManyConstructors(int p0, int p1, int p2, int p3) {}
+        ManyConstructors(int p0) {}
+    }
+
+    def "order of constructors is based on number of parameters"() {
+        // We rely on processing the constructors in a predictable order (fewest parameters -> most)
+        def constructors = generator.generate(ManyConstructors).getConstructors()
+        expect:
+        int count = 0
+        constructors.each { constructor ->
+            assert count <= constructor.parameterTypes.length
+            count = constructor.parameterTypes.length
+        }
+    }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/ConstructorComparatorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/ConstructorComparatorTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.instantiation.generator
+
+import spock.lang.Specification
+
+class ConstructorComparatorTest extends Specification {
+    def comparator = new ConstructorComparator()
+
+    def "constructors with fewer parameters are first"() {
+        def lhs = Stub(ClassGenerator.GeneratedConstructor)
+        lhs.parameterTypes >> [String]
+        def rhs = Stub(ClassGenerator.GeneratedConstructor)
+        rhs.parameterTypes >> [String, Number]
+
+        expect:
+        comparator.compare(lhs, rhs) == -1
+        comparator.compare(rhs, lhs) == 1
+    }
+
+    def "constructors with equal parameters are sorted by type names"() {
+        def lhs = Stub(ClassGenerator.GeneratedConstructor)
+        lhs.parameterTypes >> [String, Boolean]
+        def rhs = Stub(ClassGenerator.GeneratedConstructor)
+        rhs.parameterTypes >> [String, Number]
+
+        expect:
+        comparator.compare(lhs, rhs) == -1
+        comparator.compare(rhs, lhs) == 1
+    }
+
+    def "can sort a list of constructors"() {
+        def first = Stub(ClassGenerator.GeneratedConstructor)
+        first.parameterTypes >> [String]
+        def second = Stub(ClassGenerator.GeneratedConstructor)
+        second.parameterTypes >> [String, Boolean]
+        def third = Stub(ClassGenerator.GeneratedConstructor)
+        third.parameterTypes >> [String, Number, Boolean]
+
+        def list = [second, third, first]
+        expect:
+        list.sort(false, comparator) == [first, second, third]
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
@@ -145,11 +145,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         def inst = instantiator.newInstance(HasSeveralParameters, ["a", 0, false] as Object[])
 
         then:
-        inst.a == "a"
-        inst.b == 0
-        inst.c == 99
-        !inst.d
-        inst.x == "A B D"
+        inst.assertConstructor("String a, int b, boolean d")
     }
 
     def "fails on non-static inner class when outer type not provided as first parameter"() {
@@ -201,28 +197,24 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
     }
 
     static class HasSeveralParameters {
-        private final String a
-        private final int b
-        private final int c
-        private final String x
-        private final boolean d
+        private final String usedConstructor
 
         HasSeveralParameters(String a, int b, String x, boolean d) {
-            this(a, b, -1, d, x)
+            this("String a, int b, String x, boolean d")
         }
         HasSeveralParameters(String a, int b, int c, boolean d) {
-            this(a, b, c, d, "A B C D")
+            this("String a, int b, int c, boolean d")
         }
         HasSeveralParameters(String a, int b, boolean d) {
-            this(a, b, 99, d, "A B D")
+            this("String a, int b, boolean d")
         }
 
-        private HasSeveralParameters(String a, int b, int c, boolean d, String x) {
-            this.a = a
-            this.b = b
-            this.c = c
-            this.d = d
-            this.x = x
+        private HasSeveralParameters(String usedConstructor) {
+            this.usedConstructor = usedConstructor
+        }
+
+        void assertConstructor(String expectedConstructor) {
+            assert usedConstructor == expectedConstructor
         }
     }
     static class HasConstructors {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
@@ -133,8 +133,8 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
         TextUtil.normaliseLineSeparators(e.cause.message) == """Multiple constructors for parameters ['a']:
-  1. candidate: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, boolean)
-  2. best match: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, Number)"""
+  1. candidate: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, Number)
+  2. best match: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, boolean)"""
     }
 
     def "uses exact match constructor when constructors could be ambiguous with multiple parameters"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/DependencyInjectionUsingLenientConstructorSelectorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.instantiation.generator
 
 import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.internal.service.ServiceLookup
+import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
 class DependencyInjectionUsingLenientConstructorSelectorTest extends Specification {
@@ -131,7 +132,7 @@ class DependencyInjectionUsingLenientConstructorSelectorTest extends Specificati
         then:
         ObjectInstantiationException e = thrown()
         e.cause instanceof IllegalArgumentException
-        e.cause.message == """Multiple constructors for parameters ['a']:
+        TextUtil.normaliseLineSeparators(e.cause.message) == """Multiple constructors for parameters ['a']:
   1. candidate: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, boolean)
   2. best match: DependencyInjectionUsingLenientConstructorSelectorTest.HasConstructors(String, Number)"""
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.instantiation.generator;
 
+import com.google.common.collect.Ordering;
 import org.gradle.api.Describable;
 import org.gradle.internal.instantiation.ClassGenerationException;
 import org.gradle.internal.instantiation.InstanceGenerator;
@@ -28,6 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 class IdentityClassGenerator implements ClassGenerator {
@@ -97,7 +99,12 @@ class IdentityClassGenerator implements ClassGenerator {
                         }
                     });
                 }
-                return constructors;
+                return Ordering.from(new Comparator<GeneratedConstructor>() {
+                    @Override
+                    public int compare(GeneratedConstructor o1, GeneratedConstructor o2) {
+                        return Integer.compare(o1.getParameterTypes().length, o2.getParameterTypes().length);
+                    }
+                }).sortedCopy(constructors);
             }
         };
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/generator/IdentityClassGenerator.java
@@ -29,7 +29,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 class IdentityClassGenerator implements ClassGenerator {
@@ -99,12 +98,7 @@ class IdentityClassGenerator implements ClassGenerator {
                         }
                     });
                 }
-                return Ordering.from(new Comparator<GeneratedConstructor>() {
-                    @Override
-                    public int compare(GeneratedConstructor o1, GeneratedConstructor o2) {
-                        return Integer.compare(o1.getParameterTypes().length, o2.getParameterTypes().length);
-                    }
-                }).sortedCopy(constructors);
+                return Ordering.from(new ConstructorComparator()).sortedCopy(constructors);
             }
         };
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -66,6 +66,9 @@ abstract class AbstractSmokeTest extends Specification {
         // https://plugins.gradle.org/plugin/nebula.lint
         static nebulaLint = "17.0.0"
 
+        // https://plugins.gradle.org/plugin/org.jetbrains.gradle.plugin.idea-ext
+        static ideaExt = "1.0.1"
+
         // https://plugins.gradle.org/plugin/nebula.dependency-lock
         // TODO: Re-add "8.8.x", "9.4.x" and "10.1.x" if fixed:
         //   https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues/215

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/IdeaExtSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/IdeaExtSmokeTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+class IdeaExtSmokeTest extends AbstractSmokeTest {
+    def "can use org.jetbrains.gradle.plugin.idea-ext"() {
+        buildFile << """
+            plugins {
+                id "org.jetbrains.gradle.plugin.idea-ext" version "${TestedVersions.ideaExt}"
+                id "java"
+            }
+        """
+        expect:
+        runner("help").build()
+    }
+}


### PR DESCRIPTION
When trying to instantiate a type, we look for a matching constructor based on the types of the parameters provided.

There was an underlying bug in this selection process that I unleashed when I added a constructor to the polymorphic container.

- Imagine you have a class with a constructor that takes (A, B, C, D) and another constructor that takes (A, B, C). You call the instantiator with (a, b, c) and all is good.
- You then add a constructor that takes (A, B, C, X) and keep all of the other constructors too.
- We now have a potential problem because the instantiator depends on the order of the constructors from the JDK.
  - If we see both 4-parameter constructors first, we will fail with that error.
  - If we see one of the 4-parameter constructors and then the 3-parameter constructor, we will be OK.
  - If we see the 3-parameter constructor first, we will be OK.

My fix is to sort the constructors by parameter count and break ties by looking at the parameter type names, so we the constructor selector can rely on finding the shortest matching constructor first.
