### PR TITLE
Enable the configuration cache persistently on gradle/gradle build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,22 @@ Contributors must follow the Code of Conduct outlined at [https://gradle.org/con
 
 ## Making Changes
 
+### Configuration cache enabled by default
+
+The build of Gradle enables the configuration cache by default as an experiment.
+
+Most frequent use cases when contributing support the configuration cache but some don't. For example, building the documentation currently requires to disable the configuration cache.
+
+The build is configured to fail if a problem is found. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
+
+Tasks known to have problems:
+
+- Core reporting tasks such as `dependencies`, `projects`, `properties` etc...
+- Documentation tasks such as `:docs:userguide*`, `:docs:*Sample*` and `:docs:*Snippet*` thus `:docs:docs`, `:docs:serveDocs`, `:docs:docsTest` and building the `-all` distribution. See `GradleBuildDocumentationConfigurationCacheSmokeTest` for what is supported in `:docs`.
+- Tasks from third parties plugins such as Spotless, Gradle Doctor etc...
+
+For more information on the configuration cache, see the [user manual](https://docs.gradle.org/current/userguide/configuration_cache.html).
+
 ### Installing from source
 
 To create an install from the source tree you can run either of the following:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Contributors must follow the Code of Conduct outlined at [https://gradle.org/con
 
 The build of Gradle enables the configuration cache by default as an experiment.
 
-Most frequent use cases when contributing support the configuration cache but some don't. For example, building the documentation currently requires to disable the configuration cache.
+Most use cases support the configuration cache but some don't. For example, building the documentation currently requires to disable the configuration cache.
 
 The build is configured to fail if a task that is known to have problems is scheduled. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ The build of Gradle enables the configuration cache by default as an experiment.
 
 Most use cases support the configuration cache but some don't. For example, building the documentation currently requires to disable the configuration cache.
 
-The build is configured to fail if a task that is known to have problems is scheduled. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
+The build fails if a task that is known to have problems is scheduled. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
 
 Tasks known to have problems are listed in the build logic. You can find this list at:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,11 @@ The build of Gradle enables the configuration cache by default as an experiment.
 
 Most frequent use cases when contributing support the configuration cache but some don't. For example, building the documentation currently requires to disable the configuration cache.
 
-The build is configured to fail if a problem is found. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
+The build is configured to fail if a task that is known to have problems is scheduled. You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.
 
-Tasks known to have problems:
+Tasks known to have problems are listed in the build logic. You can find this list at:
 
-- Core reporting tasks such as `dependencies`, `projects`, `properties` etc...
-- Documentation tasks such as `:docs:userguide*`, `:docs:*Sample*` and `:docs:*Snippet*` thus `:docs:docs`, `:docs:serveDocs`, `:docs:docsTest` and building the `-all` distribution. See `GradleBuildDocumentationConfigurationCacheSmokeTest` for what is supported in `:docs`.
-- Tasks from third parties plugins such as Spotless, Gradle Doctor etc...
+    build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
 
 For more information on the configuration cache, see the [user manual](https://docs.gradle.org/current/userguide/configuration_cache.html).
 

--- a/build-logic-settings/cc-experiment-plugin/build.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-rootProject.name = "build-logic-settings"
-
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
-    }
+plugins {
+   `kotlin-dsl`
 }
 
-include("allprojects-plugin")
-include("testfiltering-plugin")
-include("cc-experiment-plugin")
-
+dependencies {
+    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.7")
+}

--- a/build-logic-settings/cc-experiment-plugin/build.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/build.gradle.kts
@@ -17,7 +17,3 @@
 plugins {
    `kotlin-dsl`
 }
-
-dependencies {
-    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.7")
-}

--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -30,6 +30,10 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
     val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
         when {
 
+            // Working tasks that would otherwise be matched by filters below
+            task.name in listOf("publishLocalPublicationToLocalRepository", "validateExternalPlugins") -> false
+            task.name.startsWith("validatePluginWithId") -> false
+
             // Core tasks
             task.name in listOf(
                 "buildEnvironment",

--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import org.gradle.api.internal.StartParameterInternal
+import org.gradle.api.internal.plugins.DslObject
 import org.gradle.initialization.StartParameterBuildOptions
 
 val startParameterInternal =
@@ -31,7 +32,10 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
         when {
 
             // Working tasks that would otherwise be matched by filters below
-            task.name in listOf("publishLocalPublicationToLocalRepository", "validateExternalPlugins") -> false
+            task.name in listOf(
+                "publishLocalPublicationToLocalRepository",
+                "validateExternalPlugins",
+            ) -> false
             task.name.startsWith("validatePluginWithId") -> false
 
             // Core tasks
@@ -48,8 +52,11 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
                 "dependantComponents",
                 "model",
             ) -> true
-            task.name.startsWith("publish") -> true
-            task.name.startsWith("idea") -> true
+            task.name.startsWithAnyOf(
+                "publish",
+                "idea",
+            ) -> true
+            task is GradleBuild -> true
 
             // gradle/gradle build tasks
             task.name in listOf(
@@ -58,18 +65,20 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
                 "resolveAllDependencies",
             ) -> true
             task.name.endsWith("Wrapper") -> true
-            task.path.startsWith(":docs") -> {
-                when {
-                    task.name in listOf("docs", "stageDocs", "docsTest", "serveDocs") -> true
-                    task.name.startsWith("userguide") -> true
-                    task.name.contains("Sample") -> true
-                    task.name.contains("Snippet") -> true
-                    else -> false
-                }
-            }
-            task.path.startsWith(":performance") -> true
-            task.path.startsWith(":build-scan-performance") -> true
-            task.path.startsWith(":internal-android-performance-testing") -> true
+            task.name in listOf("docs", "stageDocs", "docsTest", "serveDocs") -> true
+            task.name.startsWith("userguide") -> true
+            task.name.contains("Sample") -> true
+            task.name.contains("Snippet") -> true
+            task.typeSimpleName in listOf(
+                "KtsProjectGeneratorTask",
+                "JavaExecProjectGeneratorTask",
+                "JvmProjectGeneratorTask",
+                "NativeProjectGeneratorTask",
+                "MonolithicNativeProjectGeneratorTask",
+                "NativeProjectWithDepsGeneratorTask",
+                "CppMultiProjectGeneratorTask",
+                "BuildBuilderGenerator",
+            ) -> true
 
             // Third parties tasks
 
@@ -94,24 +103,26 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
                 "ripples",
                 "aggregateAdvice",
             ) -> true
-            task.name.startsWith("abiAnalysis") -> true
-            task.name.startsWith("advice") -> true
-            task.name.startsWith("analyzeClassUsage") -> true
-            task.name.startsWith("analyzeJar") -> true
-            task.name.startsWith("artifactsReport") -> true
-            task.name.startsWith("constantUsageDetector") -> true
-            task.name.startsWith("createVariantFiles") -> true
-            task.name.startsWith("findDeclaredProcs") -> true
-            task.name.startsWith("findUnusedProcs") -> true
-            task.name.startsWith("generalsUsageDetector") -> true
-            task.name.startsWith("importFinder") -> true
-            task.name.startsWith("inlineMemberExtractor") -> true
-            task.name.startsWith("locateDependencies") -> true
-            task.name.startsWith("misusedDependencies") -> true
-            task.name.startsWith("reason") -> true
-            task.name.startsWith("redundantKaptCheck") -> true
-            task.name.startsWith("redundantPluginAlert") -> true
-            task.name.startsWith("serviceLoader") -> true
+            task.name.startsWithAnyOf(
+                "abiAnalysis",
+                "advice",
+                "analyzeClassUsage",
+                "analyzeJar",
+                "artifactsReport",
+                "constantUsageDetector",
+                "createVariantFiles",
+                "findDeclaredProcs",
+                "findUnusedProcs",
+                "generalsUsageDetector",
+                "importFinder",
+                "inlineMemberExtractor",
+                "locateDependencies",
+                "misusedDependencies",
+                "reason",
+                "redundantKaptCheck",
+                "redundantPluginAlert",
+                "serviceLoader",
+            ) -> true
 
             else -> false
         }
@@ -138,3 +149,10 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
         }
     }
 }
