### PR TITLE
Use JUnit Platform for all test tasks in toolchains sample

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -19,7 +19,9 @@ Include only their name, impactful features should be called out separately belo
 [yinghao niu](https://github.com/towith),
 [Björn Kautler](https://github.com/Vampire),
 [Alexis Tual](https://github.com/alextu),
-[Tomasz Godzik](https://github.com/tgodzik)
+[Tomasz Godzik](https://github.com/tgodzik),
+[Matthew Haughton](https://github.com/3flex)
+
 
 ## Upgrade instructions
 

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/groovy/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -18,7 +18,7 @@ java {
 // end::toolchain[]
 
 
-tasks.named('test') {
+tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 

--- a/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
+++ b/subprojects/docs/src/samples/java/jvm-multi-project-with-toolchains/kotlin/buildSrc/src/main/kotlin/myproject.java-conventions.gradle.kts
@@ -17,7 +17,7 @@ java {
 }
 // end::toolchain[]
 
-tasks.test {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
I downloaded the jvm-multi-project-with-toolchains sample, but when I ran the `:list:testsOn14` task the tests did not run. This is because the JUnit Platform is only enabled on the `:list:test` task.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
