### PR TITLE
Fix some tasks in :docs for the configuration cache

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/DecorateReleaseNotes.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/DecorateReleaseNotes.java
@@ -19,6 +19,7 @@ package gradlebuild.docs;
 import org.apache.tools.ant.filters.ReplaceTokens;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.CacheableTask;
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
@@ -89,11 +91,14 @@ public abstract class DecorateReleaseNotes extends DefaultTask {
     @Input
     public abstract MapProperty<String, String> getReplacementTokens();
 
+    @Inject
+    protected abstract FileSystemOperations getFs();
+
     @TaskAction
     public void transform() {
         File destinationFile = getDestinationFile().get().getAsFile();
 
-        getProject().copy(copySpec -> {
+        getFs().copy(copySpec -> {
             copySpec.from(getHtmlFile());
             copySpec.into(destinationFile.getParentFile());
             copySpec.rename(s -> destinationFile.getName());

--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GenerateDocInfo.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GenerateDocInfo.java
@@ -19,6 +19,7 @@ package gradlebuild.docs;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -27,6 +28,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -47,11 +49,14 @@ public abstract class GenerateDocInfo extends DefaultTask {
     @OutputDirectory
     public abstract DirectoryProperty getDestinationDirectory();
 
+    @Inject
+    protected abstract FileSystemOperations getFs();
+
     @TaskAction
     public void generate() {
         // TODO: This could probably use InputChanges API
         File destinationDirectory = getDestinationDirectory().get().getAsFile();
-        getProject().delete(destinationDirectory);
+        getFs().delete(spec -> spec.delete(destinationDirectory));
         destinationDirectory.mkdirs();
 
         Path adocDir = getDocumentationRoot().get().getAsFile().toPath();

--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -32,11 +32,7 @@ Here's an example:
 
 ### Generating
 
-Run the `viewReleaseNotes` task to generate the release notes, and open them in your browser (requires Java 6).
-
-### Editing
-
-You can run the `editReleaseNotes` task to open the raw markdown notes in whatever editor is registered for this file type (requires Java 6).
+Run the `:docs:releaseNotes` task to generate the release notes.
 
 ## User Manual
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildDocumentationConfigurationCacheSmokeTest.groovy
@@ -23,11 +23,18 @@ import spock.lang.Ignore
 
 class GradleBuildDocumentationConfigurationCacheSmokeTest extends AbstractGradleBuildConfigurationCacheSmokeTest {
 
-    def "can build DSL documentation with configuration cache enabled"() {
+    def "can build documentation with configuration cache enabled"() {
 
         given:
         def tasks = [
-            ':docs:dslHtml'
+            ':docs:dslHtml',
+            ':docs:releaseNotes',
+            ':docs:generateDocInfo',
+            ':docs:apiMapping',
+            ':docs:defaultImports',
+            ':docs:checkDeadInternalLinks',
+            ':docs:checkstyleApi',
+            ':docs:incubationReport',
         ]
 
         when:
@@ -45,6 +52,13 @@ class GradleBuildDocumentationConfigurationCacheSmokeTest extends AbstractGradle
         then:
         assertConfigurationCacheStateLoaded()
         result.task(":docs:dslHtml").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:releaseNotes").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:generateDocInfo").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:apiMapping").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:defaultImports").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:checkDeadInternalLinks").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:checkstyleApi").outcome == TaskOutcome.FROM_CACHE
+        result.task(":docs:incubationReport").outcome == TaskOutcome.FROM_CACHE
     }
 
     @Ignore("Broken by at least the Asciidoctor plugin, and takes 40mins on CI")


### PR DESCRIPTION
And capture which `:docs` task work with the configuration cache in the gradleception smoke test.