+
+
+fun String.startsWithAnyOf(vararg prefixes: String): Boolean =
+    prefixes.any { prefix -> startsWith(prefix) }
+
+val Task.typeSimpleName: String
+    get() = DslObject(this).declaredType.simpleName

--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.gradle.api.internal.StartParameterInternal
+import org.gradle.configurationcache.problems.ProblemsListener
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.BuildOperationListener
+import org.gradle.internal.operations.BuildOperationListenerManager
+import org.gradle.internal.operations.OperationFinishEvent
+import org.gradle.internal.operations.OperationIdentifier
+import org.gradle.internal.operations.OperationProgressEvent
+import org.gradle.internal.operations.OperationStartEvent
+import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType
+import org.gradle.kotlin.dsl.support.serviceOf
+
+plugins {
+    id("com.gradle.enterprise")
+}
+
+if ((gradle.startParameter as StartParameterInternal).configurationCache.get()) {
+    gradleEnterprise {
+        buildScan {
+            val buildOpListenerManager = gradle.serviceOf<BuildOperationListenerManager>()
+            val configCacheProblems = gradle.serviceOf<ProblemsListener>()
+            background {
+                buildOpListenerManager.addListener(object : BuildOperationListener {
+
+                    override fun started(op: BuildOperationDescriptor, event: OperationStartEvent) = Unit
+                    override fun progress(id: OperationIdentifier, event: OperationProgressEvent) = Unit
+
+                    override fun finished(op: BuildOperationDescriptor, event: OperationFinishEvent) {
+                        when (event.result) {
+                            is BuildFinishedFileSystemWatchingBuildOperationType.Result -> {
+                                buildOpListenerManager.removeListener(this)
+                                // TODO if (!configCacheProblems.hasProblems) return
+                                value("configuration-cache:problems", "true")
+                                printProblemsHelp()
+                            }
+                        }
+                    }
+
+                    private
+                    fun printProblemsHelp() {
+                        val prefix = "CC>"
+                        println("$prefix The gradle/gradle build enables the configuration cache as an experiment. It seems you are using a feature of this build that is not yet supported.")
+                        println("$prefix You can disable the configuration cache with `--no-configuration-cache`. You can ignore problems with `--configuration-cache-problems=warn`.")
+                        println("$prefix Please see further instructions in CONTRIBUTING.md")
+                    }
+                })
+            }
+        }
+    }
+}

