### PR TITLE
Fix ordering issue when the name of a project and its parent is customized in the settings script

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectHierarchyCustomizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectHierarchyCustomizationIntegrationTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class ProjectHierarchyCustomizationIntegrationTest extends AbstractIntegrationSpec {
+    @Issue("https://github.com/gradle/gradle/issues/18726")
+    def "can customize name of child project before customizing the name of parent project"() {
+        settingsFile << """
+            include("modules:projectA:projectB")
+
+            project(':modules:projectA:projectB').name = 'project-b'
+            project(':modules:projectA').name = 'project-a'
+        """
+
+        // This tests current behaviour, not desired behaviour
+        buildFile << """
+            project(":modules:project-a") {
+                task test { }
+            }
+            // should be 'project-a', not 'projectA'
+            project(":modules:projectA:project-b") {
+                task test { }
+            }
+        """
+
+        when:
+        run("test")
+
+        then:
+        result.assertTasksExecuted(":modules:project-a:test", ":modules:projectA:project-b:test")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -305,11 +305,19 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry {
                 if (this.project != null) {
                     throw new IllegalStateException(String.format("The project object for project %s has already been attached.", getIdentityPath()));
                 }
+
                 ProjectInternal parent;
-                if (projectPath.equals(Path.ROOT)) {
-                    parent = null;
+                if (descriptor.getParent() != null) {
+                    // Identity path of parent can be different to identity path parent, if the names are tweaked in the settings file
+                    // They should be exactly the same, always
+                    Path parentPath = owner.calculateIdentityPathForProject(descriptor.getParent().path());
+                    ProjectStateImpl parentState = projectsByPath.get(parentPath);
+                    if (parentState == null) {
+                        throw new IllegalStateException("Parent project " + parentPath + " is not registered for project " + identityPath);
+                    }
+                    parent = parentState.getMutableModel();
                 } else {
-                    parent = projectsByPath.get(identityPath.getParent()).getMutableModel();
+                    parent = null;
                 }
                 this.project = projectFactory.createProject(owner.getMutableModel(), descriptor, this, parent, selfClassLoaderScope, baseClassLoaderScope);
             }


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
