### PR TITLE
Replace env var filter with something configuration-cache compatible

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -17,6 +17,7 @@
 package gradlebuild
 
 import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.os.OperatingSystem
 
 
 val propagatedEnvironmentVariables = listOf(
@@ -61,7 +62,69 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by performance test to recognize TeamCity buildId
     "BUILD_ID",
-    "JPROFILER_HOME"
+    "JPROFILER_HOME",
+
+    "LANG",
+    "LANGUAGE",
+    // It is possible to have many LC_xxx variables for different aspects of the locale. However, LC_ALL overrides all of them, and it is what CI uses.
+    "LC_ALL",
+    "LC_CTYPE",
+
+    "JDK_10",
+    "JDK_10_0",
+    "JDK_10_0_x64",
+    "JDK_10_x64",
+    "JDK_11",
+    "JDK_11_0",
+    "JDK_11_0_x64",
+    "JDK_11_x64",
+    "JDK_12",
+    "JDK_12_0",
+    "JDK_12_0_x64",
+    "JDK_12_x64",
+    "JDK_13",
+    "JDK_13_0",
+    "JDK_13_0_x64",
+    "JDK_13_x64",
+    "JDK_14",
+    "JDK_14_0",
+    "JDK_14_0_x64",
+    "JDK_15",
+    "JDK_15_0",
+    "JDK_15_0_x64",
+    "JDK_16",
+    "JDK_16_0",
+    "JDK_16_0_x64",
+    "JDK_16_x64",
+    "JDK_17",
+    "JDK_17_0",
+    "JDK_17_0_x64",
+    "JDK_17_x64",
+    "JDK_18",
+    "JDK_18_x64",
+    "JDK_19",
+    "JDK_19_x64",
+    "JDK_1_6",
+    "JDK_1_6_x64",
+    "JDK_1_7",
+    "JDK_1_7_x64",
+    "JDK_1_8",
+    "JDK_1_8_x64",
+    "JDK_9",
+    "JDK_9_0",
+    "JDK_9_0_x64",
+    "JDK_9_x64",
+    "JDK_HOME",
+    "JRE_HOME",
+    "CommonProgramFiles",
+    "CommonProgramFiles(x86)",
+    "CommonProgramW6432",
+    "ProgramData",
+    "ProgramFiles",
+    "ProgramFiles(x86)",
+    // Simply putting PATH there isn't enough. Windows has case-insensitive env vars but something else fails if the Path variable is published as PATH for test tasks.
+    OperatingSystem.current().pathVar,
+    "PATHEXT",
 )
 
 
@@ -78,7 +141,7 @@ val credentialsKeywords = listOf(
 
 
 fun Test.filterEnvironmentVariables() {
-    environment = System.getenv().entries.mapNotNull(::sanitize).toMap()
+    environment = makePropagatedEnvironment()
     environment.forEach { (key, _) ->
         if (credentialsKeywords.any { key.contains(it, true) }) {
             throw IllegalArgumentException("Found sensitive data in filtered environment variables: $key")
@@ -88,21 +151,13 @@ fun Test.filterEnvironmentVariables() {
 
 
 private
-fun sanitize(entry: MutableMap.MutableEntry<String, String>): Pair<String, String>? {
-    return when {
-        entry.key in propagatedEnvironmentVariables -> entry.key to entry.value
-        entry.key.startsWith("LC_") -> entry.key to entry.value
-        entry.key.startsWith("LANG") -> entry.key to entry.value
-        entry.key.startsWith("JDK_") -> entry.key to entry.value
-        entry.key.startsWith("JRE_") -> entry.key to entry.value
-
-        // Visual Studio installation info
-        entry.key.startsWith("VS") -> entry.key to entry.value
-        entry.key.startsWith("CommonProgram") -> entry.key to entry.value
-        entry.key.startsWith("ProgramFiles") -> entry.key to entry.value
-        entry.key.startsWith("ProgramData") -> entry.key to entry.value
-
-        entry.key.equals("Path", true) -> entry.key to entry.value
-        else -> null
+fun makePropagatedEnvironment(): Map<String, String?> {
+    val result = HashMap<String, String?>()
+    for (key in propagatedEnvironmentVariables) {
+        val value = System.getenv(key)
+        if (value != null) {
+            result[key] = value
+        }
     }
+    return result
 }


### PR DESCRIPTION
The filtering approach required enumerating all available environment
variables. This makes all these variables inputs to the configuration
cache so any change will invalidate the cache once the tracking code for
environment variables.

With this commit the enumeration of the variables and name-based
filtering is replaced with the explicit list of variables because of the
limitations of the provider API. Currently, it isn't possible to ask for
a subset of environment variables. Unfortunately, this makes adding new
environment variables a bit harder. However, the new API to request a
subset of variables based on the prefix is currently considered so we
can move to it when it is available.