--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -32,7 +32,8 @@ if (isConfigurationCacheEnabled) {
                 "projects",
                 "idea",
                 "kotlinDslAccessorsReport",
-                "outgoingVariants"
+                "outgoingVariants",
+                "javaToolchains",
             ) -> true
             task.name.startsWith("publish") -> true
 

--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -124,17 +124,17 @@ if (isConfigurationCacheEnabled && isConfigurationCacheProblemsFail) {
             val displayedTasks = unsupportedTasks.takeLast(maxDisplayed).reversed().joinToString(separator = ", ") { it.path } +
                 if (unsupportedTasks.size > maxDisplayed) " and more..."
                 else ""
-            throw GradleException(
-                "Tasks unsupported with the configuration cache were scheduled: $displayedTasks\n" +
-                    "\n" +
-                    "  The gradle/gradle build enables the configuration cache as an experiment.\n" +
-                    "  It seems you are using a feature of this build that is not yet supported.\n" +
-                    "\n" +
-                    "  You can disable the configuration cache with `--no-configuration-cache`.\n" +
-                    "  You can ignore problems with `--configuration-cache-problems=warn`.\n" +
-                    "\n" +
-                    "  Please see further instructions in CONTRIBUTING.md"
-            )
+            throw GradleException("""
+                Tasks unsupported with the configuration cache were scheduled: $displayedTasks
+
+                  The gradle/gradle build enables the configuration cache as an experiment.
+                  It seems you are using a feature of this build that is not yet supported.
+
+                  You can disable the configuration cache with `--no-configuration-cache`.
+                  You can ignore problems with `--configuration-cache-problems=warn`.
+
+                  Please see further instructions in CONTRIBUTING.md
+            """.trimIndent())
         }
     }
 }

