### PR TITLE
Add support for ProviderConvertible in Kotlin DSL

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -23,6 +23,38 @@
             "changes": [
                 "org.gradle.kotlin.dsl.support.delegates.SettingsDelegate.include(java.lang.String[])"
             ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.ProviderConvertible,kotlin.jvm.functions.Function1)",
+            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.ProviderConvertible)",
+            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.ProviderConvertible,kotlin.jvm.functions.Function1)",
+            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
+        },
+        {
+            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
+            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.ProviderConvertible)",
+            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
+            "changes": [
+                "METHOD_ADDED_TO_PUBLIC_CLASS"
+            ]
         }
     ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -315,6 +315,29 @@ public interface DependencyHandler extends ExtensionAware {
     <T> void addProvider(String configurationName, Provider<T> dependencyNotation);
 
     /**
+     * Adds a dependency provider to the given configuration, eventually configures the dependency using the given action.
+     *
+     * @param configurationName The name of the configuration.
+     * @param dependencyNotation The dependency provider notation, in one of the notations described above.
+     * @param configuration The action to use to configure the dependency.
+     *
+     * @since 7.4
+     */
+    @Incubating
+    <T, U extends ExternalModuleDependency> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation, Action<? super U> configuration);
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param configurationName The name of the configuration.
+     * @param dependencyNotation The dependency provider notation, in one of the notations described above.
+     *
+     * @since 7.4
+     */
+    @Incubating
+    <T> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation);
+
+    /**
      * Creates a dependency without adding it to a configuration.
      *
      * @param dependencyNotation The dependency notation, in one of the notations described above.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -135,6 +135,16 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         addProvider(configurationName, dependencyNotation, Actions.doNothing());
     }
 
+    @Override
+    public <T, U extends ExternalModuleDependency> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation, Action<? super U> configuration) {
+        addProvider(configurationName, dependencyNotation.asProvider(), configuration);
+    }
+
+    @Override
+    public <T> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation) {
+        addProviderConvertible(configurationName, dependencyNotation, Actions.doNothing());
+    }
+
     @SuppressWarnings("ConstantConditions")
     private <U extends ExternalModuleDependency> Closure<Object> closureOf(Action<? super U> configuration) {
         return new Closure<Object>(this, this) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerScope.kt
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.kotlin.dsl.support.delegates.DependencyHandlerDelegate
 
 
@@ -257,6 +258,31 @@ private constructor(
      * @param dependency the dependency provider to be added.
      * @param dependencyConfiguration the configuration to be applied to the dependency
      *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 7.4
+     */
+    @Incubating
+    operator fun <T : Any> Configuration.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProviderConvertible(name, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 7.4
+     */
+    @Incubating
+    operator fun <T : Any> Configuration.invoke(dependency: ProviderConvertible<T>) =
+        addProviderConvertible(name, dependency)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
      * @see [DependencyHandler.addProvider]
      * @since 7.0
      */
@@ -275,6 +301,31 @@ private constructor(
     @Incubating
     operator fun <T : Any> String.invoke(dependency: Provider<T>) =
         addProvider(this, dependency)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     * @param dependencyConfiguration the configuration to be applied to the dependency
+     *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 7.4
+     */
+    @Incubating
+    operator fun <T : Any> String.invoke(dependency: ProviderConvertible<T>, dependencyConfiguration: ExternalModuleDependency.() -> Unit) =
+        addProviderConvertible(this, dependency, dependencyConfiguration)
+
+    /**
+     * Adds a dependency provider to the given configuration.
+     *
+     * @param dependency the dependency provider to be added.
+     *
+     * @see [DependencyHandler.addProviderConvertible]
+     * @since 7.4
+     */
+    @Incubating
+    operator fun <T : Any> String.invoke(dependency: ProviderConvertible<T>) =
+        addProviderConvertible(this, dependency)
 
     /**
      * Configures the dependencies.

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -37,6 +37,7 @@ import org.gradle.kotlin.dsl.support.bytecode.genericTypeOf
 import org.gradle.kotlin.dsl.support.bytecode.internalName
 import org.gradle.kotlin.dsl.support.bytecode.jvmGetterSignatureFor
 import org.gradle.kotlin.dsl.support.bytecode.kotlinDeprecation
+import org.gradle.kotlin.dsl.support.bytecode.providerConvertibleOfStar
 import org.gradle.kotlin.dsl.support.bytecode.providerOfStar
 import org.gradle.kotlin.dsl.support.bytecode.publicFunctionFlags
 import org.gradle.kotlin.dsl.support.bytecode.publicFunctionWithAnnotationsFlags
@@ -213,6 +214,57 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             signature = JvmMethodSignature(
                 propertyName,
                 "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;)V"
+            )
+        ),
+        AccessorFragment(
+            source = name.run {
+                """
+                    /**
+                     * Adds a dependency to the '$original' configuration.
+                     *
+                     * @param dependencyNotation notation for the dependency to be added.
+                     * @param dependencyConfiguration expression to use to configure the dependency.
+                     * @return The dependency.
+                     *
+                     * @see [DependencyHandler.add]
+                     */$deprecationBlock
+                    fun DependencyHandler.`$kotlinIdentifier`(
+                        dependencyNotation: ProviderConvertible<*>,
+                        dependencyConfiguration: Action<ExternalModuleDependency>
+                    ): Unit = addConfiguredDependencyTo(
+                        this, "$stringLiteral", dependencyNotation, dependencyConfiguration
+                    )
+                """
+            },
+            bytecode = {
+                publicStaticMaybeDeprecatedMethod(signature, config) {
+                    ALOAD(0)
+                    LDC(propertyName)
+                    ALOAD(1)
+                    ALOAD(2)
+                    invokeRuntime(
+                        "addConfiguredDependencyTo",
+                        "(L${GradleTypeName.dependencyHandler};Ljava/lang/String;Lorg/gradle/api/provider/ProviderConvertible;Lorg/gradle/api/Action;)V"
+                    )
+                    RETURN()
+                }
+            },
+            metadata = {
+                writer.writeFunctionOf(
+                    functionFlags = functionFlags,
+                    receiverType = GradleType.dependencyHandler,
+                    returnType = KotlinType.unit,
+                    name = propertyName,
+                    parameters = {
+                        visitParameter("dependencyNotation", providerConvertibleOfStar())
+                        visitParameter("dependencyConfiguration", actionTypeOf(GradleType.externalModuleDependency))
+                    },
+                    signature = signature
+                )
+            },
+            signature = JvmMethodSignature(
+                propertyName,
+                "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Lorg/gradle/api/provider/ProviderConvertible;Lorg/gradle/api/Action;)V"
             )
         ),
         AccessorFragment(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -623,6 +623,7 @@ import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/runtime/Runtime.kt
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 
 import org.gradle.kotlin.dsl.support.mapOfNonNullValuesOf
 import org.gradle.kotlin.dsl.support.uncheckedCast
@@ -70,6 +71,16 @@ fun addConfiguredDependencyTo(
     configurationAction: Action<ExternalModuleDependency>
 ) {
     dependencies.addProvider(configuration, dependencyNotation, configurationAction)
+}
+
+
+fun addConfiguredDependencyTo(
+    dependencies: DependencyHandler,
+    configuration: String,
+    dependencyNotation: ProviderConvertible<*>,
+    configurationAction: Action<ExternalModuleDependency>
+) {
+    dependencies.addProviderConvertible(configuration, dependencyNotation, configurationAction)
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/bytecode/KotlinMetadata.kt
@@ -285,6 +285,13 @@ fun providerOfStar(): KmTypeBuilder = {
 }
 
 
+internal
+fun providerConvertibleOfStar(): KmTypeBuilder = {
+    visitClass("org/gradle/api/provider/ProviderConvertible")
+    visitStarProjection()
+}
+
+
 /**
  * [receiverType].() -> [returnType]
  */

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -35,6 +35,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeContainer
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
 
 
 /**
@@ -61,6 +62,12 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
 
     override fun <T : Any?> addProvider(configurationName: String, dependencyNotation: Provider<T>) =
         delegate.addProvider(configurationName, dependencyNotation)
+
+    override fun <T : Any, U : ExternalModuleDependency> addProviderConvertible(configurationName: String, dependencyNotation: ProviderConvertible<T>, configuration: Action<in U>) =
+        delegate.addProviderConvertible(configurationName, dependencyNotation, configuration)
+
+    override fun <T : Any?> addProviderConvertible(configurationName: String, dependencyNotation: ProviderConvertible<T>) =
+        delegate.addProviderConvertible(configurationName, dependencyNotation)
 
     override fun create(dependencyNotation: Any): Dependency =
         delegate.create(dependencyNotation)

--- a/subprojects/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
+++ b/subprojects/kotlin-dsl/src/test/resources/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors-expected-output.txt
@@ -111,6 +111,23 @@
     /**
      * Adds a dependency to the 'api' configuration.
      *
+     * @param dependencyNotation notation for the dependency to be added.
+     * @param dependencyConfiguration expression to use to configure the dependency.
+     * @return The dependency.
+     *
+     * @see [DependencyHandler.add]
+     */
+    fun DependencyHandler.`api`(
+        dependencyNotation: ProviderConvertible<*>,
+        dependencyConfiguration: Action<ExternalModuleDependency>
+    ): Unit = addConfiguredDependencyTo(
+        this, "api", dependencyNotation, dependencyConfiguration
+    )
+
+
+    /**
+     * Adds a dependency to the 'api' configuration.
+     *
      * @param group the group of the module to be added as a dependency.
      * @param name the name of the module to be added as a dependency.
      * @param version the optional version of the module to be added as a dependency.
@@ -249,6 +266,24 @@
     @Deprecated(message = "The compile configuration has been deprecated for dependency declaration. Please use the 'api' or 'implementation' configuration instead.")
     fun DependencyHandler.`compile`(
         dependencyNotation: Provider<*>,
+        dependencyConfiguration: Action<ExternalModuleDependency>
+    ): Unit = addConfiguredDependencyTo(
+        this, "compile", dependencyNotation, dependencyConfiguration
+    )
+
+
+    /**
+     * Adds a dependency to the 'compile' configuration.
+     *
+     * @param dependencyNotation notation for the dependency to be added.
+     * @param dependencyConfiguration expression to use to configure the dependency.
+     * @return The dependency.
+     *
+     * @see [DependencyHandler.add]
+     */
+    @Deprecated(message = "The compile configuration has been deprecated for dependency declaration. Please use the 'api' or 'implementation' configuration instead.")
+    fun DependencyHandler.`compile`(
+        dependencyNotation: ProviderConvertible<*>,
         dependencyConfiguration: Action<ExternalModuleDependency>
     ): Unit = addConfiguredDependencyTo(
         this, "compile", dependencyNotation, dependencyConfiguration


### PR DESCRIPTION
I covered the generated accessors, Configuration.invoke, and String.invoke. Not sure if there's any other relevant spots. Fixes #18617