### PR TITLE
Disable test file verification for now

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.ci-reporting.gradle.kts
@@ -52,7 +52,8 @@ if (BuildEnvironment.isCiServer && project.name != "gradle-kotlin-dsl-accessors"
         prepareReportsForCiPublishing(if (tmpTestFiles.isEmpty()) failedTasks else executedTasks, executedTasks, tmpTestFiles.keys)
         cleanUp(tmpTestFiles.keys)
         if (!isCleanupRunnerStep(gradle!!)) {
-            verifyTestFilesCleanup(failedTasks, tmpTestFiles)
+            // Disable it before we fix https://github.com/gradle/gradle-private/issues/3463
+            // verifyTestFilesCleanup(failedTasks, tmpTestFiles)
         }
     }
 }


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/3463

There is an issue that `taskGraph.tasks` always returns empty list,
which breaks verifyTestFilesCleanup(): the build will fail if there
is any test failures, regardless of retry or not. Now let's disable
it to unblock master before we fix the issue.
