### PR TITLE
Use template methods instead of calling super

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -97,9 +97,7 @@ public class HierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdater {
     }
 
     @Override
-    protected FileHierarchySet updateWatchedHierarchies(SnapshotHierarchy root) {
-        FileHierarchySet newWatchedFiles = super.updateWatchedHierarchies(root);
-
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet newWatchedFiles) {
         ImmutableSet<File> oldWatchedHierarchies = watchedHierarchies;
         ImmutableSet.Builder<File> watchedHierarchiesBuilder = ImmutableSet.builder();
         newWatchedFiles.visitRoots(absolutePath -> watchedHierarchiesBuilder.add(new File(absolutePath)));
@@ -129,12 +127,21 @@ public class HierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdater {
 
             LOGGER.info("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
         }
-        return newWatchedFiles;
     }
 
     @Override
     protected SnapshotHierarchy doUpdateVfsOnBuildStarted(SnapshotHierarchy root) {
         return movedHierarchyHandler.handleMovedHierarchies(root);
+    }
+
+    @Override
+    protected void startWatchingProbeDirectory(File probeDirectory) {
+        // We already started watching the hierarchy.
+    }
+
+    @Override
+    protected void stopWatchingProbeDirectory(File probeDirectory) {
+        // We already stopped watching the hierarchy.
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multiset;
 import net.rubygrapefruit.platform.NativeException;
 import net.rubygrapefruit.platform.file.FileWatcher;
+import org.gradle.internal.file.FileHierarchySet;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocationSnapshotTransformer;
@@ -94,6 +95,11 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     @Override
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet watchedFiles) {
+        // The changes already happened in `handleVirtualFileSystemContentsChanged`.
+    }
+
+    @Override
     protected WatchableHierarchies.Invalidator createInvalidator() {
         return (location, currentRoot) -> {
             SnapshotCollectingDiffListener diffListener = new SnapshotCollectingDiffListener();
@@ -104,17 +110,13 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     @Override
-    protected void armWatchProbeForHierarchy(File probedHierarchy, File probeDirectory) {
-        // Make sure probe directories are watched
+    protected void startWatchingProbeDirectory(File probeDirectory) {
         updateWatchedDirectories(ImmutableMap.of(probeDirectory.getAbsolutePath(), 1));
-        super.armWatchProbeForHierarchy(probedHierarchy, probeDirectory);
     }
 
     @Override
-    protected void disarmWatchProbeForHierarchy(File probedHierarchy, File probeDirectory) {
-        // Make sure probe directories are not watched anymore
+    protected void stopWatchingProbeDirectory(File probeDirectory) {
         updateWatchedDirectories(ImmutableMap.of(probeDirectory.getAbsolutePath(), -1));
-        super.disarmWatchProbeForHierarchy(probedHierarchy, probeDirectory);
     }
 
     @Override


### PR DESCRIPTION
That makes it clearer to me what is happening in AbstractFileWatcherUpdater,
without having to look too closely at the subclasses.