### PR TITLE
Write `gradleProperty` and `environmentVariable` inputs only once to the configuration cache fingerprint

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOptionsIntegrationTest.groovy
@@ -414,7 +414,7 @@ class ConfigurationCacheBuildOptionsIntegrationTest extends AbstractConfiguratio
         where:
         kind     | option | description | reportedInput
         'system' | 'D'    | 'system'    | "system property 'greeting'"
-        'gradle' | 'P'    | 'Gradle'    | "build logic input of type 'GradlePropertyValueSource'"
+        'gradle' | 'P'    | 'Gradle'    | "Gradle property 'greeting'"
     }
 
     def "mapped system property used as task input"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache
 
 import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.internal.properties.GradleProperties
 import org.gradle.api.internal.provider.ConfigurationTimeBarrier
 import org.gradle.api.internal.provider.DefaultConfigurationTimeBarrier
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
@@ -402,6 +403,8 @@ class DefaultConfigurationCache internal constructor(
                     checkFingerprint(object : ConfigurationCacheFingerprintController.Host {
                         override val valueSourceProviderFactory: ValueSourceProviderFactory
                             get() = host.service()
+                        override val gradleProperties: GradleProperties
+                            get() = gradlePropertiesController.gradleProperties
                     })
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
@@ -50,6 +50,11 @@ sealed class ConfigurationCacheFingerprint {
         val obtainedValue: ObtainedValue
     ) : ConfigurationCacheFingerprint()
 
+    data class UndeclaredGradleProperty(
+        val key: String,
+        val value: String?
+    ) : ConfigurationCacheFingerprint()
+
     data class UndeclaredSystemProperty(
         val key: String,
         val value: Any?

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -40,6 +40,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val gradleUserHomeDir: File
         val allInitScripts: List<File>
         val buildStartTime: Long
+        fun gradleProperty(propertyName: String): String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
         fun displayNameOf(fileOrDirectory: File): String
@@ -105,6 +106,11 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
             is ConfigurationCacheFingerprint.InitScripts -> input.run {
                 val reason = checkInitScriptsAreUpToDate(fingerprints, host.allInitScripts)
                 if (reason != null) return reason
+            }
+            is ConfigurationCacheFingerprint.UndeclaredGradleProperty -> input.run {
+                if (host.gradleProperty(key) != value) {
+                    return "Gradle property '$key' has changed"
+                }
             }
             is ConfigurationCacheFingerprint.UndeclaredSystemProperty -> input.run {
                 if (System.getProperty(key) != value) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -20,6 +20,7 @@ import org.gradle.api.execution.internal.TaskInputsListeners
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.properties.GradleProperties
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.configuration.internal.UserCodeApplicationContext
@@ -71,8 +72,10 @@ class ConfigurationCacheFingerprintController internal constructor(
     private val report: ConfigurationCacheReport,
     private val userCodeApplicationContext: UserCodeApplicationContext
 ) : Stoppable {
+
     interface Host {
         val valueSourceProviderFactory: ValueSourceProviderFactory
+        val gradleProperties: GradleProperties
     }
 
     private
@@ -266,6 +269,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         private val host: Host
     ) : ConfigurationCacheFingerprintChecker.Host {
 
+        private
+        val gradleProperties by lazy(host::gradleProperties)
+
         override val gradleUserHomeDir: File
             get() = startParameter.gradleUserHomeDir
 
@@ -274,6 +280,9 @@ class ConfigurationCacheFingerprintController internal constructor(
 
         override val buildStartTime: Long
             get() = buildCommencedTimeProvider.currentTime
+
+        override fun gradleProperty(propertyName: String): String? =
+            gradleProperties.find(propertyName)
 
         override fun hashCodeOf(file: File) =
             fileSystemAccess.hashCodeOf(file)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -31,7 +31,9 @@ import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree
 import org.gradle.api.internal.provider.ValueSourceProviderFactory
+import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource
 import org.gradle.api.internal.provider.sources.FileContentValueSource
+import org.gradle.api.internal.provider.sources.GradlePropertyValueSource
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.util.PatternSet
@@ -81,6 +83,9 @@ class ConfigurationCacheFingerprintWriter(
 
     private
     val capturedFiles = newConcurrentHashSet<File>()
+
+    private
+    val undeclaredGradleProperties = newConcurrentHashSet<String>()
 
     private
     val undeclaredSystemProperties = newConcurrentHashSet<String>()
@@ -153,6 +158,14 @@ class ConfigurationCacheFingerprintWriter(
         captureFile(file)
     }
 
+    private
+    fun gradlePropertyRead(key: String, value: String?, consumer: String?) {
+        if (undeclaredGradleProperties.add(key)) {
+            write(ConfigurationCacheFingerprint.UndeclaredGradleProperty(key, value))
+            reportGradlePropertyInput(key, consumer)
+        }
+    }
+
     override fun systemPropertyRead(key: String, value: Any?, consumer: String?) {
         if (undeclaredSystemProperties.add(key)) {
             write(ConfigurationCacheFingerprint.UndeclaredSystemProperty(key, value))
@@ -176,6 +189,9 @@ class ConfigurationCacheFingerprintWriter(
                     // TODO - consider the potential race condition in computing the hash code here
                     captureFile(file)
                 }
+            }
+            is GradlePropertyValueSource.Parameters -> {
+                gradlePropertyRead(parameters.propertyName.get(), obtainedValue.value.get() as? String, null)
             }
             is SystemPropertyValueSource.Parameters -> {
                 systemPropertyRead(parameters.propertyName.get(), obtainedValue.value.get(), null)
@@ -287,6 +303,14 @@ class ConfigurationCacheFingerprintWriter(
         reportInput(consumer = null, documentationSection = null) {
             text("build logic input of type ")
             reference(valueSourceType.simpleName)
+        }
+    }
+
+    private
+    fun reportGradlePropertyInput(key: String, consumer: String?) {
+        reportInput(consumer, DocumentationSection.RequirementsUndeclaredGradlePropRead) {
+            text("Gradle property ")
+            reference(key)
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -196,6 +196,9 @@ class ConfigurationCacheFingerprintWriter(
             is SystemPropertyValueSource.Parameters -> {
                 systemPropertyRead(parameters.propertyName.get(), obtainedValue.value.get(), null)
             }
+            is EnvironmentVariableValueSource.Parameters -> {
+                envVariableRead(parameters.variableName.get(), obtainedValue.value.get() as? String, null)
+            }
             else -> {
                 captureValueSource(obtainedValue)
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
@@ -40,6 +40,7 @@ enum class DocumentationSection(val anchor: String) {
     RequirementsBuildListeners("config_cache:requirements:build_listeners"),
     RequirementsDisallowedTypes("config_cache:requirements:disallowed_types"),
     RequirementsTaskAccess("config_cache:requirements:task_access"),
+    RequirementsUndeclaredGradlePropRead("config_cache:requirements:undeclared_gradle_prop_read"),
     RequirementsUndeclaredSysPropRead("config_cache:requirements:undeclared_sys_prop_read"),
     RequirementsUndeclaredEnvVarRead("config_cache:requirements:undeclared_env_var_read"),
     RequirementsUseProjectDuringExecution("config_cache:requirements:use_project_during_execution")

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesController.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradlePropertiesController.java
@@ -17,6 +17,8 @@
 package org.gradle.initialization;
 
 import org.gradle.api.internal.properties.GradleProperties;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
 
 import java.io.File;
 
@@ -24,6 +26,7 @@ import java.io.File;
  * Controls the state (not loaded / loaded) of the attached {@link GradleProperties} instance
  * so that the set of Gradle properties is deterministically loaded only once per build.
  */
+@ServiceScope(Scopes.Build.class)
 public interface GradlePropertiesController {
 
     /**


### PR DESCRIPTION
The behavior was already present for `systemProperty` inputs.

This reduces the fingerprint overhead of build logic inputs from 6.7mb to 55kb in a typical `gradle/gradle` build scenario and makes fingerprint validation significantly cheaper.

