### PR TITLE
Introduce TaskPropertiesService

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 @NonNullApi
 public class TaskPropertyUtils {
@@ -29,7 +28,6 @@ public class TaskPropertyUtils {
      * Visits both properties declared via annotations on the properties of the task type as well as
      * properties declared via the runtime API ({@link org.gradle.api.tasks.TaskInputs} etc.).
      */
-    @UsedByScanPlugin("test-distribution")
     public static void visitProperties(PropertyWalker propertyWalker, TaskInternal task, PropertyVisitor visitor) {
         visitProperties(propertyWalker, task, TypeValidationContext.NOOP, visitor);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputFilePropertyType.java
@@ -16,9 +16,6 @@
 
 package org.gradle.api.internal.tasks.properties;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
-@UsedByScanPlugin("test-distribution")
 public enum InputFilePropertyType {
     FILE(ValidationActions.INPUT_FILE_VALIDATOR),
     DIRECTORY(ValidationActions.INPUT_DIRECTORY_VALIDATOR),

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputFilePropertyType.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.properties;
 import org.gradle.internal.file.TreeType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
-@UsedByScanPlugin("test-distribution")
 public enum  OutputFilePropertyType {
     FILE(TreeType.FILE),
     DIRECTORY(TreeType.DIRECTORY),
@@ -32,7 +31,6 @@ public enum  OutputFilePropertyType {
         this.outputType = outputType;
     }
 
-    @UsedByScanPlugin("test-distribution")
     public TreeType getOutputType() {
         return outputType;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
@@ -19,14 +19,12 @@ package org.gradle.api.internal.tasks.properties;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 
 /**
  * Visits properties of beans which are inputs, outputs, destroyables or local state.
  */
-@UsedByScanPlugin("test-distribution")
 public interface PropertyVisitor {
     void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType, ContentTracking contentTracking);
 
@@ -38,9 +36,7 @@ public interface PropertyVisitor {
 
     void visitLocalStateProperty(Object value);
 
-    @UsedByScanPlugin("test-distribution")
     class Adapter implements PropertyVisitor {
-        @UsedByScanPlugin("test-distribution")
         @Override
         public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, DirectorySensitivity directorySensitivity, LineEndingSensitivity lineEndingSensitivity, boolean incremental, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType, ContentTracking contentTracking) {
         }
@@ -50,7 +46,6 @@ public interface PropertyVisitor {
         }
 
         @Override
-        @UsedByScanPlugin("test-distribution")
         public void visitOutputFileProperty(String propertyName, boolean optional, ContentTracking contentTracking, PropertyValue value, OutputFilePropertyType filePropertyType) {
         }
 

--- a/subprojects/enterprise/build.gradle.kts
+++ b/subprojects/enterprise/build.gradle.kts
@@ -5,13 +5,16 @@ plugins {
 dependencies {
     api(project(":base-services")) // leaks BuildOperationNotificationListener on API
 
-    implementation(libs.jsr305)
     implementation(libs.inject)
-    implementation(project(":logging"))
-    implementation(project(":core-api"))
+    implementation(libs.jsr305)
+    implementation(libs.guava)
     implementation(project(":build-option"))
     implementation(project(":core"))
+    implementation(project(":core-api"))
+    implementation(project(":file-collections"))
     implementation(project(":launcher"))
+    implementation(project(":logging"))
+    implementation(project(":model-core"))
     implementation(project(":snapshots"))
 
     integTestImplementation(project(":internal-testing"))

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/FileProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/FileProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+import java.io.File;
+import java.util.Set;
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+public interface FileProperty extends TaskProperty {
+
+    Set<File> getFiles();
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/InputFileProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/InputFileProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
-
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+public interface InputFileProperty extends FileProperty {
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/OutputFileProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/OutputFileProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+public interface OutputFileProperty extends FileProperty {
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+    TreeType getTreeType();
+
+    enum TreeType {
+        FILE,
+        DIRECTORY
+    }
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskProperties.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+import java.util.Set;
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+public interface TaskProperties {
+
+    Set<InputFileProperty> getInputFiles();
+
+    Set<OutputFileProperty> getOutputFiles();
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskPropertiesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.api.Task;
+import org.gradle.internal.scan.UsedByScanPlugin;
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+@UsedByScanPlugin("test-distribution")
+public interface TaskPropertiesService {
+
+    TaskProperties collectProperties(Task task);
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/TaskProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+public interface TaskProperty {
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+    String getPropertyName();
+    
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultInputFileProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultInputFileProperty.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tasks.impl;
+
+import org.gradle.internal.tasks.InputFileProperty;
+
+import java.io.File;
+import java.util.Set;
+
+public class DefaultInputFileProperty implements InputFileProperty {
+
+    private final String propertyName;
+    private final Set<File> files;
+
+    public DefaultInputFileProperty(String propertyName, Set<File> files) {
+        this.propertyName = propertyName;
+        this.files = files;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Set<File> getFiles() {
+        return files;
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultOutputFileProperty.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultOutputFileProperty.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tasks.impl;
+
+import org.gradle.internal.tasks.OutputFileProperty;
+
+import java.io.File;
+import java.util.Set;
+
+public class DefaultOutputFileProperty implements OutputFileProperty {
+
+    private final String propertyName;
+    private final Set<File> files;
+    private final TreeType treeType;
+
+    public DefaultOutputFileProperty(String propertyName, Set<File> files, TreeType treeType) {
+        this.propertyName = propertyName;
+        this.files = files;
+        this.treeType = treeType;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Set<File> getFiles() {
+        return files;
+    }
+
+    @Override
+    public TreeType getTreeType() {
+        return treeType;
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultTaskProperties.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultTaskProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tasks.impl;
+
+import org.gradle.internal.tasks.InputFileProperty;
+import org.gradle.internal.tasks.OutputFileProperty;
+import org.gradle.internal.tasks.TaskProperties;
+
+import java.util.Set;
+
+public class DefaultTaskProperties implements TaskProperties {
+
+    private final Set<InputFileProperty> inputFiles;
+    private final Set<OutputFileProperty> outputFiles;
+
+    DefaultTaskProperties(Set<InputFileProperty> inputFiles, Set<OutputFileProperty> outputFiles) {
+        this.inputFiles = inputFiles;
+        this.outputFiles = outputFiles;
+    }
+
+    public Set<InputFileProperty> getInputFiles() {
+        return inputFiles;
+    }
+
+    public Set<OutputFileProperty> getOutputFiles() {
+        return outputFiles;
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultTaskPropertiesService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/DefaultTaskPropertiesService.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.tasks.impl;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Task;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.tasks.TaskPropertyUtils;
+import org.gradle.api.internal.tasks.properties.ContentTracking;
+import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
+import org.gradle.api.internal.tasks.properties.OutputFilePropertyType;
+import org.gradle.api.internal.tasks.properties.PropertyValue;
+import org.gradle.api.internal.tasks.properties.PropertyVisitor;
+import org.gradle.api.internal.tasks.properties.PropertyWalker;
+import org.gradle.api.tasks.FileNormalizer;
+import org.gradle.internal.file.TreeType;
+import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.LineEndingSensitivity;
+import org.gradle.internal.tasks.InputFileProperty;
+import org.gradle.internal.tasks.OutputFileProperty;
+import org.gradle.internal.tasks.TaskProperties;
+import org.gradle.internal.tasks.TaskPropertiesService;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+
+public class DefaultTaskPropertiesService implements TaskPropertiesService {
+
+    private final PropertyWalker propertyWalker;
+    private final FileCollectionFactory fileCollectionFactory;
+
+    @Inject
+    public DefaultTaskPropertiesService(PropertyWalker propertyWalker, FileCollectionFactory fileCollectionFactory) {
+        this.propertyWalker = propertyWalker;
+        this.fileCollectionFactory = fileCollectionFactory;
+    }
+
+    @Override
+    public TaskProperties collectProperties(Task task) {
+        ImmutableSet.Builder<InputFileProperty> inputFiles = ImmutableSet.builder();
+        ImmutableSet.Builder<OutputFileProperty> outputFiles = ImmutableSet.builder();
+        TaskPropertyUtils.visitProperties(propertyWalker, (TaskInternal) task, new PropertyVisitor.Adapter() {
+            @Override
+            public void visitInputFileProperty(
+                String propertyName,
+                boolean optional,
+                boolean skipWhenEmpty,
+                DirectorySensitivity directorySensitivity,
+                LineEndingSensitivity lineEndingSensitivity,
+                boolean incremental,
+                @Nullable Class<? extends FileNormalizer> fileNormalizer,
+                PropertyValue value,
+                InputFilePropertyType filePropertyType,
+                ContentTracking contentTracking
+            ) {
+                Set<File> files = resolveLeniently(value);
+                inputFiles.add(new DefaultInputFileProperty(propertyName, files));
+            }
+
+            @Override
+            public void visitOutputFileProperty(
+                String propertyName,
+                boolean optional,
+                ContentTracking contentTracking,
+                PropertyValue value,
+                OutputFilePropertyType filePropertyType
+            ) {
+                Set<File> files = resolveLeniently(value);
+                OutputFileProperty.TreeType treeType = filePropertyType.getOutputType() == TreeType.DIRECTORY
+                    ? OutputFileProperty.TreeType.DIRECTORY
+                    : OutputFileProperty.TreeType.FILE;
+                outputFiles.add(new DefaultOutputFileProperty(propertyName, files, treeType));
+            }
+        });
+        return new DefaultTaskProperties(inputFiles.build(), outputFiles.build());
+    }
+
+    private Set<File> resolveLeniently(PropertyValue value) {
+        Object sources = value.call();
+        return sources == null ? emptySet() : fileCollectionFactory.resolvingLeniently(sources).getFiles();
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/TasksServices.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/TasksServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.tasks.impl;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
+public class TasksServices extends AbstractPluginServiceRegistry {
+
+    @Override
+    public void registerProjectServices(ServiceRegistration registration) {
+        registration.add(DefaultTaskPropertiesService.class);
+    }
+
 }

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/package-info.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+@NonNullApi
+package org.gradle.internal.tasks.impl;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
-
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
-}
+import org.gradle.api.NonNullApi;

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/package-info.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/tasks/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+@NonNullApi
+package org.gradle.internal.tasks;
 
-import org.gradle.internal.reflect.validation.TypeValidationContext;
-
-/**
- * Walks properties declared by the type.
- */
-public interface PropertyWalker {
-    void visitProperties(Object instance, TypeValidationContext validationContext, PropertyVisitor visitor);
-}
+import org.gradle.api.NonNullApi;

--- a/subprojects/enterprise/src/main/resources/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
+++ b/subprojects/enterprise/src/main/resources/META-INF/services/org.gradle.internal.service.scopes.PluginServiceRegistry
@@ -1,2 +1,3 @@
 org.gradle.internal.enterprise.impl.GradleEnterprisePluginServices
 org.gradle.internal.snapshot.impl.SnapshottingServices
+org.gradle.internal.tasks.impl.TasksServices


### PR DESCRIPTION
This commit introduces a stable API for querying task input/output file
properties for Gradle Enterprise Gradle plugins. I will add tests and
API docs once we've agreed on the API.