### PR TITLE
Fix extractCheckStyleBuildScanData configuration

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -155,13 +155,13 @@ fun extractCheckstyleAndCodenarcData() {
         tasks.withType<Checkstyle>().configureEach {
             finalizedBy(extractCheckstyleBuildScanData)
             extractCheckstyleBuildScanData {
-                reports.xml.outputLocation.orNull?.let { xmlOutputs.from(it.asFile) }
+                xmlOutputs.from(reports.xml.outputLocation)
             }
         }
         tasks.withType<CodeNarc>().configureEach {
             finalizedBy(extractCodeNarcBuildScanData)
             extractCodeNarcBuildScanData {
-                reports.xml.outputLocation.orNull?.let { xmlOutputs.from(it.asFile) }
+                xmlOutputs.from(reports.xml.outputLocation)
             }
         }
     }


### PR DESCRIPTION
Previously the xml location of extractCheckstyleBuildScanData depends
on configuration order, now we make it configuration-order-irrelevant.
