### PR TITLE
Avoid the use of tasks.matching in gradle/gradle build-logic

### DIFF
--- a/build-logic-commons/code-quality/src/main/kotlin/gradlebuild.code-quality.gradle.kts
+++ b/build-logic-commons/code-quality/src/main/kotlin/gradlebuild.code-quality.gradle.kts
@@ -23,8 +23,12 @@ plugins {
 }
 
 val codeQuality = tasks.register("codeQuality") {
-    dependsOn(tasks.matching { it is CodeNarc || it is Checkstyle || it is Classycle || it is ValidatePlugins })
+    dependsOn(tasks.withType<CodeNarc>())
+    dependsOn(tasks.withType<Checkstyle>())
+    dependsOn(tasks.withType<Classycle>())
+    dependsOn(tasks.withType<ValidatePlugins>())
 }
+
 tasks.withType<Test>().configureEach {
     shouldRunAfter(codeQuality)
 }


### PR DESCRIPTION
This causes all tasks to be realized whenever the codeQuality task is
realized.
