### PR TITLE
Exclude javadoc/sources jar from DistributionTest classpath

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/tasks/DistributionTest.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/tasks/DistributionTest.kt
@@ -147,7 +147,10 @@ class LocalRepositoryEnvironmentProvider(project: Project) : CommandLineArgument
 
     @get:Classpath
     val jars: SortedSet<File>
-        get() = localRepo.asFileTree.matching { include("**/*.jar") }.files.toSortedSet()
+        get() = localRepo.asFileTree.matching {
+            include("**/*.jar")
+            exclude("**/*-javadoc.jar")
+        }.files.toSortedSet()
 
     /**
      * Make sure this stays type FileCollection (lazy) to not loose dependency information.


### PR DESCRIPTION
We didn't make them reproducible.
