### PR TITLE
Adapt documentation of `ArtifactHandler` after PR #13505

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ArtifactHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ArtifactHandler.java
@@ -43,7 +43,7 @@ import org.gradle.api.artifacts.PublishArtifact;
  *
  * <li>A {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}.</li>
  *
- * <li>A {@link org.gradle.api.provider.Provider} of {@link java.io.File}, {@link org.gradle.api.file.RegularFile} or {@link org.gradle.api.file.Directory}. The information for publishing the artifact is extracted from the file or directory name. When the provider represents an output of a particular task, that task will be executed if the artifact is required.</li>
+ * <li>A {@link org.gradle.api.provider.Provider} of {@link java.io.File}, {@link org.gradle.api.file.RegularFile}, {@link org.gradle.api.file.Directory} or {@link org.gradle.api.Task}, with the limitation that the latter has to define a single file output property. The information for publishing the artifact is extracted from the file or directory name. When the provider represents an output of a particular task, that task will be executed if the artifact is required.</li>
  *
  * <li>{@link java.io.File}. The information for publishing the artifact is extracted from the file name.</li>
  *

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -20,6 +20,7 @@ Include only their name, impactful features should be called out separately belo
 [Björn Kautler](https://github.com/Vampire),
 [Alexis Tual](https://github.com/alextu),
 [Tomasz Godzik](https://github.com/tgodzik),
+[Kristian Kraljic](https://github.com/kristian),
 [Matthew Haughton](https://github.com/3flex)
 
 


### PR DESCRIPTION
Make it more clear that artifacts now lazily accept task outputs.

Signed-off-by: Kristian Kraljic <kris@kra.lc><!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
