### PR TITLE
Allow gc to claim classes faster when worker API is used

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/generator/InjectUtil.java
@@ -32,16 +32,16 @@ class InjectUtil {
      * @param type the type to find the injectable constructor of.
      * @param reportAs errors are reported against this type, useful when the real type is generated, and we'd like to show the original type in messages instead.
      */
-    public static <T> ClassGenerator.GeneratedConstructor<T> selectConstructor(ClassGenerator.GeneratedClass<T> type, Class<?> reportAs) {
+    public static <T> int selectConstructor(ClassGenerator.GeneratedClass<T> type, Class<?> reportAs) {
         List<ClassGenerator.GeneratedConstructor<T>> constructors = type.getConstructors();
 
         if (constructors.size() == 1) {
             ClassGenerator.GeneratedConstructor<T> constructor = constructors.get(0);
             if (constructor.getParameterTypes().length == 0 && isPublicOrPackageScoped(type.getGeneratedClass(), constructor)) {
-                return constructor;
+                return 0;
             }
             if (constructor.getAnnotation(Inject.class) != null) {
-                return constructor;
+                return 0;
             }
             if (constructor.getParameterTypes().length == 0) {
                 TreeFormatter formatter = new TreeFormatter();
@@ -58,10 +58,11 @@ class InjectUtil {
             }
         }
 
-        List<ClassGenerator.GeneratedConstructor<T>> injectConstructors = new ArrayList<ClassGenerator.GeneratedConstructor<T>>();
-        for (ClassGenerator.GeneratedConstructor<T> constructor : constructors) {
+        List<Integer> injectConstructors = new ArrayList<>();
+        for (int i = 0; i < constructors.size(); i++) {
+            ClassGenerator.GeneratedConstructor<T> constructor = constructors.get(i);
             if (constructor.getAnnotation(Inject.class) != null) {
-                injectConstructors.add(constructor);
+                injectConstructors.add(i);
             }
         }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

This allows gc to collect classes faster when using worker api isolation mode. Reproducer can be found here:  #18313. While this is not solution for #18313, it allows gc to collect classes after every session.

With my fix you can run reproducer with `while true; do; ./gradlew foo; done` with   `-XX:MaxMetaspaceSize=500M`. While with current master it fails with OOMetaspace exception and you need `-XX:MaxMetaspaceSize=1000M`.

Metaspace with current master for reproducer with `-XX:MaxMetaspaceSize=1000M`:
<img width="1467" alt="Screenshot 2021-09-21 at 19 33 26" src="https://user-images.githubusercontent.com/3939893/134220065-ee9febb0-90dd-4374-b917-ceb5268afed2.png">

Metaspace with this fix for reproducer  `-XX:MaxMetaspaceSize=1000M`:
<img width="1422" alt="Screenshot 2021-09-21 at 19 30 37" src="https://user-images.githubusercontent.com/3939893/134220150-e8201c64-3d71-4e4a-8dd1-a5fd5d446acb.png">

