### PR TITLE
Provide a link in Kotlin DSL docs to the compat matrix

### DIFF
--- a/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
+++ b/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleBuildDocumentationPlugin.java
@@ -117,8 +117,8 @@ public class GradleBuildDocumentationPlugin implements Plugin<Project> {
 
             int webserverPort = 8000;
             task.workingDir(extension.getDocumentationRenderedRoot());
-            task.executable("python");
-            task.args("-m", "SimpleHTTPServer", webserverPort);
+            task.executable("python3");
+            task.args("-m", "http.server", webserverPort);
 
             task.dependsOn(extension.getRenderedDocumentation());
 

--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -735,7 +735,7 @@ Gradle embeds Kotlin in order to provide support for Kotlin-based scripts.
 
 === Kotlin versions
 
-Gradle ships with `kotlin-compiler-embeddable` plus matching versions of `kotlin-stdlib` and `kotlin-reflect` libraries. For example, Gradle 4.3 ships with the Kotlin DSL v0.12.1 that includes Kotlin 1.1.51 versions of these modules. The `kotlin` package from those modules is visible through the Gradle classpath.
+Gradle ships with `kotlin-compiler-embeddable` plus matching versions of `kotlin-stdlib` and `kotlin-reflect` libraries. For details see the Kotlin section of Gradle's <<compatibility#kotlin,compatibility matrix>>. The `kotlin` package from those modules is visible through the Gradle classpath.
 
 The link:https://kotlinlang.org/docs/reference/compatibility.html[compatibility guarantees] provided by Kotlin apply for both backward and forward compatibility.
 

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -41,6 +41,7 @@ For older Gradle versions, please see the table below which Java version is supp
 |17|7.3
 |===
 
+[[kotlin]]
 == Kotlin
 Gradle is tested with Kotlin 1.3.72 through 1.5.31.
 


### PR DESCRIPTION
This replaces an old example with what is now an updated source of information on what versions of Kotlin Gradle is using.

I also changed the Python command to `python3` and the new `http.server` module, since `python` is no longer guaranteed to be Python 2 on all machines anymore.

Fixes #18571