### PR TITLE
Suggested changes for https://github.com/gradle/gradle/pull/18865

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -276,7 +276,7 @@ public interface DependencyHandler extends ExtensionAware {
      * @param dependencyNotation
      *
      * The dependency notation, in one of the notations described above.
-     * @return The dependency.
+     * @return The dependency, or null if dependencyNotation is a provider.
      */
     @Nullable
     Dependency add(String configurationName, Object dependencyNotation);
@@ -287,7 +287,7 @@ public interface DependencyHandler extends ExtensionAware {
      * @param configurationName The name of the configuration.
      * @param dependencyNotation The dependency notation, in one of the notations described above.
      * @param configureClosure The closure to use to configure the dependency.
-     * @return The dependency.
+     * @return The dependency, or null if dependencyNotation is a provider.
      */
     Dependency add(String configurationName, Object dependencyNotation, Closure configureClosure);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -289,7 +289,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @param configureClosure The closure to use to configure the dependency.
      * @return The dependency.
      */
-    @Nullable
     Dependency add(String configurationName, Object dependencyNotation, Closure configureClosure);
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -175,6 +175,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     }
 
     @SuppressWarnings("rawtypes")
+    @Nullable
     private Dependency doAdd(Configuration configuration, Object dependencyNotation, @Nullable Closure configureClosure) {
         if (dependencyNotation instanceof Configuration) {
             DeprecationLogger.deprecateBehaviour("Adding a Configuration as a dependency is a confusing behavior which isn't recommended.")
@@ -200,6 +201,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         return dependency;
     }
 
+    @Nullable
     private Dependency doAddProvider(Configuration configuration, Provider<?> dependencyNotation, Closure<?> configureClosure) {
         if (dependencyNotation instanceof DefaultValueSourceProviderFactory.ValueSourceProvider) {
             Class<? extends ValueSource<?, ?>> valueSourceType = ((DefaultValueSourceProviderFactory.ValueSourceProvider<?, ?>) dependencyNotation).getValueSourceType();
@@ -233,6 +235,7 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
         };
     }
 
+    @Nullable
     private Dependency doAddConfiguration(Configuration configuration, Configuration dependencyNotation) {
         Configuration other = dependencyNotation;
         if (!configurationContainer.contains(other)) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScope.kt
@@ -96,7 +96,7 @@ private constructor(
         dependencyNotation: Provider<MinimalExternalModuleDependency>,
         dependencyConfiguration: ExternalModuleDependency.() -> Unit
     ) {
-        add(CLASSPATH_CONFIGURATION, dependencyNotation, closureOf(dependencyConfiguration))
+        addProvider(CLASSPATH_CONFIGURATION, dependencyNotation, dependencyConfiguration)
     }
 
     /**
@@ -112,7 +112,7 @@ private constructor(
         dependencyNotation: ProviderConvertible<MinimalExternalModuleDependency>,
         dependencyConfiguration: ExternalModuleDependency.() -> Unit
     ) {
-        add(CLASSPATH_CONFIGURATION, dependencyNotation, closureOf(dependencyConfiguration))
+        addProviderConvertible(CLASSPATH_CONFIGURATION, dependencyNotation, dependencyConfiguration)
     }
 
     /**

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -54,7 +54,7 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
     override fun add(configurationName: String, dependencyNotation: Any): Dependency? =
         delegate.add(configurationName, dependencyNotation)
 
-    override fun add(configurationName: String, dependencyNotation: Any, configureClosure: Closure<Any>): Dependency? =
+    override fun add(configurationName: String, dependencyNotation: Any, configureClosure: Closure<Any>): Dependency =
         delegate.add(configurationName, dependencyNotation, configureClosure)
 
     override fun <T : Any, U : ExternalModuleDependency> addProvider(configurationName: String, dependencyNotation: Provider<T>, configuration: Action<in U>) =

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/ScriptHandlerScopeTest.kt
@@ -53,10 +53,8 @@ class ScriptHandlerScopeTest {
             }
         }
 
-        verify(dependencies).add(eq("classpath"), eq(notation), any())
-        verify(dependencies).add(
-            eq("classpath"), eq(notation), any()
-        )
+        verify(dependencies).add(eq("classpath"), eq(notation))
+        verify(dependencies).addProvider(eq("classpath"), eq(notation), any<Action<ExternalModuleDependency>>())
         // Because it's a Provider, this isn't called until evaluation
         verify(dependency, never()).exclude(mapOf("module" to "com.google.guava"))
     }
@@ -77,10 +75,8 @@ class ScriptHandlerScopeTest {
             }
         }
 
-        verify(dependencies).add(eq("classpath"), eq(notation), any())
-        verify(dependencies).add(
-            eq("classpath"), eq(notation), any()
-        )
+        verify(dependencies).add(eq("classpath"), eq(notation))
+        verify(dependencies).addProviderConvertible(eq("classpath"), eq(notation), any<Action<ExternalModuleDependency>>())
         // Because it's a Provider, this isn't called until evaluation
         verify(dependency, never()).exclude(mapOf("module" to "com.google.guava"))
     }


### PR DESCRIPTION
See https://github.com/gradle/gradle/pull/18865

No breaking public API change required. The binary compatibility check still fails validation because of the added kotlin extensions that must either be `@Incubating` or accepted as stable.