### PR TITLE
Check if the sourceSetDir is null. Use empty set instead.

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpecFactory.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrSpecFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.antlr.AntlrTask;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -41,7 +42,13 @@ public class AntlrSpecFactory {
         if (antlrTask.isTraceTreeWalker() && !arguments.contains("-traceTreeWalker")) {
             arguments.add("-traceTreeWalker");
         }
+        Set<File> sourceSetDirectoriesFiles;
+        if (sourceSetDirectories == null) {
+            sourceSetDirectoriesFiles = Collections.emptySet();
+        } else {
+            sourceSetDirectoriesFiles = sourceSetDirectories.getFiles();
+        }
 
-        return new AntlrSpec(arguments, grammarFiles, sourceSetDirectories.getFiles(), antlrTask.getOutputDirectory(), antlrTask.getMaxHeapSize());
+        return new AntlrSpec(arguments, grammarFiles, sourceSetDirectoriesFiles, antlrTask.getOutputDirectory(), antlrTask.getMaxHeapSize());
     }
 }

--- a/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/AntlrSpecFactoryTest.groovy
+++ b/subprojects/antlr/src/test/groovy/org/gradle/api/plugins/antlr/internal/AntlrSpecFactoryTest.groovy
@@ -25,11 +25,9 @@ class AntlrSpecFactoryTest extends Specification {
     private AntlrSpecFactory factory = new AntlrSpecFactory()
     private FileCollection sourceSetDirectories = Mock()
 
-    def setup(){
-        1 * sourceSetDirectories.getFiles() >> []
-    }
     def tracePropertiesAddedToArgumentList() {
         when:
+        sourceSetDirectoriesAreEmptySet()
         AntlrTask task = Mock()
 
         _ * task.outputDirectory >> destFile()
@@ -48,8 +46,26 @@ class AntlrSpecFactoryTest extends Specification {
         spec.arguments.contains("-traceTreeWalker")
     }
 
+    def sourceSetDirectoriesNull() {
+        when:
+        AntlrTask task = Mock()
+
+        _ * task.outputDirectory >> destFile()
+        _ * task.getArguments() >> []
+        _ * task.isTrace() >> true
+        _ * task.isTraceLexer() >> true
+        _ * task.isTraceParser() >> true
+        _ * task.isTraceTreeWalker() >> true
+
+        def spec = factory.create(task, [] as Set, null)
+
+        then:
+        spec.inputDirectories.isEmpty()
+    }
+
     def customTraceArgumentsOverrideProperties() {
         when:
+        sourceSetDirectoriesAreEmptySet()
         AntlrTask task = Mock()
         _ * task.outputDirectory >> destFile()
         _ * task.getArguments() >> ["-trace", "-traceLexer", "-traceParser", "-traceTreeWalker"]
@@ -65,6 +81,7 @@ class AntlrSpecFactoryTest extends Specification {
 
     def traceArgumentsDoNotDuplicateTrueTraceProperties() {
         when:
+        sourceSetDirectoriesAreEmptySet()
         AntlrTask task = Mock()
         _ * task.outputDirectory >> destFile()
         _ * task.getArguments() >> ["-trace", "-traceLexer", "-traceParser", "-traceTreeWalker"]
@@ -80,6 +97,10 @@ class AntlrSpecFactoryTest extends Specification {
         spec.arguments.count { it == "-traceLexer" } == 1
         spec.arguments.count { it == "-traceParser" } == 1
         spec.arguments.count { it == "-traceTreeWalker" } == 1
+    }
+
+    private void sourceSetDirectoriesAreEmptySet() {
+        1 * sourceSetDirectories.getFiles() >> []
     }
 
     def destFile() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/gradle/gradle/issues/18134

AntlrSpecFactory would crash on an NPE whenever sourceSetDirectoriesFiles is null. 
It appears that AntrExecutor.AntlrTool handles empty sourceInputDirectories properly.
=> converted sourceSetDirectoriesFiles from null to empty set.

### Context
https://github.com/gradle/gradle/issues/18134

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
