### PR TITLE
Speed up a slow test by splitting it into 2 classes, once per DSL.

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractMultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractMultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.buildinit.plugins
 
-import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Unroll
@@ -26,7 +25,9 @@ import static org.gradle.buildinit.plugins.internal.modifiers.Language.JAVA
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.KOTLIN
 import static org.gradle.buildinit.plugins.internal.modifiers.Language.SCALA
 
-class MultiProjectJvmApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
+abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
+    abstract BuildInitDsl getBuildDsl()
+
     @Override
     String subprojectName() {
         return null
@@ -97,12 +98,18 @@ class MultiProjectJvmApplicationInitIntegrationTest extends AbstractInitIntegrat
         outputContains("Hello World!")
 
         where:
-        [jvmLanguage, scriptDsl] << [[JAVA, GROOVY, KOTLIN, SCALA], ScriptDslFixture.SCRIPT_DSLS].combinations()
+        [jvmLanguage, scriptDsl] << [[JAVA, GROOVY, KOTLIN, SCALA], getBuildDsl()].combinations()
     }
 
-    def "can explicitly configure application not to split projects"() {
+    def "can explicitly configure application not to split projects with #scriptDsl build scripts"() {
+        given:
+        def dsl = scriptDsl as BuildInitDsl
+
         expect:
-        succeeds('init', '--type', "java-application", '--dsl', 'groovy')
+        succeeds('init', '--type', "java-application", '--dsl', dsl.id)
+
+        where:
+        scriptDsl << getBuildDsl()
     }
 
     void assertTestPassed(String subprojectName, String className, String name) {
@@ -110,5 +117,4 @@ class MultiProjectJvmApplicationInitIntegrationTest extends AbstractInitIntegrat
         result.assertTestClassesExecuted(className)
         result.testClass(className).assertTestPassed(name)
     }
-
 }

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyDslMultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyDslMultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.buildinit.plugins
+
+
+import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
+
+class GroovyDslMultiProjectJvmApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.GROOVY
+    }
+}

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinDslMultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinDslMultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.buildinit.plugins
+
+
+import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
+
+class KotlinDslMultiProjectJvmApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.KOTLIN
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
MultiProjectJvmApplicationInitIntegrationTest was running progressively slower.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
