### PR TITLE
scala_plugin.adoc: replace compile/testCompile with implementation/testImplementation

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/scala_plugin.adoc
@@ -121,7 +121,7 @@ include::sample[dir="snippets/scala/customizedLayout/kotlin",files="build.gradle
 
 Scala projects need to declare a `scala-library` dependency. This dependency will then be used on compile and runtime class paths. It will also be used to get hold of the Scala compiler and Scaladoc tool, respectively.footnote:[See <<#sec:configure_scala_classpath,Automatic configuration of Scala classpath>>.]
 
-If Scala is used for production code, the `scala-library` dependency should be added to the `compile` configuration:
+If Scala is used for production code, the `scala-library` dependency should be added to the `implementation` configuration:
 
 .Declaring a Scala dependency for production code
 ====
@@ -137,7 +137,7 @@ include::sample[dir="snippets/scala/scala3/groovy",files="build.gradle"]
 include::sample[dir="snippets/scala/scala3/kotlin",files="build.gradle.kts"]
 ====
 
-If Scala is only used for test code, the `scala-library` dependency should be added to the `testCompile` configuration:
+If Scala is only used for test code, the `scala-library` dependency should be added to the `testImplementation` configuration:
 
 .Declaring a Scala dependency for test code
 ====


### PR DESCRIPTION
### Context
I noticed that latest [scala plugin docs](https://docs.gradle.org/current/userguide/scala_plugin.html) still use `testCompile` and `compile` configurations in the wording (not in examples). This is just to replace that and keep it consistent.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
