### PR TITLE
Extend Gradle Module Metadata publication support for Ivy

### DIFF
--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -195,17 +195,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
             IvyRepositoryDescriptor desc = (IvyRepositoryDescriptor) descriptor;
             List<String> artifactPatterns = desc.getArtifactPatterns();
             if (artifactPatterns.size() == 1) {
-                if (!artifactPatterns.get(0).equals(IvyArtifactRepository.GRADLE_ARTIFACT_PATTERN)) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-            List<String> ivyPatterns = desc.getIvyPatterns();
-            if (ivyPatterns.size() == 1) {
-                if (!ivyPatterns.get(0).equals(IvyArtifactRepository.GRADLE_IVY_PATTERN)) {
-                    return false;
-                }
+                return artifactPatterns.get(0).equals(IvyArtifactRepository.GRADLE_ARTIFACT_PATTERN);
             } else {
                 return false;
             }


### PR DESCRIPTION
Previously any custom Ivy repository configuration would prevent Gradle
Module Metadata publication.
This is now supported as long as only the Ivy pattern is modified.
This is OK because Gradle Module Metadata has no relationship to the Ivy
XML and only needs to understand the artifact pattern.

