### PR TITLE
Enable @IntegrationTimeout for some embedded tests

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.integtests.composite
 
 
 import org.gradle.integtests.fixtures.build.BuildTestFile
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -191,6 +193,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         executed ":pluginBuild:jar", ":pluginDependencyA:jar", ":buildB:jar", ":jar"
     }
 
+    @IntegrationTestTimeout(value = 30, onlyIf = { GradleContextualExecuter.embedded })
     def "can co-develop plugin and multiple consumers as included builds with transitive plugin library dependency using library included build and 'apply plugin'"() {
         given:
         def buildB = singleProjectBuild("buildB") {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.ProjectLifecycleFixture
 import org.gradle.integtests.fixtures.extensions.FluidDependenciesResolveTest
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -535,6 +536,7 @@ task printExt {
 
     @ToBeFixedForConfigurationCache(because = "runs the dependencies task")
     @Issue("https://github.com/gradle/gradle/issues/18460")
+    @IntegrationTestTimeout(value = 60, onlyIf = { GradleContextualExecuter.embedded })
     def "can query dependencies with configure on demand enabled"() {
         def subprojects = ["a", "b"]
         multiProjectBuild("outputRegistry", subprojects)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeout.java
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.timeout;
 
+import groovy.lang.Closure;
 import org.spockframework.runtime.extension.ExtensionAnnotation;
 
 import java.lang.annotation.ElementType;
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 @ExtensionAnnotation(IntegrationTestTimeoutExtension.class)
 public @interface IntegrationTestTimeout {
     int DEFAULT_TIMEOUT_SECONDS = 600;
+
     /**
      * Returns the duration after which the execution of the annotated feature or fixture
      * method times out.
@@ -55,5 +57,22 @@ public @interface IntegrationTestTimeout {
      * @return the duration's time unit
      */
     TimeUnit unit() default TimeUnit.SECONDS;
-}
 
+    /**
+     * Only enables the timeout when the closure is evaluated to `true`.
+     *
+     * @return the closure
+     */
+    Class<? extends Closure> onlyIf() default AlwaysTrue.class;
+
+    class AlwaysTrue extends Closure<Boolean> {
+        public AlwaysTrue() {
+            super(null);
+        }
+
+        @Override
+        public Boolean call() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Recently we found some tests are flakily 5x slower,
but eventually pass. To get the test reports for
troubleshooting, we enable timeout annotation for them.