### PR TITLE
Deprecate implicit rootProject.name assignment

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/RootProjectNameIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/RootProjectNameIntegrationTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Ignore
+import spock.lang.Issue
+
+@Issue("https://github.com/gradle/gradle/issues/15655")
+class RootProjectNameIntegrationTest extends AbstractIntegrationSpec {
+    @Ignore("This is hard to implement.")
+    def "rootProject name is 'root' if the settings file is in the filesystem root"() {
+    }
+
+    def "deprecation warning is raised if rootProject name is not explicitly set"() {
+        settingsFile << """
+        """
+
+        executer.expectDeprecationWarning(
+            "Implicit rootProject.name has been deprecated. This will fail with an error in Gradle 8.0. Set the 'rootProject.name' in the settings file."
+        )
+
+        expect:
+        succeeds()
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultProjectDescriptor.java
@@ -50,6 +50,7 @@ public class DefaultProjectDescriptor implements ProjectDescriptor, ProjectIdent
     private ProjectDescriptorRegistry projectDescriptorRegistry;
     private Path path;
     private String buildFileName;
+    private boolean nameChanged;
 
     public DefaultProjectDescriptor(@Nullable DefaultProjectDescriptor parent, String name, File dir,
                                     ProjectDescriptorRegistry projectDescriptorRegistry, PathToFileResolver fileResolver) {
@@ -102,6 +103,11 @@ public class DefaultProjectDescriptor implements ProjectDescriptor, ProjectIdent
             INVALID_NAME_IN_INCLUDE_HINT);
         projectDescriptorRegistry.changeDescriptorPath(path, path(name));
         this.name = name;
+        this.nameChanged = true;
+    }
+
+    public boolean isNameChanged() {
+        return nameChanged;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettings.java
@@ -91,7 +91,11 @@ public abstract class DefaultSettings extends AbstractPluginAware implements Set
         this.settingsScript = settingsScript;
         this.startParameter = startParameter;
         this.services = serviceRegistryFactory.createFor(this);
-        this.rootProjectDescriptor = createProjectDescriptor(null, settingsDir.getName(), settingsDir);
+        String name = settingsDir.getName();
+        if (name.isEmpty()) {
+            name = "root";
+        }
+        this.rootProjectDescriptor = createProjectDescriptor(null, name, settingsDir);
         this.dependencyResolutionManagement = services.get(DependencyResolutionManagementInternal.class);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsEvaluatedCallbackFiringSettingsProcessor.java
@@ -20,6 +20,7 @@ import org.gradle.StartParameter;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 public class SettingsEvaluatedCallbackFiringSettingsProcessor implements SettingsProcessor {
 
@@ -34,6 +35,13 @@ public class SettingsEvaluatedCallbackFiringSettingsProcessor implements Setting
         SettingsInternal settings = delegate.process(gradle, settingsLocation, buildRootClassLoaderScope, startParameter);
         gradle.getBuildListenerBroadcaster().settingsEvaluated(settings);
         settings.preventFromFurtherMutation();
+        if (!((DefaultProjectDescriptor) settings.getRootProject()).isNameChanged()) {
+            DeprecationLogger.deprecate("Implicit rootProject.name")
+                .withAdvice("Set the 'rootProject.name' in the settings file.")
+                .willBecomeAnErrorInGradle8()
+                .withUserManual("multi_project_builds", "naming_recommendations")
+                .nagUser();
+        }
         return settings;
     }
 }


### PR DESCRIPTION
Also assigns 'root' if the name is empty.

If this deprecation seems sensible, I'll add docs to describe it.

Fixes #15655