### PR TITLE
Tweak the javadoc of JvmVendorSpec

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmVendorSpec.java
@@ -28,7 +28,7 @@ import org.gradle.jvm.toolchain.internal.DefaultJvmVendorSpec;
 public abstract class JvmVendorSpec {
 
     /**
-     * A constant for using <a href="https://projects.eclipse.org/projects/adoptium.temurin">Eclipse Temurin</a> as the JVM vendor.
+     * A constant for using <a href="https://projects.eclipse.org/projects/adoptium">Eclipse Adoptium</a> as the JVM vendor.
      *
      * @since 7.4
      */


### PR DESCRIPTION
### Context
The vendor variable is named `ADOPTIUM` here, so making the javadoc also state that as the vendor prevents confusion. Additionally, I changed the URL to match the text.