### PR TITLE
If, at the time of jvm-test-suite plugin application, the test task has been created but the test sourceset has not, don't try to link the test sourceset to the test task.

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
@@ -56,10 +56,15 @@ public class JvmTestSuitePlugin implements Plugin<Project> {
         // TODO: Deprecate this behavior?
         // Why would any Test task created need to use the test source set's classes?
         project.getTasks().withType(Test.class).configureEach(test -> {
-            SourceSet testSourceSet = java.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
-            test.getConventionMapping().map("testClassesDirs", () -> testSourceSet.getOutput().getClassesDirs());
-            test.getConventionMapping().map("classpath", () -> testSourceSet.getRuntimeClasspath());
-            test.getModularity().getInferModulePath().convention(java.getModularity().getInferModulePath());
+            SourceSet testSourceSet = java.getSourceSets().findByName(SourceSet.TEST_SOURCE_SET_NAME);
+            // In rare classes, such as applying the Kotlin multi-platform plugin, the test task may have already been created,
+            // but the test sourceSet may not exist yet.  In this case, there is no need to link the test task to it here
+            // See https://github.com/gradle/gradle/issues/18622
+            if (null != testSourceSet) {
+                test.getConventionMapping().map("testClassesDirs", () -> testSourceSet.getOutput().getClassesDirs());
+                test.getConventionMapping().map("classpath", () -> testSourceSet.getRuntimeClasspath());
+                test.getModularity().getInferModulePath().convention(java.getModularity().getInferModulePath());
+            }
         });
 
         testSuites.withType(JvmTestSuite.class).all(testSuite -> {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes 18622

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
