### PR TITLE
Fall back to archive tree empty check when checking for empty sources.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
@@ -44,9 +44,8 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         description                           | inputDeclaration
         "empty file collection"               | "files()"
         "empty directory as file tree"        | "fileTree(file('emptyDir'))"
-        // TODO: Archive trees are not supported yet and will be handled in a follow up PR to #17837
-        //        "empty zip tree"                      | "zipTree(file('emptyZip.zip'))"
-        //        "empty tar tree"                      | "tarTree(file('emptyTar.tar'))"
+        "empty zip tree"                      | "zipTree(file('emptyZip.zip'))"
+        "empty tar tree"                      | "tarTree(file('emptyTar.tar'))"
         "empty tar tree without backing file" | "tarTree(inputTarResource)"
         "empty directory"                     | "files('emptyDir')"
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -51,6 +51,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
         ((FileCollectionInternal) fileCollection).visitStructure(visitor);
         FileSystemSnapshot snapshot = CompositeFileSystemSnapshot.of(visitor.getRoots());
         boolean fileTreeOnly = visitor.isFileTreeOnly();
+        boolean containsArchiveTrees = visitor.containsArchiveTrees();
         return new Result() {
             @Override
             public FileSystemSnapshot getSnapshot() {
@@ -61,12 +62,18 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             public boolean isFileTreeOnly() {
                 return fileTreeOnly;
             }
+
+            @Override
+            public boolean containsArchiveTrees() {
+                return containsArchiveTrees;
+            }
         };
     }
 
     private class SnapshottingVisitor implements FileCollectionStructureVisitor {
         private final List<FileSystemSnapshot> roots = new ArrayList<>();
         private Boolean fileTreeOnly;
+        private boolean containsArchiveTrees;
 
         @Override
         public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
@@ -102,6 +109,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
         public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
             fileSystemAccess.read(file.getAbsolutePath(), roots::add);
             fileTreeOnly = false;
+            containsArchiveTrees = true;
         }
 
         public List<FileSystemSnapshot> getRoots() {
@@ -110,6 +118,10 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
 
         public boolean isFileTreeOnly() {
             return fileTreeOnly != null && fileTreeOnly;
+        }
+
+        public boolean containsArchiveTrees() {
+            return containsArchiveTrees;
         }
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionSnapshotter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionSnapshotter.java
@@ -27,11 +27,16 @@ public interface FileCollectionSnapshotter {
         FileSystemSnapshot getSnapshot();
 
         /**
-         * Whether or not the snapshotted file collection consists only of file trees.
+         * Whether the snapshot file collection consists only of file trees.
          *
          * If the file collection does not contain any file trees, then this will return {@code false}.
          */
         boolean isFileTreeOnly();
+
+        /**
+         * Whether any of the snapshot file collections is an archive tree backed by a file.
+         */
+        boolean containsArchiveTrees();
     }
 
     /**

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/InputFingerprinter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.fingerprint;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
@@ -160,6 +161,13 @@ public interface InputFingerprinter {
          * Returns all the file fingerprints, including the previously known ones.
          */
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> getAllFileFingerprints();
+
+        /**
+         * Returns the file property names which need an isEmpty() check when used with {@link org.gradle.api.tasks.SkipWhenEmpty}.
+         *
+         * Archive file trees backed by a file need the isEmpty() check, since the fingerprint will be the backing file.
+         */
+        ImmutableSet<String> getPropertiesRequiringIsEmptyCheck();
     }
 
     class InputFingerprintingException extends RuntimeException {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -70,6 +70,7 @@ class DefaultInputFingerprinterTest extends Specification {
         1 * valueSnapshotter.snapshot(input) >> inputSnapshot
         1 * snapshotter.snapshot(fileInput) >> fileInputSnapshotResult
         _ * fileInputSnapshotResult.fileTreeOnly >> false
+        _ * fileInputSnapshotResult.containsArchiveTrees() >> false
         1 * fileInputSnapshotResult.snapshot >> fileInputSnapshot
         1 * fingerprinter.fingerprint(fileInputSnapshot, null) >> fileInputFingerprint
         0 * _

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinterTest.groovy
@@ -80,6 +80,48 @@ class DefaultInputFingerprinterTest extends Specification {
         result.fileFingerprints as Map == ["file": fileInputFingerprint]
     }
 
+    def "marks archive trees as properties requiring empty check"() {
+        def archiveTreeInput = Mock(FileCollection)
+        def archiveTreeInputSnapshotResult = Mock(FileCollectionSnapshotter.Result)
+        def archiveTreeInputSnapshot = Mock(FileSystemSnapshot)
+        def archiveTreeInputFingerprint = Mock(CurrentFileCollectionFingerprint)
+
+        when:
+        def result = fingerprintInputProperties { visitor ->
+            visitor.visitInputFileProperty(
+                "file",
+                NON_INCREMENTAL,
+                new FileValueSupplier(fileInput, FileNormalizer, DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, { fileInput }))
+            visitor.visitInputFileProperty(
+                "archiveTree",
+                NON_INCREMENTAL,
+                new FileValueSupplier(fileInput, FileNormalizer, DirectorySensitivity.DEFAULT, LineEndingSensitivity.DEFAULT, { archiveTreeInput }))
+        }
+
+        then:
+        1 * snapshotter.snapshot(fileInput) >> fileInputSnapshotResult
+        _ * fileInputSnapshotResult.fileTreeOnly >> false
+        _ * fileInputSnapshotResult.containsArchiveTrees() >> false
+        1 * fileInputSnapshotResult.snapshot >> fileInputSnapshot
+        1 * fingerprinter.fingerprint(fileInputSnapshot, null) >> fileInputFingerprint
+
+        then:
+        1 * snapshotter.snapshot(archiveTreeInput) >> archiveTreeInputSnapshotResult
+        _ * archiveTreeInputSnapshotResult.fileTreeOnly >> false
+        _ * archiveTreeInputSnapshotResult.containsArchiveTrees() >> true
+        1 * archiveTreeInputSnapshotResult.snapshot >> archiveTreeInputSnapshot
+        1 * fingerprinter.fingerprint(archiveTreeInputSnapshot, null) >> archiveTreeInputFingerprint
+
+        0 * _
+
+        then:
+        result.fileFingerprints as Map == [
+            "file": fileInputFingerprint,
+            "archiveTree": archiveTreeInputFingerprint
+        ]
+        result.propertiesRequiringIsEmptyCheck == (["archiveTree"] as Set)
+    }
+
     def "ignores already known properties"() {
         when:
         def result = fingerprintInputProperties(

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.steps
 
+import com.google.common.collect.ImmutableSet
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.execution.OutputSnapshotter
 import org.gradle.internal.execution.UnitOfWork
@@ -122,7 +123,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
             knownInputProperties,
             ImmutableSortedMap.of("input", inputSnapshot),
             knownInputFileProperties,
-            ImmutableSortedMap.of("input-file", inputFileFingerprint))
+            ImmutableSortedMap.of("input-file", inputFileFingerprint),
+            ImmutableSet.of())
         interaction { snapshotState() }
         1 * delegate.execute(work, _ as BeforeExecutionContext) >> { UnitOfWork work, BeforeExecutionContext delegateContext ->
             def state = delegateContext.beforeExecutionState.get()
@@ -231,7 +233,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
         _ * work.visitImplementations(_ as UnitOfWork.ImplementationVisitor) >> { UnitOfWork.ImplementationVisitor visitor ->
             visitor.visitImplementation(implementationSnapshot)
         }
-        _ * inputFingerprinter.fingerprintInputProperties(_, _, _, _, _) >> new DefaultInputFingerprinter.InputFingerprints(ImmutableSortedMap.of(), ImmutableSortedMap.of(), ImmutableSortedMap.of(), ImmutableSortedMap.of())
+        _ * inputFingerprinter.fingerprintInputProperties(_, _, _, _, _) >> new DefaultInputFingerprinter.InputFingerprints(ImmutableSortedMap.of(), ImmutableSortedMap.of(), ImmutableSortedMap.of(), ImmutableSortedMap.of(), ImmutableSet.of())
         _ * work.overlappingOutputHandling >> IGNORE_OVERLAPS
         _ * outputSnapshotter.snapshotOutputs(work, _) >> ImmutableSortedMap.of()
         _ * context.history >> Optional.of(executionHistoryStore)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.steps
 
+import com.google.common.collect.ImmutableSet
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.fingerprint.InputFingerprinter
@@ -54,7 +55,8 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of("input", inputSnapshot),
             ImmutableSortedMap.of(),
-            ImmutableSortedMap.of("input-files", inputFilesFingerprint)
+            ImmutableSortedMap.of("input-files", inputFilesFingerprint),
+            ImmutableSet.of()
         )
 
         1 * delegate.execute(work, _ as IdentityContext) >> { UnitOfWork work, IdentityContext delegateContext ->

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.execution.steps
 
+import com.google.common.collect.ImmutableSet
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.execution.OutputChangeListener
@@ -81,7 +82,8 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
             knownInputProperties,
             ImmutableSortedMap.of(),
             knownInputFileProperties,
-            ImmutableSortedMap.of())
+            ImmutableSortedMap.of(),
+            ImmutableSet.of())
 
         then:
         1 * delegate.execute(work, {
@@ -113,7 +115,8 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
             knownInputProperties,
             ImmutableSortedMap.of(),
             knownInputFileProperties,
-            ImmutableSortedMap.of("source-file", sourceFileFingerprint))
+            ImmutableSortedMap.of("source-file", sourceFileFingerprint),
+            ImmutableSet.of())
 
         then:
         1 * sourceFileFingerprint.empty >> false
@@ -149,7 +152,8 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
             knownInputProperties,
             ImmutableSortedMap.of(),
             knownInputFileProperties,
-            ImmutableSortedMap.of("source-file", sourceFileFingerprint))
+            ImmutableSortedMap.of("source-file", sourceFileFingerprint),
+            ImmutableSet.of())
 
         then:
         1 * sourceFileFingerprint.empty >> true
@@ -237,7 +241,8 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),
-            ImmutableSortedMap.of("source-file", sourceFileFingerprint))
+            ImmutableSortedMap.of("source-file", sourceFileFingerprint),
+            ImmutableSet.of())
 
         1 * sourceFileFingerprint.empty >> true
     }


### PR DESCRIPTION
To keep backwards compatibility. This is a follow up to #17837.