### PR TITLE
Fix Scala test

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/AbstractToolchainZincScalaCompileIntegrationTest.groovy
@@ -43,6 +43,15 @@ abstract class AbstractToolchainZincScalaCompileIntegrationTest extends BasicZin
 
     abstract Jvm computeJdkForTest()
 
+    def "joint compile good java code with interface using default and static methods do not fail the build"() {
+        given:
+        goodJavaInterfaceCode()
+        goodCodeUsingJavaInterface()
+
+        expect:
+        succeeds 'compileScala', '-s'
+    }
+
     def "can generate ScalaDoc"() {
         given:
         goodCode()

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/BasicZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/BasicZincScalaCompilerIntegrationTest.groovy
@@ -99,15 +99,6 @@ abstract class BasicZincScalaCompilerIntegrationTest extends MultiVersionIntegra
         succeeds 'compileScala'
     }
 
-    def "joint compile good java code with interface using default and static methods do not fail the build"() {
-        given:
-        goodJavaInterfaceCode()
-        goodCodeUsingJavaInterface()
-
-        expect:
-        succeeds 'compileScala', '-s'
-    }
-
     def "joint compile bad java code do not fail the build when options.failOnError is false"() {
         given:
         goodCode()


### PR DESCRIPTION
This test cannot pass for Scala 2.11 without toolchain.
It needs the -target flag specified.