### PR TITLE
Smoke test Kotlin 1.6.0-RC

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/versions/KotlinGradlePluginVersions.groovy
@@ -25,7 +25,8 @@ class KotlinGradlePluginVersions {
     private static final List<String> LATEST_VERSIONS = [
         '1.3.72',
         '1.4.0', '1.4.10', '1.4.21', '1.4.31',
-        '1.5.0', '1.5.31'
+        '1.5.0', '1.5.31',
+        '1.6.0-RC'
     ]
 
     List<String> getLatests() {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -167,7 +167,7 @@ abstract class AbstractSmokeTest extends Specification {
 
         // https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.allopen
         // https://plugins.gradle.org/plugin/org.jetbrains.kotlin.plugin.spring
-        static kotlinPlugins = Versions.of("1.4.21-2", "1.4.31", "1.5.31", "1.6.0-M1")
+        static kotlinPlugins = Versions.of("1.4.21-2", "1.4.31", "1.5.31", "1.6.0-RC")
 
         // https://plugins.gradle.org/plugin/com.moowork.grunt
         // https://plugins.gradle.org/plugin/com.moowork.gulp


### PR DESCRIPTION
See https://github.com/JetBrains/kotlin/releases/tag/v1.6.0-RC
