### PR TITLE
Rebase performance test

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
-        runner.targetVersions = ["7.2-20210720234250+0000"]
+        runner.targetVersions = ["7.4-20211001144533+0000"]
     }
 
     @RunFor(


### PR DESCRIPTION
Test has been flaky for a while and an unrelated PR #18509 causes it to
go over.
The regression could be caused by the new test suite logic.