### PR TITLE
Handle "verification failures"

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/VerificationFailureHandlingIntegraitonTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/VerificationFailureHandlingIntegraitonTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class VerificationFailureHandlingIntegraitonTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            // 1) add producer and consumer tasks
+            // 2) producer throws VerificationException
+            // 3) consumer's input is wired to producer's output
+
+            abstract class ProducerTask extends DefaultTask {
+
+                @OutputFile
+                abstract RegularFileProperty getProducerOutput()
+
+                @TaskAction
+                void doAction() {
+                    throw new VerificationException("ProducerTask threw VerificationException")
+                }
+            }
+
+            def producerTask = tasks.register('producerTask', ProducerTask) {
+                producerOutput.convention(project.layout.buildDirectory.file('producerOutput.txt'))
+            }
+
+            tasks.register('consumerTask') {
+                inputs.file(producerTask.flatMap { it.producerOutput })
+            }
+        """
+    }
+
+    def 'consumer task executes when it has a producer task output dependency and producer task has verification failure, with --continue'() {
+        expect:
+        fails('consumerTask', '--continue')
+        result.assertTaskExecuted(':producerTask')
+        result.assertTaskExecuted(':consumerTask')
+    }
+
+    def 'producer task doLast action does not execute after verification failure is thrown; consumer task does not execute even with --continue'() {
+        given:
+        buildFile << '''
+            tasks.named('producerTask', ProducerTask).configure {
+                doLast {
+                    throw new RuntimeException('intentional failure in doLast action')
+                }
+            }
+        '''
+
+        expect:
+        fails('consumerTask', '--continue')
+        result.assertTaskExecuted(':producerTask')
+        result.assertTaskNotExecuted(':customTask')
+        failure.assertHasCause('ProducerTask threw VerificationException')
+        outputDoesNotContain('intentional failure in doLast action')
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -121,6 +121,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private final DefaultTaskDependency dependencies;
 
+    /**
+     * "lifecycle dependencies" are dependencies declared via an explicit {@link Task#dependsOn(Object...)}
+     */
+    private final DefaultTaskDependency lifecycleDependencies;
+
     private final DefaultTaskDependency mustRunAfter;
 
     private final DefaultTaskDependency finalizedBy;
@@ -180,6 +185,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         this.mustRunAfter = new DefaultTaskDependency(tasks);
         this.finalizedBy = new DefaultTaskDependency(tasks);
         this.shouldRunAfter = new DefaultTaskDependency(tasks);
+        this.lifecycleDependencies = new DefaultTaskDependency(tasks);
+
         this.services = project.getServices();
 
         PropertyWalker propertyWalker = services.get(PropertyWalker.class);
@@ -190,7 +197,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskDestroyables = new DefaultTaskDestroyables(taskMutator, fileCollectionFactory);
         taskLocalState = new DefaultTaskLocalState(taskMutator, fileCollectionFactory);
 
-        this.dependencies = new DefaultTaskDependency(tasks, ImmutableSet.of(taskInputs));
+        this.dependencies = new DefaultTaskDependency(tasks, ImmutableSet.of(taskInputs, lifecycleDependencies));
 
         this.timeout = project.getObjects().property(Duration.class);
     }
@@ -290,9 +297,15 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     @Internal
     @Override
+    public TaskDependencyInternal getLifecycleDependencies() {
+        return lifecycleDependencies;
+    }
+
+    @Internal
+    @Override
     public Set<Object> getDependsOn() {
         notifyTaskDependenciesAccess("Task.dependsOn");
-        return dependencies.getMutableValues();
+        return lifecycleDependencies.getMutableValues();
     }
 
     @Override
@@ -300,7 +313,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskMutator.mutate("Task.setDependsOn(Iterable)", new Runnable() {
             @Override
             public void run() {
-                dependencies.setValues(dependsOn);
+                lifecycleDependencies.setValues(dependsOn);
             }
         });
     }
@@ -432,7 +445,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskMutator.mutate("Task.dependsOn(Object...)", new Runnable() {
             @Override
             public void run() {
-                dependencies.add(paths);
+                lifecycleDependencies.add(paths);
             }
         });
         return this;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -25,6 +25,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Factory;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.resources.ResourceLock;
@@ -109,4 +110,12 @@ public interface TaskInternal extends Task, Configurable<Task> {
      */
     @Internal
     List<? extends ResourceLock> getSharedResources();
+
+    /**
+     * "Lifecycle dependencies" are dependencies of this task declared via an explicit {@link Task#dependsOn(Object...)} call,
+     * as opposed to the recommended approach of connecting producer tasks' outputs to consumer tasks' inputs.
+     * @return the dependencies of this task declared via an explicit {@link Task#dependsOn(Object...)}
+     */
+    @Internal
+    TaskDependency getLifecycleDependencies();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/VerificationException.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/VerificationException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Incubating;
+
+/**
+ * Signals that tests have failed. This is only thrown when tests are executed and some tests have failed execution.
+ *
+ * @since 7.4
+ */
+@Incubating
+public class VerificationException extends GradleException {
+    public VerificationException(String message) {
+        super(message);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.tasks.VerificationException;
 import org.gradle.internal.resources.ResourceLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +96,14 @@ public abstract class Node implements Comparable<Node> {
         return (state == ExecutionState.EXECUTED && !isFailed())
             || state == ExecutionState.NOT_REQUIRED
             || state == ExecutionState.MUST_NOT_RUN;
+    }
+
+    /**
+     * Whether this node failed with a verification failure.
+     * @return true if failed and threw {@link VerificationException}, false otherwise
+     */
+    public boolean isVerificationFailure() {
+        return getNodeFailure() != null && getNodeFailure().getCause() instanceof VerificationException;
     }
 
     public boolean isFailed() {
@@ -228,12 +237,32 @@ public abstract class Node implements Comparable<Node> {
     }
 
     public boolean allDependenciesSuccessful() {
-        for (Node dependency : dependencySuccessors) {
-            if (!dependency.isSuccessful()) {
-                return false;
-            }
-        }
-        return true;
+        return dependencySuccessors.stream().allMatch(this::shouldContinueExecution);
+    }
+
+    /**
+     * This {@link Node} may continue execution if the successor Node was successful, or if non-successful when two specific criteria are met:
+     * <ol>
+     *     <li>The successor node failure is a "verification failure"</li>
+     *     <li>The relationship to the successor Node is via task output/task input wiring, not an explicit dependsOn relationship (which are discouraged)</li>
+     * </ol>
+     *
+     * @param dependency a successor node in the execution plan
+     * @return true if the successor task was successful, or failed but a "recoverable" verification failure and this Node may continue execution; false otherwise
+     * @see <a href="https://github.com/gradle/gradle/issues/18912">gradle/gradle#18912</a>
+     */
+    protected boolean shouldContinueExecution(Node dependency) {
+        return dependency.isSuccessful() || (dependency.isVerificationFailure() && !dependsOnOutcome(dependency));
+    }
+
+    /**
+     * Can be overridden to indicate the relationship between this {@link Node} and a successor Node.
+     *
+     * @param dependency a non-successful successor node in the execution plan
+     * @return Always returns false unless overridden.
+     */
+    protected boolean dependsOnOutcome(Node dependency) {
+        return false;
     }
 
     @OverridingMethodsMustInvokeSuper

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -140,6 +140,11 @@ public class TaskInAnotherBuild extends TaskNode {
     }
 
     @Override
+    public boolean isVerificationFailure() {
+        return false;
+    }
+
+    @Override
     public boolean isFailed() {
         return state == IncludedBuildTaskResource.State.Failed;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -60,6 +60,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     TaskInternal task(Map<String, ?> options = [:], String name) {
         def task = createTask(name, options.project ?: this.project, options.type ?: TaskInternal)
         _ * task.taskDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
+        _ * task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
         _ * task.finalizedBy >> taskDependencyResolvingTo(task, options.finalizedBy ?: [])
         _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, [])
         _ * task.mustRunAfter >> taskDependencyResolvingTo(task, options.mustRunAfter ?: [])

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -907,6 +907,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
 
     private void relationships(Map options, TaskInternal task) {
         dependsOn(task, options.dependsOn ?: [])
+        task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
         mustRunAfter(task, options.mustRunAfter ?: [])
         shouldRunAfter(task, options.shouldRunAfter ?: [])
         finalizedBy(task, options.finalizedBy ?: [])

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -622,6 +622,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
 
     def addDependencies(Task task, Task... dependsOn) {
         _ * task.taskDependencies >> taskDependencyResolvingTo(task, dependsOn as List)
+        _ * task.lifecycleDependencies >> taskDependencyResolvingTo(task, dependsOn as List)
         _ * task.finalizedBy >> taskDependencyResolvingTo(task, [])
         _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, [])
         _ * task.mustRunAfter >> taskDependencyResolvingTo(task, [])
@@ -638,6 +639,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
             rethrowFailure() >> { throw failure }
         }
         _ * mock.taskDependencies >> Stub(TaskDependency)
+        _ * mock.lifecycleDependencies >> Stub(TaskDependency)
         _ * mock.finalizedBy >> Stub(TaskDependency)
         _ * mock.mustRunAfter >> Stub(TaskDependency)
         _ * mock.shouldRunAfter >> Stub(TaskDependency)

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -28,6 +28,8 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.testing.internal.util.RetryUtil;
 import org.hamcrest.Matcher;
+import org.intellij.lang.annotations.Language;
+import org.junit.Assert;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -89,6 +91,11 @@ public class TestFile extends File {
     public TestFile usingNativeTools() {
         useNativeTools = true;
         return this;
+    }
+
+    public TestFile java(@Language("java") String src) {
+        Assert.assertTrue(getName() + " doesn't look like a Java file.", getName().endsWith(".java"));
+        return setText(src);
     }
 
     Object writeReplace() throws ObjectStreamException {

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -21,7 +21,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileSystemOperations;
@@ -60,6 +59,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.api.tasks.testing.logging.TestLogging;
@@ -648,7 +648,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         if (getIgnoreFailures()) {
             getLogger().warn(message);
         } else {
-            throw new GradleException(message);
+            throw new VerificationException(message);
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestVerificationFailureHandlingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestVerificationFailureHandlingIntegrationTest.groovy
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.util.Matchers
+
+class TestVerificationFailureHandlingIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        // create single project with java plugin
+        buildFile << """
+            plugins {
+              id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        useJUnitJupiter()
+                    }
+                }
+            }
+        """
+    }
+
+    def 'task does not execute when it has a test task output dependency and VM exits unexpectedly'() {
+        given:
+        withFatalTestExecutionError()
+        withCustomTaskInputFromTestTaskOutput()
+
+        expect:
+        fails('customTask')
+        result.assertTaskExecuted(':test')
+        result.assertTaskNotExecuted(':customTask')
+        assertFatalTestExecutionError()
+    }
+
+    def 'task does not execute when it has a test task output dependency with failing test(s)'() {
+        given:
+        withTestVerificationFailure()
+        withCustomTaskInputFromTestTaskOutput()
+
+        expect:
+        fails('customTask')
+        result.assertTaskExecuted(':test')
+        result.assertTaskNotExecuted(':customTask')
+        failure.assertTestsFailed()
+    }
+
+    def 'task executes when it has a test task output dependency with failing test(s) and --continue'() {
+        given:
+        withTestVerificationFailure()
+        withCustomTaskInputFromTestTaskOutput()
+
+        expect:
+        fails('customTask', '--continue')
+        result.assertTaskExecuted(':test')
+        result.assertTaskExecuted(':customTask')
+        failure.assertTestsFailed()
+    }
+
+    def 'task does not execute when it dependsOn test with failing test(s) and --continue'() {
+        given:
+        withTestVerificationFailure()
+        withCustomTaskDependsOnTestTask()
+
+        expect:
+        fails('customTask', '--continue')
+        result.assertTaskExecuted(':test')
+        result.assertTaskNotExecuted(':customTask')
+        failure.assertTestsFailed()
+    }
+
+    def 'task does not execute when it has a test task output dependency and redundant dependsOn test with failing test(s) and --continue'() {
+        given:
+        withTestVerificationFailure()
+        withCustomTaskDependsOnTestTaskAndTestTaskOutput()
+
+        expect:
+        fails('customTask', '--continue')
+        result.assertTaskExecuted(':test')
+        result.assertTaskNotExecuted(':customTask')
+        failure.assertTestsFailed()
+    }
+
+    // helpers
+
+    def withPassingTest() {
+        file('src/test/java/example/PassingUnitTest.java').java '''
+            package example;
+
+            import org.junit.jupiter.api.Test;
+
+            import static org.junit.jupiter.api.Assertions.assertTrue;
+
+            public class PassingUnitTest {
+                @Test
+                public void unitTest() {
+                    assertTrue(true);
+                }
+            }
+        '''
+    }
+
+    /**
+     * Cause the test VM to fail at startup by providing an invalid JVM argument.
+     */
+    def withFatalTestExecutionError() {
+        if (OperatingSystem.current().windows) {
+            executer.withStackTraceChecksDisabled() // ignore additional ST only seen on Windows
+        }
+        withPassingTest()
+        buildFile << '''
+            tasks.named('test', Test).configure {
+                jvmArgs '-XX:UnknownArgument'
+            }
+        '''
+    }
+
+    void assertFatalTestExecutionError() {
+        failure.assertThatCause(Matchers.matchesRegexp("Process 'Gradle Test Executor \\d+' finished with non-zero exit value \\d+"))
+    }
+
+    def withTestVerificationFailure() {
+        file('src/test/java/example/UnitTestWithVerificationFailure.java').java '''
+            package example;
+
+            import org.junit.jupiter.api.Test;
+
+            import static org.junit.jupiter.api.Assertions.fail;
+
+            public class UnitTestWithVerificationFailure {
+                @Test
+                public void unitTest() {
+                    fail("intentional verification failure");
+                }
+            }
+        '''
+    }
+
+    def withCustomTaskDependsOnTestTask() {
+        buildFile << '''
+            tasks.register('customTask') {
+                dependsOn tasks.named('test', Test)
+            }
+        '''
+    }
+
+    def withCustomTaskInputFromTestTaskOutput() {
+        buildFile << '''
+            abstract class CustomTask extends DefaultTask {
+
+                @InputFiles
+                abstract ConfigurableFileCollection getCustomInput()
+
+                @TaskAction
+                public void doAction() {
+                    // no-op
+                }
+            }
+
+            def testTask = tasks.named('test', Test)
+
+            tasks.register('customTask', CustomTask) {
+                customInput.from(testTask.flatMap { it.binaryResultsDirectory })
+            }
+        '''
+    }
+
+    /**
+     * Helper method to setup a custom task wired to the test in two ways:
+     * <ol>
+     *     <li>A direct dependency via dependsOn declarartion</li>
+     *     <li>Via Test#binaryResultsDirectory output wired to customTask#customInput</li>
+     * </ol>
+     *
+     * This intentional redundancy is to test automatic exclusion of direct dependsOn relationships.
+     */
+    def withCustomTaskDependsOnTestTaskAndTestTaskOutput() {
+        withCustomTaskInputFromTestTaskOutput()
+        buildFile << '''
+            tasks.named('customTask', CustomTask).configure {
+                dependsOn tasks.named('test', Test)
+            }
+        '''
+    }
+
+}


### PR DESCRIPTION
Handle "verification failures"

 - Test tasks now throw TestVerificationException in case of a verification failure
 - Downstream consumers can continue execution after a verification failure if they have a task input wired to an upsteam output
 - Tasks with explicit `dependsOn` relationships will never continue executing after a verification failure
 - In AbstractTask, a task's dependencies are now composed of its task inputs and explicit dependsOn relationships

--

Example usage and differences between expected/actual behavior are best observed in `VerificationFailureHandlingIntegrationTest.groovy`