### PR TITLE
Do not force AdoptOpenJDK vendor for M1 Macs

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -48,7 +48,10 @@ tasks.registerCITestDistributionLifecycleTasks()
 fun configureCompile() {
     java.toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+        // Do not force AdoptOpenJDK vendor for M1 Macs
+        if (!OperatingSystem.current().toString().contains("aarch64")) {
+            vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+        }
     }
 
     tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
 - Toolchains will attempt to download https://api.adoptopenjdk.net/v3/binary/latest/11/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk, which does not exist

<!--- The issue this PR addresses -->
Fixes gradle/gradle-private#3429. Note this only affects the build logic for `gradle/gradle` build; this does not affect the Gradle build tool.
