### PR TITLE
Adds `DependencyHandler.plugin` method to declare dependency on Gradle plugins artifacts

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -30,6 +30,7 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
+import org.gradle.plugin.use.PluginDependency;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -550,6 +551,28 @@ public interface DependencyHandler extends ExtensionAware {
      * @since 5.3
      */
     <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction);
+
+    /**
+     * Declares a dependency on a Gradle plugin.
+     *
+     * @param notation the id of the plugin
+     * @return The dependency.
+     *
+     * @since 8.0
+     */
+    PluginDependency plugin(Object notation);
+
+    /**
+     * Declares a dependency on a Gradle plugin. The dependency is configured using the given closure before
+     * it is returned.
+     *
+     * @param notation the id of the plugin
+     * @param configureAction the dependency configuration block
+     * @return The dependency.
+     *
+     * @since 8.0
+     */
+    PluginDependency plugin(Object notation, Action<? super PluginDependency> configureAction);
 
     /**
      * Declares a dependency on a platform. If the target coordinates represent multiple

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DependencyFactory.java
@@ -17,9 +17,10 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import groovy.lang.Closure;
 import org.gradle.api.artifacts.ClientModule;
-import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.plugin.use.PluginDependency;
 
 import java.util.Map;
 
@@ -41,6 +42,7 @@ public interface DependencyFactory {
 
     Dependency createDependency(Object dependencyNotation); //we should consider to change the return type to DirectDependency, which requires adjustment in Kotlin DSL
     DependencyConstraint createDependencyConstraint(Object dependencyNotation);
+    PluginDependency createPluginDependency(Object dependencyNotation);
     ClientModule createModule(Object dependencyNotation, Closure configureClosure);
     ProjectDependency createProjectDependencyFromMap(ProjectFinder projectFinder, Map<? extends String, ? extends Object> map);
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyNotationIntegrationSpec.groovy
@@ -86,6 +86,45 @@ task checkDeps {
         succeeds 'checkDeps'
     }
 
+    def "understands plugin dependency notations"() {
+        when:
+        buildFile <<  """
+import org.gradle.api.internal.artifacts.dependencies.*
+
+configurations {
+    conf
+}
+
+dependencies {
+    conf plugin('org.jetbrains.kotlin.jvm:1.6.0')
+
+    conf(plugin('org.jetbrains.dokka')) {
+        version {
+           prefer '1.4.30'
+        }
+        transitive = false
+        force = true
+    }
+}
+
+task checkDeps {
+    doLast {
+        def deps = configurations.conf.incoming.dependencies
+
+        assert deps.find { it instanceof ExternalDependency && it.group == 'org.jetbrains.kotlin.jvm' && it.name == 'org.jetbrains.kotlin.jvm.gradle.plugin' && it.version == '1.6.0'  }
+
+        def configuredDep = deps.find { it instanceof ExternalDependency && it.group == 'org.jetbrains.dokka' && it.name == 'org.jetbrains.dokka.gradle.plugin' }
+        assert configuredDep.version == '1.4.30'
+        assert configuredDep.transitive == false
+        assert configuredDep.force == true
+    }
+}
+"""
+        then:
+        executer.expectDeprecationWarning()
+        succeeds 'checkDeps'
+    }
+
     def "understands project notations"() {
         when:
         settingsFile << "include 'otherProject'"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -30,12 +30,14 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.plugin.use.PluginDependency;
 
 import java.util.Map;
 
 public class DefaultDependencyFactory implements DependencyFactory {
     private final NotationParser<Object, Dependency> dependencyNotationParser;
     private final NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser;
+    private final NotationParser<Object, PluginDependency> pluginDependencyNotationParser;
     private final NotationParser<Object, ClientModule> clientModuleNotationParser;
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ProjectDependencyFactory projectDependencyFactory;
@@ -43,12 +45,14 @@ public class DefaultDependencyFactory implements DependencyFactory {
 
     public DefaultDependencyFactory(NotationParser<Object, Dependency> dependencyNotationParser,
                                     NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser,
+                                    NotationParser<Object, PluginDependency> dependencyPluginNotationParser,
                                     NotationParser<Object, ClientModule> clientModuleNotationParser,
                                     NotationParser<Object, Capability> capabilityNotationParser,
                                     ProjectDependencyFactory projectDependencyFactory,
                                     ImmutableAttributesFactory attributesFactory) {
         this.dependencyNotationParser = dependencyNotationParser;
         this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
+        this.pluginDependencyNotationParser = dependencyPluginNotationParser;
         this.clientModuleNotationParser = clientModuleNotationParser;
         this.capabilityNotationParser = capabilityNotationParser;
         this.projectDependencyFactory = projectDependencyFactory;
@@ -60,6 +64,11 @@ public class DefaultDependencyFactory implements DependencyFactory {
         Dependency dependency = dependencyNotationParser.parseNotation(dependencyNotation);
         injectServices(dependency);
         return dependency;
+    }
+
+    @Override
+    public PluginDependency createPluginDependency(Object dependencyNotation) {
+        return pluginDependencyNotationParser.parseNotation(dependencyNotation);
     }
 
     private void injectServices(Dependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -122,6 +122,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.notations.ClientModuleNotationParserFactory;
 import org.gradle.api.internal.notations.DependencyConstraintNotationParser;
 import org.gradle.api.internal.notations.DependencyNotationParser;
+import org.gradle.api.internal.notations.PluginDependencyNotationParser;
 import org.gradle.api.internal.notations.ProjectDependencyFactory;
 import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.internal.resources.ApiTextResourceAdapter;
@@ -308,6 +309,7 @@ class DependencyManagementBuildScopeServices {
         return new DefaultDependencyFactory(
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation, stringInterner, attributesFactory, capabilityNotationParser),
             DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner, attributesFactory),
+            PluginDependencyNotationParser.parser(stringInterner),
             new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
             capabilityNotationParser, projectDependencyFactory,
             attributesFactory);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -60,6 +60,7 @@ import org.gradle.internal.component.external.model.ProjectTestFixtures;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
+import org.gradle.plugin.use.PluginDependency;
 import org.gradle.util.internal.ConfigureUtil;
 
 import javax.annotation.Nullable;
@@ -352,6 +353,18 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     @Override
     public <T extends TransformParameters> void registerTransform(Class<? extends TransformAction<T>> actionType, Action<? super TransformSpec<T>> registrationAction) {
         transforms.registerTransform(actionType, registrationAction);
+    }
+
+    @Override
+    public PluginDependency plugin(Object notation) {
+        return dependencyFactory.createPluginDependency(notation);
+    }
+
+    @Override
+    public PluginDependency plugin(Object notation, Action<? super PluginDependency> configureAction) {
+        PluginDependency dependency = plugin(notation);
+        configureAction.execute(dependency);
+        return dependency;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -39,6 +39,7 @@ import org.gradle.internal.typeconversion.NotationConverter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 import org.gradle.internal.typeconversion.TypeConversionException;
+import org.gradle.plugin.use.PluginDependency;
 
 public class DependencyNotationParser {
     public static NotationParser<Object, Dependency> parser(Instantiator instantiator,
@@ -50,11 +51,14 @@ public class DependencyNotationParser {
                                                             Interner<String> stringInterner,
                                                             ImmutableAttributesFactory attributesFactory,
                                                             NotationParser<Object, Capability> capabilityNotationParser) {
+        MinimalExternalDependencyNotationConverter minimalConverter =
+            new MinimalExternalDependencyNotationConverter(instantiator, attributesFactory, capabilityNotationParser);
         return NotationParserBuilder
             .toType(Dependency.class)
             .fromCharSequence(new DependencyStringNotationConverter<>(instantiator, DefaultExternalModuleDependency.class, stringInterner))
-            .fromType(MinimalExternalModuleDependency.class, new MinimalExternalDependencyNotationConverter(instantiator, attributesFactory, capabilityNotationParser))
+            .fromType(MinimalExternalModuleDependency.class, minimalConverter)
             .converter(new DependencyMapNotationConverter<>(instantiator, DefaultExternalModuleDependency.class))
+            .fromType(PluginDependency.class, new DependencyPluginNotationConverter(minimalConverter))
             .fromType(FileCollection.class, new DependencyFilesNotationConverter(instantiator))
             .fromType(Project.class, new DependencyProjectNotationConverter(dependencyFactory))
             .fromType(DependencyFactory.ClassPathNotation.class, new DependencyClassPathNotationConverter(instantiator, classPathRegistry, fileCollectionFactory, runtimeShadedJarFactory, currentGradleInstallation))

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyPluginNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyPluginNotationConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.notations;
+
+import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.internal.artifacts.dependencies.DefaultMinimalDependency;
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
+import org.gradle.internal.exceptions.DiagnosticsVisitor;
+import org.gradle.internal.typeconversion.NotationConvertResult;
+import org.gradle.internal.typeconversion.NotationConverter;
+import org.gradle.internal.typeconversion.TypeConversionException;
+import org.gradle.plugin.use.PluginDependency;
+
+public class DependencyPluginNotationConverter implements NotationConverter<PluginDependency, DefaultExternalModuleDependency> {
+    private final NotationConverter<MinimalExternalModuleDependency, DefaultExternalModuleDependency> minimalConverter;
+
+    public DependencyPluginNotationConverter(NotationConverter<MinimalExternalModuleDependency, DefaultExternalModuleDependency> minimalConverter) {
+        this.minimalConverter = minimalConverter;
+    }
+
+    @Override
+    public void describe(DiagnosticsVisitor visitor) {
+        visitor.candidate("PluginDependency").example("plugin('org.gradle.java:1.0')");
+    }
+
+    @Override
+    public void convert(PluginDependency notation, NotationConvertResult<? super DefaultExternalModuleDependency> result) throws TypeConversionException {
+        ModuleIdentifier module = DefaultModuleIdentifier.newId(notation.getPluginId(), notation.getPluginId() + ".gradle.plugin");
+        MutableVersionConstraint version = new DefaultMutableVersionConstraint(notation.getVersion());
+        MinimalExternalModuleDependency minimalDependency = new DefaultMinimalDependency(module, version);
+
+        minimalConverter.convert(minimalDependency, result);
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/PluginDependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/PluginDependencyNotationParser.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations;
+
+import com.google.common.collect.Interner;
+import org.gradle.api.IllegalDependencyNotation;
+import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DefaultPluginDependency;
+import org.gradle.internal.exceptions.DiagnosticsVisitor;
+import org.gradle.internal.typeconversion.MapKey;
+import org.gradle.internal.typeconversion.MapNotationConverter;
+import org.gradle.internal.typeconversion.NotationConvertResult;
+import org.gradle.internal.typeconversion.NotationConverter;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.typeconversion.NotationParserBuilder;
+import org.gradle.internal.typeconversion.TypeConversionException;
+import org.gradle.plugin.use.PluginDependency;
+
+import javax.annotation.Nullable;
+
+import static org.gradle.api.internal.notations.ModuleNotationValidation.validate;
+
+public class PluginDependencyNotationParser {
+    public static NotationParser<Object, PluginDependency> parser(
+        Interner<String> stringInterner
+    ) {
+        return NotationParserBuilder
+            .toType(PluginDependency.class)
+            .fromCharSequence(new StringConverter(stringInterner))
+            .converter(new MapConverter(stringInterner))
+            .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
+            .toComposite();
+    }
+
+    private static class StringConverter implements NotationConverter<String, PluginDependency> {
+        private final Interner<String> stringInterner;
+
+        StringConverter(Interner<String> stringInterner) {
+            this.stringInterner = stringInterner;
+        }
+
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.candidate("String or CharSequence values").example("'org.gradle.java:1.0'");
+        }
+
+        @Override
+        public void convert(String notation, NotationConvertResult<? super PluginDependency> result) throws TypeConversionException {
+            result.converted(createDependencyFromString(stringInterner, notation));
+        }
+
+        private PluginDependency createDependencyFromString(Interner<String> stringInterner, String notation) {
+            String[] coordinates = notation.split(":");
+            if (coordinates.length > 2) {
+                throw new IllegalDependencyNotation("Supplied String plugin notation '" + notation + "' is invalid. Example notation: 'org.gradle.java:1.0'.");
+            }
+            return createDependency(stringInterner, coordinates[0], coordinates.length > 1 ? coordinates[1] : null);
+        }
+
+    }
+
+    private static class MapConverter extends MapNotationConverter<PluginDependency> {
+        private final Interner<String> stringInterner;
+
+        MapConverter(Interner<String> stringInterner) {
+            this.stringInterner = stringInterner;
+        }
+
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.candidate("Maps").example("[id: 'org.gradle.java', version: '1.0']");
+        }
+
+        protected PluginDependency parseMap(
+            @MapKey("id") String id,
+            @MapKey("version") @Nullable String version
+        ) {
+            return createDependency(stringInterner, id, version);
+        }
+
+    }
+
+    private static PluginDependency createDependency(
+        Interner<String> stringInterner,
+        String pluginId,
+        @Nullable String version
+    ) {
+        return new DefaultPluginDependency(
+            validate(stringInterner.intern(pluginId.trim())),
+            DefaultMutableVersionConstraint.withVersion(version == null ? null : validate(stringInterner.intern(version.trim())))
+        );
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -40,6 +40,7 @@ import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.Factory
+import org.gradle.plugin.use.PluginDependency
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -214,6 +215,34 @@ class DefaultDependencyHandlerTest extends Specification {
         e.message.startsWith('Could not find method someConf() for arguments [] on ')
     }
 
+    void "creates a plugin dependency from map"() {
+        PluginDependency dependency = Mock()
+
+        when:
+        def result = dependencyHandler.plugin([:])
+
+        then:
+        result == dependency
+
+        and:
+        1 * dependencyFactory.createPluginDependency([:]) >> dependency
+    }
+
+    void "creates and configures a plugin from some notation"() {
+        PluginDependency dependency = Mock()
+        Action<PluginDependency> configure = Mock()
+
+        when:
+        def result = dependencyHandler.plugin("someNotation", configure)
+
+        then:
+        result == dependency
+        1 * configure.execute(dependency)
+
+        and:
+        1 * dependencyFactory.createPluginDependency("someNotation") >> dependency
+    }
+
     void "creates a project dependency from map"() {
         ProjectDependency projectDependency = Mock()
 
@@ -338,6 +367,21 @@ class DefaultDependencyHandlerTest extends Specification {
         then:
         1 * dependencyFactory.createDependency(null)
     }
+
+    void "plugin dependencies delegates to parser"() {
+        PluginDependency dependency = Mock()
+        Action<PluginDependency> configure = Mock()
+
+        when:
+        def result = dependencyHandler.plugin("org.test.plugin:0.1.0", configure)
+
+        then:
+        result == dependency
+        1 * configure.execute(dependency)
+
+        and:
+        1 * dependencyFactory.createPluginDependency("org.test.plugin:0.1.0") >> dependency
+   }
 
     void "platform dependencies are endorsing"() {
         ModuleDependency dep1 = new DefaultExternalModuleDependency("org", "platform", "")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyPluginNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyPluginNotationConverterTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations
+
+
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
+import org.gradle.internal.typeconversion.NotationConvertResult
+import org.gradle.internal.typeconversion.NotationConverter
+import org.gradle.plugin.use.PluginDependency
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class DependencyPluginNotationConverterTest extends Specification {
+    final NotationConverter<MinimalExternalModuleDependency, DefaultExternalModuleDependency> minimalConverter = Mock()
+
+    @Subject converter = new DependencyPluginNotationConverter(minimalConverter)
+
+    @Unroll("Parses plugin dependency #pluginId:#version")
+    def "converts plugin dependency and delegates to minimalConverter"() {
+        final PluginDependency pluginDependency = Mock()
+        final NotationConvertResult<? super DefaultExternalModuleDependency> result = Mock()
+
+        when:
+        converter.convert(pluginDependency, result)
+
+        then:
+        1 * minimalConverter.convert({
+            it.module.group == pluginId &&
+                it.module.name == "${pluginId}.gradle.plugin" &&
+                it.versionConstraint.requiredVersion == (version ?: '')
+        }, result)
+
+        and:
+        pluginDependency.pluginId >> pluginId
+        pluginDependency.version >> DefaultImmutableVersionConstraint.of((String) version)
+
+        where:
+        pluginId | version
+        'java'   | '1.0'
+        'java'   | null
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/PluginDependencyNotationParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/PluginDependencyNotationParserTest.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations
+
+
+import org.gradle.internal.typeconversion.NotationParser
+import org.gradle.plugin.use.PluginDependency
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class PluginDependencyNotationParserTest extends Specification {
+
+    @Subject
+    NotationParser<Object, PluginDependency> parser = PluginDependencyNotationParser.parser({ it })
+
+    @Unroll("Parses #notation")
+    def "can parse a plugin dependency notation"() {
+        when:
+        def dependency = parser.parseNotation(notation)
+
+        then:
+        dependency instanceof PluginDependency
+        dependency.pluginId == expectedPluginId
+        dependency.version.getRequiredVersion() == expectedVersion
+
+        where:
+        notation                                    | expectedPluginId | expectedVersion
+        'i:v'                                       | 'i'              | 'v'
+        'i'                                         | 'i'              | ''
+        'id:1.0'                                    | 'id'             | '1.0'
+        'id'                                        | 'id'             | ''
+        'id  :1.0  '                                | 'id'             | '1.0'
+        "${-> 'id'}:1.1"                            | 'id'             | '1.1'
+        [id: 'pluginId']                            | 'pluginId'       | ''
+        [id: 'pluginId', version: '1.4-beta-1']     | 'pluginId'       | '1.4-beta-1'
+        [id: ' pluginId ', version: '  1.4-beta-1'] | 'pluginId'       | '1.4-beta-1'
+    }
+
+    @Unroll("Fails to parse #notation")
+    def "fails to parse map notation which doesn't pass validation"() {
+        when:
+        parser.parseNotation(notation)
+
+        then:
+        Exception ex = thrown()
+        ex.message.startsWith(error)
+
+        where:
+        notation               | error
+        'id:1.0:somethingElse' | "Supplied String plugin notation 'id:1.0:somethingElse' is invalid"
+        [:]                    | "Required keys [id] are missing from map {}."
+        [version: 'foo']       | "Required keys [id] are missing from map {version=foo}."
+    }
+
+}

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -30,6 +30,7 @@ import org.gradle.kotlin.dsl.support.delegates.ClientModuleDelegate
 import org.gradle.kotlin.dsl.support.excludeMapFor
 import org.gradle.kotlin.dsl.support.mapOfNonNullValuesOf
 import org.gradle.kotlin.dsl.support.uncheckedCast
+import org.gradle.plugin.use.PluginDependency
 
 
 /**
@@ -233,6 +234,23 @@ fun DependencyHandler.project(
             else mapOf("path" to path)
         )
     )
+
+
+/**
+ * Creates a dependency on a Gradle plugin.
+ *
+ * @param id the id of the plugin to be added as a dependency.
+ * @param version the optional version of the module to be added as a dependency.
+ *
+ * @return The dependency.
+ *
+ * @see [DependencyHandler.plugin]
+ */
+fun DependencyHandler.plugin(
+    id: String,
+    version: String? = null
+): PluginDependency =
+    plugin(mapOfNonNullValuesOf("id" to id, "version" to version))
 
 
 /**

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -36,6 +36,7 @@ import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderConvertible
+import org.gradle.plugin.use.PluginDependency
 
 
 /**
@@ -132,6 +133,12 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
 
     override fun <T : TransformParameters?> registerTransform(actionType: Class<out TransformAction<T>>, registrationAction: Action<in TransformSpec<T>>) =
         delegate.registerTransform(actionType, registrationAction)
+
+    override fun plugin(notation: Any): PluginDependency =
+        delegate.plugin(notation)
+
+    override fun plugin(notation: Any, configureAction: Action<in PluginDependency>): PluginDependency =
+        delegate.plugin(notation, configureAction)
 
     override fun platform(notation: Any): Dependency =
         delegate.platform(notation)

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
+import org.gradle.plugin.use.PluginDependency
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
@@ -222,6 +223,27 @@ class DependencyHandlerExtensionsTest {
 
         verify(antModule).addDependency(antLauncherDependency)
         verify(antModule).addDependency(antJUnitDependency)
+    }
+
+    @Test
+    fun `given id and version, 'plugin' extension will build corresponding map`() {
+
+        val expectedModuleMap = mapOf(
+            "id" to "i",
+            "version" to "v",
+        )
+
+        val dependencies = newDependencyHandlerMock()
+        val dependency: PluginDependency = mock()
+        whenever(dependencies.plugin(expectedModuleMap)).thenReturn(dependency)
+
+        assertThat(
+            dependencies.plugin(
+                id = "i",
+                version = "v"
+            ),
+            sameInstance(dependency)
+        )
     }
 
     @Test


### PR DESCRIPTION
Implements #18620 and fixes #17963

### Context
Introduces a new `plugin` DSL method under `DependencyHandler` allowing to delcare a plugin's artifact dependency by using the `$pluginId:$pluginId.gradle.plugin:version` convention. 

This simplifies the integration with `buildSrc` module or any plugins author that builds upon other plugins:
```kotlin
dependencies {
    implementation(plugin("org.gradle.android.cache-fix:2.4.4"))
}
```

It's implemented in two phases:
1) A dedicated `NotationParser` that accepts:
- String notations with the format `pluginId:version` (version is optional).
- Map notation with the format `{id: "org.gradle.java", version: "0.1.0"}`
And creates a `PluginDependency`.

2) `DependencyNotationParser` was enriched with a `NotationConverter` to transform `PluginDependency` into `ExternalModuleDependency` (fixes #17963)

Also added a Kotlin DSL, unit tests, and an integration test.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
