### PR TITLE
Improve error message when --project-cache-dir is used together with --watch-fs

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -146,6 +146,6 @@ class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatching
         fails("help", "--watch-fs", "--project-cache-dir=broken")
 
         then:
-        failure.assertHasDescription("Cannot probe file system watching when project cache directory is set")
+        failure.assertHasDescription("Enabling file system watching via --watch-fs (or via the org.gradle.vfs.watch property) with --project-cache-dir also specified is not supported; remove either option to fix this problem")
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -18,6 +18,7 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.changedetection.state.FileHasherStatistics;
+import org.gradle.initialization.StartParameterBuildOptions;
 import org.gradle.internal.buildtree.BuildActionRunner;
 import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.file.StatStatistics;
@@ -89,9 +90,9 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
             // See https://github.com/gradle/gradle/issues/17262
             switch (watchFileSystemMode) {
                 case ENABLED:
-                    throw new IllegalStateException("Cannot probe file system watching when project cache directory is set");
+                    throw new IllegalStateException("Enabling file system watching via --watch-fs (or via the " + StartParameterBuildOptions.WatchFileSystemOption.GRADLE_PROPERTY + " property) with --project-cache-dir also specified is not supported; remove either option to fix this problem");
                 case DEFAULT:
-                    LOGGER.info("Cannot probe file system watching when project cache directory is set, disabling file system watching");
+                    LOGGER.info("File system watching is disabled because --project-cache-dir is specified");
                     watchFileSystemMode = WatchMode.DISABLED;
                     break;
                 default:

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -129,6 +129,6 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
 
         then:
         def ex = thrown IllegalStateException
-        ex.message == "Cannot probe file system watching when project cache directory is set"
+        ex.message == "Enabling file system watching via --watch-fs (or via the org.gradle.vfs.watch property) with --project-cache-dir also specified is not supported; remove either option to fix this problem"
     }
 }


### PR DESCRIPTION
Fixes #18635.

