### PR TITLE
Add special handling for aggregating and enumerating methods

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
@@ -16,11 +16,10 @@
 
 package org.gradle.internal.classpath;
 
-import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ForwardingSet;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -30,14 +29,16 @@ import java.util.function.Consumer;
  * The special-cased implementation of {@link Set} that tracks all accesses to its elements.
  * @param <E> the type of elements
  */
-class AccessTrackingSet<E> extends AbstractSet<E> {
+class AccessTrackingSet<E> extends ForwardingSet<E> {
     // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of entrySet/keySet methods are currently tracked.
     private final Set<? extends E> delegate;
     private final Consumer<Object> onAccess;
+    private final Runnable onAggregatingAccess;
 
-    public AccessTrackingSet(Set<? extends E> delegate, Consumer<Object> onAccess) {
+    public AccessTrackingSet(Set<? extends E> delegate, Consumer<Object> onAccess, Runnable onAggregatingAccess) {
         this.delegate = delegate;
         this.onAccess = onAccess;
+        this.onAggregatingAccess = onAggregatingAccess;
     }
 
     @Override
@@ -74,23 +75,54 @@ class AccessTrackingSet<E> extends AbstractSet<E> {
 
     @Override
     public Iterator<E> iterator() {
-        return new AbstractIterator<E>() {
-            private final Iterator<? extends E> inner = delegate.iterator();
-
-            @Override
-            protected E computeNext() {
-                if (!inner.hasNext()) {
-                    return endOfData();
-                }
-                E value = inner.next();
-                onAccess.accept(value);
-                return value;
-            }
-        };
+        reportAggregatingAccess();
+        return delegate().iterator();
     }
 
     @Override
     public int size() {
+        reportAggregatingAccess();
         return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        reportAggregatingAccess();
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        reportAggregatingAccess();
+        return super.equals(object);
+    }
+
+    @Override
+    public int hashCode() {
+        reportAggregatingAccess();
+        return super.hashCode();
+    }
+
+    @Override
+    public Object[] toArray() {
+        reportAggregatingAccess();
+        return delegate.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] array) {
+        reportAggregatingAccess();
+        return delegate.toArray(array);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Set<E> delegate() {
+        // The entrySet/keySet disallow adding elements to the set, making it covariant, so downcast is safe there.
+        return (Set<E>) delegate;
+    }
+
+    private void reportAggregatingAccess() {
+        onAggregatingAccess.run();
     }
 }


### PR DESCRIPTION
Some methods of maps returned by System.getProperties() and
System.getenv() do not work with concrete keys. Instead, these methods
aggregate the whole contents of the map (like size() or hashCode()) or
expose the contents to the caller (like iterator() or forEach()). If
such a method is called during the configuration phase then any
change in the environment (environment variable or system property)
can change the behavior of the caller. The configuration cache has no
idea what changes affect the configuration and what don't. Therefore,
the only way to keep correctness is to add a fingerprint of the whole
environment to the cache, and we should discourage build authors from
using such patterns to improve cache hit rates.

This commit moves us closer to the described ideal by fingerprinting
every property/variable if an aggregating or enumerating method is
called. This approach is quicker to implement than adding a full-blown
special fingerprint. While not all environment changes are detected
(e.g. adding a variable will not invalidate the cache), some are and
the sheer number of inputs can highlight to the build author that
they are doing something fishy.


NB: this is the last PR I have in the works for tracking env vars/system variables. Further refinement is postponed.