### PR TITLE
Let :docs:dslHtml work with the configuration cache

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
@@ -22,6 +22,31 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Ignore
 
 class GradleBuildDocumentationConfigurationCacheSmokeTest extends AbstractGradleBuildConfigurationCacheSmokeTest {
+
+    def "can build DSL documentation with configuration cache enabled"() {
+
+        given:
+        def tasks = [
+            ':docs:dslHtml'
+        ]
+
+        when:
+        configurationCacheRun(tasks, 0)
+
+        then:
+        assertConfigurationCacheStateStored()
+
+        when:
+        run([":docs:clean"])
+
+        then:
+        configurationCacheRun(tasks, 1)
+
+        then:
+        assertConfigurationCacheStateLoaded()
+        result.task(":docs:dslHtml").outcome == TaskOutcome.FROM_CACHE
+    }
+
     @Ignore("Broken by at least the Asciidoctor plugin, and takes 40mins on CI")
     @NotYetImplemented
     def "can build and test Gradle documentation with configuration cache enabled"() {


### PR DESCRIPTION
By not using `Task.project` at execution time.
