### PR TITLE
Minimal javadoc for test-suites

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -31,17 +31,57 @@ import org.gradle.testing.base.TestSuite;
  */
 @Incubating
 public interface JvmTestSuite extends TestSuite, Buildable {
+    /**
+     * Returns the {@link SourceSet} containing tests for this suite.
+     * @return the {@link SourceSet} containing tests for this suite.
+     */
     SourceSet getSources();
-    void sources(Action<? super SourceSet> configuration);
 
+    /**
+     * Configures the {@link SourceSet} containing tests for this suite.
+     * @param sourceSet an action to execute against the {@link SourceSet}
+     */
+    void sources(Action<? super SourceSet> sourceSet);
+
+    /**
+     * Returns the container of {@link JvmTestSuiteTarget} objects part of this suite.
+     * @return the container of {@link JvmTestSuiteTarget} objects part of this suite.
+     */
     ExtensiblePolymorphicDomainObjectContainer<? extends JvmTestSuiteTarget> getTargets();
 
+    /**
+     * Configures this suite to use the JUnit Jupiter platform libraries.  Defaults to version {@code 5.7.1}
+     */
     void useJUnitJupiter();
+
+    /**
+     * Configures this suite to use the JUnit Jupiter platform libraries.
+     * @param version the version of JUnit Jupiter platform to use, ex. {@code 5.7.1}
+     */
     void useJUnitJupiter(String version);
+
+    /**
+     * Configures this suite to use JUnit 4 libraries.  Defaults to version {@code 4.13}
+     */
     void useJUnit();
+
+    /**
+     * Configures this suite to use JUnit 4 libraries.
+     * @param version the version of JUnit 4 to use, ex. {@code 4.13}
+     */
     void useJUnit(String version);
+
     // TODO: Spock, TestNG?
 
+    /**
+     * Returns the container for any dependencies needed to compile and run a {@link JvmTestSuite}.
+     * @return the container for any dependencies needed to compile and run a {@link JvmTestSuite}.
+     */
     ComponentDependencies getDependencies();
+
+    /**
+     * Configures the container for any dependencies needed to compile and run a {@link JvmTestSuite}.
+     * @param dependencies an action to execute against the container
+     */
     void dependencies(Action<? super ComponentDependencies> dependencies);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuiteTarget.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuiteTarget.java
@@ -31,5 +31,10 @@ import org.gradle.testing.base.TestSuiteTarget;
  */
 @Incubating
 public interface JvmTestSuiteTarget extends TestSuiteTarget {
+
+    /**
+     * Returns a {@link TaskProvider} for this target's {@link Test} task
+     * @return a {@link TaskProvider} for this target's {@link Test} task
+     */
     TaskProvider<Test> getTestTask();
 }


### PR DESCRIPTION
 - Enables documentation tool to process new public APIs for DSL

Relates to #18241

There's a high chance of merge conflicts or duplicated work on JvmTestSuite.java, so I'd like to merge this ASAP