### PR TITLE
Ignore registrations for BuildOutputCleanupRegistry after finalization

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.integtests.fixtures.executer.ProjectLifecycleFixture
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
 import org.junit.Rule
 import spock.lang.IgnoreIf
+import spock.lang.Issue
 
 @FluidDependenciesResolveTest
 class ConfigurationOnDemandIntegrationTest extends AbstractIntegrationSpec {
@@ -530,5 +531,32 @@ task printExt {
 
         then:
         outputContains("The Foo says Moo!!!")
+    }
+
+    @ToBeFixedForConfigurationCache(because = "runs the dependencies task")
+    @Issue("https://github.com/gradle/gradle/issues/18460")
+    def "can query dependencies with configure on demand enabled"() {
+        def subprojects = ["a", "b"]
+        multiProjectBuild("outputRegistry", subprojects)
+        subprojects.each { projectName ->
+            file("${projectName}/build.gradle") << """
+                plugins {
+                    id("java-library")
+                }
+            """
+        }
+        file("a/build.gradle") << """
+            dependencies {
+                implementation(project(":b"))
+            }
+        """
+
+        when:
+        succeeds("a:dependencies", "--configure-on-demand", "--debug")
+        then:
+        outputContains("More outputs are being registered even though the build output cleanup registry has already been finalized.")
+
+        expect:
+        succeeds("a:dependencies", "--configure-on-demand")
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/cleanup/DefaultBuildOutputCleanupRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/cleanup/DefaultBuildOutputCleanupRegistryTest.groovy
@@ -63,14 +63,14 @@ class DefaultBuildOutputCleanupRegistryTest extends Specification {
         !registry.isOutputOwnedByBuild(file('different-file/build/outputs'))
     }
 
-    def "cannot register files after the outputs have been resolved"() {
+    def "outputs registered after finalization are ignored"() {
         given:
         registry.resolveOutputs()
 
         when:
         registry.registerOutputs(file('build'))
         then:
-        thrown(GradleException)
+        !registry.isOutputOwnedByBuild(file("build"))
     }
 
     def "cannot query outputs when they have not been resolved"() {


### PR DESCRIPTION
instead of failing the build. Failing the build did break running the `dependencies` task with configure on demand.

Fixes #18460.