### PR TITLE
Fail build fast when --scan is used together with --offline

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -391,4 +391,12 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
         inTestDirectory().withArguments("-p", settingsDir.getAbsolutePath()).withTasks("thing").runWithFailure()
             .assertHasDescription("Task 'thing' not found in root project 'gradle'.");
     }
+
+    @Test
+    public void raisesExceptionWhenScanAndOfflineOptionsAreUsedTogether() {
+        getTestDirectory().createDir("root").file("build.gradle");
+
+        inTestDirectory().withArguments("--offline", "--scan").runWithFailure()
+            .assertHasDescription("--scan option is incompatible with --offline because scan cannot be published");
+    }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StartParamsValidatingActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/StartParamsValidatingActionExecuter.java
@@ -60,6 +60,10 @@ public class StartParamsValidatingActionExecuter implements BuildActionExecuter<
             validateIsFileAndExists(initScript, "initialization script");
         }
 
+        if (startParameter.isBuildScan() && startParameter.isOffline()) {
+            throw new IllegalArgumentException("--scan option is incompatible with --offline because scan cannot be published");
+        }
+
         return delegate.execute(action, actionParameters, requestContext);
     }
 


### PR DESCRIPTION
Fixes: #18474

Signed-off-by: piotr.sliwa <me@psliwa.org>

<!--- The issue this PR addresses -->
Fixes #18474

### Context
This PR implements a feature requested here: https://github.com/gradle/gradle/issues/18474

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
