### PR TITLE
Add directorySensitivity to the strategy hash

### DIFF
--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.changedetection.state.RuntimeClasspathResourceHas
 import org.gradle.api.internal.changedetection.state.ZipHasher;
 import org.gradle.internal.RelativePathSupplier;
 import org.gradle.internal.file.FileType;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
@@ -89,7 +88,7 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
         ResourceSnapshotterCacheService cacheService,
         Interner<String> stringInterner
     ) {
-        super(identifier, DirectorySensitivity.DEFAULT, zipHasher);
+        super(identifier, zipHasher);
         this.nonZipFingerprintingStrategy = nonZipFingerprintingStrategy;
         this.classpathResourceHasher = classpathResourceHasher;
         this.cacheService = cacheService;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -34,7 +34,7 @@ import java.util.Map;
 /**
  * Fingerprint files without path or content normalization.
  */
-public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingStrategy {
+public class AbsolutePathFingerprintingStrategy extends AbstractDirectorySensitiveFingerprintingStrategy {
     public static final FingerprintingStrategy DEFAULT = new AbsolutePathFingerprintingStrategy(DirectorySensitivity.DEFAULT);
     public static final FingerprintingStrategy IGNORE_DIRECTORIES = new AbsolutePathFingerprintingStrategy(DirectorySensitivity.IGNORE_DIRECTORIES);
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractDirectorySensitiveFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractDirectorySensitiveFingerprintingStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.fingerprint.impl;
+
+import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
+
+public abstract class AbstractDirectorySensitiveFingerprintingStrategy extends AbstractFingerprintingStrategy {
+    private final DirectorySensitivity directorySensitivity;
+
+    public AbstractDirectorySensitiveFingerprintingStrategy(String identifier, DirectorySensitivity directorySensitivity, ConfigurableNormalizer contentNormalizer) {
+        super(identifier, hasher -> {
+            contentNormalizer.appendConfigurationToHasher(hasher);
+            hasher.putInt(directorySensitivity.ordinal());
+        });
+        this.directorySensitivity = directorySensitivity;
+    }
+
+    protected DirectorySensitivity getDirectorySensitivity() {
+        return directorySensitivity;
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintingStrategy.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.fingerprint.impl;
 
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
 import org.gradle.internal.fingerprint.hashing.ConfigurableNormalizer;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
@@ -33,20 +32,17 @@ import java.io.UncheckedIOException;
 public abstract class AbstractFingerprintingStrategy implements FingerprintingStrategy {
     private final String identifier;
     private final CurrentFileCollectionFingerprint emptyFingerprint;
-    private final DirectorySensitivity directorySensitivity;
     private final HashCode configurationHash;
 
     public AbstractFingerprintingStrategy(
         String identifier,
-        DirectorySensitivity directorySensitivity,
-        ConfigurableNormalizer contentNormalizer
+        ConfigurableNormalizer configurableNormalizer
     ) {
         this.identifier = identifier;
         this.emptyFingerprint = new EmptyCurrentFileCollectionFingerprint(identifier);
-        this.directorySensitivity = directorySensitivity;
         Hasher hasher = Hashing.newHasher();
         hasher.putString(getClass().getName());
-        contentNormalizer.appendConfigurationToHasher(hasher);
+        configurableNormalizer.appendConfigurationToHasher(hasher);
         this.configurationHash = hasher.hash();
     }
 
@@ -73,10 +69,6 @@ public abstract class AbstractFingerprintingStrategy implements FingerprintingSt
 
     private static String failedToNormalize(FileSystemLocationSnapshot snapshot) {
         return String.format("Failed to normalize content of '%s'.", snapshot.getAbsolutePath());
-    }
-
-    protected DirectorySensitivity getDirectorySensitivity() {
-        return directorySensitivity;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMap;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
 import org.gradle.internal.fingerprint.hashing.FileSystemLocationSnapshotHasher;
@@ -45,7 +44,7 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     private final FileSystemLocationSnapshotHasher normalizedContentHasher;
 
     public IgnoredPathFingerprintingStrategy(FileSystemLocationSnapshotHasher normalizedContentHasher) {
-        super(IDENTIFIER, DirectorySensitivity.DEFAULT, normalizedContentHasher);
+        super(IDENTIFIER, normalizedContentHasher);
         this.normalizedContentHasher = normalizedContentHasher;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -36,7 +36,7 @@ import java.util.Map;
  *
  * File names for root directories are ignored.
  */
-public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrategy {
+public class NameOnlyFingerprintingStrategy extends AbstractDirectorySensitiveFingerprintingStrategy {
     public static final NameOnlyFingerprintingStrategy DEFAULT = new NameOnlyFingerprintingStrategy(DirectorySensitivity.DEFAULT);
     public static final NameOnlyFingerprintingStrategy IGNORE_DIRECTORIES = new NameOnlyFingerprintingStrategy(DirectorySensitivity.IGNORE_DIRECTORIES);
     public static final String IDENTIFIER = "NAME_ONLY";

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -38,7 +38,7 @@ import java.util.Map;
  *
  * File names for root directories are ignored. For root files, the file name is used as normalized path.
  */
-public class RelativePathFingerprintingStrategy extends AbstractFingerprintingStrategy {
+public class RelativePathFingerprintingStrategy extends AbstractDirectorySensitiveFingerprintingStrategy {
     public static final String IDENTIFIER = "RELATIVE_PATH";
 
     private final Interner<String> stringInterner;


### PR DESCRIPTION
for the fingerprinting strategies which actually use it. This could be a problem when re-using the input hashes from the previous run and the directory sensitivity changed.