### PR TITLE
Use DetachedResolver to resolve Gradle libs in IDE plugins

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractSourcesAndJavadocJarsIntegrationTest.groovy
@@ -484,6 +484,32 @@ dependencies {
         ideFileContainsNoSourcesAndJavadocEntry()
     }
 
+    @ToBeFixedForConfigurationCache
+    def "does not add project repository to download localGroovy() sources"() {
+        given:
+        def repo = givenGroovyExistsInGradleRepo()
+        executer.withEnvironmentVars('GRADLE_LIBS_REPO_OVERRIDE': "$repo.uri/")
+        settingsFile << """
+            dependencyResolutionManagement { repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS }
+        """
+
+        buildScript """
+            apply plugin: "java"
+            apply plugin: "idea"
+            apply plugin: "eclipse"
+
+            dependencies {
+                implementation localGroovy()
+            }
+        """
+
+        when:
+        succeeds ideTask
+
+        then:
+        ideFileContainsEntry("groovy-${groovyVersion}.jar", ["groovy-${groovyVersion}-sources.jar"], [])
+    }
+
     void assertSourcesDirectoryDoesNotExistInDistribution() {
         gradleDistributionSrcDir().assertDoesNotExist()
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -349,7 +349,7 @@ public class EclipseClasspath {
                 inferModulePath = JavaModuleDetector.isModuleSource(true, sourceRoots);
             }
         }
-        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(project), inferModulePath);
+        ClasspathFactory classpathFactory = new ClasspathFactory(this, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()), inferModulePath);
         return classpathFactory.createEntries();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -606,7 +606,7 @@ public class IdeaModule {
     public Set<Dependency> resolveDependencies() {
         ProjectInternal projectInternal = (ProjectInternal) project;
         IdeArtifactRegistry ideArtifactRegistry = projectInternal.getServices().get(IdeArtifactRegistry.class);
-        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(project));
+        IdeaDependenciesProvider ideaDependenciesProvider = new IdeaDependenciesProvider(projectInternal, ideArtifactRegistry, new DefaultGradleApiSourcesResolver(projectInternal.newDetachedResolver()));
         return ideaDependenciesProvider.provide(this);
     }
 


### PR DESCRIPTION
Fixes #15732

Trivial change so no unit or integration tests. Just existing test suite.
Also no public API changes, so no changes in docs.

### Context
Allows using `RepositoriesMode.FAIL_ON_PROJECT_REPOS` in `dependencyResolutionManagement` when running/syncing from IDE. Also removes a lot of warnings in case of `RepositoriesMode.PREFER_SETTINGS` in same case.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
