### PR TITLE
Accessing properties from init script throws IllegalStateException

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -66,6 +66,31 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
         output.contains("Project hello evaluated")
     }
 
+    def 'init script can access properties'() {
+        given:
+        file('init.gradle') << '''
+            properties.forEach { name, value ->
+                println "property: ${name}=${value}"
+            }
+        '''.stripIndent()
+
+        executer.usingInitScript(file('init.gradle'))
+
+        file('settings.gradle') << '''
+        '''.stripIndent()
+
+        buildFile << '''
+            task info {
+            }
+        '''.stripIndent()
+
+        when:
+        succeeds 'info'
+
+        then:
+        output.contains("property:")
+    }
+
     def 'init scripts passed in the Gradle user home are applied to buildSrc'() {
         given:
         settingsFile << "rootProject.name = 'hello'"

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle_DecoratedBeanInfo.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle_DecoratedBeanInfo.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.invocation;
+
+import groovy.lang.Closure;
+import groovy.lang.GroovyRuntimeException;
+import groovy.lang.MetaClass;
+import org.gradle.api.Action;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.internal.metaobject.BeanDynamicObject;
+
+import java.awt.Image;
+import java.beans.BeanDescriptor;
+import java.beans.BeanInfo;
+import java.beans.EventSetDescriptor;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.MethodDescriptor;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import static org.gradle.internal.UncheckedException.throwAsUncheckedException;
+
+/**
+ * This {@link BeanInfo} class provides a corrected subset of PropertyDescriptors for the {@link Introspector}
+ * to fix its miscategorization of: 1) the generated {@code Gradle.settings} property as well as 2) the
+ * {@link Gradle#settingsEvaluated(Action)} and {@link Gradle#settingsEvaluated(Closure)} methods.
+ *
+ * These were being miscategorised into PropertyDescriptors by the {@link Introspector} since they look like
+ * JavaBeans setter methods. As a consequence the two {@code Gradle.settingsEvaluated()} functions were being
+ * reported as a write-only property named {@code tingsEvaluated} by the {@link MetaClass#getProperties()}
+ * function. This in turn was triggering a {@link GroovyRuntimeException} to be thrown when the
+ * {@link BeanDynamicObject#getProperties()} function was evaluated on {@link Gradle} objects, making it
+ * impossible use the {@link Gradle} object's properties values directly in init scripts like we do for
+ * settings and project scripts.
+ */
+@SuppressWarnings("typeName")
+public class DefaultGradle_DecoratedBeanInfo implements BeanInfo {
+    private final Method getBaseNameMethod;
+    private final BeanInfo delegate;
+
+    public DefaultGradle_DecoratedBeanInfo() throws IntrospectionException, NoSuchMethodException, ClassNotFoundException {
+        // work around: PropertyDescriptor.getBaseName() is package private
+        Method getBaseNameMethod = PropertyDescriptor.class.getDeclaredMethod("getBaseName");
+        getBaseNameMethod.setAccessible(true);
+        this.getBaseNameMethod = getBaseNameMethod;
+
+        // work around: the "DefaultGradle_Decorated" class is not available at compile time
+        Class<? extends DefaultGradle> defaultGradleClass =
+            Class.forName("org.gradle.invocation.DefaultGradle_Decorated").asSubclass(DefaultGradle.class);
+        this.delegate = Introspector.getBeanInfo(defaultGradleClass, Introspector.IGNORE_IMMEDIATE_BEANINFO);
+    }
+
+    @Override
+    public PropertyDescriptor[] getPropertyDescriptors() {
+        // filter out the miscategorised Bean Properties
+        PropertyDescriptor[] propertyDescriptors = delegate.getPropertyDescriptors();
+        if (null == propertyDescriptors) {
+            return null;
+        }
+
+        int idx = 0;
+
+        for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+            // Filter out any descriptors where the baseName == name. In other words: keep only the
+            // propertyDescriptors where camel casing indicates that a Bean Property was intended. For example:
+            // camel casing in getXxxx()/setXxxx(), indicates an intentional Bean Property with baseName = "Xxxx"
+            // and name = "xxxx", while the lack of camel casing in settingsEvaluated() indicates that it is not
+            // intended to be Bean Property with baseName = "tingsEvaluated" and name = "tingsEvaluated".
+            try {
+                if (!Objects.equals(getBaseNameMethod.invoke(propertyDescriptor), propertyDescriptor.getName())) {
+                    propertyDescriptors[idx++] = propertyDescriptor;
+                }
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                // this should never happen
+                throwAsUncheckedException(ex);
+            }
+        }
+
+        PropertyDescriptor[] result = new PropertyDescriptor[idx];
+        System.arraycopy(propertyDescriptors, 0, result, 0, idx);
+
+        return result;
+    }
+
+    @Override
+    public BeanDescriptor getBeanDescriptor() {
+        return delegate.getBeanDescriptor();
+    }
+
+    @Override
+    public EventSetDescriptor[] getEventSetDescriptors() {
+        return delegate.getEventSetDescriptors();
+    }
+
+    @Override
+    public int getDefaultEventIndex() {
+        return delegate.getDefaultEventIndex();
+    }
+
+    @Override
+    public int getDefaultPropertyIndex() {
+        return delegate.getDefaultPropertyIndex();
+    }
+
+    @Override
+    public MethodDescriptor[] getMethodDescriptors() {
+        return delegate.getMethodDescriptors();
+    }
+
+    @Override
+    public BeanInfo[] getAdditionalBeanInfo() {
+        return delegate.getAdditionalBeanInfo();
+    }
+
+    @Override
+    public Image getIcon(int iconKind) {
+        return delegate.getIcon(iconKind);
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/BeanDynamicObject.java
@@ -437,7 +437,17 @@ public class BeanDynamicObject extends AbstractDynamicObject {
                         continue;
                     }
                 }
-                properties.put(metaProperty.getName(), metaProperty.getProperty(bean));
+                if (metaProperty instanceof MultipleSetterProperty) {
+                    MultipleSetterProperty multipleSetterProperty = (MultipleSetterProperty) metaProperty;
+                    if (multipleSetterProperty.getGetter() == null) {
+                        continue;
+                    }
+                }
+                try {
+                    properties.put(metaProperty.getName(), metaProperty.getProperty(bean));
+                } catch (IllegalStateException ignored) {
+                    // Ignore dynamic properties that are inaccessible at runtime.
+                }
             }
             if (bean instanceof PropertyMixIn) {
                 PropertyMixIn propertyMixIn = (PropertyMixIn) bean;


### PR DESCRIPTION
In particular accessing properties from an init script was throwing:
    "java.lang.IllegalStateException: The default project is not yet available for build."

E.g: with init script:
```
properties.forEach { name, value ->
    println "property: ${name}=${value}"
}
```

Changes:
1) `BeanDynamicObject.getProperties()` now ignores bean properties like
`Gradle.getRootProject()` when they throw an `IllegalStateException`.
2) `BeanDynamicObject.getProperties()` now also ignores bean properties
where `MultipleSetterProperty.getGetter() == null`.
3) `DefaultGradle_DecoratedBeanInfo` class added to prevent the
`java.beans.Introspector` from miscategorizing methods like
`Gradle.settingsEvaluated()` as a bean property named `tingsEvaluated`.

Signed-off-by: Steffen Yount <steffenyount@gmail.com>

<!--- The issue this PR addresses -->
Fixes #18350

### Contex
Accessing properties from init script is broken, this PR fixes it.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
