### PR TITLE
Improve failure context

### DIFF
--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 classycle {
     // Needed for the factory methods in the base class
     excludePatterns.add("org/gradle/util/GradleVersion**")
+    excludePatterns.add("org/gradle/internal/exceptions/Contextual**")
 }
 
 jmh.includes.set(listOf("HashingAlgorithmsBenchmark"))

--- a/subprojects/base-services/src/main/java/org/gradle/api/InvalidUserDataException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/InvalidUserDataException.java
@@ -16,9 +16,12 @@
 
 package org.gradle.api;
 
+import org.gradle.internal.exceptions.Contextual;
+
 /**
  * A <code>InvalidUserDataException</code> is thrown, if a user is providing illegal data for the build.
  */
+@Contextual
 public class InvalidUserDataException extends GradleException {
     public InvalidUserDataException() {
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import org.gradle.StartParameter;
-import org.gradle.api.GradleException;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
@@ -32,6 +31,7 @@ import org.gradle.api.internal.artifacts.verification.signatures.BuildTreeDefine
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.properties.GradleProperties;
+import org.gradle.api.internal.tasks.TaskDependencyResolveException;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -243,7 +243,7 @@ public class StartParameterResolutionOverride {
 
         @Override
         public ModuleComponentRepository overrideDependencyVerification(ModuleComponentRepository original, String resolveContextName, ResolutionStrategyInternal resolutionStrategy) {
-            throw new GradleException("Dependency verification cannot be performed", error);
+            throw new TaskDependencyResolveException("Dependency verification cannot be performed", error);
         }
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #18373 

Turns out that when the failure described in the issue happens, enough information is available about it, but Gradle will not print out all of it. This is due to the way how `ContextAwareException` behaves when visiting the cause tree, see `visitCause()` method. The detailed explanation of the failure is in the message of an `InvalidUserDataException`, which is the cause of another `InvalidUserDataException` which is the cause of a `GradleException`. In order to get all their messages printed, these exceptions need to be annotated with the `Contextual` annotation (RUNTIME retention). That is what the fix does.

Due to the fix, the reported error goes from:

```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all dependencies for configuration ':compileClasspath'.
   > Dependency verification cannot be performed
```

to

```
* What went wrong:
Execution failed for task ':app:compileJava'.
> Could not resolve all dependencies for configuration ':app:compileClasspath'.
   > Dependency verification cannot be performed
      > Unable to read dependency verification metadata from /Users/jozsef/Work/bt-support/18373/gradle/verification-metadata.xml
         > Invalid dependency verification metadata file: <trusted-keys> must be found under the <configuration> tag
```

That in itself should be good, but there are two problems:
* what other logging will be affected by this change? (checking it is WIP)
* the annotation is internal, while the annotated exception are public/api ones... this is not nice, but it's not the only occurrence in the codebase, so I did what the other occurrences do (to make it not trigger errors): hacked the `classycle` block in the build file... not too proud of it, but what else could we do?