### PR TITLE
Exclude src from gradleBuildSmokeTest

### DIFF
--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -80,16 +80,24 @@ tasks {
         }
     }
 
-    fun SmokeTest.configureForSmokeTest(vararg remoteProjects: TaskProvider<RemoteProject>) {
+    fun SmokeTest.configureForSmokeTest(remoteProjectOutputFiles: Any? = null) {
         group = "Verification"
         testClassesDirs = smokeTestSourceSet.output.classesDirs
         classpath = smokeTestSourceSet.runtimeClasspath
         maxParallelForks = 1 // those tests are pretty expensive, we shouldn't execute them concurrently
         inputs.property("androidHomeIsSet", System.getenv("ANDROID_HOME") != null)
         inputs.property("androidSdkRootIsSet", System.getenv("ANDROID_SDK_ROOT") != null)
-        inputs.files(remoteProjects.map { it.map { it.outputDirectory } })
-            .withPropertyName("remoteProjectsSource")
-            .withPathSensitivity(PathSensitivity.RELATIVE)
+
+        if (remoteProjectOutputFiles != null) {
+            inputs.files(remoteProjectOutputFiles)
+                .withPropertyName("remoteProjectsSource")
+                .ignoreEmptyDirectories()
+                .withPathSensitivity(PathSensitivity.RELATIVE)
+        }
+    }
+
+    fun SmokeTest.configureForSmokeTest(remoteProject: TaskProvider<RemoteProject>) {
+        configureForSmokeTest(remoteProject.map { it.outputDirectory })
     }
 
     val gradleBuildTestPattern = "org.gradle.smoketests.GradleBuild*SmokeTest"
@@ -121,7 +129,15 @@ tasks {
 
     register<SmokeTest>("gradleBuildSmokeTest") {
         description = "Runs Smoke tests against the Gradle build"
-        configureForSmokeTest(gradleBuildCurrent)
+        configureForSmokeTest(gradleBuildCurrent.map {
+            project.fileTree(it.outputDirectory) {
+                exclude("subprojects/*/src/**")
+                exclude(".idea/**")
+                exclude(".github/**")
+                exclude(".teamcity/**")
+                exclude(".teamcityTest/**")
+            }
+        })
         useJUnitPlatform {
             filter {
                 includeTestsMatching(gradleBuildTestPattern)


### PR DESCRIPTION
`gradleBuildSmokeTest` aims at testing gradle build logic,
so we exclude source code - the quality of source code is guaranteed
by other tasks.
