### PR TITLE
Supports `--release` option for `javadoc` task

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -296,6 +296,60 @@ Joe!""")
         succeeds("javadoc")
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/18274")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "supports release option for javadoc task"() {
+        buildFile << """
+            apply plugin: 'java'
+
+            javadoc {
+                options.release = 11
+            }
+        """
+        writeSourceFile()
+
+        expect:
+        succeeds("javadoc")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18274")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "supports release option for javadoc task in kotlin-dsl"() {
+        buildKotlinFile << """
+            plugins {
+                java
+            }
+
+            tasks.javadoc {
+                options.release = 11
+            }
+        """
+        writeSourceFile()
+
+        expect:
+        succeeds("javadoc")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/18274")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def "fails with invalid release option"() {
+        Integer version = 1
+        buildFile << """
+            apply plugin: 'java'
+
+            javadoc {
+                options.release = $version
+            }
+        """
+        writeSourceFile()
+
+        when:
+        fails("javadoc")
+
+        then:
+        failure.hasErrorOutput("error: release version $version not supported")
+    }
+
     private TestFile writeSourceFile() {
         file("src/main/java/Foo.java") << "public class Foo {}"
     }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -49,6 +49,7 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
     private final JavadocOptionFileOption<Boolean> breakIterator;
     private final JavadocOptionFileOption<String> locale;
     private final JavadocOptionFileOption<String> encoding;
+    private final JavadocOptionFileOption<String> release;
     private final OptionLessJavadocOptionFileOption<List<String>> sourceNames;
     private List<String> jFlags = new ArrayList<String>();
     private List<File> optionFiles = new ArrayList<File>();
@@ -73,6 +74,7 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
         breakIterator = addBooleanOption("breakiterator");
         locale = addStringOption("locale");
         encoding = addStringOption("encoding");
+        release = addStringOption("-release");
 
         sourceNames = optionFile.getSourceNames();
     }
@@ -93,6 +95,7 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
         breakIterator = optionFile.getOption("breakiterator");
         locale = optionFile.getOption("locale");
         encoding = optionFile.getOption("encoding");
+        release = optionFile.getOption("-release");
 
         sourceNames = optionFile.getSourceNames();
         jFlags = original.jFlags;
@@ -535,6 +538,22 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
     @Override
     public MinimalJavadocOptions sourceNames(String... sourceNames) {
         this.sourceNames.getValue().addAll(Arrays.asList(sourceNames));
+        return this;
+    }
+
+    @Override
+    public Integer getRelease() {
+        return release.getValue() == null ? null : Integer.valueOf(release.getValue());
+    }
+
+    @Override
+    public void setRelease(Integer release) {
+        this.release.setValue(release == null ? null : release.toString());
+    }
+
+    @Override
+    public MinimalJavadocOptions release(Integer release) {
+        setRelease(release);
         return this;
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/MinimalJavadocOptions.java
@@ -16,6 +16,7 @@
 
 package org.gradle.external.javadoc;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Console;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
@@ -203,6 +204,30 @@ public interface MinimalJavadocOptions {
     void setSourceNames(@Nullable List<String> sourceNames);
 
     MinimalJavadocOptions sourceNames(String... sourceNames);
+
+    /**
+     * The --release
+     *
+     * @since 7.3
+     */
+    @Incubating @Optional @Input
+    Integer getRelease();
+
+    /**
+     * The --release
+     *
+     * @since 7.3
+     */
+    @Incubating
+    void setRelease(Integer release);
+
+    /**
+     * The --release
+     *
+     * @since 7.3
+     */
+    @Incubating
+    MinimalJavadocOptions release(Integer release);
 
     void contributeCommandLineOptions(ExecSpec execHandleBuilder);
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
@@ -91,6 +91,7 @@ public class StandardJavadocDocletOptionsTest {
         assertEmpty(options.getNoQualifiers());
         assertTrue(options.isNoTimestamp());
         assertFalse(options.isNoComment());
+        assertNull(options.getRelease());
     }
 
     @Test
@@ -438,6 +439,13 @@ public class StandardJavadocDocletOptionsTest {
     public void testFluentNoComment() {
         assertEquals(options, options.noComment());
         assertTrue(options.isNoComment());
+    }
+
+    @Test
+    public void testFluentRelease() {
+        final Integer release = 11;
+        assertEquals(options, options.release(release));
+        assertEquals(release, options.getRelease());
     }
 
     @After


### PR DESCRIPTION
Signed-off-by: Xin Wang <scaventz@outlook.com>

<!--- The issue this PR addresses -->
Fixes [#18274](https://github.com/gradle/gradle/issues/18274)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
