### PR TITLE
Revert to TD Gradle plugin to v2.2

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.7")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.1-milestone-1") // Sync with `settings.gradle.kts`
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.19.1")
         api("com.gradle.publish:plugin-publish-plugin:0.16.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("com.gradle.enterprise").version("3.7")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.2")
     id("gradlebuild.base.allprojects")
-    id("com.gradle.enterprise.test-distribution").version("2.2.1-milestone-1") // Sync with `build-logic/build-platform/build.gradle.kts`
+    id("com.gradle.enterprise.test-distribution").version("2.2") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("gradlebuild.internal.testfiltering")
     id("com.gradle.internal.test-selection").version("0.6.4-rc-1")
 }


### PR DESCRIPTION
It seems that upgrading the TD agent to v1.6.1 indeed fixed [this problem](https://github.com/gradle/dotcom/issues/10001) ([no occurrence since 3 days](https://ge.gradle.org/scans/failures?failures.failureClassification=non_verification&failures.failureMessage=Execution%20failed%20for%20task%20*%0A%3E%20java.util.concurrent.RejectedExecutionException:%20Unexpected%20state:%20current%3DWAITING_FOR_SESSION_OPENING,%20expected%3D%5BIDLE%5D&search.relativeStartTime=P7D&search.timeZoneId=Asia/Shanghai)), therefore we no longer need the additional logging and want to revert back to the latest official release v2.2.
