### PR TITLE
Fix broken merging release to master

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -214,7 +214,6 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
 
     @Override
     public void stop() {
-        state.assertInState(State.Finished);
         try {
             CompositeStoppable.stoppable(buildServices).stop();
         } finally {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/build/DefaultBuildLifecycleControllerTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.scopes.BuildScopeServices
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
-import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.util.function.Consumer
@@ -467,7 +466,6 @@ class DefaultBuildLifecycleControllerTest extends Specification {
         1 * buildCompletionListener.completed()
     }
 
-    @Ignore("Broken after merging")
     void testCanStopWithoutFinishingWhenBuildHasDoneNothing() {
         given:
         def controller = controller()


### PR DESCRIPTION
When merging release to master, a conflict was not properly
resolved, resulting in test failures.
