### PR TITLE
Use auto-imported Groovy classes

### DIFF
--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/canCompileAgainstGroovyClassThatDependsOnExternalClass/src/test/groovy/MyGroovyTestCase.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/canCompileAgainstGroovyClassThatDependsOnExternalClass/src/test/groovy/MyGroovyTestCase.groovy
@@ -1,5 +1,3 @@
-import groovy.test.GroovyTestCase
-
 // GroovyTestCase depends on external class junit.framework.TestCase
 class MyGroovyTestCase extends GroovyTestCase {
     void testSomething() {

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/groovyToolClassesAreNotVisible/src/main/groovy/Thing.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/groovyToolClassesAreNotVisible/src/main/groovy/Thing.groovy
@@ -1,3 +1,3 @@
 class Thing {
-    def builder = new groovy.ant.AntBuilder()
+    def builder = new AntBuilder()
 }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformThatReferencesGroovyTestCase/src/main/groovy/TestCaseTransform.java
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformThatReferencesGroovyTestCase/src/main/groovy/TestCaseTransform.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import groovy.test.GroovyTestCase;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.control.SourceUnit;

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformThatReferencesGroovyTestCase/src/test/groovy/TestCaseTransformTest.groovy
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/GroovyCompilerIntegrationSpec/canUseAstTransformThatReferencesGroovyTestCase/src/test/groovy/TestCaseTransformTest.groovy
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import groovy.test.GroovyTestCase
-
 @TestCase
 class TestCaseTransformTest {
     void testAddsGroovyTestCaseAsSuperclass() {


### PR DESCRIPTION
This is to fix failing Groovy compiler tests:

https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsIntegMultiVersion_34_Trigger/46764729

Currently the auto-import imports deprecated classes, but we'll change the auto-import when upgrading to Groovy 4, so they will point to the right classes again. So the source code of the tests can remain the same, without an additional import statement or FQCN.