### PR TITLE
Be more silent for watching errors

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -67,7 +67,7 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     @Override
     public final SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode) {
         watchableHierarchies.updateUnsupportedFileSystems(watchMode);
-        SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchableContentOnBuildStart(root, createInvalidator());
+        SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchableContentOnBuildStart(root, createInvalidator(), watchMode);
         newRoot = doUpdateVfsOnBuildStarted(newRoot);
         if (root != newRoot) {
             updateWatchedHierarchies(newRoot);

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -150,18 +150,18 @@ public class WatchableHierarchies {
         return invalidatedRoot;
     }
 
-    public SnapshotHierarchy removeUnwatchableContentOnBuildStart(SnapshotHierarchy root, Invalidator invalidator) {
+    public SnapshotHierarchy removeUnwatchableContentOnBuildStart(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode) {
         SnapshotHierarchy newRoot = root;
-        newRoot = removeUnprovenHierarchies(newRoot, invalidator);
+        newRoot = removeUnprovenHierarchies(newRoot, invalidator, watchMode);
         return newRoot;
     }
 
     @Nonnull
-    private SnapshotHierarchy removeUnprovenHierarchies(SnapshotHierarchy root, Invalidator invalidator) {
+    private SnapshotHierarchy removeUnprovenHierarchies(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode) {
         return probeRegistry.unprovenHierarchies()
             .reduce(root, (currentRoot, unprovenHierarchy) -> {
                 if (hierarchies.remove(unprovenHierarchy)) {
-                    LOGGER.warn(INVALIDATING_HIERARCHY_MESSAGE + " {}", unprovenHierarchy);
+                    watchMode.loggerForWarnings(LOGGER).warn(INVALIDATING_HIERARCHY_MESSAGE + " {}", unprovenHierarchy);
                     return invalidator.invalidate(unprovenHierarchy.getAbsolutePath(), currentRoot);
                 } else {
                     return currentRoot;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchMode.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/WatchMode.java
@@ -16,10 +16,28 @@
 
 package org.gradle.internal.watch.vfs;
 
+import org.slf4j.Logger;
+import org.slf4j.helpers.NOPLogger;
+
 public enum WatchMode {
-    ENABLED(true, "enabled"),
-    DEFAULT(true, "enabled if available"),
-    DISABLED(false, "disabled");
+    ENABLED(true, "enabled") {
+        @Override
+        public Logger loggerForWarnings(Logger currentLogger) {
+            return currentLogger;
+        }
+    },
+    DEFAULT(true, "enabled if available") {
+        @Override
+        public Logger loggerForWarnings(Logger currentLogger) {
+            return currentLogger.isInfoEnabled() ? currentLogger : NOPLogger.NOP_LOGGER;
+        }
+    },
+    DISABLED(false, "disabled") {
+        @Override
+        public Logger loggerForWarnings(Logger currentLogger) {
+            return NOPLogger.NOP_LOGGER;
+        }
+    };
 
     private final boolean enabled;
     private final String description;
@@ -32,6 +50,8 @@ public enum WatchMode {
     public boolean isEnabled() {
         return enabled;
     }
+
+    public abstract Logger loggerForWarnings(Logger currentLogger);
 
     public String getDescription() {
         return description;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -40,7 +40,6 @@ import org.gradle.internal.watch.vfs.WatchLogging;
 import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.NOPLogger;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -97,7 +96,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
 
     @Override
     public boolean afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
-        warningLogger = watchMode == WatchMode.ENABLED || LOGGER.isInfoEnabled() ? LOGGER : NOPLogger.NOP_LOGGER;
+        warningLogger = watchMode.loggerForWarnings(LOGGER);
         reasonForNotWatchingFiles = null;
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override


### PR DESCRIPTION
Log them on info log by default, and only log on warn when file system watching has been explicitly requested.

This is to not confuse users like in https://github.com/gradle/gradle/issues/18294.