### PR TITLE
Capture dropping state in the VFS because probes didn't trigger

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
@@ -79,7 +79,6 @@ class BuildOperationsFileSystemWatchingIntegrationTest extends AbstractFileSyste
         finishedResult.watchingEnabled
         !finishedResult.stoppedWatchingDuringTheBuild
         finishedResult.statistics.numberOfWatchedHierarchies > 0
-        finishedResult.statistics.numberOfWatchedHierarchies == 1
         retainedFiles(finishedResult)
     }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/BuildOperationsFileSystemWatchingIntegrationTest.groovy
@@ -60,6 +60,7 @@ class BuildOperationsFileSystemWatchingIntegrationTest extends AbstractFileSyste
         finishedResult.watchingEnabled
         !finishedResult.stoppedWatchingDuringTheBuild
         finishedResult.statistics.numberOfWatchedHierarchies > 0
+        !finishedResult.stateInvalidatedAtStartOfBuild
         retainedFiles(finishedResult)
 
         when:
@@ -71,12 +72,14 @@ class BuildOperationsFileSystemWatchingIntegrationTest extends AbstractFileSyste
         then:
         startedResult.watchingEnabled
         !startedResult.startedWatching
+        !finishedResult.stateInvalidatedAtStartOfBuild
         startedResult.statistics.numberOfReceivedEvents > 0
         retainedFiles(startedResult)
 
         finishedResult.watchingEnabled
         !finishedResult.stoppedWatchingDuringTheBuild
         finishedResult.statistics.numberOfWatchedHierarchies > 0
+        finishedResult.statistics.numberOfWatchedHierarchies == 1
         retainedFiles(finishedResult)
     }
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildFinishedFileSystemWatchingBuildOperationType.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildFinishedFileSystemWatchingBuildOperationType.java
@@ -40,6 +40,11 @@ public interface BuildFinishedFileSystemWatchingBuildOperationType extends Build
             }
 
             @Override
+            public boolean isStateInvalidatedAtStartOfBuild() {
+                return false;
+            }
+
+            @Override
             public FileSystemWatchingStatistics getStatistics() {
                 return null;
             }
@@ -48,6 +53,8 @@ public interface BuildFinishedFileSystemWatchingBuildOperationType extends Build
         boolean isWatchingEnabled();
 
         boolean isStoppedWatchingDuringTheBuild();
+
+        boolean isStateInvalidatedAtStartOfBuild();
 
         @Nullable
         FileSystemWatchingStatistics getStatistics();

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -129,7 +129,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                                 statisticsSinceLastBuild.getRetainedMissingFiles()
                             );
                             if (stateInvalidatedAtStartOfBuild) {
-                                LOGGER.warn("Parts of the virtual file system have been removed since they didn't support watching");
+                                LOGGER.warn("Parts of the virtual file system have been invalidated since they didn't support watching");
                             }
                         }
                     }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -68,6 +68,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
 
     private FileWatcherRegistry watchRegistry;
     private Exception reasonForNotWatchingFiles;
+    private boolean stateInvalidatedAtStartOfBuild;
 
     public WatchingVirtualFileSystem(
         FileWatcherRegistryFactory watcherRegistryFactory,
@@ -97,6 +98,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
     @Override
     public boolean afterBuildStarted(WatchMode watchMode, VfsLogging vfsLogging, WatchLogging watchLogging, BuildOperationRunner buildOperationRunner) {
         warningLogger = watchMode.loggerForWarnings(LOGGER);
+        stateInvalidatedAtStartOfBuild = false;
         reasonForNotWatchingFiles = null;
         rootReference.update(currentRoot -> buildOperationRunner.call(new CallableBuildOperation<SnapshotHierarchy>() {
             @Override
@@ -115,6 +117,7 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         } else {
                             newRoot = watchRegistry.updateVfsOnBuildStarted(currentRoot, watchMode);
                         }
+                        stateInvalidatedAtStartOfBuild = newRoot != currentRoot;
                         statisticsSinceLastBuild = new DefaultFileSystemWatchingStatistics(statistics, newRoot);
                         if (vfsLogging == VfsLogging.VERBOSE) {
                             LOGGER.warn("Received {} file system events since last build while watching {} locations",
@@ -125,6 +128,9 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                                 statisticsSinceLastBuild.getRetainedDirectories(),
                                 statisticsSinceLastBuild.getRetainedMissingFiles()
                             );
+                            if (stateInvalidatedAtStartOfBuild) {
+                                LOGGER.warn("Parts of the virtual file system have been removed since they didn't support watching");
+                            }
                         }
                     }
                     if (watchRegistry != null) {
@@ -211,10 +217,15 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                                 statisticsDuringBuild.getRetainedDirectories(),
                                 statisticsDuringBuild.getRetainedMissingFiles()
                             );
+                            if (stateInvalidatedAtStartOfBuild) {
+                                LOGGER.warn("Parts of the virtual file system have been removed at the start of the build since they didn't support watching");
+                            }
                         }
                     }
                     boolean stoppedWatchingDuringTheBuild = watchRegistry == null;
                     context.setResult(new BuildFinishedFileSystemWatchingBuildOperationType.Result() {
+                        private final boolean stateInvalidatedAtStartOfBuild = WatchingVirtualFileSystem.this.stateInvalidatedAtStartOfBuild;
+
                         @Override
                         public boolean isWatchingEnabled() {
                             return true;
@@ -223,6 +234,11 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
                         @Override
                         public boolean isStoppedWatchingDuringTheBuild() {
                             return stoppedWatchingDuringTheBuild;
+                        }
+
+                        @Override
+                        public boolean isStateInvalidatedAtStartOfBuild() {
+                            return stateInvalidatedAtStartOfBuild;
                         }
 
                         @Override


### PR DESCRIPTION
We log the event and we also capture it in a build operation, so we can add it as a custom value to build scans. This allows us to detect whether the problem happens to us in our build.