### PR TITLE
Declare `PerformanceTest` uses `PerformanceTestService`

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -413,6 +413,7 @@ class PerformanceTestExtension(
             testClassesDirs = performanceSourceSet.output.classesDirs
             classpath = performanceSourceSet.runtimeClasspath
 
+            usesService(buildService)
             performanceTestService.set(buildService)
 
             testProjectName.set(generatorTask.name)


### PR DESCRIPTION
So `maxParallelUsages` can be honored.