### PR TITLE
Fix parallelTest for PMD

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
@@ -75,6 +76,9 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails("check")
         failure.assertHasCause("Incremental analysis only supports PMD 6.0.0 and newer. Please upgrade from PMD 5.1.1 or disable incremental analysis.")
+        if (GradleContextualExecuter.isParallel()) {
+            failure.assertHasFailures(2)
+        }
     }
 
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.plugins.quality.pmd
 
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.util.internal.VersionNumber
 import org.hamcrest.Matcher
 import spock.lang.Issue
@@ -143,6 +144,10 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         expect:
         fails("check")
         failure.assertHasCause("Invalid rulesMinimumPriority '11'.  Valid range 1 (highest) to 5 (lowest).")
+        if (GradleContextualExecuter.isParallel()) {
+            // pmdMain and pmdTest
+            failure.assertHasFailures(2)
+        }
     }
 
     def "gets reasonable message when priority level threshold is out of range from task"() {


### PR DESCRIPTION
Due to some changes, now this test fails with two exceptions with
parallel executer: `pmdTest` and `pmdMain`.
