### PR TITLE
Ensure listener installed by configuration cache is always disposed of

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -35,6 +35,7 @@ import org.gradle.initialization.GradlePropertiesController
 import org.gradle.internal.Factory
 import org.gradle.internal.buildtree.BuildActionModelRequirements
 import org.gradle.internal.classpath.Instrumented
+import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
@@ -58,7 +59,7 @@ class DefaultConfigurationCache internal constructor(
      */
     @Suppress("unused")
     private val fileSystemAccess: FileSystemAccess
-) : BuildTreeConfigurationCache {
+) : BuildTreeConfigurationCache, Stoppable {
 
     interface Host {
 
@@ -197,6 +198,10 @@ class DefaultConfigurationCache internal constructor(
                 }
             }
         }
+    }
+
+    override fun stop() {
+        Instrumented.discardListener()
     }
 
     private


### PR DESCRIPTION
At the end of the build by making the `DefaultConfigurationCache` build tree scoped service `Stoppable`.