### PR TITLE
Provide option to hide welcome message on gradle startup 

### DIFF
--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ProviderMigrationArchitectureTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/ProviderMigrationArchitectureTest.java
@@ -34,6 +34,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.resources.TextResource;
@@ -72,6 +73,7 @@ public class ProviderMigrationArchitectureTest {
     private static final DescribedPredicate<JavaMethod> mutable_public_API_properties = ArchPredicates.<JavaMethod>are(public_api_methods)
         .and(not(declaredIn(assignableTo(Task.class))))
         .and(not(declaredIn(StartParameter.class)))
+        .and(not(declaredIn(WelcomeMessageConfiguration.class))) // used in StartParameter
         .and(not(declaredIn(Configuration.class)))
         .and(not(declaredIn(FileCollection.class)))
         .and(not(declaredIn(ConfigurableFileCollection.class)))

--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -22,6 +22,8 @@ import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
+import org.gradle.api.launcher.cli.WelcomeMessageDisplayMode;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
@@ -99,6 +101,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
     private DependencyVerificationMode verificationMode = DependencyVerificationMode.STRICT;
     private boolean isRefreshKeys;
     private boolean isExportKeys;
+    private WelcomeMessageConfiguration welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.ONCE);
 
     /**
      * {@inheritDoc}
@@ -260,6 +263,7 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
         p.verificationMode = verificationMode;
         p.isRefreshKeys = isRefreshKeys;
         p.isExportKeys = isExportKeys;
+        p.welcomeMessageConfiguration = welcomeMessageConfiguration;
         return p;
     }
 
@@ -936,5 +940,29 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      */
     public void setExportKeys(boolean exportKeys) {
         isExportKeys = exportKeys;
+    }
+
+    /**
+     * Returns when to display a welcome message on the command line.
+     *
+     * @return The welcome message configuration.
+     * @see WelcomeMessageDisplayMode
+     * @since 7.5
+     */
+    @Incubating
+    public WelcomeMessageConfiguration getWelcomeMessageConfiguration() {
+        return welcomeMessageConfiguration;
+    }
+
+    /**
+     * Updates when to display a welcome message on the command line.
+     *
+     * @param welcomeMessageConfiguration The welcome message configuration.
+     * @see WelcomeMessageDisplayMode
+     * @since 7.5
+     */
+    @Incubating
+    public void setWelcomeMessageConfiguration(WelcomeMessageConfiguration welcomeMessageConfiguration) {
+        this.welcomeMessageConfiguration = welcomeMessageConfiguration;
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/WelcomeMessageConfiguration.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/WelcomeMessageConfiguration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.launcher.cli;
+
+import org.gradle.api.Incubating;
+
+import java.io.Serializable;
+
+/**
+ * Configures when to display the welcome message on the command line.
+ *
+ * @since 7.5
+ */
+@Incubating
+public class WelcomeMessageConfiguration implements Serializable {
+
+    private WelcomeMessageDisplayMode welcomeMessageDisplayMode;
+
+    public WelcomeMessageConfiguration(WelcomeMessageDisplayMode welcomeMessageDisplayMode) {
+        this.welcomeMessageDisplayMode = welcomeMessageDisplayMode;
+    }
+
+    public WelcomeMessageDisplayMode getWelcomeMessageDisplayMode() {
+        return welcomeMessageDisplayMode;
+    }
+
+    public void setWelcomeMessageDisplayMode(WelcomeMessageDisplayMode welcomeMessageDisplayMode) {
+        this.welcomeMessageDisplayMode = welcomeMessageDisplayMode;
+    }
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/WelcomeMessageDisplayMode.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/WelcomeMessageDisplayMode.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.launcher.cli;
+
+import org.gradle.api.Incubating;
+
+/**
+ * The possible strategies for displaying a welcome message on the command line.
+ *
+ * @since 7.5
+ */
+@Incubating
+public enum WelcomeMessageDisplayMode {
+    ONCE, // the default, show the welcome message once per Gradle version
+    NEVER // suppress the welcome message
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/launcher/cli/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interfaces for configuring the cli client.
+ */
+package org.gradle.api.launcher.cli;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -31,6 +31,7 @@ We would like to thank the following community members for their contributions t
 [Tyler Burke](https://github.com/T-A-B),
 [Matthew Haughton](https://github.com/3flex),
 [Filip Daca](https://github.com/filip-daca)
+[Edgars Jasmans](https://github.com/yasmans)
 
 <!--
 Include only their name, impactful features should be called out separately below.

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -134,6 +134,12 @@ When set to `all` or `full`, a stacktrace is present in the output for all excep
 Using `full` doesn't truncate the stacktrace, which leads to a much more verbose output.
 _Default is `internal`._
 
+`org.gradle.welcome=(never,once)::
+Controls whether Gradle should print a welcome message.
+If set to _never_ then the welcome message will be suppressed.
+If set to _once_ then the message is printed once for each new version of Gradle.
+_Default is `once`._
+
 The following example demonstrates usage of various properties.
 
 .Setting properties with a gradle.properties file

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/NotificationsIntegrationTest.groovy
@@ -69,6 +69,24 @@ ${getReleaseNotesDetailsMessage(distribution.version)}
         markerFile.exists()
     }
 
+    def "show reasonable error message for invalid configuration property"() {
+        when:
+        file("gradle.properties") << "org.gradle.welcome=foo"
+        fails()
+
+        then:
+        errorOutput.contains("Option org.gradle.welcome doesn't accept value 'foo'. Possible values are [ONCE, NEVER]")
+    }
+
+    def "abort rendering welcome message using configuration property"() {
+        when:
+        file("gradle.properties") << "org.gradle.welcome=never"
+        succeeds()
+
+        then:
+        outputDoesNotContain(welcomeMessage)
+    }
+
     def "when debug logging is enabled, debug warning is logged first"() {
         given:
         def expectedWarning = """

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/LayoutToPropertiesConverter.java
@@ -54,7 +54,8 @@ public class LayoutToPropertiesConverter {
         this.buildLayoutFactory = buildLayoutFactory;
         allBuildOptions.addAll(new BuildLayoutParametersBuildOptions().getAllOptions());
         allBuildOptions.addAll(new StartParameterBuildOptions().getAllOptions());
-        allBuildOptions.addAll(new LoggingConfigurationBuildOptions().getAllOptions());
+        allBuildOptions.addAll(new LoggingConfigurationBuildOptions().getAllOptions()); // TODO maybe a new converter also here
+        allBuildOptions.addAll(new WelcomeMessageBuildOptions().getAllOptions()); // TODO maybe a new converter also here
         allBuildOptions.addAll(new DaemonBuildOptions().getAllOptions());
         allBuildOptions.addAll(new ParallelismBuildOptions().getAllOptions());
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/StartParameterConverter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/StartParameterConverter.java
@@ -16,6 +16,7 @@
 package org.gradle.launcher.cli.converter;
 
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.cli.CommandLineArgumentException;
 import org.gradle.cli.CommandLineParser;
@@ -29,12 +30,14 @@ import org.gradle.launcher.configuration.AllProperties;
 import org.gradle.launcher.configuration.BuildLayoutResult;
 
 public class StartParameterConverter {
+    private final BuildOptionBackedConverter<WelcomeMessageConfiguration> welcomeMessageConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new WelcomeMessageBuildOptions());
     private final BuildOptionBackedConverter<LoggingConfiguration> loggingConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new LoggingConfigurationBuildOptions());
     private final BuildOptionBackedConverter<ParallelismConfiguration> parallelConfigurationCommandLineConverter = new BuildOptionBackedConverter<>(new ParallelismBuildOptions());
     private final ProjectPropertiesCommandLineConverter projectPropertiesCommandLineConverter = new ProjectPropertiesCommandLineConverter();
     private final BuildOptionBackedConverter<StartParameterInternal> buildOptionsConverter = new BuildOptionBackedConverter<>(new StartParameterBuildOptions());
 
     public void configure(CommandLineParser parser) {
+        welcomeMessageConfigurationCommandLineConverter.configure(parser);
         loggingConfigurationCommandLineConverter.configure(parser);
         parallelConfigurationCommandLineConverter.configure(parser);
         projectPropertiesCommandLineConverter.configure(parser);
@@ -45,6 +48,7 @@ public class StartParameterConverter {
     public StartParameterInternal convert(ParsedCommandLine parsedCommandLine, BuildLayoutResult buildLayout, AllProperties properties, StartParameterInternal startParameter) throws CommandLineArgumentException {
         buildLayout.applyTo(startParameter);
 
+        welcomeMessageConfigurationCommandLineConverter.convert(parsedCommandLine, properties, startParameter.getWelcomeMessageConfiguration());
         loggingConfigurationCommandLineConverter.convert(parsedCommandLine, properties, startParameter);
         parallelConfigurationCommandLineConverter.convert(parsedCommandLine, properties, startParameter);
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/WelcomeMessageBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/converter/WelcomeMessageBuildOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.cli.converter;
+
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
+import org.gradle.api.launcher.cli.WelcomeMessageDisplayMode;
+import org.gradle.internal.buildoption.BuildOption;
+import org.gradle.internal.buildoption.BuildOptionSet;
+import org.gradle.internal.buildoption.EnumBuildOption;
+import org.gradle.internal.buildoption.Origin;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WelcomeMessageBuildOptions extends BuildOptionSet<WelcomeMessageConfiguration> {
+
+    private static List<BuildOption<WelcomeMessageConfiguration>> options = Collections.singletonList(new WelcomeMessageOption());
+
+    @Override
+    public List<? extends BuildOption<? super WelcomeMessageConfiguration>> getAllOptions() {
+        return options;
+    }
+
+    public static class WelcomeMessageOption extends EnumBuildOption<WelcomeMessageDisplayMode, WelcomeMessageConfiguration> {
+
+        public static final String PROPERTY_NAME = "org.gradle.welcome";
+
+        public WelcomeMessageOption() {
+            super(PROPERTY_NAME, WelcomeMessageDisplayMode.class, WelcomeMessageDisplayMode.values(), PROPERTY_NAME);
+        }
+
+        @Override
+        public void applyTo(WelcomeMessageDisplayMode value, WelcomeMessageConfiguration settings, Origin origin) {
+            settings.setWelcomeMessageDisplayMode(value);
+        }
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -19,6 +19,8 @@ package org.gradle.tooling.internal.provider.action;
 import org.gradle.TaskExecutionRequest;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
 import org.gradle.api.internal.StartParameterInternal;
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration;
+import org.gradle.api.launcher.cli.WelcomeMessageDisplayMode;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.ShowStacktrace;
@@ -151,6 +153,7 @@ public class BuildActionSerializer {
             encoder.writeString(startParameter.getDependencyVerificationMode().name());
             encoder.writeBoolean(startParameter.isRefreshKeys());
             encoder.writeBoolean(startParameter.isExportKeys());
+            encoder.writeString(startParameter.getWelcomeMessageConfiguration().getWelcomeMessageDisplayMode().name());
         }
 
         private void writeTaskRequests(Encoder encoder, List<TaskExecutionRequest> taskRequests) throws Exception {
@@ -235,6 +238,7 @@ public class BuildActionSerializer {
             startParameter.setDependencyVerificationMode(DependencyVerificationMode.valueOf(decoder.readString()));
             startParameter.setRefreshKeys(decoder.readBoolean());
             startParameter.setExportKeys(decoder.readBoolean());
+            startParameter.setWelcomeMessageConfiguration(new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.valueOf(decoder.readString())));
 
             return startParameter;
         }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/WelcomeMessageActionTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.launcher.cli
 
 import com.google.common.base.Function
 import org.gradle.api.Action
+import org.gradle.api.launcher.cli.WelcomeMessageConfiguration
+import org.gradle.api.launcher.cli.WelcomeMessageDisplayMode
 import org.gradle.internal.logging.ToStringLogger
 import org.gradle.launcher.bootstrap.ExecutionListener
 import org.gradle.launcher.configuration.BuildLayoutResult
@@ -44,6 +46,7 @@ class WelcomeMessageActionTest extends Specification {
     ToStringLogger log
     Action<ExecutionListener> delegateAction
     ExecutionListener listener
+    WelcomeMessageConfiguration welcomeMessageConfiguration
 
     def setup() {
         gradleUserHomeDir = temporaryFolder
@@ -53,10 +56,11 @@ class WelcomeMessageActionTest extends Specification {
         log = new ToStringLogger()
         delegateAction = Mock()
         listener = Mock()
+        welcomeMessageConfiguration = Stub()
     }
 
     private WelcomeMessageAction createWelcomeMessage(GradleVersion gradleVersion = GradleVersion.current(), String welcomeMessage) {
-        return new WelcomeMessageAction(log, buildLayout, gradleVersion, { welcomeMessage == null ? null : new ByteArrayInputStream(welcomeMessage.bytes) } as Function, delegateAction)
+        return new WelcomeMessageAction(log, buildLayout, welcomeMessageConfiguration, gradleVersion, { welcomeMessage == null ? null : new ByteArrayInputStream(welcomeMessage.bytes) } as Function, delegateAction)
     }
 
     def "prints highlights when file exists and contains visible content"() {
@@ -117,7 +121,7 @@ For more details see https://docs.gradle.org/42.0/release-notes.html''')
                 }
             }
         }
-        def action = new WelcomeMessageAction(log, buildLayout, GradleVersion.version("42.0"), inputStreamProvider, delegateAction)
+        def action = new WelcomeMessageAction(log, buildLayout, welcomeMessageConfiguration, GradleVersion.version("42.0"), inputStreamProvider, delegateAction)
 
         when:
         action.execute(listener)
@@ -183,6 +187,19 @@ For more details see https://docs.gradle.org/42.0/release-notes.html''')
     def "does not print anything if system property is set to false"() {
         given:
         System.setProperty(WELCOME_MESSAGE_ENABLED_SYSTEM_PROPERTY, "false")
+        def action = createWelcomeMessage(null)
+
+        when:
+        action.execute(listener)
+
+        then:
+        log.toString().isEmpty()
+        1 * delegateAction.execute(_)
+    }
+
+    def "does not print anything if gradle property is set to hide welcome message"() {
+        given:
+        welcomeMessageConfiguration = new WelcomeMessageConfiguration(WelcomeMessageDisplayMode.NEVER)
         def action = createWelcomeMessage(null)
 
         when:


### PR DESCRIPTION
Add a property **org.gradle.welcome-message** to provide build authors and executors control over weather to show Gradle welcome message or not. As mentioned in linked issue, this can be useful in automated execution environments where this information is irrelevant and creates noise.

Fixes #12550 