### PR TITLE
Remove now outdated performance warning in Kotlin DSL doc

### DIFF
--- a/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/api/kotlin_dsl.adoc
@@ -89,7 +89,6 @@ The Kotlin DSL is fully supported by IntelliJ IDEA and Android Studio. Other IDE
 
 As mentioned in the limitations, you must link:https://www.jetbrains.com/help/idea/gradle.html#gradle_import[import your project from the Gradle model] to get content-assist and refactoring tools for Kotlin DSL scripts in IntelliJ IDEA.
 
-In addition, IntelliJ IDEA and Android Studio might spawn up to 3 Gradle daemons when editing Gradle scripts — one for each type of script: build scripts, settings files and initialization scripts.
 Builds with slow configuration time might affect the IDE responsiveness, so please check out the <<performance.adoc#performance_gradle,performance section>> to help resolve such issues.
 
 === Automatic build import vs. automatic reloading of script dependencies


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/gradle/gradle/pull/18646 for `release`.
