### PR TITLE
Use new Groovy AntBuilder class

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -23,6 +23,14 @@
             "changes": [
                 "org.gradle.kotlin.dsl.support.delegates.SettingsDelegate.include(java.lang.String[])"
             ]
+        },
+        {
+            "type": "org.gradle.api.AntBuilder",
+            "member": "Class org.gradle.api.AntBuilder",
+            "acceptation": "The super-class has been moved from groovy.util.AntBuilder to groovy.ant.AntBuilder",
+            "changes": [
+                "Abstract method has been added in implemented interface"
+            ]
         }
     ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
@@ -20,8 +20,7 @@ import java.util.Map;
 /**
  * <p>An {@code AntBuilder} allows you to use Ant from your build script.</p>
  */
-@SuppressWarnings("deprecation")
-public abstract class AntBuilder extends groovy.util.AntBuilder {
+public abstract class AntBuilder extends groovy.ant.AntBuilder {
     /**
      * Returns the properties of the Ant project. This is a live map, you that you can make changes to the map and these
      * changes are reflected in the Ant project.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.project.ant;
 import org.apache.tools.ant.ComponentHelper;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Target;
+import org.gradle.api.AntBuilder;
 import org.gradle.api.Transformer;
 import org.gradle.api.internal.file.ant.AntFileResource;
 import org.gradle.api.internal.file.ant.BaseDirSelector;
@@ -27,8 +28,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings("deprecation")
-public class BasicAntBuilder extends org.gradle.api.AntBuilder implements Closeable {
+public class BasicAntBuilder extends AntBuilder implements Closeable {
     private final Field nodeField;
     private final List children;
 
@@ -36,9 +36,9 @@ public class BasicAntBuilder extends org.gradle.api.AntBuilder implements Closea
         // These are used to discard references to tasks so they can be garbage collected
         Field collectorField;
         try {
-            nodeField = groovy.util.AntBuilder.class.getDeclaredField("lastCompletedNode");
+            nodeField = groovy.ant.AntBuilder.class.getDeclaredField("lastCompletedNode");
             nodeField.setAccessible(true);
-            collectorField = groovy.util.AntBuilder.class.getDeclaredField("collectorTarget");
+            collectorField = groovy.ant.AntBuilder.class.getDeclaredField("collectorTarget");
             collectorField.setAccessible(true);
             Target target = (Target) collectorField.get(this);
             Field childrenField = Target.class.getDeclaredField("children");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
@@ -164,7 +164,7 @@ class DefaultAntBuilderTest extends AbstractProjectBuilderSpec {
         ant.antProject.targets.size() == 0
 
         when:
-        Field field = groovy.util.AntBuilder.class.getDeclaredField('collectorTarget')
+        Field field = groovy.ant.AntBuilder.class.getDeclaredField('collectorTarget')
         field.accessible = true
         Target target = field.get(ant)
         field = target.class.getDeclaredField('children')


### PR DESCRIPTION
In Groovy 3 `groovy.util.AntBuilder` has been moved to `groovy.ant.AntBuilder`. This class is the basis of `org.gradle.api.AntBuilder`, and we need to make the change to prepare for the Groovy 4 upgrade. However, it is a slight breaking change in our API.

This has been moved out of https://github.com/gradle/gradle/pull/18665 to keep that PR free of breaking changes, so we can discuss and ship this separately. We can for example delay shipping this until Gradle 8.0 when we are expected to also upgrade to Groovy 4.