### PR TITLE
Ignore missing files for IgnoreEmptyDirectories

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
-import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot;
@@ -87,11 +86,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             fileSystemAccess.read(
                 root.getAbsolutePath(),
                 new PatternSetSnapshottingFilter(patterns, stat),
-                snapshot -> {
-                    if (snapshot.getType() != FileType.Missing) {
-                        roots.add(snapshot);
-                    }
-                }
+                roots::add
             );
             if (fileTreeOnly == null) {
                 fileTreeOnly = true;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
@@ -33,7 +33,7 @@ public enum DirectorySensitivity {
     /**
      * Ignore directories
      */
-    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() != FileType.Directory),
+    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() == FileType.RegularFile),
     /**
      * Used to denote that no directory sensitivity has been specified explicitly.
      *

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/DirectorySensitivity.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.fingerprint;
 
+import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 
@@ -31,9 +32,11 @@ public enum DirectorySensitivity {
      */
     DEFAULT(snapshot -> true),
     /**
-     * Ignore directories
+     * Ignore directories.
+     *
+     * More precisely, ignore directories and missing files which are not broken symlinks.
      */
-    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() == FileType.RegularFile),
+    IGNORE_DIRECTORIES(snapshot -> snapshot.getType() == FileType.RegularFile || isBrokenSymlink(snapshot)),
     /**
      * Used to denote that no directory sensitivity has been specified explicitly.
      *
@@ -45,6 +48,10 @@ public enum DirectorySensitivity {
     UNSPECIFIED(snapshot -> {
         throw new AssertionError("Unspecified must not be used as directory sensitivity");
     });
+
+    private static boolean isBrokenSymlink(FileSystemLocationSnapshot snapshot) {
+        return snapshot.getType() == FileType.Missing && snapshot.getAccessType() == FileMetadata.AccessType.VIA_SYMLINK;
+    }
 
     private final Predicate<FileSystemLocationSnapshot> fingerprintCheck;
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -18,6 +18,7 @@ package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Interner;
+import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
@@ -74,8 +75,10 @@ public class RelativePathFingerprintingStrategy extends AbstractDirectorySensiti
                 if (relativePath.isRoot()) {
                     if (snapshot.getType() == FileType.Directory) {
                         fingerprint = IgnoredPathFileSystemLocationFingerprint.DIRECTORY;
-                    } else {
+                    } else if (snapshot.getType() != FileType.Missing || snapshot.getAccessType() == FileMetadata.AccessType.VIA_SYMLINK){
                         fingerprint = fingerprint(snapshot.getName(), snapshot.getType(), snapshot);
+                    } else {
+                        return SnapshotVisitResult.CONTINUE;
                     }
                 } else {
                     fingerprint = fingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot.getType(), snapshot);

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -101,6 +101,7 @@ class PathNormalizationStrategyTest extends Specification {
             assert fingerprints[file] == file.name
         }
         fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
+        fingerprints[missingFile] == rootMissingFileFingerprintFor(missingFile.name, strategy.directorySensitivity)
         fingerprints[resources] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
 
         where:
@@ -123,7 +124,7 @@ class PathNormalizationStrategyTest extends Specification {
         fingerprints[resources.file(subDirB)]       == directoryFingerprintFor(subDirB, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirB)] == fileInSubdirB
         fingerprints[emptyRootDir]                  == rootDirectoryFingerprintFor(strategy.directorySensitivity)
-        fingerprints[missingFile]                   == missingFile.name
+        fingerprints[missingFile]                   == rootMissingFileFingerprintFor(missingFile.name, strategy.directorySensitivity)
 
         where:
         strategy << [
@@ -153,6 +154,10 @@ class PathNormalizationStrategyTest extends Specification {
         return directorySensitivity == DirectorySensitivity.DEFAULT ? IGNORED : null
     }
 
+    String rootMissingFileFingerprintFor(String value, DirectorySensitivity directorySensitivity) {
+        return directorySensitivity == DirectorySensitivity.DEFAULT ? value : null
+    }
+
     String directoryFingerprintFor(String value, DirectorySensitivity directorySensitivity) {
         return directorySensitivity == DirectorySensitivity.DEFAULT ? value : null
     }
@@ -162,10 +167,10 @@ class PathNormalizationStrategyTest extends Specification {
     }
 
     List<File> getAllFilesToFingerprint(DirectorySensitivity directorySensitivity) {
-        def dirs = [emptyRootDir, resources.file(subDirA), resources.file(subDirB), resources]
-        def files = [jarFile1, jarFile2, missingFile, resources.file(fileInRoot), resources.file(fileInSubdirA), resources.file(fileInSubdirB)]
+        def dirsAndMissingFiles = [emptyRootDir, resources.file(subDirA), resources.file(subDirB), resources, missingFile]
+        def files = [jarFile1, jarFile2, resources.file(fileInRoot), resources.file(fileInSubdirA), resources.file(fileInSubdirB)]
 
-        return directorySensitivity == DirectorySensitivity.DEFAULT ? (dirs + files) : files
+        return directorySensitivity == DirectorySensitivity.DEFAULT ? (dirsAndMissingFiles + files) : files
     }
 
     protected TestFile file(String... path) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -101,7 +101,7 @@ class PathNormalizationStrategyTest extends Specification {
             assert fingerprints[file] == file.name
         }
         fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
-        fingerprints[missingFile] == rootMissingFileFingerprintFor(missingFile.name, strategy.directorySensitivity)
+        fingerprints[missingFile] == (strategy.directorySensitivity == DirectorySensitivity.DEFAULT ? missingFile.name : null)
         fingerprints[resources] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
 
         where:
@@ -124,7 +124,7 @@ class PathNormalizationStrategyTest extends Specification {
         fingerprints[resources.file(subDirB)]       == directoryFingerprintFor(subDirB, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirB)] == fileInSubdirB
         fingerprints[emptyRootDir]                  == rootDirectoryFingerprintFor(strategy.directorySensitivity)
-        fingerprints[missingFile]                   == rootMissingFileFingerprintFor(missingFile.name, strategy.directorySensitivity)
+        fingerprints[missingFile]                   == null
 
         where:
         strategy << [
@@ -152,10 +152,6 @@ class PathNormalizationStrategyTest extends Specification {
 
     String rootDirectoryFingerprintFor(DirectorySensitivity directorySensitivity) {
         return directorySensitivity == DirectorySensitivity.DEFAULT ? IGNORED : null
-    }
-
-    String rootMissingFileFingerprintFor(String value, DirectorySensitivity directorySensitivity) {
-        return directorySensitivity == DirectorySensitivity.DEFAULT ? value : null
     }
 
     String directoryFingerprintFor(String value, DirectorySensitivity directorySensitivity) {


### PR DESCRIPTION
So that we can remove the special handling for file trees in snapshotting.