### PR TITLE
Fix BuildOperationTrace with debug on Java 8

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/BuildInitializationBuildOperationsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.initialization
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationNotificationsFixture
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import spock.lang.Issue
 
 class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -231,4 +232,17 @@ class BuildInitializationBuildOperationsIntegrationTest extends AbstractIntegrat
         loadProjectsBuildOperations*.result.rootProject.projectDir == dirs
     }
 
+    @Issue("https://github.com/gradle/gradle/pull/18484")
+    def "can run a build with build operation trace and --debug"() {
+        buildFile << """
+            task foo {
+                doLast {
+                    println 'foo'
+                }
+            }
+        """
+        executer.withStackTraceChecksDisabled()
+        expect:
+        succeeds('foo', "--debug")
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -38,7 +38,6 @@ import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
 import org.junit.Rule
-import spock.lang.Ignore
 
 import java.util.regex.Pattern
 
@@ -273,7 +272,6 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         assertNestedTaskOutputTracked()
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3393")
     def "supports debug level logging"() {
         when:
         buildFile << """

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -22,7 +22,6 @@ import com.google.common.io.Files;
 import com.google.common.io.LineProcessor;
 import groovy.json.JsonOutput;
 import groovy.json.JsonSlurper;
-import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.gradle.StartParameter;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.Stoppable;
@@ -111,13 +110,6 @@ public class BuildOperationTrace implements Stoppable {
 
     public BuildOperationTrace(StartParameter startParameter, BuildOperationListenerManager buildOperationListenerManager) {
         this.buildOperationListenerManager = buildOperationListenerManager;
-        // Initialize the Groovy VMPlugin
-        // If we don't do this here, then the first call to JsonOutput.toJson will force the initialization.
-        // That is not bad as is, only on Java 8 this causes the logging of an exception while initializing the VMPlugin.
-        // And from the debug logging, we end up in the trace again which tries to call JsonOutput.toJson again.
-        // Since the VMplugin isn't initialized, yet (we are just in the middle of it), we end up with an NPE and the build fails.
-        // So we need to initialize the VMPlugin before we start writing traces.
-        DefaultGroovyMethods.getMetaClass(JsonOutput.class);
 
         Map<String, String> sysProps = startParameter.getSystemPropertiesArgs();
         String basePath = sysProps.get(SYSPROP);

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContext.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContext.java
@@ -34,6 +34,7 @@ public class OutputEventListenerBackedLoggerContext implements ILoggerFactory {
 
     static final String HTTP_CLIENT_WIRE_LOGGER_NAME = "org.apache.http.wire";
     static final String META_INF_EXTENSION_MODULE_LOGGER_NAME = "org.codehaus.groovy.runtime.m12n.MetaInfExtensionModule";
+    private static final String GROOVY_VM_PLUGIN_FACTORY = "org.codehaus.groovy.vmplugin.VMPluginFactory";
 
     private final ConcurrentMap<String, Logger> loggers = new ConcurrentHashMap<String, Logger>();
     private final AtomicReference<LogLevel> level = new AtomicReference<LogLevel>();
@@ -51,6 +52,10 @@ public class OutputEventListenerBackedLoggerContext implements ILoggerFactory {
         addNoOpLogger("org.apache.http.headers");
         addNoOpLogger(META_INF_EXTENSION_MODULE_LOGGER_NAME);
         addNoOpLogger("org.littleshoot.proxy.HttpRequestHandler");
+        // We ignore logging from here because this is when the Groovy runtime is initialized.
+        // This may happen in BuildOperationTrace, and then the logging from the plugin factory would go into the build operation trace again.
+        // That then will fail because we can't use JsonOutput in BuildOperationTrace when the Groovy VM hasn't been initialized.
+        addNoOpLogger(GROOVY_VM_PLUGIN_FACTORY);
     }
 
     private void addNoOpLogger(String name) {

--- a/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
+++ b/subprojects/soak/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/ScriptCachingIntegrationTest.kt
@@ -38,7 +38,6 @@ import org.junit.Test
 import java.util.UUID
 
 
-@Ignore("https://github.com/gradle/gradle-private/issues/3393")
 class ScriptCachingIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
     @Test


### PR DESCRIPTION
The first log event which ends up in BuildOperationTrace initializes the Groovy VM on the call of `JsonOutput.toJson()`. That is not bad as is, only on Java 8 this causes the logging of an exception while initializing the VMPlugin. And from the debug logging, we end up in the trace again which tries to call `JsonOutput.toJson()` again. Since the VMplugin isn't initialized, yet (we are just in the middle of it), we end up with an NPE and the build fails.
 
So we need to initialize the VMPlugin before we start writing traces.

If the log level is not debug, the Groovy VM doesn't log the error, so we don't come into this situation.

Fixes https://github.com/gradle/gradle-private/issues/3393.