### PR TITLE
Remove wrong statement in CompileOptions.getJavaModuleVersion() JavaDoc

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -459,7 +459,7 @@ public class CompileOptions extends AbstractOptions {
 
 
     /**
-     * Set the version of the Java module - defaults to {@link org.gradle.api.Project#getVersion()}.
+     * Set the version of the Java module.
      *
      * @since 6.4
      */


### PR DESCRIPTION
### Context
See: #12863

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [ ] ~Ensure that tests pass sanity check: `./gradlew sanityCheck`~
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
