### PR TITLE
Fine tune some normalization strategies

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
-import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot;
@@ -87,11 +86,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             fileSystemAccess.read(
                 root.getAbsolutePath(),
                 new PatternSetSnapshottingFilter(patterns, stat),
-                snapshot -> {
-                    if (snapshot.getType() != FileType.Missing) {
-                        roots.add(snapshot);
-                    }
-                }
+                roots::add
             );
             if (fileTreeOnly == null) {
                 fileTreeOnly = true;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
@@ -33,7 +33,7 @@ public enum DirectorySensitivity {
     /**
      * Ignore directories
      */
-    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() != FileType.Directory),
+    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() == FileType.RegularFile),
     /**
      * Used to denote that no directory sensitivity has been specified explicitly.
      *

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileSystemLocationFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFileSystemLocationFingerprint.java
@@ -23,7 +23,7 @@ import org.gradle.internal.hash.Hasher;
 
 public class IgnoredPathFileSystemLocationFingerprint implements FileSystemLocationFingerprint {
 
-    public static final IgnoredPathFileSystemLocationFingerprint DIRECTORY = new IgnoredPathFileSystemLocationFingerprint(FileType.Directory, DIR_SIGNATURE);
+    private static final IgnoredPathFileSystemLocationFingerprint DIRECTORY = new IgnoredPathFileSystemLocationFingerprint(FileType.Directory, DIR_SIGNATURE);
     private static final IgnoredPathFileSystemLocationFingerprint MISSING_FILE = new IgnoredPathFileSystemLocationFingerprint(FileType.Missing, MISSING_FILE_SIGNATURE);
 
     private final FileType type;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -65,9 +65,8 @@ public class NameOnlyFingerprintingStrategy extends AbstractDirectorySensitiveFi
             public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
                 String absolutePath = snapshot.getAbsolutePath();
                 if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
-                    if (isRoot && snapshot.getType() == FileType.Directory) {
-                        builder.put(absolutePath, IgnoredPathFileSystemLocationFingerprint.DIRECTORY);
-                    } else {
+                    // We exclude root directories for some reason.
+                    if (!isRoot || snapshot.getType() != FileType.Directory) {
                         HashCode normalizedContentHash = getNormalizedContentHash(snapshot, normalizedContentHasher);
                         if (normalizedContentHash != null) {
                             builder.put(absolutePath, new DefaultFileSystemLocationFingerprint(snapshot.getName(), snapshot.getType(), normalizedContentHash));

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -72,10 +72,10 @@ public class RelativePathFingerprintingStrategy extends AbstractDirectorySensiti
             if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
                 FileSystemLocationFingerprint fingerprint;
                 if (relativePath.isRoot()) {
-                    if (snapshot.getType() == FileType.Directory) {
-                        fingerprint = IgnoredPathFileSystemLocationFingerprint.DIRECTORY;
-                    } else {
+                    if (snapshot.getType() == FileType.RegularFile) {
                         fingerprint = fingerprint(snapshot.getName(), snapshot.getType(), snapshot);
+                    } else {
+                        fingerprint = null;
                     }
                 } else {
                     fingerprint = fingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot.getType(), snapshot);

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -100,8 +100,8 @@ class PathNormalizationStrategyTest extends Specification {
         (getAllFilesToFingerprint(strategy.directorySensitivity) - emptyRootDir - resources).each { file ->
             assert fingerprints[file] == file.name
         }
-        fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
-        fingerprints[resources] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
+        fingerprints[emptyRootDir] == null
+        fingerprints[resources] == null
 
         where:
         strategy << [

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -116,14 +116,14 @@ class PathNormalizationStrategyTest extends Specification {
         expect:
         fingerprints[jarFile1]                      == jarFile1.name
         fingerprints[jarFile2]                      == jarFile2.name
-        fingerprints[resources]                     == rootDirectoryFingerprintFor(strategy.directorySensitivity)
+        fingerprints[resources]                     == null
         fingerprints[resources.file(fileInRoot)]    == fileInRoot
         fingerprints[resources.file(subDirA)]       == directoryFingerprintFor(subDirA, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirA)] == fileInSubdirA
         fingerprints[resources.file(subDirB)]       == directoryFingerprintFor(subDirB, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirB)] == fileInSubdirB
-        fingerprints[emptyRootDir]                  == rootDirectoryFingerprintFor(strategy.directorySensitivity)
-        fingerprints[missingFile]                   == missingFile.name
+        fingerprints[emptyRootDir]                  == null
+        fingerprints[missingFile]                   == null
 
         where:
         strategy << [
@@ -163,9 +163,10 @@ class PathNormalizationStrategyTest extends Specification {
 
     List<File> getAllFilesToFingerprint(DirectorySensitivity directorySensitivity) {
         def dirs = [emptyRootDir, resources.file(subDirA), resources.file(subDirB), resources]
-        def files = [jarFile1, jarFile2, missingFile, resources.file(fileInRoot), resources.file(fileInSubdirA), resources.file(fileInSubdirB)]
+        def files = [jarFile1, jarFile2, resources.file(fileInRoot), resources.file(fileInSubdirA), resources.file(fileInSubdirB)]
+        def missingFiles = [missingFile]
 
-        return directorySensitivity == DirectorySensitivity.DEFAULT ? (dirs + files) : files
+        return directorySensitivity == DirectorySensitivity.DEFAULT ? (dirs + files + missingFiles) : files
     }
 
     protected TestFile file(String... path) {


### PR DESCRIPTION
The main goal of this PR is to get rid of a special case for file trees in snapshotting: https://github.com/gradle/gradle/blob/694b90883d5f14498e61ea3ee473003d1804f525/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java#L90-L94

All this should be handled by fingerprinting.

The main remedy for this problem is to ignore missing files when ignoring empty directories as well. We could also only ignore missing root files, or missing files which are not broken symlinks.

There are two other changes in this PR:

- Ignore roots which are not regular files for RelativePath normalization: I think this makes sense, since for relative paths we also don't capture the name of the root file, so why include it at all?
- Ignore root directories for name only normalization: Same here, for root directories, we don't capture the names.

Especially the change for ignoring root directories for relative path normalization is helpful for using fingerprints for empty source checking: We'd ignore empty root directories for the copy task, which helps to keep the behavior that `processResources` yields no-source for an existing, but empty resources directory.