### PR TITLE
Append operators for MapProperty, ListProperty, and SetProperty are discarding convention values

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -125,6 +125,11 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
         return value;
     }
 
+    protected void setSupplier(S supplier) {
+        assertCanMutate();
+        this.value = supplier;
+    }
+
     protected Value<? extends T> calculateOwnValueNoProducer(ValueConsumer consumer) {
         beforeRead(null, consumer);
         return doCalculateValue(consumer);
@@ -217,7 +222,7 @@ public abstract class AbstractProperty<T, S extends ValueSupplier> extends Abstr
 
     protected abstract S finalValue(S value, ValueConsumer consumer);
 
-    protected void setSupplier(S supplier) {
+    protected void setExplicitSupplier(S supplier) {
         assertCanMutate();
         this.value = state.explicitValue(supplier);
     }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProperty.java
@@ -68,7 +68,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
         if (value == null) {
             discardValue();
         } else {
-            setSupplier(Providers.fixedValue(getValidationDisplayName(), value, type, sanitizer));
+            setExplicitSupplier(Providers.fixedValue(getValidationDisplayName(), value, type, sanitizer));
         }
     }
 
@@ -97,7 +97,7 @@ public class DefaultProperty<T> extends AbstractProperty<T, ProviderInternal<? e
     public void set(Provider<? extends T> provider) {
         Preconditions.checkArgument(provider != null, "Cannot set the value of a property using a null provider.");
         ProviderInternal<? extends T> p = Providers.internal(provider);
-        setSupplier(p.asSupplier(getValidationDisplayName(), type, sanitizer));
+        setExplicitSupplier(p.asSupplier(getValidationDisplayName(), type, sanitizer));
     }
 
     @Override


### PR DESCRIPTION
We shouldn't be discarding convention() values when calling MapProperty.put()/putAll() or
AbstractCollectionProperty.add()/addAll() since this undermines the users ability to build
upon the Map's or the Collection's convention() values.

Changes:
1) renamed: AbstractProperty.setSupplier() -> AbstractProperty.setExplicitSupplier()
This function has side effects beyond simple mutation of the supplier field, namely
it also sets the AbstractProperty.explicitValue = true. The new name is intended to
reflect this side effect.
2) added: new AbstractProperty.setSupplier() mutator with no side affects
It is intended for use in the MapProperty and AbstractCollectionProperty classes, where
append operators can extend the basic Property get()/convention()/set() contract.
3) fixed: the addCollector() functions
The MapProperty.addCollector() and AbstractCollectionProperty.addCollector() functions
now just append collectors without changing the "AbstractProperty.explicitValue" state.

Signed-off-by: Steffen Yount <steffenyount@gmail.com>

<!--- The issue this PR addresses -->
Fixes #18352

### Context
This PR fixes the issue.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
