### PR TITLE
Deprecate eager task container calls

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -46,6 +46,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The task. Returns null if so such task exists.
      */
     @Nullable
+    @Deprecated
     Task findByPath(String path);
 
     /**
@@ -57,6 +58,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The task. Never returns null
      * @throws UnknownTaskException If no task with the given path exists.
      */
+    @Deprecated
     Task getByPath(String path) throws UnknownTaskException;
 
     /**
@@ -105,6 +107,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws NullPointerException If any of the values in <code>{@value org.gradle.api.Task#TASK_CONSTRUCTOR_ARGS}</code> is null.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
+    @Deprecated
     Task create(Map<String, ?> options) throws InvalidUserDataException;
 
     /**
@@ -121,6 +124,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
+    @Deprecated
     Task create(Map<String, ?> options, Closure configureClosure) throws InvalidUserDataException;
 
     /**
@@ -137,6 +141,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
     @Override
+    @Deprecated
     Task create(String name, Closure configureClosure) throws InvalidUserDataException;
 
     /**
@@ -151,6 +156,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
     @Override
+    @Deprecated
     Task create(String name) throws InvalidUserDataException;
 
     /**
@@ -166,6 +172,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
     @Override
+    @Deprecated
     <T extends Task> T create(String name, Class<T> type) throws InvalidUserDataException;
 
     /**
@@ -185,6 +192,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      * @since 4.7
      */
+    @Deprecated
     <T extends Task> T create(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
 
     /**
@@ -201,6 +209,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
     @Override
+    @Deprecated
     <T extends Task> T create(String name, Class<T> type, Action<? super T> configuration) throws InvalidUserDataException;
 
     /**
@@ -287,6 +296,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
+    @Deprecated
     Task replace(String name);
 
     /**
@@ -301,5 +311,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @return The newly created task object
      * @see Project#getProperties()  More information about how tasks are exposed by name in build scripts
      */
+    @Deprecated
     <T extends Task> T replace(String name, Class<T> type);
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
New plugin authors can easily fall into the trap of eager task creation.  This PR deprecates the legacy methods in efforts to direct them to methods like register(...) and named(...).

@runningcode told me this is a good idea! 😸 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
