### PR TITLE
Move Santa Tracker smoke tests to separate santaTrackerSmokeTest task

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -22,5 +22,6 @@ enum class JvmCategory(
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
     MAX_VERSION(JvmVendor.oracle, JvmVersion.java16),
+    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.oracle, JvmVersion.java11),
     EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java17)
 }

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -22,6 +22,6 @@ enum class JvmCategory(
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
     MAX_VERSION(JvmVendor.oracle, JvmVersion.java16),
-    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.oracle, JvmVersion.java11),
+    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java11),
     EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java17)
 }

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -60,6 +60,8 @@ data class CIBuildModel(
                 SpecificBuild.Gradleception,
                 SpecificBuild.CheckLinks,
                 SpecificBuild.SmokeTestsMaxJavaVersion,
+                SpecificBuild.SantaTrackerSmokeTests,
+                SpecificBuild.ConfigCacheSantaTrackerSmokeTests,
                 SpecificBuild.GradleBuildSmokeTests,
                 SpecificBuild.ConfigCacheSmokeTestsMaxJavaVersion,
                 SpecificBuild.ConfigCacheSmokeTestsMinJavaVersion
@@ -399,6 +401,16 @@ enum class SpecificBuild {
     SmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
             return SmokeTests(model, stage, JvmCategory.MAX_VERSION)
+        }
+    },
+    SantaTrackerSmokeTests {
+        override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
+            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "santaTrackerSmokeTest")
+        }
+    },
+    ConfigCacheSantaTrackerSmokeTests {
+        override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
+            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "configCacheSantaTrackerSmokeTest")
         }
     },
     GradleBuildSmokeTests {

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -94,23 +94,27 @@ tasks {
 
     val gradleBuildTestPattern = "org.gradle.smoketests.GradleBuild*SmokeTest"
 
+    val santaTrackerTestPattern = "org.gradle.smoketests.AndroidSantaTracker*SmokeTest"
+
     register<SmokeTest>("smokeTest") {
         description = "Runs Smoke tests"
-        configureForSmokeTest(santaTracker)
+        configureForSmokeTest()
         useJUnitPlatform {
             filter {
                 excludeTestsMatching(gradleBuildTestPattern)
+                excludeTestsMatching(santaTrackerTestPattern)
             }
         }
     }
 
     register<SmokeTest>("configCacheSmokeTest") {
         description = "Runs Smoke tests with the configuration cache"
-        configureForSmokeTest(santaTracker)
         systemProperty("org.gradle.integtest.executer", "configCache")
+        configureForSmokeTest()
         useJUnitPlatform {
             filter {
                 excludeTestsMatching(gradleBuildTestPattern)
+                excludeTestsMatching(santaTrackerTestPattern)
             }
         }
     }
@@ -121,6 +125,27 @@ tasks {
         useJUnitPlatform {
             filter {
                 includeTestsMatching(gradleBuildTestPattern)
+            }
+        }
+    }
+
+    register<SmokeTest>("santaTrackerSmokeTest") {
+        description = "Runs Santa Tracker Smoke tests"
+        configureForSmokeTest(santaTracker)
+        useJUnitPlatform {
+            filter {
+                includeTestsMatching(santaTrackerTestPattern)
+            }
+        }
+    }
+
+    register<SmokeTest>("configCacheSantaTrackerSmokeTest") {
+        description = "Runs Santa Tracker Smoke tests with the configuration cache"
+        configureForSmokeTest(santaTracker)
+        systemProperty("org.gradle.integtest.executer", "configCache")
+        useJUnitPlatform {
+            filter {
+                includeTestsMatching(santaTrackerTestPattern)
             }
         }
     }

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -15,8 +15,8 @@ val smokeTestSourceSet = sourceSets.create("smokeTest") {
 
 addDependenciesAndConfigurations("smoke")
 
-val smokeTestImplementation: Configuration by configurations.getting
-val smokeTestDistributionRuntimeOnly: Configuration by configurations.getting
+val smokeTestImplementation: Configuration by configurations
+val smokeTestDistributionRuntimeOnly: Configuration by configurations
 
 dependencies {
     smokeTestImplementation(project(":base-services"))
@@ -127,8 +127,8 @@ tasks {
 }
 
 plugins.withType<IdeaPlugin>().configureEach {
-    val smokeTestCompileClasspath: Configuration by configurations.getting
-    val smokeTestRuntimeClasspath: Configuration by configurations.getting
+    val smokeTestCompileClasspath: Configuration by configurations
+    val smokeTestRuntimeClasspath: Configuration by configurations
     model.module {
         testSourceDirs = testSourceDirs + smokeTestSourceSet.groovy.srcDirs
         testResourceDirs = testResourceDirs + smokeTestSourceSet.resources.srcDirs


### PR DESCRIPTION
So the JVM used to run it can be configured independently from the other tests.