### PR TITLE
Always notify the build scan plugin once at the completion of the build

### DIFF
--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -141,6 +141,9 @@ class GradleEnterprisePluginCheckInFixture {
                             $GradleEnterprisePluginEndOfBuildListener.name getEndOfBuildListener() {
                                 return { $GradleEnterprisePluginEndOfBuildListener.BuildResult.name buildResult ->
                                     println "gradleEnterprisePlugin.endOfBuild.buildResult.failure = \$buildResult.failure"
+                                    if (System.getProperty("build-listener-failure") != null) {
+                                        throw new RuntimeException("broken")
+                                    }
                                 } as $GradleEnterprisePluginEndOfBuildListener.name
                             }
                         }
@@ -174,6 +177,7 @@ class GradleEnterprisePluginCheckInFixture {
     }
 
     void assertEndOfBuildWithFailure(String output, @Nullable String failure) {
+        assert output.count("gradleEnterprisePlugin.endOfBuild.buildResult.failure = ") == 1
         assert output.contains("gradleEnterprisePlugin.endOfBuild.buildResult.failure = $failure")
     }
 

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildCallbackIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildCallbackIntegrationTest.groovy
@@ -61,4 +61,20 @@ class GradleEnterprisePluginEndOfBuildCallbackIntegrationTest extends AbstractIn
         plugin.assertEndOfBuildWithFailure(output, "org.gradle.internal.exceptions.LocationAwareException")
     }
 
+    def "end of build listener may fail with an exception"() {
+        when:
+        fails "t", "-Dbuild-listener-failure"
+
+        then:
+        plugin.assertEndOfBuildWithFailure(output, null)
+        failure.assertHasDescription("broken")
+
+        when:
+        fails "t", "-Dbuild-listener-failure"
+
+        then:
+        plugin.assertEndOfBuildWithFailure(output, null)
+        failure.assertHasDescription("broken")
+    }
+
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildCompletionNotifyingBuildActionRunner.java
@@ -39,14 +39,14 @@ public class BuildCompletionNotifyingBuildActionRunner implements BuildActionRun
         Result result;
         try {
             result = delegate.run(action, buildController);
-            notifyEnterprisePluginManager(result);
-            return result;
         } catch (Throwable t) {
             // Note: throw the failure rather than returning a result object containing the failure, as console failure logging based on the _result_ happens down in the root build scope
             // whereas console failure logging based on the _thrown exception_ happens up outside session scope. It would be better to refactor so that a result can be returned from here
             notifyEnterprisePluginManager(Result.failed(t));
             throw UncheckedException.throwAsUncheckedException(t);
         }
+        notifyEnterprisePluginManager(result);
+        return result;
     }
 
     private void notifyEnterprisePluginManager(Result result) {


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
