### PR TITLE
Allow the build scan plugin to read environment variables and reenable test

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -21,15 +21,11 @@ import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.scan.config.fixtures.ApplyGradleEnterprisePluginFixture
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 
 import java.util.regex.Pattern
 
 class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
-    // https://github.com/gradle/gradle-private/issues/3475
-    @Requires(TestPrecondition.NOT_MAC_OS_X)
     def "can publish build scan with composite build"() {
         given:
         def configurationCache = newConfigurationCacheFixture()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -74,6 +74,9 @@ class InstrumentedInputAccessListener(
     }
 
     override fun envVariableQueried(key: String, value: String?, consumer: String) {
+        if (Workarounds.canReadEnvironmentVariable(consumer)) {
+            return
+        }
         broadcast.envVariableRead(key, value, consumer)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
@@ -32,6 +32,20 @@ object Workarounds {
         ignoredBeanFields.contains(field.name to field.declaringClass.name)
 
     fun canReadSystemProperty(from: String): Boolean {
+        return isBuildScanPlugin(from) && !shouldDisableInputWorkaroundsFor("systemProps")
+    }
+
+    fun canReadEnvironmentVariable(from: String): Boolean {
+        return isBuildScanPlugin(from) && !shouldDisableInputWorkaroundsFor("envVars")
+    }
+
+    private
+    fun isBuildScanPlugin(from: String): Boolean {
         return from.startsWith("com.gradle.scan.plugin.internal.")
+    }
+
+    private
+    fun shouldDisableInputWorkaroundsFor(area: String): Boolean {
+        return System.getProperty("org.gradle.internal.disable.input.workarounds")?.contains(area, ignoreCase = true) ?: false
     }
 }


### PR DESCRIPTION
Some versions of the build scan plugin read environment variables during the configuration phase but do not take decisions upon them, so recording these variables as inputs to the configuration cache is a false positive.
Similar to system properties, we skip these accesses. The escape hatch to disable the workarounds is provided to make fixing the issues in the scan plugin easier in the future. Workarounds for environment variables and system properties can be turned off separately.