### PR TITLE
Use trademark note around Build Scan

### DIFF
--- a/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
+++ b/subprojects/docs/src/docs/stylesheets/userGuideHtmlCommon.xsl
@@ -211,7 +211,7 @@
                     <div class="site-footer__link-group">
                         <header><strong>Products</strong></header>
                         <ul class="site-footer__links-list">
-                            <li itemprop="name"><a href="https://gradle.com/build-scans" itemprop="url">Build Scans</a></li>
+                            <li itemprop="name"><a href="https://gradle.com/build-scans" itemprop="url">Build Scan™</a></li>
                             <li itemprop="name"><a href="https://gradle.com/build-cache" itemprop="url">Build Cache</a></li>
                             <li itemprop="name"><a href="https://gradle.com/enterprise/resources" itemprop="url">Enterprise Docs</a></li>
                         </ul>

--- a/subprojects/docs/src/docs/userguide/userguide.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide.adoc
@@ -45,7 +45,7 @@ If you're currently using Maven, see a visual link:{website}/maven-vs-gradle/[Gr
 
 Gradle supports many major IDEs, including **Android Studio, Eclipse, IntelliJ IDEA, Visual Studio 2019, and XCode**.
 You can also invoke Gradle via its <<command_line_interface.adoc#command_line_interface,command-line interface>> in your terminal or through your continuous integration server.
-link:https://scans.gradle.com/[Gradle build scans] help you understand build results, improve build performance, and collaborate to fix problems faster.
+link:https://scans.gradle.com/[Gradle Build Scan™] help you understand build results, improve build performance, and collaborate to fix problems faster.
 
 ++++
 <div class="ui-logos">

--- a/subprojects/docs/src/main/resources/footer.html
+++ b/subprojects/docs/src/main/resources/footer.html
@@ -27,7 +27,7 @@
             <div class="site-footer__link-group">
                 <header><strong>Products</strong></header>
                 <ul class="site-footer__links-list">
-                    <li itemprop="name"><a href="https://gradle.com/build-scans/" itemprop="url">Build Scans</a></li>
+                    <li itemprop="name"><a href="https://gradle.com/build-scans/" itemprop="url">Build Scan™</a></li>
                     <li itemprop="name"><a href="https://gradle.com/build-cache/" itemprop="url">Build Cache</a></li>
                     <li itemprop="name"><a href="https://gradle.com/enterprise/resources/" itemprop="url">Enterprise Docs</a></li>
                 </ul>


### PR DESCRIPTION
This changeset is limited to the first page and footers of
documentation.