### PR TITLE
Capture working dir early

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -17,10 +17,13 @@
 package org.gradle.testfixtures.internal;
 
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.test.fixtures.file.TestFile;
 
 import java.io.File;
 
 public class NativeServicesTestFixture {
+    // Collect this early, as the process' current directory can change during embedded test execution
+    public static final TestFile TEST_DIR = new TestFile(new File(".").toURI());
     static NativeServices nativeServices;
     static boolean initialized;
 
@@ -42,6 +45,6 @@ public class NativeServicesTestFixture {
     }
 
     public static File getNativeServicesDir() {
-        return new File("build/native-libs");
+        return TEST_DIR.file("build/native-libs");
     }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 public class NativeServicesTestFixture {
     // Collect this early, as the process' current directory can change during embedded test execution
-    public static final TestFile TEST_DIR = new TestFile(new File(".").toURI());
+    private static final TestFile TEST_DIR = new TestFile(new File(".").toURI());
     static NativeServices nativeServices;
     static boolean initialized;
 


### PR DESCRIPTION
This is an attempt to fix flaky test https://ge.gradle.org/s/v5xrarvewlvvm/tests/:diagnostics:embeddedIntegTest/org.gradle.api.tasks.diagnostics.HelpTaskIntegrationTest/shows%20help%20message%20when%20tasks%20%5Bhelp%5D%20run%20in%20a%20directory%20with%20no%20build%20definition%20present?top-execution=1

From the error message,

```
testDirectory.assertIsEmptyDir() |  
java.lang.AssertionError: For dir: C:\tcagent1\temp\buildTmp\gradle4102024770654894043 |  
extra files: [build/native-libs/.tmp], missing files: [], expected: [] expected:<[]> but was:<[build/native-libs/.tmp]>
```

It seems like `new File("build/native-libs")` was somehow pointing to `C:\tcagent1\temp\buildTmp\gradle4102024770654894043`, the only explanation for this is that working directory was changed to this directory during embedded integration test. Another evidence is that this test is only flaky in `embeddedIntegTest`.

https://github.com/gradle/gradle/blob/289303e6d63746f390c2a9b52f05593b5761f6ad/subprojects/internal-testing/src/main/groovy/org/gradle/testfixtures/internal/NativeServicesTestFixture.java#L45

Now we are trying to fix it by capturing working directory early. We can't reference `IntegrationBuildContext` in `NativeServicesFixtures` because `NativeServicesFixtures` is also used in unit test.