### PR TITLE
Fail when stating unreadable files

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -360,7 +360,7 @@ public class TaskExecution implements UnitOfWork {
     }
 
     private void nagUserAboutUnreadableInputsOrOutputs(String propertyType, String propertyName, Throwable cause) {
-        if (!(cause instanceof UncheckedIOException)) {
+        if (!(cause instanceof UncheckedIOException || cause instanceof org.gradle.api.UncheckedIOException)) {
             throw UncheckedException.throwAsUncheckedException(cause);
         }
         LOGGER.info("Cannot access {} property '{}' of {}", propertyType, propertyName, getDisplayName(), cause);

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/NioFileMetadataAccessor.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.nativeintegration.filesystem.jdk7;
 
+import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileMetadata.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadata;
@@ -50,7 +51,7 @@ public class NioFileMetadataAccessor implements FileMetadataAccessor {
             return DefaultFileMetadata.directory(accessType);
         }
         if (attributes.isOther()) {
-            return DefaultFileMetadata.missing(accessType);
+            throw new UncheckedIOException("Unsupported file type for " + file.getAbsolutePath());
         }
         return DefaultFileMetadata.file(attributes.lastModifiedTime().toMillis(), attributes.size(), accessType);
     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.nativeintegration.filesystem.services;
 
+import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileMetadata.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadata;
@@ -35,6 +36,6 @@ public class FallbackFileMetadataAccessor implements FileMetadataAccessor {
         if (f.isFile()) {
             return DefaultFileMetadata.file(f.lastModified(), f.length(), AccessType.DIRECT);
         }
-        return DefaultFileMetadata.missing(AccessType.DIRECT);
+        throw new UncheckedIOException("Unsupported file type for " + f.getAbsolutePath());
     }
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
@@ -19,6 +19,7 @@ package org.gradle.internal.nativeintegration.filesystem.services;
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.file.FileInfo;
 import net.rubygrapefruit.platform.file.Files;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileMetadata.AccessType;
 import org.gradle.internal.file.impl.DefaultFileMetadata;
@@ -39,14 +40,18 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
         try {
             stat = files.stat(f, false);
         } catch (NativeException e) {
-            return DefaultFileMetadata.missing(AccessType.DIRECT);
+            throw new UncheckedIOException("Could not stat file " + f.getAbsolutePath(), e);
         }
         AccessType accessType = AccessType.viaSymlink(stat.getType() == FileInfo.Type.Symlink);
         if (accessType == AccessType.VIA_SYMLINK) {
             try {
                 stat = files.stat(f, true);
             } catch (NativeException e) {
-                return DefaultFileMetadata.missing(AccessType.VIA_SYMLINK);
+                // For a symlink cycle, file.exists() returns false when unable to stat the file.
+                if (!f.exists()) {
+                    return DefaultFileMetadata.missing(accessType);
+                }
+                throw new UncheckedIOException("Could not stat file " + f.getAbsolutePath(), e);
             }
         }
         switch (stat.getType()) {
@@ -55,8 +60,9 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
             case Directory:
                 return DefaultFileMetadata.directory(accessType);
             case Missing:
-            case Other:
                 return DefaultFileMetadata.missing(accessType);
+            case Other:
+                throw new UncheckedIOException("Unsupported file type for " + f.getAbsolutePath() + ": " + stat.getType());
             default:
                 throw new IllegalArgumentException("Unrecognised file type: " + stat.getType());
         }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
@@ -62,7 +62,7 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
             case Missing:
                 return DefaultFileMetadata.missing(accessType);
             case Other:
-                throw new UncheckedIOException("Unsupported file type for " + f.getAbsolutePath() + ": " + stat.getType());
+                throw new UncheckedIOException("Unsupported file type for " + f.getAbsolutePath());
             default:
                 throw new IllegalArgumentException("Unrecognised file type: " + stat.getType());
         }


### PR DESCRIPTION
We had some problems masked by treating files we could not stat as missing, see for example #17551. With the new `@Untracked` annotation we also give folks a tool how to deal with such files in their custom tasks. So let's fail when we are unable to `stat` a file and not silently return a stat for a missing file.