### PR TITLE
Switch to ge-td-dogfooding.grdev.net

### DIFF
--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -20,7 +20,7 @@ class CheckProject(
     params {
         param("credentialsStorageType", "credentialsJSON")
         param("teamcity.ui.settings.readOnly", "true")
-        param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%")
+        param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%;%ge-td-dogfooding.grdev.net.access.key%")
     }
 
     var prevStage: Stage? = null

--- a/buildSrc/subprojects/jvm/build.gradle.kts
+++ b/buildSrc/subprojects/jvm/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation("org.ow2.asm:asm-commons")
     implementation("com.google.code.gson:gson")
     implementation("org.gradle:test-retry-gradle-plugin")
-    implementation("com.gradle.enterprise:test-distribution-gradle-plugin:1.1.2-rc-1")
+    implementation("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.1-rc-1")
 
     implementation("com.thoughtworks.qdox:qdox") {
         because("ParameterNamesIndex")

--- a/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/buildSrc/subprojects/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.tasks.ClasspathManifest
@@ -221,9 +222,11 @@ fun configureTests() {
 
         if (project.testDistributionEnabled()) {
             distribution {
-                maxLocalExecutors.set(0)
-                maxRemoteExecutors.set(if ("test" == testName) 5 else 20)
+                this as TestDistributionExtensionInternal
                 enabled.set(true)
+                distribution.maxRemoteExecutors.set(null)
+                // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
+                server.set(uri("https://ge-td-dogfooding.grdev.net"))
                 when {
                     OperatingSystem.current().isLinux -> requirements.set(listOf("os=linux"))
                     OperatingSystem.current().isWindows -> requirements.set(listOf("os=windows"))


### PR DESCRIPTION
- Use ge-td-dogfooding as TD backend
- Add `%ge-td-dogfooding.grdev.net.access.key%`
