### PR TITLE
Clarify configuration cache ide support in docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -292,7 +292,7 @@ link:{gradle-issues}13455[[.green]#✓#]:: <<distribution_plugin.adoc#distributi
 link:{gradle-issues}13455[[.green]#✓#]:: <<java_library_distribution_plugin.adoc#java_library_distribution_plugin,Java Library Distribution>>
 
 h| Code analysis
-h| IDE integration
+h| IDE project files generation
 h| Utility
 
 a|


### PR DESCRIPTION
The core plugins are only about IDE files generation.