### PR TITLE
Apply dead code elimination to the `configuration-cache-report`

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.configuration-cache-report.gradle.kts
@@ -26,30 +26,11 @@ dependencies {
     compileOnly(kotlin("stdlib-js"))
 }
 
-val unpackKotlinJsStdlib by tasks.registering(Copy::class) {
-    description = "Unpacks the Kotlin JavaScript standard library"
-
-    val kotlinStdLibJsJar = configurations.named("compileClasspath").map { compileClasspath ->
-        val kotlinStdlibJsJarRegex = Regex("kotlin-stdlib-js-.+\\.jar")
-        compileClasspath.single { file -> file.name.matches(kotlinStdlibJsJarRegex) }
-    }
-
-    from(kotlinStdLibJsJar.map(::zipTree)) {
-        include("**/*.js")
-        exclude("META-INF/**")
-    }
-
-    into(layout.buildDirectory.dir(name))
-
-    includeEmptyDirs = false
-}
-
 val assembleReport by tasks.registering(MergeReportAssets::class) {
     htmlFile.set(webpackFile("configuration-cache-report.html"))
     logoFile.set(webpackFile("configuration-cache-report-logo.png"))
     cssFile.set(webpackFile("configuration-cache-report.css"))
     jsFile.set(webpackFile("configuration-cache-report.js"))
-    kotlinJs.set(unpackKotlinJsStdlib.map { projectFile(it.destinationDir.resolve("kotlin.js")) })
     outputFile.set(layout.buildDirectory.file("$name/configuration-cache-report.html"))
 }
 

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/configcachereport/tasks/MergeReportAssets.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/configcachereport/tasks/MergeReportAssets.kt
@@ -47,10 +47,6 @@ abstract class MergeReportAssets : DefaultTask() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val jsFile: RegularFileProperty
 
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val kotlinJs: RegularFileProperty
-
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
@@ -59,7 +55,6 @@ abstract class MergeReportAssets : DefaultTask() {
         outputFile.get().asFile.writeText(
             htmlFile.get().asFile.readText().also {
                 require(it.contains(cssTag))
-                require(it.contains(kotlinJsTag))
                 require(it.contains(jsTag))
             }.replace(
                 cssTag,
@@ -74,13 +69,6 @@ abstract class MergeReportAssets : DefaultTask() {
                 </style>
                 """.trimIndent()
             ).replace(
-                kotlinJsTag,
-                """
-                <script type="text/javascript">
-                ${kotlinJs.get().asFile.readText()}
-                </script>
-                """.trimIndent()
-            ).replace(
                 jsTag,
                 """
                 <script type="text/javascript">
@@ -93,9 +81,6 @@ abstract class MergeReportAssets : DefaultTask() {
 
     private
     val cssTag = """<link rel="stylesheet" href="./configuration-cache-report.css">"""
-
-    private
-    val kotlinJsTag = """<script type="text/javascript" src="kotlin.js"></script>"""
 
     private
     val jsTag = """<script type="text/javascript" src="configuration-cache-report.js"></script>"""

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
+import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
 plugins {
     kotlin("js")
@@ -25,7 +26,7 @@ plugins {
 }
 
 kotlin {
-    js {
+    js(KotlinJsCompilerType.IR) {
         browser {
             webpackTask {
                 sourceMaps = false

--- a/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.html
+++ b/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.html
@@ -18,7 +18,6 @@
     Loading...
 </div>
 
-<script type="text/javascript" src="kotlin.js"></script>
 <script type="text/javascript" src="configuration-cache-report-data.js"></script>
 <script type="text/javascript" src="configuration-cache-report.js"></script>
 


### PR DESCRIPTION
For a 10x reduction in size.