--- a/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
+++ b/build-logic-settings/testfiltering-plugin/src/main/kotlin/gradlebuild.internal.testfiltering.settings.gradle.kts
@@ -15,8 +15,9 @@
  */
 
 val testFilteringProperty = "gradle.internal.testselection.enabled"
-val gitBranchName: String? = System.getenv("BUILD_BRANCH")
-if (!System.getProperties().containsKey(testFilteringProperty) && gitBranchName != null) {
+val testFilteringProvider = providers.systemProperty(testFilteringProperty).forUseAtConfigurationTime()
+val gitBranchName: String? = providers.environmentVariable("BUILD_BRANCH").forUseAtConfigurationTime().orNull
+if (!testFilteringProvider.isPresent && gitBranchName != null) {
     val protectedBranches = listOf("master", "release")
     if (!protectedBranches.contains(gitBranchName) && !gitBranchName.startsWith("pre-test/")) {
         System.setProperty(testFilteringProperty, "true")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,8 @@ org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 org.gradle.parallel=true
 org.gradle.caching=true
 
+org.gradle.unsafe.configuration-cache=true
+
 systemProp.gradle.publish.skip.namespace.check=true
 
 # Temporarily force IDEs to produce build scans

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     id("com.gradle.enterprise.test-distribution").version("2.2.1-milestone-1") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("gradlebuild.internal.testfiltering")
     id("com.gradle.internal.test-selection").version("0.6.4-rc-1")
+    id("gradlebuild.internal.cc-experiment")
 }
 
 includeBuild("build-logic-commons")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -72,6 +72,9 @@ class ConfigurationCacheProblems(
         listenerManager.addListener(postBuildHandler)
     }
 
+    override val hasProblems: Boolean
+        get() = summarizer.get().problemCount > 0
+
     override fun close() {
         listenerManager.removeListener(postBuildHandler)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -72,9 +72,6 @@ class ConfigurationCacheProblems(
         listenerManager.addListener(postBuildHandler)
     }
 
-    override val hasProblems: Boolean
-        get() = summarizer.get().problemCount > 0
-
     override fun close() {
         listenerManager.removeListener(postBuildHandler)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
@@ -24,6 +24,4 @@ import org.gradle.internal.service.scopes.Scopes
 interface ProblemsListener {
 
     fun onProblem(problem: PropertyProblem)
-
-    val hasProblems: Boolean
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
@@ -24,4 +24,6 @@ import org.gradle.internal.service.scopes.Scopes
 interface ProblemsListener {
 
     fun onProblem(problem: PropertyProblem)
+
+    val hasProblems: Boolean
 }

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -58,6 +58,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
         executer.with {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
+            withArgument("--no-configuration-cache") // TODO:configuration-cache remove me
             withTasks(':distributions-full:binDistributionZip')
             withArgument("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
             withArgument("-Porg.gradle.java.installations.paths=${Jvm.current().javaHome.absolutePath}")


### PR DESCRIPTION
This PR enables the configuration cache persistently for the `gradle/gradle` build itself in its `gradle.properties` file.

A settings plugin is added that fail the build as early as possible when a task known to have problems with the configuration cache is scheduled. To this effect, that plugin includes a "list" of tasks known to have problems. The failure advise to disable the configuration cache using `--no-configuration-cache`. One can also use `--configuration-cache-problems=warn` to disable the early failure and explore the CC problems.

Going forward the plan is to reduce that list and eventually remove that plugin once all tasks are supported.

Note that CC was already explicitly disabled on all `gradle/gradle` CI jobs in https://github.com/gradle/gradle/pull/18401