### PR TITLE
Add Community Slack invite link to docs

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -35,6 +35,11 @@
                             </a>
                         </div>
                         <div class="site-header__navigation-submenu-item" itemprop="name">
+                            <a target="_top" class="site-header__navigation-submenu-item-link" href="https://gradle.com/slack-invite?_ga=2.80448343.1527799464.1634546704-1419875506.1630512939" itemprop="url">
+                                <span class="site-header__navigation-submenu-item-link-text">Community Slack</span>
+                            </a>
+                        </div>
+                        <div class="site-header__navigation-submenu-item" itemprop="name">
                             <a target="_top" class="site-header__navigation-submenu-item-link" href="https://discuss.gradle.org/" itemprop="url">
                                 <span class="site-header__navigation-submenu-item-link-text">Community Forums</span>
                             </a>


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

It looks like this:
<img width="1744" alt="Screenshot 2021-10-18 at 17 24 48" src="https://user-images.githubusercontent.com/3939893/137763285-ff27f558-7ff4-40ae-9ecd-a6908e49f59b.png">

It seems that one from https://help.gradle.org/ is not in gradle/gradle.

Update: found source of https://help.gradle.org