### PR TITLE
Fix repo mirror url in build script

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -90,7 +90,7 @@ allprojects {
         }
         maven {
             name = "ge-release-candidates"
-            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local")
+            url = uri("https://repo.gradle.org/gradle/enterprise-libs-release-candidates")
         }
     }
 }

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -27,7 +27,7 @@ val originalUrls: Map<String, String> = mapOf(
     "gradle-libs" to "https://repo.gradle.org/gradle/libs",
     "gradle-releases" to "https://repo.gradle.org/gradle/libs-releases",
     "gradle-snapshots" to "https://repo.gradle.org/gradle/libs-snapshots",
-    "gradle-enterprise-rc" to "https://repo.gradle.org/gradle/enterprise-libs-release-candidates-local"
+    "gradle-enterprise-rc" to "https://repo.gradle.org/gradle/enterprise-libs-release-candidates"
 )
 
 val mirrorUrls: Map<String, String> =


### PR DESCRIPTION
Since we've made repo.gradle.org a mirror of repo.grdev.net, there's no longer
enterprise-libs-release-candidates-"local". Fix this so that builds are not failing
on `release6x` branch.
