### PR TITLE
Do not fall back to ignoring empty directories for skip when empty

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
@@ -80,34 +80,12 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         "tar tree without backing file with files"      | "tarTree(inputTarResource)"
     }
 
-    def "emit a deprecation warning when file tree source does not ignore directories"() {
-        def inputDir = file("inputDir").createDir()
-        inputDir.file("input.txt").createFile()
-
-        buildFile << getSourceTask(false)
-        buildFile << """
-            tasks.register("sourceTask", MySourceTask) {
-                sources.setFrom(fileTree("inputDir"))
-                outputFile.set(file("build/output.txt"))
-            }
-        """
-
-        when:
-        executer.expectDocumentedDeprecationWarning("Relying on FileTrees for ignoring empty directories when using @SkipWhenEmpty has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. " +
-            "Annotate the property sources with @IgnoreEmptyDirectories or remove @SkipWhenEmpty. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#empty_directories_file_tree")
-        run ":sourceTask"
-        then:
-        executedAndNotSkipped(":sourceTask")
-    }
-
-    private String getSourceTask(boolean ignoreEmptyDirectories = true) {
+    private String getSourceTask() {
         """
             import java.nio.file.Files
 
             abstract class MySourceTask extends DefaultTask {
-                @SkipWhenEmpty ${ignoreEmptyDirectories ? "@IgnoreEmptyDirectories" : ""}
+                @SkipWhenEmpty @IgnoreEmptyDirectories
                 @InputFiles
                 abstract ConfigurableFileCollection getSources()
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputFilePropertyRegistration.java
@@ -31,8 +31,7 @@ public class DefaultTaskInputFilePropertyRegistration extends AbstractTaskFilePr
 
     private final InputFilePropertyType filePropertyType;
     private boolean skipWhenEmpty;
-    @SuppressWarnings("deprecation")
-    private DirectorySensitivity directorySensitivity = DirectorySensitivity.UNSPECIFIED;
+    private DirectorySensitivity directorySensitivity = DirectorySensitivity.DEFAULT;
     private LineEndingSensitivity lineEndingSensitivity = LineEndingSensitivity.DEFAULT;
     private Class<? extends FileNormalizer> normalizer = AbsolutePathInputNormalizer.class;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -572,10 +572,8 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             .put(IgnoredPathInputNormalizer.class, FINGERPRINTING_STRATEGY_IGNORED_PATH)
             .build();
 
-        @SuppressWarnings("deprecation")
         private static final Map<DirectorySensitivity, FilePropertyAttribute> BY_DIRECTORY_SENSITIVITY = Maps.immutableEnumMap(ImmutableMap.<DirectorySensitivity, FilePropertyAttribute>builder()
             .put(DirectorySensitivity.DEFAULT, DIRECTORY_SENSITIVITY_DEFAULT)
-            .put(DirectorySensitivity.UNSPECIFIED, DIRECTORY_SENSITIVITY_DEFAULT)
             .put(DirectorySensitivity.IGNORE_DIRECTORIES, DIRECTORY_SENSITIVITY_IGNORE_DIRECTORIES)
             .build());
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
@@ -16,29 +16,19 @@
 
 package org.gradle.api.internal.tasks.properties;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.PropertyFileCollection;
-import org.gradle.api.tasks.ClasspathNormalizer;
-import org.gradle.api.tasks.CompileClasspathNormalizer;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
-import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
-    private static final ImmutableSet<Class<? extends FileNormalizer>> NORMALIZERS_IGNORING_DIRECTORIES = ImmutableSet.of(
-        ClasspathNormalizer.class,
-        CompileClasspathNormalizer.class,
-        IgnoredPathInputNormalizer.class
-    );
-
     private final List<InputFilePropertySpec> specs = Lists.newArrayList();
     private final FileCollectionFactory fileCollectionFactory;
     private final String ownerDisplayName;
@@ -72,18 +62,12 @@ public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
             value,
             skipWhenEmpty,
             incremental,
-            normalizeDirectorySensitivity(normalizer, directorySensitivity),
+            directorySensitivity,
             lineEndingSensitivity
         ));
         if (skipWhenEmpty) {
             hasSourceFiles = true;
         }
-    }
-
-    private DirectorySensitivity normalizeDirectorySensitivity(Class<? extends FileNormalizer> fileNormalizer, DirectorySensitivity directorySensitivity) {
-        return NORMALIZERS_IGNORING_DIRECTORIES.contains(fileNormalizer)
-            ? DirectorySensitivity.DEFAULT
-            : directorySensitivity;
     }
 
     public ImmutableSortedSet<InputFilePropertySpec> getFileProperties() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -84,11 +84,10 @@ public abstract class AbstractInputFilePropertyAnnotationHandler implements Prop
         );
     }
 
-    @SuppressWarnings("deprecation")
     protected DirectorySensitivity determineDirectorySensitivity(PropertyMetadata propertyMetadata) {
         return propertyMetadata.isAnnotationPresent(IgnoreEmptyDirectories.class)
             ? DirectorySensitivity.IGNORE_DIRECTORIES
-            : DirectorySensitivity.UNSPECIFIED;
+            : DirectorySensitivity.DEFAULT;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -191,11 +191,10 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
     }
 
     InputFingerprinter createInputFingerprinter(
-        FileCollectionSnapshotter snapshotter,
         FileCollectionFingerprinterRegistry fingerprinterRegistry,
         ValueSnapshotter valueSnapshotter
     ) {
-        return new DefaultInputFingerprinter(snapshotter, fingerprinterRegistry, valueSnapshotter);
+        return new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter);
     }
 
     TaskExecutionModeResolver createExecutionModeResolver(

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -44,12 +44,12 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
 
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
-        FileSystemSnapshot snapshot = fileCollectionSnapshotter.snapshot(files);
-        return fingerprint(snapshot, null);
+        return fingerprint(files, null);
     }
 
     @Override
-    public CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot snapshot, @Nullable FileCollectionFingerprint previousFingerprint) {
+    public CurrentFileCollectionFingerprint fingerprint(FileCollection files, @Nullable FileCollectionFingerprint previousFingerprint) {
+        FileSystemSnapshot snapshot = fileCollectionSnapshotter.snapshot(files);
         return DefaultCurrentFileCollectionFingerprint.from(snapshot, fingerprintingStrategy, previousFingerprint);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -44,8 +44,8 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
 
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
-        FileCollectionSnapshotter.Result snapshotResult = fileCollectionSnapshotter.snapshot(files);
-        return fingerprint(snapshotResult.getSnapshot(), null);
+        FileSystemSnapshot snapshot = fileCollectionSnapshotter.snapshot(files);
+        return fingerprint(snapshot, null);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileCollectionFingerprinterRegistrations.java
@@ -153,7 +153,7 @@ public class FileCollectionFingerprinterRegistrations {
     }
 
     private static <T> Stream<T> withAllDirectorySensitivities(Function<DirectorySensitivity, Stream<T>> f) {
-        return Stream.of(DirectorySensitivity.DEFAULT, DirectorySensitivity.IGNORE_DIRECTORIES).flatMap(f);
+        return stream(DirectorySensitivity.values()).flatMap(f);
     }
 
     public Set<FingerprinterRegistration> getRegistrants() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -408,11 +408,10 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
         }
 
         InputFingerprinter createInputFingerprinter(
-            FileCollectionSnapshotter snapshotter,
             FileCollectionFingerprinterRegistry fingerprinterRegistry,
             ValueSnapshotter valueSnapshotter
         ) {
-            return new DefaultInputFingerprinter(snapshotter, fingerprinterRegistry, valueSnapshotter);
+            return new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter);
         }
 
         ResourceSnapshotterCacheService createResourceSnapshotterCacheService(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/DefaultEmptySourceTaskSkipperTest.groovy
@@ -225,7 +225,7 @@ class DefaultEmptySourceTaskSkipperTest extends Specification {
 
     def snapshot(File... files) {
         ImmutableSortedMap.<String, FileSystemSnapshot> of(
-            "output", fileCollectionSnapshotter.snapshot(TestFiles.fixed(files)).snapshot
+            "output", fileCollectionSnapshotter.snapshot(TestFiles.fixed(files))
         )
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -146,7 +146,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
         }
     }
     def valueSnapshotter = new DefaultValueSnapshotter(classloaderHierarchyHasher, null)
-    def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionSnapshotter, fingerprinterRegistry, valueSnapshotter)
+    def inputFingerprinter = new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter)
     def reservedFileSystemLocationRegistry = Stub(ReservedFileSystemLocationRegistry)
     def emptySourceTaskSkipper = Stub(EmptySourceTaskSkipper)
     def overlappingOutputDetector = Stub(OverlappingOutputDetector)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotterTest.groovy
@@ -95,33 +95,29 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
         TestFile zip = tempDir.file('archive.zip')
         archiveBaseDir.zipTo(zip)
         def zipTree = TestFiles.fileOperations(tempDir, testFileProvider()).zipTree(zip)
-        def result = snapshotter.snapshot(zipTree)
+        def snapshot = snapshotter.snapshot(zipTree)
 
         then:
-        assertSingleFileSnapshot(result.snapshot)
-        !result.fileTreeOnly
+        assertSingleFileSnapshot(snapshot)
 
         when:
         TestFile tar = tempDir.file('archive.tar')
         archiveBaseDir.tarTo(tar)
         def tarTree = TestFiles.fileOperations(tempDir, testFileProvider()).tarTree(tar)
-        result = snapshotter.snapshot(tarTree)
-        !result.fileTreeOnly
+        snapshot = snapshotter.snapshot(tarTree)
 
         then:
-        assertSingleFileSnapshot(result.snapshot)
-        !result.fileTreeOnly
+        assertSingleFileSnapshot(snapshot)
 
         when:
         def tarDir = tmpDir.createDir('tarDir')
         TestFile emptyTar = tempDir.file('emptyArchive.tar')
         tarDir.tarTo(emptyTar)
         def emptyTarTree = TestFiles.fileOperations(tempDir, testFileProvider()).tarTree(tar)
-        result = snapshotter.snapshot(emptyTarTree)
+        snapshot = snapshotter.snapshot(emptyTarTree)
 
         then:
-        assertSingleFileSnapshot(result.snapshot)
-        !result.fileTreeOnly
+        assertSingleFileSnapshot(snapshot)
 
         when:
         def tgzDir = tmpDir.createDir('tgzDir')
@@ -129,11 +125,10 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
         tgzDir.tgzTo(tgz)
         def localResource = new LocalResourceAdapter(TestFiles.fileRepository().localResource(tgz))
         def emptyTgzTree = TestFiles.fileOperations(tempDir, testFileProvider()).tarTree(localResource)
-        result = snapshotter.snapshot(emptyTgzTree)
+        snapshot = snapshotter.snapshot(emptyTgzTree)
 
         then:
-        assertSingleFileSnapshot(result.snapshot)
-        !result.fileTreeOnly
+        assertSingleFileSnapshot(snapshot)
 
         when:
         def readableResource = new ReadableResource() {
@@ -158,11 +153,10 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
             }
         }
         def resourceTarTree = TestFiles.fileOperations(tempDir, testFileProvider()).tarTree(readableResource)
-        result = snapshotter.snapshot(resourceTarTree)
+        snapshot = snapshotter.snapshot(resourceTarTree)
 
         then:
-        result.snapshot == FileSystemSnapshot.EMPTY
-        !result.fileTreeOnly
+        snapshot == FileSystemSnapshot.EMPTY
     }
 
     def "snapshots a generated singletonFileTree as RegularFileSnapshot"() {
@@ -212,20 +206,17 @@ class DefaultFileCollectionSnapshotterTest extends Specification {
     }
 
     void assertEmptyTree(FileCollection fileCollection) {
-        def result = snapshotter.snapshot(fileCollection)
-        assert result.snapshot == FileSystemSnapshot.EMPTY
-        assert result.fileTreeOnly
+        def snapshot = snapshotter.snapshot(fileCollection)
+        assert snapshot == FileSystemSnapshot.EMPTY
         assert fileCollection.files.empty
     }
 
     void assertSingleFileTree(FileCollection fileCollection) {
         assert fileCollection.files.size() == 1
         def file = fileCollection.files[0]
-        def result = snapshotter.snapshot(fileCollection)
-        def snapshot = result.snapshot
+        def snapshot = snapshotter.snapshot(fileCollection)
         assertSingleFileSnapshot(snapshot)
         assert snapshot.absolutePath == file.absolutePath
-        assert result.fileTreeOnly
     }
 
     void assertSingleFileSnapshot(snapshot) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -218,7 +218,6 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
         private DirectorySensitivity directorySensitivity = DirectorySensitivity.DEFAULT;
         private LineEndingSensitivity lineEndingSensitivity = LineEndingSensitivity.DEFAULT;
 
-        @SuppressWarnings("deprecation")
         @Override
         public void visitInputFileProperty(
             String propertyName,
@@ -232,9 +231,7 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
             InputFilePropertyType filePropertyType
         ) {
             this.normalizer = fileNormalizer;
-            this.directorySensitivity = directorySensitivity == DirectorySensitivity.UNSPECIFIED
-                ? DirectorySensitivity.DEFAULT
-                : directorySensitivity;
+            this.directorySensitivity = directorySensitivity;
             this.lineEndingSensitivity = lineEndingSensitivity;
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -96,7 +96,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
 
     def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(DirectorySensitivity.DEFAULT, fileCollectionSnapshotter, FileSystemLocationSnapshotHasher.DEFAULT)
     def fileCollectionFingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, dependencyFingerprinter)])
-    def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionSnapshotter, fileCollectionFingerprinterRegistry, valueSnapshotter)
+    def inputFingerprinter = new DefaultInputFingerprinter(fileCollectionFingerprinterRegistry, valueSnapshotter)
 
     def projectServiceRegistry = Stub(ServiceRegistry) {
         get(TransformationWorkspaceServices) >> new TestTransformationWorkspaceServices(mutableTransformsStoreDirectory, executionHistoryStore)

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -124,7 +124,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def outputSnapshotter = new DefaultOutputSnapshotter(snapshotter)
     def fingerprinterRegistry = new DefaultFileCollectionFingerprinterRegistry([FingerprinterRegistration.registration(DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, fingerprinter)])
     def valueSnapshotter = new DefaultValueSnapshotter(classloaderHierarchyHasher, null)
-    def inputFingerprinter = new DefaultInputFingerprinter(snapshotter, fingerprinterRegistry, valueSnapshotter)
+    def inputFingerprinter = new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter)
     def buildCacheController = Mock(BuildCacheController)
     def buildOperationExecutor = new TestBuildOperationExecutor()
     def validationWarningReporter = Mock(ValidateStep.ValidationWarningRecorder)

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
@@ -20,7 +20,6 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
-import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +37,7 @@ public interface FileCollectionFingerprinter {
     /**
      * Creates a fingerprint from the snapshot of a file collection.
      */
-    CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot snapshot, @Nullable FileCollectionFingerprint previousFingerprint);
+    CurrentFileCollectionFingerprint fingerprint(FileCollection files, @Nullable FileCollectionFingerprint previousFingerprint);
 
     /**
      * Returns an empty fingerprint.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionSnapshotter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionSnapshotter.java
@@ -23,19 +23,8 @@ import org.gradle.internal.snapshot.FileSystemSnapshot;
  * Service for snapshotting {@link FileCollection}s.
  */
 public interface FileCollectionSnapshotter {
-    interface Result {
-        FileSystemSnapshot getSnapshot();
-
-        /**
-         * Whether or not the snapshotted file collection consists only of file trees.
-         *
-         * If the file collection does not contain any file trees, then this will return {@code false}.
-         */
-        boolean isFileTreeOnly();
-    }
-
     /**
      * Snapshot the roots of a file collection.
      */
-    Result snapshot(FileCollection fileCollection);
+    FileSystemSnapshot snapshot(FileCollection fileCollection);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
@@ -18,14 +18,12 @@ package org.gradle.internal.execution.fingerprint.impl;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.execution.fingerprint.FileNormalizationSpec;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
@@ -127,30 +125,15 @@ public class DefaultInputFingerprinter implements InputFingerprinter {
             FileCollectionFingerprint previousFingerprint = previousFingerprints.get(propertyName);
             try {
                 FileCollectionSnapshotter.Result result = snapshotter.snapshot(value.getFiles());
-                DirectorySensitivity directorySensitivity = determineDirectorySensitivity(propertyName, type, value, result);
-                FileNormalizationSpec normalizationSpec = DefaultFileNormalizationSpec.from(value.getNormalizer(), directorySensitivity, value.getLineEndingNormalization());
+                FileNormalizationSpec normalizationSpec = DefaultFileNormalizationSpec.from(
+                    value.getNormalizer(),
+                    value.getDirectorySensitivity(),
+                    value.getLineEndingNormalization());
                 FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(normalizationSpec);
                 CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(result.getSnapshot(), previousFingerprint);
                 fingerprintsBuilder.put(propertyName, fingerprint);
             } catch (Exception e) {
                 throw new InputFileFingerprintingException(propertyName, e);
-            }
-        }
-
-        @SuppressWarnings("deprecation")
-        private DirectorySensitivity determineDirectorySensitivity(String propertyName, InputPropertyType type, FileValueSupplier value, FileCollectionSnapshotter.Result result) {
-            if (value.getDirectorySensitivity() != DirectorySensitivity.UNSPECIFIED) {
-                return value.getDirectorySensitivity();
-            }
-            if (result.isFileTreeOnly() && type.isSkipWhenEmpty()) {
-                DeprecationLogger.deprecateIndirectUsage("Relying on FileTrees for ignoring empty directories when using @SkipWhenEmpty")
-                    .withAdvice("Annotate the property " + propertyName + " with @IgnoreEmptyDirectories or remove @SkipWhenEmpty.")
-                    .willBeRemovedInGradle8()
-                    .withUpgradeGuideSection(7, "empty_directories_file_tree")
-                    .nagUser();
-                return DirectorySensitivity.IGNORE_DIRECTORIES;
-            } else {
-                return DirectorySensitivity.DEFAULT;
             }
         }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
@@ -25,6 +25,7 @@ import org.gradle.internal.execution.fingerprint.FileNormalizationSpec;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 
@@ -124,13 +125,13 @@ public class DefaultInputFingerprinter implements InputFingerprinter {
 
             FileCollectionFingerprint previousFingerprint = previousFingerprints.get(propertyName);
             try {
-                FileCollectionSnapshotter.Result result = snapshotter.snapshot(value.getFiles());
                 FileNormalizationSpec normalizationSpec = DefaultFileNormalizationSpec.from(
                     value.getNormalizer(),
                     value.getDirectorySensitivity(),
                     value.getLineEndingNormalization());
                 FileCollectionFingerprinter fingerprinter = fingerprinterRegistry.getFingerprinter(normalizationSpec);
-                CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(result.getSnapshot(), previousFingerprint);
+                FileSystemSnapshot snapshot = snapshotter.snapshot(value.getFiles());
+                CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(snapshot, previousFingerprint);
                 fingerprintsBuilder.put(propertyName, fingerprint);
             } catch (Exception e) {
                 throw new InputFileFingerprintingException(propertyName, e);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultOutputSnapshotter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultOutputSnapshotter.java
@@ -41,7 +41,7 @@ public class DefaultOutputSnapshotter implements OutputSnapshotter {
             public void visitOutputProperty(String propertyName, TreeType type, File root, FileCollection contents) {
                 FileSystemSnapshot snapshot;
                 try {
-                    snapshot = fileCollectionSnapshotter.snapshot(contents).getSnapshot();
+                    snapshot = fileCollectionSnapshotter.snapshot(contents);
                 } catch (Exception ex) {
                     throw new OutputFileSnapshottingException(propertyName, ex);
                 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.FileNormalizer
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinterRegistry
-import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter
 import org.gradle.internal.execution.fingerprint.FileNormalizationSpec
 import org.gradle.internal.execution.fingerprint.InputFingerprinter
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.FileValueSupplier
@@ -31,7 +30,6 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.LineEndingSensitivity
-import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.ValueSnapshot
 import org.gradle.internal.snapshot.ValueSnapshotter
 import spock.lang.Specification
@@ -42,17 +40,15 @@ import static org.gradle.internal.execution.fingerprint.InputFingerprinter.Input
 
 class DefaultInputFingerprinterTest extends Specification {
     def fingerprinter = Mock(FileCollectionFingerprinter)
-    def snapshotter = Mock(FileCollectionSnapshotter)
     def fingerprinterRegistry = Stub(FileCollectionFingerprinterRegistry) {
         getFingerprinter(_ as FileNormalizationSpec) >> fingerprinter
     }
     def valueSnapshotter = Mock(ValueSnapshotter)
-    def inputFingerprinter = new DefaultInputFingerprinter(snapshotter, fingerprinterRegistry, valueSnapshotter)
+    def inputFingerprinter = new DefaultInputFingerprinter(fingerprinterRegistry, valueSnapshotter)
 
     def input = Mock(Object)
     def inputSnapshot = Mock(ValueSnapshot)
     def fileInput = Mock(FileCollection)
-    def fileInputSnapshot = Mock(FileSystemSnapshot)
     def fileInputFingerprint = Mock(CurrentFileCollectionFingerprint)
 
     def "visits properties"() {
@@ -67,8 +63,7 @@ class DefaultInputFingerprinterTest extends Specification {
 
         then:
         1 * valueSnapshotter.snapshot(input) >> inputSnapshot
-        1 * snapshotter.snapshot(fileInput) >> fileInputSnapshot
-        1 * fingerprinter.fingerprint(fileInputSnapshot, null) >> fileInputFingerprint
+        1 * fingerprinter.fingerprint(fileInput, null) >> fileInputFingerprint
         0 * _
 
         then:
@@ -147,7 +142,7 @@ class DefaultInputFingerprinterTest extends Specification {
         }
 
         then:
-        1 * snapshotter.snapshot(fileInput) >> { throw failure }
+        1 * fingerprinter.fingerprint(fileInput, null) >> { throw failure }
         0 * _
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -53,7 +53,6 @@ class DefaultInputFingerprinterTest extends Specification {
     def inputSnapshot = Mock(ValueSnapshot)
     def fileInput = Mock(FileCollection)
     def fileInputSnapshot = Mock(FileSystemSnapshot)
-    def fileInputSnapshotResult = Mock(FileCollectionSnapshotter.Result)
     def fileInputFingerprint = Mock(CurrentFileCollectionFingerprint)
 
     def "visits properties"() {
@@ -68,9 +67,7 @@ class DefaultInputFingerprinterTest extends Specification {
 
         then:
         1 * valueSnapshotter.snapshot(input) >> inputSnapshot
-        1 * snapshotter.snapshot(fileInput) >> fileInputSnapshotResult
-        _ * fileInputSnapshotResult.fileTreeOnly >> false
-        1 * fileInputSnapshotResult.snapshot >> fileInputSnapshot
+        1 * snapshotter.snapshot(fileInput) >> fileInputSnapshot
         1 * fingerprinter.fingerprint(fileInputSnapshot, null) >> fileInputFingerprint
         0 * _
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultOutputSnapshotterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/impl/DefaultOutputSnapshotterTest.groovy
@@ -48,9 +48,7 @@ class DefaultOutputSnapshotterTest extends Specification {
         1 * work.visitOutputs(workspace, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor outputVisitor ->
             outputVisitor.visitOutputProperty("output", TreeType.FILE, root, contents)
         }
-        1 * fileCollectionSnapshotter.snapshot(contents) >> Stub(FileCollectionSnapshotter.Result) {
-            snapshot >> outputSnapshot
-        }
+        1 * fileCollectionSnapshotter.snapshot(contents) >> outputSnapshot
         0 * _
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SnasphotterFixture.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SnasphotterFixture.groovy
@@ -37,13 +37,13 @@ trait SnasphotterFixture {
                     ? it as File
                     : temporaryFolder.file(it)
             }
-            def snapshot = snapshotter.snapshot(TestFiles.fixed(files)).snapshot
+            def snapshot = snapshotter.snapshot(TestFiles.fixed(files))
             builder.put(propertyName, snapshot)
         }
         return builder.build()
     }
 
     FileSystemSnapshot snapshot(File... files) {
-        snapshotter.snapshot(TestFiles.fixed(files)).snapshot
+        snapshotter.snapshot(TestFiles.fixed(files))
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractAndroidSantaTrackerSmokeTest.groovy
@@ -53,13 +53,11 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
     }
 
     protected BuildResult buildLocation(File projectDir, String agpVersion) {
-        return expectFileTreeDeprecations(agpVersion, runnerForLocation(projectDir, agpVersion, "assembleDebug"))
-            .build()
+        return runnerForLocation(projectDir, agpVersion, "assembleDebug").build()
     }
 
     protected BuildResult buildLocationMaybeExpectingWorkerExecutorDeprecation(File location, String agpVersion) {
-        return expectFileTreeDeprecations(agpVersion, runnerForLocationMaybeExpectingWorkerExecutorDeprecation(location, agpVersion, "assembleDebug"))
-            .build()
+        return runnerForLocationMaybeExpectingWorkerExecutorDeprecation(location, agpVersion, "assembleDebug").build()
     }
 
     protected SmokeTestGradleRunner runnerForLocationMaybeExpectingWorkerExecutorDeprecation(File location, String agpVersion, String... tasks) {
@@ -70,21 +68,6 @@ class AbstractAndroidSantaTrackerSmokeTest extends AbstractSmokeTest {
                     "Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. " +
                     "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#method_workerexecutor_submit_is_deprecated for more details."
             )
-    }
-
-    private SmokeTestGradleRunner expectFileTreeDeprecations(String agpVersion, SmokeTestGradleRunner runner) {
-        return expectFileTreeResourcesDeprecation(runner)
-            .expectLegacyDeprecationWarningIf(agpVersion.startsWith("4."),
-                deprecationOfFileTreeForEmptySources("projectNativeLibs")
-            )
-    }
-
-    protected SmokeTestGradleRunner expectFileTreeResourcesDeprecation(SmokeTestGradleRunner runner) {
-        runner.expectDeprecationWarning(
-            deprecationOfFileTreeForEmptySources("resources"),
-            "https://issuetracker.google.com/issues/204425803"
-        )
-
     }
 
     protected BuildResult cleanLocation(File projectDir, String agpVersion) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -34,7 +34,6 @@ import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.DefaultGradleRunner
-import org.gradle.util.GradleVersion
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -322,13 +321,6 @@ abstract class AbstractSmokeTest extends Specification {
             extraArgs += ["-I", init.canonicalPath]
         }
         return runner.withArguments([runner.arguments, extraArgs].flatten())
-    }
-
-    protected static String deprecationOfFileTreeForEmptySources(String propertyName) {
-        return "Relying on FileTrees for ignoring empty directories when using @SkipWhenEmpty has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. " +
-            "Annotate the property ${propertyName} with @IgnoreEmptyDirectories or remove @SkipWhenEmpty. " +
-            "Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#empty_directories_file_tree"
     }
 
     protected void replaceVariablesInBuildFile(Map binding) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -97,7 +97,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         assertConfigurationCacheStateStored()
 
         when: 'up-to-date build'
-        result = buildMaybeExpectingFileTreeDeprecations(runner, agpVersion)
+        result = runner.build()
 
         then:
         result.task(':app:compileDebugJavaWithJavac').outcome == TaskOutcome.UP_TO_DATE
@@ -141,18 +141,11 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
     }
 
     private static BuildResult buildMaybeExpectingWorkerExecutorDeprecation(SmokeTestGradleRunner runner, String agpVersion) {
-        return buildMaybeExpectingFileTreeDeprecations(
-            runner.expectLegacyDeprecationWarningIf(agpVersion.startsWith('4.1'),
+        return runner
+            .expectLegacyDeprecationWarningIf(agpVersion.startsWith('4.1'),
                 "The WorkerExecutor.submit() method has been deprecated. " +
                     "This is scheduled to be removed in Gradle 8.0. Please use the noIsolation(), classLoaderIsolation() or processIsolation() method instead. " +
                     "See https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_5.html#method_workerexecutor_submit_is_deprecated for more details.")
-            , agpVersion)
-    }
-
-    private static BuildResult buildMaybeExpectingFileTreeDeprecations(SmokeTestGradleRunner runner, String agpVersion) {
-        return runner
-            .expectLegacyDeprecationWarningIf(agpVersion.startsWith("4."),
-                deprecationOfFileTreeForEmptySources("projectNativeLibs"))
             .build()
     }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -119,10 +119,6 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
     }
 
     private SmokeTestGradleRunner runnerForLocationExpectingLintDeprecations(File location, boolean isCleanBuild, String agpVersion, String... tasks) {
-        SmokeTestGradleRunner runner = isCleanBuild ? runnerForLocationMaybeExpectingWorkerExecutorDeprecation(location, agpVersion, tasks) : runnerForLocation(location, agpVersion, tasks)
-        if (agpVersion.startsWith("7.")) {
-            expectFileTreeResourcesDeprecation(runner)
-        }
-        return runner
+        return isCleanBuild ? runnerForLocationMaybeExpectingWorkerExecutorDeprecation(location, agpVersion, tasks) : runnerForLocation(location, agpVersion, tasks)
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AsciidoctorPluginSmokeTest.groovy
@@ -50,7 +50,6 @@ class AsciidoctorPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
                 "This is scheduled to be removed in Gradle 8.0. " +
                 "Please use the mainClass property instead. Consult the upgrading guide for further information: https://docs.gradle.org/${GradleVersion.current().version}/userguide/upgrading_version_7.html#java_exec_properties",
                 "https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/602")
-            .expectDeprecationWarning(deprecationOfFileTreeForEmptySources("sourceFileTree"), "https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/629")
             .build()
 
         then:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
@@ -61,8 +61,8 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         when:
-        def result = runner('compileJava').forwardOutput()
-            .expectDeprecationWarning(deprecationOfFileTreeForEmptySources("sourceFiles"), "https://github.com/google/protobuf-gradle-plugin/pull/530")
+        def result = runner('compileJava')
+            .forwardOutput()
             .build()
 
         then:
@@ -72,7 +72,6 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         when:
         result = runner('compileJava')
             .forwardOutput()
-            .expectDeprecationWarning(deprecationOfFileTreeForEmptySources("sourceFiles"), "https://github.com/google/protobuf-gradle-plugin/pull/530")
             .build()
 
         then:

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
@@ -33,18 +33,7 @@ public enum DirectorySensitivity {
     /**
      * Ignore directories
      */
-    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() != FileType.Directory),
-    /**
-     * Used to denote that no directory sensitivity has been specified explicitly.
-     *
-     * We currently use this to switch to {@link #IGNORE_DIRECTORIES} when an input is a file tree.
-     *
-     * @deprecated This should go away in 8.0, since the special case should go away.
-     */
-    @Deprecated
-    UNSPECIFIED(snapshot -> {
-        throw new AssertionError("Unspecified must not be used as directory sensitivity");
-    });
+    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() != FileType.Directory);
 
     private final Predicate<FileSystemLocationSnapshot> fingerprintCheck;
 


### PR DESCRIPTION
Removes the deprecation introduced in #18783 for Gradle 8.0.