### PR TITLE
Use 7.3-rc-2 as minimum version of cross version tests on Java 17

### DIFF
--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -182,7 +182,7 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
 
     static String determineMinimumVersionThatRunsOnCurrentJavaVersion(String desiredGradleVersion) {
         if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-            def compatibleVersion = GradleVersion.version("7.3-20210724022245+0000")
+            def compatibleVersion = GradleVersion.version("7.3-rc-2")
             if (GradleVersion.version(desiredGradleVersion) < compatibleVersion) {
                 return compatibleVersion.version
             }


### PR DESCRIPTION
The previous snapshot version doesn't exist any more.
