### PR TITLE
Pass --no-configuration-cache to all managed TeamCity gradle build types

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -153,6 +153,7 @@ fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true
         "-PmaxParallelForks=%maxParallelForks%",
         "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",
         "-s",
+        "--no-configuration-cache",
         if (daemon) "--daemon" else "--no-daemon",
         if (isContinue) "--continue" else ""
     )

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -133,6 +133,6 @@ class ApplyDefaultConfigurationTest {
         val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%"
         val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java15.openjdk.64bit%,%windows.java16.openjdk.64bit%,%windows.java17.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
-        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% -s $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
+        return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% -s --no-configuration-cache $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }
 }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -89,6 +89,7 @@ class PerformanceTestBuildTypeTest {
             "-PmaxParallelForks=%maxParallelForks%",
             "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",
             "-s",
+            "--no-configuration-cache",
             "--daemon",
             "--continue",
             "\"-Dscan.tag.PerformanceTest\""


### PR DESCRIPTION
In preparation to eventually enable CC persistently in this repository's `gradle.properties`.

Reasons for disabling:
* Not all use cases of the `gradle/gradle` build are CC ready
* TeamCity injects init scripts that are incompatible with CC, see https://youtrack.jetbrains.com/issue/TW-71916
* `gradle/gradle` build logic for CI (mostly capturing diagnostic data) is not yet ready for CC

----

CI checks https://builds.gradle.org/buildConfiguration/Hygiene_TestTeamCityBuildConfigurations/46243866 ✅ 