### PR TITLE
Ignore flaky `cleans up idle daemons when tooling API session is shut…

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.model.gradle.GradleBuild
 import org.junit.Rule
+import spock.lang.Ignore
 
 class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
     private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + NORMALIZED_BUILD_JVM_OPTS
@@ -48,6 +49,7 @@ class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
         thrown(IllegalStateException)
     }
 
+    @Ignore('https://github.com/gradle/gradle-private/issues/3477')
     def "cleans up idle daemons when tooling API session is shutdown"() {
         withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()


### PR DESCRIPTION
…down`

See https://github.com/gradle/gradle-private/issues/3477
