### PR TITLE
Documentation: enhance IvyVariantDerivationRule to avoid project references

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/groovy/build.gradle
@@ -1,3 +1,4 @@
+
 plugins {
     id 'java-library'
 }
@@ -10,7 +11,18 @@ repositories {
 
 // tag::ivy-component-metadata-rule[]
 abstract class IvyVariantDerivationRule implements ComponentMetadataRule {
-    @Inject abstract ObjectFactory getObjects()
+    final LibraryElements jarLibraryElements
+    final Category libraryCategory
+    final Usage javaRuntimeUsage
+    final Usage javaApiUsage
+
+    @Inject
+    IvyVariantDerivationRule(ObjectFactory objectFactory) {
+        jarLibraryElements = objectFactory.named(LibraryElements, LibraryElements.JAR)
+        libraryCategory = objectFactory.named(Category, Category.LIBRARY)
+        javaRuntimeUsage = objectFactory.named(Usage, Usage.JAVA_RUNTIME)
+        javaApiUsage = objectFactory.named(Usage, Usage.JAVA_API)
+    }
 
     void execute(ComponentMetadataContext context) {
         // This filters out any non Ivy module
@@ -20,16 +32,16 @@ abstract class IvyVariantDerivationRule implements ComponentMetadataRule {
 
         context.details.addVariant("runtimeElements", "default") {
             attributes {
-                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named(LibraryElements, LibraryElements.JAR))
-                attribute(Category.CATEGORY_ATTRIBUTE, getObjects().named(Category, Category.LIBRARY))
-                attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_RUNTIME))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, jarLibraryElements)
+                attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+                attribute(Usage.USAGE_ATTRIBUTE, javaRuntimeUsage)
             }
         }
         context.details.addVariant("apiElements", "compile") {
             attributes {
-                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named(LibraryElements, LibraryElements.JAR))
-                attribute(Category.CATEGORY_ATTRIBUTE, getObjects().named(Category, Category.LIBRARY))
-                attribute(Usage.USAGE_ATTRIBUTE, getObjects().named(Usage, Usage.JAVA_API))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, jarLibraryElements)
+                attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+                attribute(Usage.USAGE_ATTRIBUTE, javaApiUsage)
             }
         }
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-ivyMetadataRule/kotlin/build.gradle.kts
@@ -9,8 +9,18 @@ repositories {
 }
 
 // tag::ivy-component-metadata-rule[]
-abstract class IvyVariantDerivationRule : ComponentMetadataRule {
-    @Inject abstract fun getObjects(): ObjectFactory
+abstract class IvyVariantDerivationRule @Inject internal constructor(objectFactory: ObjectFactory) : ComponentMetadataRule {
+    private val jarLibraryElements: LibraryElements
+    private val libraryCategory: Category
+    private val javaRuntimeUsage: Usage
+    private val javaApiUsage: Usage
+
+    init {
+        jarLibraryElements = objectFactory.named(LibraryElements.JAR)
+        libraryCategory = objectFactory.named(Category.LIBRARY)
+        javaRuntimeUsage = objectFactory.named(Usage.JAVA_RUNTIME)
+        javaApiUsage = objectFactory.named(Usage.JAVA_API)
+    }
 
     override fun execute(context: ComponentMetadataContext) {
         // This filters out any non Ivy module
@@ -20,16 +30,16 @@ abstract class IvyVariantDerivationRule : ComponentMetadataRule {
 
         context.details.addVariant("runtimeElements", "default") {
             attributes {
-                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named<LibraryElements>(LibraryElements.JAR))
-                attribute(Category.CATEGORY_ATTRIBUTE, getObjects().named<Category>(Category.LIBRARY))
-                attribute(Usage.USAGE_ATTRIBUTE, getObjects().named<Usage>(Usage.JAVA_RUNTIME))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, jarLibraryElements)
+                attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+                attribute(Usage.USAGE_ATTRIBUTE, javaRuntimeUsage)
             }
         }
         context.details.addVariant("apiElements", "compile") {
             attributes {
-                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, getObjects().named<LibraryElements>(LibraryElements.JAR))
-                attribute(Category.CATEGORY_ATTRIBUTE, getObjects().named<Category>(Category.LIBRARY))
-                attribute(Usage.USAGE_ATTRIBUTE, getObjects().named<Usage>(Usage.JAVA_API))
+                attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, jarLibraryElements)
+                attribute(Category.CATEGORY_ATTRIBUTE, libraryCategory)
+                attribute(Usage.USAGE_ATTRIBUTE, javaApiUsage)
             }
         }
     }


### PR DESCRIPTION

### Context
https://docs.gradle.org/current/userguide/variant_model.html#sub:ivy-mapping-to-variants example uses injection for `ObjectFactory`. 

When this happens, it holds a reference to the `Project` transitively causing memory leak

![image](https://user-images.githubusercontent.com/1625920/140416708-3c13d64e-5705-4595-9ddb-bbd5c747f690.png)

Found by @DanielThomas 

This updates the docs for the Ivy rule example

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
