### PR TITLE
Don't discard build failure when unable to shutdown services

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildActionRunner.java
@@ -23,6 +23,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -129,6 +130,13 @@ public interface BuildActionRunner {
             } else {
                 return failed(new MultipleBuildFailures(newFailures));
             }
+        }
+
+        /**
+         * Returns a copy of this result adding the given failure.
+         */
+        public Result addFailure(Throwable t) {
+            return addFailures(Collections.singletonList(t));
         }
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
@@ -16,6 +16,7 @@
 
 package org.gradle.launcher.exec;
 
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.build.BuildLayoutValidator;
 import org.gradle.internal.buildtree.BuildActionModelRequirements;
 import org.gradle.internal.buildtree.BuildActionRunner;
@@ -43,22 +44,39 @@ public class BuildTreeLifecycleBuildActionExecutor implements BuildSessionAction
 
     @Override
     public BuildActionRunner.Result execute(BuildAction action, BuildSessionContext buildSession) {
-        buildLayoutValidator.validate(action.getStartParameter());
+        BuildActionRunner.Result result = null;
+        try {
+            buildLayoutValidator.validate(action.getStartParameter());
 
-        BuildActionModelRequirements actionRequirements;
-        if (action instanceof BuildModelAction && action.isCreateModel()) {
-            BuildModelAction buildModelAction = (BuildModelAction) action;
-            actionRequirements = new QueryModelRequirements(action.getStartParameter(), action.isRunTasks(), buildModelAction.getModelName());
-        } else if (action instanceof ClientProvidedBuildAction) {
-            actionRequirements = new RunActionRequirements(action.getStartParameter(), action.isRunTasks());
-        } else if (action instanceof ClientProvidedPhasedAction) {
-            actionRequirements = new RunPhasedActionRequirements(action.getStartParameter(), action.isRunTasks());
-        } else {
-            actionRequirements = new RunTasksRequirements(action.getStartParameter());
+            BuildActionModelRequirements actionRequirements;
+            if (action instanceof BuildModelAction && action.isCreateModel()) {
+                BuildModelAction buildModelAction = (BuildModelAction) action;
+                actionRequirements = new QueryModelRequirements(action.getStartParameter(), action.isRunTasks(), buildModelAction.getModelName());
+            } else if (action instanceof ClientProvidedBuildAction) {
+                actionRequirements = new RunActionRequirements(action.getStartParameter(), action.isRunTasks());
+            } else if (action instanceof ClientProvidedPhasedAction) {
+                actionRequirements = new RunPhasedActionRequirements(action.getStartParameter(), action.isRunTasks());
+            } else {
+                actionRequirements = new RunTasksRequirements(action.getStartParameter());
+            }
+            BuildTreeModelControllerServices.Supplier modelServices = buildTreeModelControllerServices.servicesForBuildTree(actionRequirements);
+            BuildTreeState buildTree = new BuildTreeState(buildSession.getServices(), modelServices);
+            try {
+                result = buildTree.run(context -> context.execute(action));
+            } finally {
+                buildTree.close();
+            }
+        } catch (Throwable t) {
+            if (result == null) {
+                // Did not create a result
+                // Note: throw the failure rather than returning a result object containing the failure, as console failure logging happens down in the build tree scope
+                throw UncheckedException.throwAsUncheckedException(t);
+            } else {
+                // Cleanup has failed, combine the cleanup failure with other failures that may be packed in the result
+                // Note: throw the failure rather than returning a result object containing the failure, as console failure logging happens down in the build tree scope
+                throw UncheckedException.throwAsUncheckedException(result.addFailure(t).getBuildFailure());
+            }
         }
-        BuildTreeModelControllerServices.Supplier modelServices = buildTreeModelControllerServices.servicesForBuildTree(actionRequirements);
-        try (BuildTreeState buildTree = new BuildTreeState(buildSession.getServices(), modelServices)) {
-            return buildTree.run(context -> context.execute(action));
-        }
+        return result;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildSessionLifecycleBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildSessionLifecycleBuildActionExecuter.java
@@ -18,10 +18,12 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.initialization.BuildRequestContext;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
+import org.gradle.internal.session.BuildSessionContext;
 import org.gradle.internal.session.BuildSessionState;
 import org.gradle.internal.session.CrossBuildSessionState;
 import org.gradle.launcher.exec.BuildActionExecuter;
@@ -30,6 +32,8 @@ import org.gradle.launcher.exec.BuildActionResult;
 import org.gradle.launcher.exec.BuildExecuter;
 import org.gradle.tooling.internal.provider.serialization.PayloadSerializer;
 import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
+
+import java.util.function.Function;
 
 /**
  * A {@link BuildExecuter} responsible for establishing the {@link BuildSessionState} to execute a {@link BuildAction} within.
@@ -50,25 +54,61 @@ public class BuildSessionLifecycleBuildActionExecuter implements BuildActionExec
             // When creating a model, do not use continuous mode
             startParameter.setContinuous(false);
         }
-        try (CrossBuildSessionState crossBuildSessionState = new CrossBuildSessionState(globalServices, startParameter)) {
-            try (BuildSessionState buildSessionState = new BuildSessionState(userHomeServiceRegistry, crossBuildSessionState, startParameter, requestContext, actionParameters.getInjectedPluginClasspath(), requestContext.getCancellationToken(), requestContext.getClient(), requestContext.getEventConsumer())) {
-                return buildSessionState.run(context -> {
-                    BuildActionRunner.Result result = context.execute(action);
-                    PayloadSerializer payloadSerializer = context.getServices().get(PayloadSerializer.class);
-                    if (result.getBuildFailure() == null) {
-                        if (result.getClientResult() instanceof SerializedPayload) {
-                            // Already serialized
-                            return BuildActionResult.of((SerializedPayload) result.getClientResult());
-                        } else {
-                            return BuildActionResult.of(payloadSerializer.serialize(result.getClientResult()));
-                        }
-                    }
-                    if (requestContext.getCancellationToken().isCancellationRequested()) {
-                        return BuildActionResult.cancelled(payloadSerializer.serialize(result.getBuildFailure()));
-                    }
-                    return BuildActionResult.failed(payloadSerializer.serialize(result.getClientFailure()));
-                });
+
+        ActionImpl actionWrapper = new ActionImpl(action, requestContext);
+        try {
+            try (CrossBuildSessionState crossBuildSessionState = new CrossBuildSessionState(globalServices, startParameter)) {
+                try (BuildSessionState buildSessionState = new BuildSessionState(userHomeServiceRegistry, crossBuildSessionState, startParameter, requestContext, actionParameters.getInjectedPluginClasspath(), requestContext.getCancellationToken(), requestContext.getClient(), requestContext.getEventConsumer())) {
+                    return buildSessionState.run(actionWrapper);
+                }
             }
+        } catch (Throwable t) {
+            if (actionWrapper.result == null) {
+                // Did not create a result
+                // Note: throw the failure rather than returning a result object containing the failure, as console failure logging happens down in the build session scope
+                throw UncheckedException.throwAsUncheckedException(t);
+            } else {
+                // Created a result which may contain failures. Combine this failure with any failures that happen to be packaged in the result
+                // Note: throw the failure rather than returning a result object containing the failure, as console failure logging happens down in the build session scope
+                throw UncheckedException.throwAsUncheckedException(actionWrapper.result.addFailure(t).getBuildFailure());
+            }
+        }
+    }
+
+    private RuntimeException wrap(Throwable failure) {
+        if (failure instanceof RuntimeException) {
+            return (RuntimeException) failure;
+        } else {
+            return new RuntimeException(failure);
+        }
+    }
+
+    private static class ActionImpl implements Function<BuildSessionContext, BuildActionResult> {
+        private final BuildAction action;
+        private final BuildRequestContext requestContext;
+        private BuildActionRunner.Result result;
+
+        public ActionImpl(BuildAction action, BuildRequestContext requestContext) {
+            this.action = action;
+            this.requestContext = requestContext;
+        }
+
+        @Override
+        public BuildActionResult apply(BuildSessionContext context) {
+            result = context.execute(action);
+            PayloadSerializer payloadSerializer = context.getServices().get(PayloadSerializer.class);
+            if (result.getBuildFailure() == null) {
+                if (result.getClientResult() instanceof SerializedPayload) {
+                    // Already serialized
+                    return BuildActionResult.of((SerializedPayload) result.getClientResult());
+                } else {
+                    return BuildActionResult.of(payloadSerializer.serialize(result.getClientResult()));
+                }
+            }
+            if (requestContext.getCancellationToken().isCancellationRequested()) {
+                return BuildActionResult.cancelled(payloadSerializer.serialize(result.getBuildFailure()));
+            }
+            return BuildActionResult.failed(payloadSerializer.serialize(result.getClientFailure()));
         }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

It was previously possible for the build failure to be discard when an internal service throws an exception when stopping. Instead, collect and report on both failures.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
