### PR TITLE
Fix CodeNarc extraction

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild/buildscan/tasks/ExtractCodeQualityBuildScanData.kt
@@ -93,9 +93,11 @@ abstract class ExtractCodeNarcBuildScanData : AbstractExtractCodeQualityBuildSca
     override fun extractIssuesFrom(xmlFile: File, basePath: File): List<String> {
         val codenarc = Jsoup.parse(xmlFile.readText(), "", Parser.xmlParser())
         return codenarc.getElementsByTag("Package").flatMap { codenarcPackage ->
+            val packagePath = codenarcPackage.attr("path")
             codenarcPackage.getElementsByTag("File").flatMap { file ->
+                val fileName = file.attr("name")
                 file.getElementsByTag("Violation").map { violation ->
-                    val filePath = File(file.attr("name")).relativeTo(basePath).path
+                    val filePath = "$packagePath/$fileName"
                     val message = violation.run {
                         getElementsByTag("Message").first()
                             ?: getElementsByTag("SourceLine").first()


### PR DESCRIPTION
Concatenate sourceDir/filePath/fileName to get the correct path.

The build scan after fix: https://ge.gradle.org/s/ucvmyj2s7o726/custom-values

This is what the xml looks like:

```
<CodeNarc url="https://www.codenarc.org" version="2.0.0">
  <Report timestamp="Oct 14, 2021, 11:08:16 AM"/>
  <Project title="">
    <SourceDirectory>/Users/zhb/Projects/gradle/subprojects/scala/src/test/groovy</SourceDirectory>
  </Project>
  <Package path="org/gradle/api/plugins/scala" totalFiles="3" filesWithViolations="1" priority1="0" priority2="0" priority3="1">
    <File name="ScalaPlugin3Test.groovy">
      <Violation ruleName="DuplicateImport" priority="3" lineNumber="30">
      <SourceLine>
        <![CDATA[ import spock.lang.Issue ]]>
      </SourceLine>
      </Violation>
   </File>
</Package>
```

The previous login was wrong. With the old code, the build failed with

```
Caused by: java.lang.IllegalArgumentException: this and base files have different roots: ScalaPlugin3Test.groovy and /Users/zhb/Projects/gradle.
        at kotlin.io.FilesKt__UtilsKt.toRelativeString(Utils.kt:117)
        at kotlin.io.FilesKt__UtilsKt.relativeTo(Utils.kt:128)
```