### PR TITLE
Skip some flaky tests with parallel executer

### DIFF
--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.samples.java
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -320,7 +321,8 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
         dsl << ['groovy', 'kotlin']
     }
 
-    @Requires(TestPrecondition.JDK9_OR_LATER)
+    // assertTaskOrder may fail with parallel executer
+    @Requires(adhoc = { TestPrecondition.JDK9_OR_LATER.fulfilled && !GradleContextualExecuter.isParallel() })
     @Unroll
     @UsesSample("java/basic")
     def "can run simple Java integration tests with #dsl dsl"() {

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.internal.TextUtil
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
+import spock.lang.IgnoreIf
 
 class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
     @Rule
@@ -143,6 +145,8 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
+    // assertTasksExecutedInOrder may fail with parallel executer
+    @IgnoreIf({ GradleContextualExecuter.isParallel() })
     @ToBeFixedForConfigurationCache
     def "can use source mappings defined in nested builds"() {
         given:


### PR DESCRIPTION
With parallel executer, some tests with `assertTasksExecutedInOrder`
may fail. Skip them.
