### PR TITLE
Temporarily disable build scans on 'IDE sync' builds

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache.isolated
 
+import spock.lang.Ignore
+
 class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
     def setup() {
         settingsFile << """
@@ -223,6 +225,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         result.assertHasPostBuildOutput("Configuration cache entry reused.")
     }
 
+    @Ignore("https://github.com/gradle/gradle/pull/18858 - Those phased build actions no longer have 'isRunsTasks' set to true")
     def "caches execution of phased BuildAction that queries custom tooling model and that runs tasks"() {
         given:
         withSomeToolingModelBuilderPluginInBuildSrc()

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildTreeLifecycleBuildActionExecutor.java
@@ -55,7 +55,7 @@ public class BuildTreeLifecycleBuildActionExecutor implements BuildSessionAction
             } else if (action instanceof ClientProvidedBuildAction) {
                 actionRequirements = new RunActionRequirements(action.getStartParameter(), action.isRunTasks());
             } else if (action instanceof ClientProvidedPhasedAction) {
-                actionRequirements = new RunPhasedActionRequirements(action.getStartParameter(), action.isRunTasks());
+                actionRequirements = new RunPhasedActionRequirements(action.getStartParameter(), false);
             } else {
                 actionRequirements = new RunTasksRequirements(action.getStartParameter());
             }


### PR DESCRIPTION
We're making this change in reaction to https://github.com/gradle/gradle/pull/18074, which creates a build operation tree that is problematic for build scans, in presence of a buildSrc build.
Given that all users requesting ClientProvidedPhasedAction actions in a build with a buildSrc build are going to be affected by that problem, we are temporarily forcing 'no build scans' for those ClientProvidedPhasedAction builds (such as IDE syncs).

We'll revert this in 7.4 and work on a proper fix.