### PR TITLE
Use @CompileClasspath for PackageListGenerator

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
@@ -22,7 +22,7 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -77,7 +77,7 @@ public class PackageListGenerator extends DefaultTask {
         excludes = DEFAULT_EXCLUDES;
     }
 
-    @Classpath
+    @CompileClasspath
     public FileCollection getClasspath() {
         return classpath;
     }


### PR DESCRIPTION
When profiling local build with non-ABI changes, we found `PackageListGenerator` should not be executed with non-ABI changes. It's probably because that task was old (2016):

https://ge.gradle.org/s/34o6kissfe4py/timeline?details=gsb6evpwkpehe&end=1635215780753.5&outcome=SUCCESS&start=1635215774667.5

Now we use `@CompileClasspath` to get rid of it.