### PR TITLE
Disable the configuration cache for buildCommitDistribution

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -88,6 +88,7 @@ abstract class BuildCommitDistribution @Inject internal constructor(
     fun getBuildCommands(): Array<String> {
         val buildCommands = mutableListOf(
             "./gradlew" + (if (OperatingSystem.current().isWindows()) ".bat" else ""),
+            "--no-configuration-cache",
             "clean",
             ":distributions-full:install",
             "-Pgradle_installPath=" + commitDistributionHome.get().asFile.absolutePath,


### PR DESCRIPTION
Fix for https://ge.gradle.org/s/cr2tj2n7cyylg/console-log?task=:performance:buildCommitDistribution#L1149