### PR TITLE
Make sure KotlinBuildScript does not apply to settings/init scripts

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/KotlinBuildScript.kt
@@ -37,7 +37,7 @@ import kotlin.script.templates.ScriptTemplateDefinition
  */
 @ScriptTemplateDefinition(
     resolver = KotlinBuildScriptDependenciesResolver::class,
-    scriptFilePattern = ".+\\.gradle\\.kts"
+    scriptFilePattern = ".+(?<!(^|\\.)(init|settings))\\.gradle\\.kts"
 )
 @ScriptTemplateAdditionalCompilerArguments(
     [


### PR DESCRIPTION
Currently, when opening `settings.gradle.kts` or `my-plugin.settings.gradle.kts` then IDEA shows that you can select the script definition:
```
Multiple script definitions are applicable for this script.
```
![image](https://user-images.githubusercontent.com/423186/137162312-a032b3e1-f843-449f-955e-5b6c5293eb69.png)

This can be fixed by changing the regular expression on `KotlinBuildScript` to exclude init and settings scripts.
