### PR TITLE
Introduce resolution strategy to deactivate global substitution rules

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -17,6 +17,8 @@
 package org.gradle.api.artifacts;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
 
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -365,6 +367,21 @@ public interface ResolutionStrategy {
      * @since 2.5
      */
     ResolutionStrategy dependencySubstitution(Action<? super DependencySubstitutions> action);
+
+    /**
+     * Gradle implicitly registers dependency substitution rules for all configurations in the whole build
+     * tree to find projects in other included builds. These rules are always active by default.
+     *
+     * There are however cases, where a certain configuration should not apply these rules when resolving.
+     * For example, if a binary version of a module should be discovered that is also represented by
+     * a project in another build.
+     *
+     * This property may be used to deactivate these global substitution rules.
+     *
+     * @since 7.4
+     */
+    @Incubating
+    Property<Boolean> getUseGlobalDependencySubstitutionRules();
 
     /**
      * Specifies the ordering for resolved artifacts. Options are:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.rules
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class DependencyResolveRulesDisableGlobalDependencySubstitutionIntegrationTest extends AbstractIntegrationSpec {
+
+    ResolveTestFixture resolveLocal
+    ResolveTestFixture resolvePublished
+
+    def setup() {
+        resolveLocal = new ResolveTestFixture(buildFile, 'localPath')
+        resolveLocal.expectDefaultConfiguration('runtime')
+        resolvePublished = new ResolveTestFixture(buildFile, 'publishedPath')
+        resolvePublished.expectDefaultConfiguration('runtime')
+        resolveLocal.addDefaultVariantDerivationStrategy()
+        resolveLocal.addJavaEcosystemSchema()
+
+        mavenRepo.module("org.test", "m2", "1.0").dependsOn("org.test", "m3", "1.0").withModuleMetadata().publish()
+        mavenRepo.module("org.test", "m3", '1.0').withModuleMetadata().publish()
+
+        settingsFile << """
+            dependencyResolutionManagement {
+                repositories.maven { url "${mavenRepo.uri}" }
+            }
+            includeBuild '.' // enable global substitution for this build
+            include 'm1', 'm2', 'm3'
+        """
+
+        buildFile << """
+            allprojects {
+                group = 'org.test'
+                version = '0.9'
+                def conf = configurations.create('conf') {
+                    canBeConsumed = false
+                    canBeResolved = false
+                }
+                configurations.create('runtime') {
+                    extendsFrom(conf)
+                    canBeConsumed = true
+                    canBeResolved = false
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                }
+            }
+            project(':m1') {
+                configurations.create('localPath') {
+                    extendsFrom(configurations.conf)
+                    canBeConsumed = false
+                    canBeResolved = true
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                }
+                configurations.create('publishedPath') {
+                    extendsFrom(configurations.conf)
+                    canBeConsumed = false
+                    canBeResolved = true
+                    resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                }
+                dependencies {
+                    conf 'org.test:m2:1.0'
+                }
+            }
+            project(':m2') {
+                dependencies {
+                    conf 'org.test:m3:1.0'
+                }
+            }
+        """
+    }
+
+    def resolveLocalPath() {
+        resolveLocal.prepare()
+        resolveLocal
+    }
+
+    def resolvePublishedPath() {
+        resolvePublished.prepare()
+        resolvePublished
+    }
+
+    def static expectResolvedToLocal(ResolveTestFixture resolve) {
+        resolve.expectGraph {
+            root(":m1", "org.test:m1:0.9") {
+                edge("org.test:m2:1.0", "project :m2", "org.test:m2:0.9") {
+                    edge("org.test:m3:1.0", "project :m3", "org.test:m3:0.9") {
+                        noArtifacts()
+                    }
+                    noArtifacts()
+                }
+            }
+        }
+        true
+    }
+
+    def static expectResolveToPublished(ResolveTestFixture resolve) {
+        resolve.expectGraph {
+            root(":m1", "org.test:m1:0.9") {
+                edge("org.test:m2:1.0", "org.test:m2:1.0") {
+                    edge("org.test:m3:1.0", "org.test:m3:1.0") { }
+                }
+            }
+        }
+        true
+    }
+
+    def "global dependency substitution is only disabled for the configuration that it is configured for"() {
+        when:
+        resolveLocalPath()
+        run ':m1:checkDeps'
+
+        then:
+        expectResolvedToLocal(resolveLocal)
+
+        when:
+        resolvePublishedPath()
+        run ':m1:checkDeps'
+
+        then:
+        expectResolveToPublished(resolvePublished)
+    }
+
+    def "global dependency substitution can be re-enabled"() {
+        given:
+        buildFile << """
+            project(':m1') {
+                configurations.publishedPath.resolutionStrategy.useGlobalDependencySubstitutionRules.set(true)
+            }
+        """
+
+        when:
+        resolvePublishedPath()
+        run ':m1:checkDeps'
+
+        then:
+        expectResolvedToLocal(resolvePublished)
+    }
+
+
+    def "global dependency substitution can be disabled for all configurations"() {
+        given:
+        buildFile << """
+            project(':m1') {
+                configurations.all {
+                    resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
+                }
+            }
+        """
+
+        when:
+        resolveLocalPath()
+        run ':m1:checkDeps'
+
+        then:
+        expectResolveToPublished(resolveLocal)
+
+        when:
+        resolvePublishedPath()
+        run ':m1:checkDeps'
+
+        then:
+        expectResolveToPublished(resolvePublished)
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategy.java
@@ -41,6 +41,7 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.internal.Actions;
 import org.gradle.internal.Cast;
 import org.gradle.internal.locking.NoOpDependencyLockingProvider;
@@ -76,6 +77,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final DependencyLockingProvider dependencyLockingProvider;
     private final CapabilitiesResolutionInternal capabilitiesResolution;
+    private final ObjectFactory objectFactory;
     private MutationValidator mutationValidator = MutationValidator.IGNORE;
 
     private boolean dependencyLockingEnabled = false;
@@ -84,6 +86,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     private boolean failOnDynamicVersions;
     private boolean failOnChangingVersions;
     private boolean verifyDependencies = true;
+    private final Property<Boolean> useGlobalDependencySubstitutionRules;
 
 
     public DefaultResolutionStrategy(DependencySubstitutionRules globalDependencySubstitutionRules,
@@ -98,10 +101,10 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
                                      ImmutableAttributesFactory attributesFactory,
                                      NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
                                      NotationParser<Object, Capability> capabilitiesNotationParser) {
-        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleSelectorNotationParser, instantiator, objectFactory, attributesFactory, capabilitiesNotationParser), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
+        this(new DefaultCachePolicy(), DefaultDependencySubstitutions.forResolutionStrategy(componentIdentifierFactory, moduleSelectorNotationParser, instantiator, objectFactory, attributesFactory, capabilitiesNotationParser), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution, objectFactory);
     }
 
-    DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider, CapabilitiesResolutionInternal capabilitiesResolution) {
+    DefaultResolutionStrategy(DefaultCachePolicy cachePolicy, DependencySubstitutionsInternal dependencySubstitutions, DependencySubstitutionRules globalDependencySubstitutionRules, VcsResolver vcsResolver, ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter, DependencyLockingProvider dependencyLockingProvider, CapabilitiesResolutionInternal capabilitiesResolution, ObjectFactory objectFactory) {
         this.cachePolicy = cachePolicy;
         this.dependencySubstitutions = dependencySubstitutions;
         this.globalDependencySubstitutionRules = globalDependencySubstitutionRules;
@@ -111,6 +114,8 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         this.componentSelectorConverter = componentSelectorConverter;
         this.dependencyLockingProvider = dependencyLockingProvider;
         this.capabilitiesResolution = capabilitiesResolution;
+        this.objectFactory = objectFactory;
+        this.useGlobalDependencySubstitutionRules = objectFactory.property(Boolean.class).convention(true);
         // This is only used for testing purposes so we can test handling of fluid dependencies without adding dependency substitution rule
         assumeFluidDependencies = Boolean.getBoolean(ASSUME_FLUID_DEPENDENCIES);
     }
@@ -225,7 +230,8 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         Set<ModuleVersionSelector> forcedModules = getForcedModules();
         Action<DependencySubstitution> moduleForcingResolveRule = Cast.uncheckedCast(forcedModules.isEmpty() ? Actions.doNothing() : new ModuleForcingResolveRule(forcedModules));
         Action<DependencySubstitution> localDependencySubstitutionsAction = this.dependencySubstitutions.getRuleAction();
-        Action<DependencySubstitution> globalDependencySubstitutionRulesAction = globalDependencySubstitutionRules.getRuleAction();
+        Action<DependencySubstitution> globalDependencySubstitutionRulesAction = (useGlobalDependencySubstitutionRules.get() ?
+           globalDependencySubstitutionRules :  DependencySubstitutionRules.NO_OP).getRuleAction();
         return Actions.composite(moduleForcingResolveRule, localDependencySubstitutionsAction, globalDependencySubstitutionRulesAction);
     }
 
@@ -238,7 +244,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     public boolean resolveGraphToDetermineTaskDependencies() {
         return assumeFluidDependencies
                 || dependencySubstitutions.rulesMayAddProjectDependency()
-                || globalDependencySubstitutionRules.rulesMayAddProjectDependency()
+                || useGlobalDependencySubstitutionRules.get() && globalDependencySubstitutionRules.rulesMayAddProjectDependency()
                 || vcsResolver.hasRules();
     }
 
@@ -300,8 +306,13 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
     }
 
     @Override
+    public Property<Boolean> getUseGlobalDependencySubstitutionRules() {
+        return useGlobalDependencySubstitutionRules;
+    }
+
+    @Override
     public DefaultResolutionStrategy copy() {
-        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), dependencySubstitutions.copy(), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution);
+        DefaultResolutionStrategy out = new DefaultResolutionStrategy(cachePolicy.copy(), dependencySubstitutions.copy(), globalDependencySubstitutionRules, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolution, objectFactory);
 
         if (conflictResolution == ConflictResolution.strict) {
             out.failOnVersionConflict();
@@ -324,6 +335,7 @@ public class DefaultResolutionStrategy implements ResolutionStrategyInternal {
         if (!isDependencyVerificationEnabled()) {
             out.disableDependencyVerification();
         }
+        out.getUseGlobalDependencySubstitutionRules().convention(useGlobalDependencySubstitutionRules.get());
         return out;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -35,6 +35,7 @@ import org.gradle.internal.Actions
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.locking.NoOpDependencyLockingProvider
 import org.gradle.internal.rules.NoInputsRuleAction
+import org.gradle.util.TestUtil
 import org.gradle.vcs.internal.VcsResolver
 import spock.lang.Shared
 import spock.lang.Specification
@@ -59,7 +60,7 @@ class DefaultResolutionStrategySpec extends Specification {
             DefaultModuleIdentifier.newId(*args)
         }
     }
-    def strategy = new DefaultResolutionStrategy(cachePolicy, dependencySubstitutions, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null)
+    def strategy = new DefaultResolutionStrategy(cachePolicy, dependencySubstitutions, globalDependencySubstitutions, vcsResolver, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, null, TestUtil.objectFactory())
 
     def "allows setting forced modules"() {
         expect:
@@ -155,6 +156,16 @@ class DefaultResolutionStrategySpec extends Specification {
         !copy.is(strategy)
         !copy.cachePolicy.is(strategy.cachePolicy)
         !copy.componentSelection.is(strategy.componentSelection)
+    }
+
+    def "use global substitution rules state is not share with copy"() {
+        when:
+        def copy = strategy.copy()
+        strategy.useGlobalDependencySubstitutionRules.set(false)
+
+        then:
+        !strategy.useGlobalDependencySubstitutionRules.get()
+        copy.useGlobalDependencySubstitutionRules.get()
     }
 
     def "provides a copy"() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.ResolutionStrategy.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.ResolutionStrategy.xml
@@ -48,6 +48,9 @@
                 <td>dependencySubstitution</td>
             </tr>
             <tr>
+                <td>getUseGlobalDependencySubstitutionRules</td>
+            </tr>
+            <tr>
                 <td>componentSelection</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
@@ -181,6 +181,21 @@ include::sample[dir="samples/build-organization/composite-builds/declared-substi
 
 With this configuration, the "my-app" composite build will substitute any dependency on `org.sample:number-utils` with a dependency on the root project of "anonymous-library".
 
+[[deactivate_included_build_substitutions]]
+=== Deactivate included build substitutions for a Configuration
+
+If you need to <<declaring_dependencies.adoc#sec:resolvable-consumable-configs,resolve>> a published version of a module that is also available as part of an included build, you can deactivate the included build substitution rules on the link:{groovyDslPath}/org.gradle.api.artifacts.ResolutionStrategy.html[ResolutionStrategy] of the Configuration that is resolved.
+This is necessary, because the rules are globally applied in the build and Gradle does not consider published versions during resolution by default.
+
+.Deactivate global dependency substitution rules
+====
+include::sample[dir="snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy",files="build.gradle[tags=disableGlobalDependencySubstitutionRules]"]
+include::sample[dir="snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin",files="build.gradle.kts[tags=disableGlobalDependencySubstitutionRules]"]
+====
+
+In this example, we create a separate `publishedRuntimeClasspath` configuration that gets resolve to the published versions of modules that also exist in one of the local builds.
+This can be used, for example, to compare published and locally built Jar files.
+
 [[included_build_substitution_requirements]]
 === Cases where included build substitutions must be declared
 

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java-library'
+}
+repositories {
+    mavenCentral()
+}
+
+// tag::disableGlobalDependencySubstitutionRules[]
+configurations.create('publishedRuntimeClasspath') {
+    resolutionStrategy.useGlobalDependencySubstitutionRules = false
+
+    extendsFrom(configurations.runtimeClasspath)
+    canBeConsumed = false
+    canBeResolved = true
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+}
+// end::disableGlobalDependencySubstitutionRules[]
+
+dependencies {
+    api 'org.test:module-a:1.0'
+}
+
+tasks.register('resolve') {
+    doLast {
+        configurations.runtimeClasspath.files.each { println(it.name) }
+        configurations.publishedRuntimeClasspath.files.each { println(it.name) }
+    }
+}
+

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/module-a/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/module-a/build.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'org.test'
+version = '0.9'

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/groovy/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'deactivate-global-substitution'
+includeBuild '.'
+include 'module-a'

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    `java-library`
+}
+repositories {
+    mavenCentral()
+}
+
+// tag::disableGlobalDependencySubstitutionRules[]
+configurations.create("publishedRuntimeClasspath") {
+    resolutionStrategy.useGlobalDependencySubstitutionRules.set(false)
+
+    extendsFrom(configurations.runtimeClasspath.get())
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+}
+// end::disableGlobalDependencySubstitutionRules[]
+
+dependencies {
+    api("org.test:module-a:1.0")
+}
+
+tasks.register("resolve") {
+    doLast {
+        configurations.runtimeClasspath.get().files.forEach { println(it.name) }
+        configurations["publishedRuntimeClasspath"].files.forEach { println(it.name) }
+    }
+}

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/module-a/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/module-a/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    `java-library`
+}
+
+group = "org.test"
+version = "0.9"

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/kotlin/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "deactivate-global-substitution"
+includeBuild(".")
+include("module-a")

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.out
@@ -1,0 +1,10 @@
+> Task :resolve FAILED
+module-a-0.9.jar
+1 actionable task: 1 executed
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':resolve'.
+> Could not resolve all files for configuration ':publishedRuntimeClasspath'.
+   > Could not find org.test:module-a:1.0.

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.sample.conf
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-deactivateGlobalSubstitution/tests/resolve.sample.conf
@@ -1,0 +1,6 @@
+executable: gradle
+args: resolve
+expect-failure: true
+expected-output-file: resolve.out
+allow-additional-output: true
+allow-disordered-output: true


### PR DESCRIPTION
Gradle implicitly registers dependency substitution rules for all configurations in the whole build tree to find projects in other included builds. These rules are always active by default.

There are however cases, where a certain configuration should not apply these rules when resolving. For example, if a binary version of a module should be discovered that is also represented by a project in the same or another build.

One use case for this is to compare the previous published Jar of a module with the latest locally built Jar of the same module. 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

In a project, we needed to resolve the **local** and the **previously published** versions of our libraries next to each other to determine if new versions need to be published. 

We can use reflection to set the `DefaultResolutionStrategy.globalDependencySubstitutionRules` field (_private final_ 😬) to `DependencySubstitutionRules.NO_OP`. This solved our use case. (But it is a very ugly hack.)

This PR proposes to make exactly this behaviour available through public API.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
