### PR TITLE
Fix ordering problems with clean tasks

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.execution.plan.TaskNode;
 import org.gradle.internal.Pair;
 import org.gradle.internal.build.BuildState;
 
@@ -52,7 +53,8 @@ public class CompositeBuildClassPathInitializer implements ScriptClassPathInitia
             buildTreeWorkGraphController.withNewWorkGraph(graph -> {
                 graph.scheduleWork(builder -> {
                     for (Pair<BuildIdentifier, TaskInternal> task : tasksToBuild) {
-                        buildTreeWorkGraphController.locateTask(task.left, task.right).queueForExecution();
+                        TaskIdentifier taskIdentifier = TaskIdentifier.of(task.right, TaskNode.UNKNOWN_ORDINAL);
+                        buildTreeWorkGraphController.locateTask(task.left, taskIdentifier).queueForExecution();
                     }
                 });
                 graph.runWork().rethrow();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
@@ -17,12 +17,10 @@ package org.gradle.composite.internal;
 
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.execution.plan.TaskNode;
-import org.gradle.internal.Pair;
 import org.gradle.internal.build.BuildState;
 
 import java.util.ArrayList;
@@ -39,22 +37,21 @@ public class CompositeBuildClassPathInitializer implements ScriptClassPathInitia
 
     @Override
     public void execute(Configuration classpath) {
-        List<Pair<BuildIdentifier, TaskInternal>> tasksToBuild = new ArrayList<>();
+        List<TaskIdentifier> tasksToBuild = new ArrayList<>();
         for (Task task : classpath.getBuildDependencies().getDependencies(null)) {
             if (!task.getState().getExecuted()) {
                 // This check should live lower down, and should have some kind of synchronization around it, as other threads may be
                 // running tasks at the same time
                 BuildState targetBuild = ((ProjectInternal) task.getProject()).getOwner().getOwner();
                 assert targetBuild != currentBuild;
-                tasksToBuild.add(Pair.of(targetBuild.getBuildIdentifier(), (TaskInternal) task));
+                tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task, TaskNode.UNKNOWN_ORDINAL));
             }
         }
         if (!tasksToBuild.isEmpty()) {
             buildTreeWorkGraphController.withNewWorkGraph(graph -> {
                 graph.scheduleWork(builder -> {
-                    for (Pair<BuildIdentifier, TaskInternal> task : tasksToBuild) {
-                        TaskIdentifier taskIdentifier = TaskIdentifier.of(task.right, TaskNode.UNKNOWN_ORDINAL);
-                        buildTreeWorkGraphController.locateTask(task.left, taskIdentifier).queueForExecution();
+                    for (TaskIdentifier taskIdentifier : tasksToBuild) {
+                        buildTreeWorkGraphController.locateTask(taskIdentifier).queueForExecution();
                     }
                 });
                 graph.runWork().rethrow();

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -191,7 +191,8 @@ class DefaultBuildController implements BuildController, Stoppable {
 
     private void visitDependenciesOf(TaskInternal task, Consumer<TaskInternal> consumer) {
         TaskNodeFactory taskNodeFactory = ((GradleInternal) task.getProject().getGradle()).getServices().get(TaskNodeFactory.class);
-        TaskNode node = taskNodeFactory.getOrCreateNode(task);
+        // TODO - should this just be getNode()?
+        TaskNode node = taskNodeFactory.getOrCreateNode(task, TaskNode.UNKNOWN_ORDINAL);
         for (Node dependency : node.getAllSuccessors()) {
             if (dependency instanceof TaskNode) {
                 consumer.accept(((TaskNode) dependency).getTask());

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -191,7 +191,6 @@ class DefaultBuildController implements BuildController, Stoppable {
 
     private void visitDependenciesOf(TaskInternal task, Consumer<TaskInternal> consumer) {
         TaskNodeFactory taskNodeFactory = ((GradleInternal) task.getProject().getGradle()).getServices().get(TaskNodeFactory.class);
-        // TODO - should this just be getNode()?
         TaskNode node = taskNodeFactory.getOrCreateNode(task, TaskNode.UNKNOWN_ORDINAL);
         for (Node dependency : node.getAllSuccessors()) {
             if (dependency instanceof TaskNode) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -83,19 +83,10 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
     }
 
     @Override
-    public IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskInternal task) {
+    public IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskIdentifier taskIdentifier) {
         return withState(workGraph -> {
             BuildState build = buildRegistry.getBuild(targetBuild);
-            ExportedTaskNode taskNode = build.getWorkGraph().locateTask(task);
-            return new TaskBackedResource(workGraph, build, taskNode);
-        });
-    }
-
-    @Override
-    public IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, String taskPath) {
-        return withState(workGraph -> {
-            BuildState build = buildRegistry.getBuild(targetBuild);
-            ExportedTaskNode taskNode = build.getWorkGraph().locateTask(taskPath);
+            ExportedTaskNode taskNode = build.getWorkGraph().locateTask(taskIdentifier);
             return new TaskBackedResource(workGraph, build, taskNode);
         });
     }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.composite.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.BuildState;
@@ -83,9 +82,9 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
     }
 
     @Override
-    public IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskIdentifier taskIdentifier) {
+    public IncludedBuildTaskResource locateTask(TaskIdentifier taskIdentifier) {
         return withState(workGraph -> {
-            BuildState build = buildRegistry.getBuild(targetBuild);
+            BuildState build = buildRegistry.getBuild(taskIdentifier.getBuildIdentifier());
             ExportedTaskNode taskNode = build.getWorkGraph().locateTask(taskIdentifier);
             return new TaskBackedResource(workGraph, build, taskNode);
         });

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.composite.internal
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.internal.build.BuildState
+import org.gradle.execution.plan.TaskNode
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.BuildWorkGraph
 import org.gradle.internal.build.BuildWorkGraphController
@@ -70,7 +71,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
     def "cannot schedule tasks when graph has not been created"() {
         when:
-        graph.locateTask(DefaultBuildIdentifier.ROOT, ":task").queueForExecution()
+        graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -80,7 +81,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
     def "cannot schedule tasks when after graph has finished execution"() {
         when:
         graph.withNewWorkGraph { 12 }
-        graph.locateTask(DefaultBuildIdentifier.ROOT, ":task").queueForExecution()
+        graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -94,7 +95,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
         when:
         graph.withNewWorkGraph { g ->
-            graph.locateTask(id, ":task").queueForExecution()
+            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
         }
 
         then:
@@ -111,7 +112,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
         graph.withNewWorkGraph { g ->
             g.scheduleWork {
             }
-            graph.locateTask(id, ":task").queueForExecution()
+            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
         }
 
         then:
@@ -128,7 +129,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
         workGraphController.newWorkGraph() >> workGraph
         workGraph.runWork() >> {
-            graph.locateTask(DefaultBuildIdentifier.ROOT, ":task").queueForExecution()
+            graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
         }
 
         when:
@@ -154,7 +155,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
             g.scheduleWork {
             }
             g.runWork()
-            graph.locateTask(id, ":task").queueForExecution()
+            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
         }
 
         then:
@@ -168,5 +169,9 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
         _ * build.workGraph >> (workGraph ?: Stub(BuildWorkGraphController))
         _ * buildStateRegistry.getBuild(id) >> build
         return build
+    }
+
+    static TaskIdentifier taskIdentifier(String taskPath) {
+        return TaskIdentifier.of(taskPath, TaskNode.UNKNOWN_ORDINAL)
     }
 }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -71,7 +71,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
     def "cannot schedule tasks when graph has not been created"() {
         when:
-        graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
+        graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -81,7 +81,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
     def "cannot schedule tasks when after graph has finished execution"() {
         when:
         graph.withNewWorkGraph { 12 }
-        graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
+        graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
 
         then:
         def e = thrown(IllegalStateException)
@@ -95,7 +95,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
         when:
         graph.withNewWorkGraph { g ->
-            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
+            graph.locateTask(taskIdentifier(id, ":task")).queueForExecution()
         }
 
         then:
@@ -112,7 +112,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
         graph.withNewWorkGraph { g ->
             g.scheduleWork {
             }
-            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
+            graph.locateTask(taskIdentifier(id, ":task")).queueForExecution()
         }
 
         then:
@@ -129,7 +129,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
 
         workGraphController.newWorkGraph() >> workGraph
         workGraph.runWork() >> {
-            graph.locateTask(DefaultBuildIdentifier.ROOT, taskIdentifier(":task")).queueForExecution()
+            graph.locateTask(taskIdentifier(DefaultBuildIdentifier.ROOT, ":task")).queueForExecution()
         }
 
         when:
@@ -155,7 +155,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
             g.scheduleWork {
             }
             g.runWork()
-            graph.locateTask(id, taskIdentifier(":task")).queueForExecution()
+            graph.locateTask(taskIdentifier(id, ":task")).queueForExecution()
         }
 
         then:
@@ -171,7 +171,7 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
         return build
     }
 
-    static TaskIdentifier taskIdentifier(String taskPath) {
-        return TaskIdentifier.of(taskPath, TaskNode.UNKNOWN_ORDINAL)
+    static TaskIdentifier taskIdentifier(BuildIdentifier id, String taskPath) {
+        return TaskIdentifier.of(id, taskPath, TaskNode.UNKNOWN_ORDINAL)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -219,6 +219,7 @@ class Codecs(
         bind(TaskNodeCodec(userTypesCodec, taskNodeFactory))
         bind(DelegatingCodec<TransformationNode>(userTypesCodec))
         bind(ActionNodeCodec(userTypesCodec))
+        bind(OrdinalNodeCodec())
 
         bind(NotImplementedCodec)
     }.build()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/OrdinalNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/OrdinalNodeCodec.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.readEnum
+import org.gradle.configurationcache.serialization.writeEnum
+import org.gradle.execution.plan.OrdinalNode
+
+
+class OrdinalNodeCodec() : Codec<OrdinalNode> {
+    override suspend fun WriteContext.encode(value: OrdinalNode) {
+        writeEnum(value.type)
+        writeInt(value.ordinal)
+    }
+
+    override suspend fun ReadContext.decode(): OrdinalNode? {
+        val ordinalType = readEnum<OrdinalNode.Type>()
+        val ordinal = readInt()
+
+        return OrdinalNode(ordinalType, ordinal)
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
@@ -32,17 +32,20 @@ class TaskInAnotherBuildCodec(
     override suspend fun WriteContext.encode(value: TaskInAnotherBuild) {
         value.run {
             writeString(taskPath)
+            writeInt(ordinal)
             write(targetBuild)
         }
     }
 
     override suspend fun ReadContext.decode(): TaskInAnotherBuild {
         val taskPath = readString()
+        val ordinal = readInt()
         val targetBuild = readNonNull<BuildIdentifier>()
         return TaskInAnotherBuild.of(
             taskPath,
             targetBuild,
-            includedTaskGraph
+            includedTaskGraph,
+            ordinal
         )
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
@@ -69,11 +69,13 @@ class TaskNodeCodec(
     override suspend fun WriteContext.encode(value: LocalTaskNode) {
         val task = value.task
         writeTask(task)
+        writeInt(value.ordinal)
     }
 
     override suspend fun ReadContext.decode(): LocalTaskNode {
         val task = readTask()
-        val node = taskNodeFactory.getOrCreateNode(task) as LocalTaskNode
+        val ordinal = readInt()
+        val node = taskNodeFactory.getOrCreateNode(task, ordinal) as LocalTaskNode
         node.isolated()
         return node
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.junit.Rule
+
+abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractIntegrationSpec {
+    @Rule
+    BlockingHttpServer server = new BlockingHttpServer()
+
+    enum ProductionType { OUTPUT, LOCAL_STATE }
+
+    BuildFixture rootBuild = new RootBuild(testDirectory)
+
+    void writeAllFiles() {
+        rootBuild.writeFiles()
+    }
+
+    ProjectFixture subproject(String path) {
+        return rootBuild.subproject(path)
+    }
+
+    BuildFixture includedBuild(String name) {
+        return rootBuild.includedBuild(name)
+    }
+
+    class RootBuild extends BuildFixture {
+        Map<String, BuildFixture> builds = [:]
+
+        RootBuild(TestFile rootDirectory) {
+            super('root', rootDirectory)
+        }
+
+        BuildFixture includedBuild(String name) {
+            return builds.get(name, new BuildFixture(name, buildDir.file(name)))
+        }
+
+        TaskFixture task(String name) {
+            return subproject(':').task(name)
+        }
+
+        void writeFiles() {
+            super.writeFiles()
+            settingsFile << """
+                ${builds.keySet().collect { "includeBuild " + quote(it) }.join('\n')}
+            """.stripIndent()
+            builds.values().each { it.writeFiles() }
+        }
+    }
+
+    class BuildFixture {
+        final String name
+        final TestFile buildDir
+        Map<String, ProjectFixture> projects = [:]
+
+        BuildFixture(String name, TestFile buildDir) {
+            this.name = name
+            this.buildDir = buildDir
+        }
+
+        ProjectFixture subproject(String path) {
+            return projects.get(path, new ProjectFixture(this, path))
+        }
+
+        void writeFiles() {
+            buildDir.file('settings.gradle') << """
+                rootProject.name = ${quote(name)}
+                include ${projects.keySet().collect { quote(it) }.join(', ')}
+            """.stripIndent()
+            projects.values().each { it.writeFiles() }
+        }
+    }
+
+    class ProjectFixture {
+        final BuildFixture build
+        final String path
+        final Map<String, TaskFixture> tasks = [:]
+
+        ProjectFixture(BuildFixture build, String path) {
+            this.build = build
+            this.path = path
+        }
+
+        TaskFixture task(String name) {
+            return tasks.get(name, new TaskFixture(this, taskPath(name)))
+        }
+
+        String taskPath(String name) {
+            return path == ':' ? ":${name}" : "${path}:${name}"
+        }
+
+        void writeFiles() {
+            def projectDirPath = path.replaceAll(':', '/')
+            def projectDir = build.buildDir.createDir(projectDirPath)
+            projectDir.file('build.gradle') << """
+                ${tasks.collect { name, task -> task.getConfig() }.join('\n') }
+            """.stripIndent()
+        }
+    }
+
+    class TaskFixture {
+        final ProjectFixture project
+        final String path
+        final Set<TaskFixture> dependencies = []
+        final Set<String> destroys = []
+        final Set<String> produces = []
+        final Set<String> localState = []
+        boolean shouldBlock
+
+        TaskFixture(ProjectFixture project, String path) {
+            this.project = project
+            this.path = path
+        }
+
+        TaskFixture dependsOn(TaskFixture dependency) {
+            dependencies.add(dependency)
+            return this
+        }
+
+        TaskFixture destroys(String path) {
+            destroys.add(path)
+            return this
+        }
+
+        TaskFixture outputs(String path) {
+            return produces(path, ProductionType.OUTPUT)
+        }
+
+        TaskFixture produces(String path, ProductionType type) {
+            if (type == ProductionType.OUTPUT) {
+                produces.add(path)
+            } else if (type == ProductionType.LOCAL_STATE) {
+                localState.add(path)
+            } else {
+                throw new IllegalArgumentException()
+            }
+            return this
+        }
+
+        TaskFixture localState(String path) {
+            produces(path, ProductionType.LOCAL_STATE)
+            return this
+        }
+
+        String getName() {
+            return path.split(':').last()
+        }
+
+        String getFullPath() {
+            return project.build == rootBuild ? path : ":${project.build.name}${path}"
+        }
+
+        TaskFixture shouldBlock() {
+            shouldBlock = true
+            return this
+        }
+
+        String getConfig() {
+            return """
+                tasks.register('${name}') {
+                    ${dependencies.collect {'dependsOn ' + dependencyFor(it) }.join('\n\t\t\t\t')}
+                    ${produces.collect { 'outputs.file file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
+                    ${destroys.collect { 'destroyables.register file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
+                    ${localState.collect { 'localState.register file(' + quote(it) + ')' }.join('\\n\\t\\t\\t\\t')}
+                    doLast {
+                        ${shouldBlock ? server.callFromTaskAction(path) : ''}
+                    }
+                }
+            """.stripIndent()
+        }
+
+        String dependencyFor(TaskFixture task) {
+            if (task.project.build == this.project.build) {
+                return quote(task.path)
+            } else {
+                return "gradle.includedBuild(${quote(task.project.build.name)}).task(${quote(task.path)})"
+            }
+        }
+    }
+
+    static String quote(String text) {
+        return "'${text}'"
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
@@ -119,6 +119,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
         final ProjectFixture project
         final String path
         final Set<TaskFixture> dependencies = []
+        final Set<TaskFixture> finalizers = []
         final Set<String> destroys = []
         final Set<String> produces = []
         final Set<String> localState = []
@@ -131,6 +132,11 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
 
         TaskFixture dependsOn(TaskFixture dependency) {
             dependencies.add(dependency)
+            return this
+        }
+
+        TaskFixture finalizedBy(TaskFixture finalizer) {
+            finalizers.add(finalizer)
             return this
         }
 
@@ -176,6 +182,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
             return """
                 tasks.register('${name}') {
                     ${dependencies.collect {'dependsOn ' + dependencyFor(it) }.join('\n\t\t\t\t')}
+                    ${finalizers.collect { 'finalizedBy ' + dependencyFor(it) }.join('\\n\\t\\t\\t\\t')}
                     ${produces.collect { 'outputs.file file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
                     ${destroys.collect { 'destroyables.register file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
                     ${localState.collect { 'localState.register file(' + quote(it) + ')' }.join('\\n\\t\\t\\t\\t')}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
-import spock.lang.Unroll
 
 class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
-    @Unroll
     def "destroyer task with a dependency in another project will run before producer tasks when ordered first (type: #type)"() {
         def foo = subproject(':foo')
         def bar = subproject(':bar')
@@ -47,7 +45,6 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         type << ProductionType.values()
     }
 
-    @Unroll
     def "a producer task will not run before a task in another project that destroys what it produces (type: #type)"() {
         def foo = subproject(':foo')
         def bar = subproject(':bar')
@@ -74,7 +71,6 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         type << ProductionType.values()
     }
 
-    @Unroll
     def "destroyer task with a dependency in another build will run before producer tasks when ordered first (type: #type)"() {
         def foo = includedBuild('child').subproject(':foo')
         def bar = subproject(':bar')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
+
+class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
+    def "destroyer task with a dependency in another project will run before producer tasks when ordered first"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "a producer task will not run before a task in another project that destroys what it produces"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = foo.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "destroyer task with a dependency in another build will run before producer tasks when ordered first"() {
+        def foo = includedBuild('child').subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "allows explicit task dependencies to override command line order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        // conflicts with command line order
+        cleanBar.dependsOn(generateBar)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(generateBar.fullPath, cleanBar.fullPath)
+    }
+
+    def "destroyer task with a dependency in another project will run before local state tasks when ordered first"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').localState('build/foo')
+        def generateBar = bar.task('generateBar').localState('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "destroyer task with a dependency in another build will run before local state tasks when ordered first"() {
+        def foo = includedBuild('child').subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').localState('build/foo')
+        def generateBar = bar.task('generateBar').localState('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "destroyer task with a dependency in another project followed by a producer task followed by a destroyer task are run in the correct order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def cleanFooLocal = foo.task('cleanFooLocalState').destroys('build/foo-local')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path, cleanFooLocal.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, TaskOrderSpecs.any(generate.fullPath, cleanFooLocal.fullPath))
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "destroyer task with a dependency in another build followed by a producer task followed by a destroyer task are run in the correct order"() {
+        def foo = includedBuild('child').subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def cleanFooLocal = foo.task('cleanFooLocalState').destroys('build/foo-local')
+        def cleanLocal = rootBuild.task('cleanLocal').dependsOn(cleanFooLocal)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, generate.path, cleanLocal.path)
+
+        then:
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, TaskOrderSpecs.any(generate.fullPath, cleanFooLocal.fullPath))
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+    }
+
+    def "multiple destroyer tasks listed on the command line followed by producers can run concurrently and are executed in the correct order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo').shouldBlock()
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').dependsOn(cleanFoo)
+        def cleanBarLocal = bar.task('cleanBarLocalState').destroys('build/bar-local').shouldBlock()
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar')
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        server.start()
+        server.expectConcurrent(cleanFoo.path, cleanBarLocal.path)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(clean.path, cleanBarLocal.path, generate.path)
+
+        then:
+        result.assertTaskOrder(TaskOrderSpecs.any(cleanFoo.fullPath, cleanBarLocal.fullPath), cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanBarLocal.fullPath, cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, generateFoo.fullPath, generate.fullPath)
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
@@ -145,7 +145,7 @@ class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrd
         def generateBar = bar.task('generateBar').outputs('build/bar').dependsOn(generateFoo)
         def packageBarSources = bar.task('packageBarSources').outputs('build/pkg-src').shouldBlock()
         def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
-        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar').destroys('build/pkg-src')
         def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
 
         server.start()
@@ -158,9 +158,10 @@ class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrd
         succeeds(generateBar.path, packageBarSources.path, clean.path)
 
         then:
-        result.assertTaskOrder(TaskOrderSpecs.any(generateFoo.fullPath, packageBarSources.fullPath), generateBar.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath)
         result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
-        result.assertTaskOrder(packageBarSources.fullPath, generateBar.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(packageBarSources.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(generateBar.fullPath, cleanBar.fullPath, clean.fullPath)
     }
 
     def "producer task finalized by a task in another project will run before destroyer tasks when ordered first"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
@@ -19,11 +19,8 @@ package org.gradle.api
 import org.gradle.api.internal.artifacts.transform.UnzipTransform
 import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
 import org.gradle.util.internal.ToBeImplemented
-import spock.lang.Unroll
-
 
 class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
-    @Unroll
     def "producer task with a dependency in another project will run before destroyer tasks when ordered first (type: #type)"() {
         def foo = subproject(':foo')
         def bar = subproject(':bar')
@@ -50,7 +47,6 @@ class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrd
         type << ProductionType.values()
     }
 
-    @Unroll
     def "producer task with a dependency in another build will run before destroyer tasks when ordered first (type: #type)"() {
         def foo = includedBuild('child').subproject(':foo')
         def bar = subproject(':bar')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
+import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Unroll
+
+
+class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
+    @Unroll
+    def "producer task with a dependency in another project will run before destroyer tasks when ordered first (type: #type)"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').produces('build/foo', type)
+        def generateBar = bar.task('generateBar').produces('build/bar', type).dependsOn(generateFoo)
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generate.path, clean.path)
+
+        then:
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, generate.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
+        result.assertTaskOrder(generateBar.fullPath, cleanBar.fullPath, clean.fullPath)
+
+        where:
+        type << ProductionType.values()
+    }
+
+    @Unroll
+    def "producer task with a dependency in another build will run before destroyer tasks when ordered first (type: #type)"() {
+        def foo = includedBuild('child').subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').produces('build/foo', type)
+        def generateBar = bar.task('generateBar').produces('build/bar', type).dependsOn(generateFoo)
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generate.path, clean.path)
+
+        then:
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, generate.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
+        result.assertTaskOrder(generateBar.fullPath, cleanBar.fullPath, clean.fullPath)
+
+        where:
+        type << ProductionType.values()
+    }
+
+    // Because we prevent destroyers from running in between producers and consumers, this does not currently work the way a user would
+    // expect.  The intermediate destroyer task will be delayed until the consumers have all run.  If we were looking at the specific
+    // outputs that a consumer required, rather than just the dependency relationships, we could support this case.
+    @ToBeImplemented
+    def "producer task followed by a destroyer task followed by a producer with a dependency on the first producer are run in the correct order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFooLocal = foo.task('cleanFooLocalState').destroys('build/foo-local')
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar').dependsOn(generateFoo)
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+        def dist = rootBuild.task('dist').outputs('build/dist').dependsOn(generateBar).dependsOn(generateFoo)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generate.path, cleanFooLocal.path, dist.path)
+
+        then:
+        // The user expects:
+        // result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, TaskOrderSpecs.any(generate.fullPath, cleanFooLocal.fullPath), dist.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, TaskOrderSpecs.any(generate.fullPath, dist.fullPath), cleanFooLocal.fullPath)
+    }
+
+    def "producer task with a dependency in another project followed by a destroyer task followed by a producer are run in the correct order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanBarLocal = bar.task('cleanBarLocalState').destroys('build/bar-local')
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar').dependsOn(generateFoo)
+        def packageBarSources = bar.task('packageBarSources').outputs('build/pkg-src')
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generateBar.path, cleanBarLocal.path, packageBarSources.path)
+
+        then:
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, cleanBarLocal.fullPath, packageBarSources.fullPath)
+    }
+
+    def "producer task with a dependency in another build followed by a destroyer task followed by a producer are run in the correct order"() {
+        def foo = includedBuild('child').subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanBarLocal = bar.task('cleanBarLocalState').destroys('build/bar-local')
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').localState('build/foo-local')
+        def generateBar = bar.task('generateBar').outputs('build/bar').dependsOn(generateFoo)
+        def packageBarSources = bar.task('packageBarSources').outputs('build/pkg-src')
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generateBar.path, cleanBarLocal.path, packageBarSources.path)
+
+        then:
+        result.assertTaskOrder(generateFoo.fullPath, generateBar.fullPath, cleanBarLocal.fullPath, packageBarSources.fullPath)
+    }
+
+    def "multiple producer tasks listed on the command line followed by a destroyer can run concurrently and are executed in the correct order"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def generateFoo = foo.task('generateFoo').outputs('build/foo').shouldBlock()
+        def generateBar = bar.task('generateBar').outputs('build/bar').dependsOn(generateFoo)
+        def packageBarSources = bar.task('packageBarSources').outputs('build/pkg-src').shouldBlock()
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+
+        server.start()
+        server.expectConcurrent(generateFoo.path, packageBarSources.path)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generateBar.path, packageBarSources.path, clean.path)
+
+        then:
+        result.assertTaskOrder(TaskOrderSpecs.any(generateFoo.fullPath, packageBarSources.fullPath), generateBar.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
+        result.assertTaskOrder(packageBarSources.fullPath, generateBar.fullPath, cleanBar.fullPath, clean.fullPath)
+    }
+}

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -974,9 +974,9 @@ task someTask(type: SomeTask) {
         """
         def inputFile = file('input.txt')
         inputFile.text = "input"
-        def expectedCounts = [inputFile: 3, outputFile: 2, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+        def expectedCounts = [inputFile: 3, outputFile: 2, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
         def expectedIncrementalCounts = expectedCounts
-        def expectedUpToDateCounts = [inputFile: 2, outputFile: 1, nestedInput: 2, inputValue: 1, nestedInputValue: 1]
+        def expectedUpToDateCounts = [inputFile: 2, outputFile: 1, nestedInput: 3, inputValue: 1, nestedInputValue: 1]
         def arguments = ["assertInputCounts"] + expectedCounts.collect { name, count -> "-P${name}Count=${count}" }
         def incrementalBuildArguments = ["assertInputCounts"] + expectedIncrementalCounts.collect { name, count -> "-P${name}Count=${count}" }
         def upToDateArguments = ["assertInputCounts"] + expectedUpToDateCounts.collect { name, count -> "-P${name}Count=${count}" }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
@@ -17,7 +17,6 @@
 package org.gradle.composite.internal;
 
 import org.gradle.api.artifacts.component.BuildIdentifier;
-import org.gradle.api.internal.TaskInternal;
 import org.gradle.internal.buildtree.BuildTreeWorkGraph;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -32,12 +31,7 @@ public interface BuildTreeWorkGraphController {
     /**
      * Locates a task node in another build's work graph. Does not schedule the task for execution, use {@link IncludedBuildTaskResource#queueForExecution()} to queue the task for execution.
      */
-    IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskInternal task);
-
-    /**
-     * Locates a task node in another build's work graph. Does not schedule the task for execution, use {@link IncludedBuildTaskResource#queueForExecution()} to queue the task for execution.
-     */
-    IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, String taskPath);
+    IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskIdentifier taskIdentifier);
 
     /**
      * Runs the given action against a new, empty work graph. This allows tasks to be run while calculating the task graph of the build tree, for example to run `buildSrc` tasks or

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildTreeWorkGraphController.java
@@ -16,7 +16,6 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.internal.buildtree.BuildTreeWorkGraph;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
@@ -31,7 +30,7 @@ public interface BuildTreeWorkGraphController {
     /**
      * Locates a task node in another build's work graph. Does not schedule the task for execution, use {@link IncludedBuildTaskResource#queueForExecution()} to queue the task for execution.
      */
-    IncludedBuildTaskResource locateTask(BuildIdentifier targetBuild, TaskIdentifier taskIdentifier);
+    IncludedBuildTaskResource locateTask(TaskIdentifier taskIdentifier);
 
     /**
      * Runs the given action against a new, empty work graph. This allows tasks to be run while calculating the task graph of the build tree, for example to run `buildSrc` tasks or

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.composite.internal;
+
+import org.gradle.api.internal.TaskInternal;
+
+public interface TaskIdentifier {
+    int getOrdinal();
+    String getTaskPath();
+
+    interface TaskBasedTaskIdentifier extends TaskIdentifier {
+        TaskInternal getTask();
+    }
+
+    static TaskBasedTaskIdentifier of(TaskInternal task, int ordinal) {
+        return new TaskBasedTaskIdentifier() {
+            @Override
+            public int getOrdinal() {
+                return ordinal;
+            }
+
+            @Override
+            public TaskInternal getTask() {
+                return task;
+            }
+
+            @Override
+            public String getTaskPath() {
+                return task.getPath();
+            }
+        };
+    }
+
+    static TaskIdentifier of(String taskPath, int ordinal) {
+        return new TaskIdentifier() {
+            @Override
+            public String getTaskPath() {
+                return taskPath;
+            }
+
+            @Override
+            public int getOrdinal() {
+                return ordinal;
+            }
+        };
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
@@ -16,9 +16,11 @@
 
 package org.gradle.composite.internal;
 
+import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 
 public interface TaskIdentifier {
+    BuildIdentifier getBuildIdentifier();
     int getOrdinal();
     String getTaskPath();
 
@@ -26,8 +28,13 @@ public interface TaskIdentifier {
         TaskInternal getTask();
     }
 
-    static TaskBasedTaskIdentifier of(TaskInternal task, int ordinal) {
+    static TaskBasedTaskIdentifier of(BuildIdentifier buildIdentifier, TaskInternal task, int ordinal) {
         return new TaskBasedTaskIdentifier() {
+            @Override
+            public BuildIdentifier getBuildIdentifier() {
+                return buildIdentifier;
+            }
+
             @Override
             public int getOrdinal() {
                 return ordinal;
@@ -45,8 +52,13 @@ public interface TaskIdentifier {
         };
     }
 
-    static TaskIdentifier of(String taskPath, int ordinal) {
+    static TaskIdentifier of(BuildIdentifier buildIdentifier, String taskPath, int ordinal) {
         return new TaskIdentifier() {
+            @Override
+            public BuildIdentifier getBuildIdentifier() {
+                return buildIdentifier;
+            }
+
             @Override
             public String getTaskPath() {
                 return taskPath;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -403,8 +403,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             if (taskClassifier.isDestroyer()) {
                 // Create (or get) a destroyer ordinal node that depends on the dependencies of this task node
                 Node ordinalNode = ordinalNodeAccess.getOrCreateDestroyableLocationNode(taskNode.getOrdinal());
-                taskNode.getDependencySuccessors().forEach(ordinalNode::addDependencySuccessor);
-                taskNode.getFinalizingSuccessors().forEach(ordinalNode::addDependencySuccessor);
+                taskNode.getHardSuccessors().forEach(ordinalNode::addDependencySuccessor);
 
                 if (taskNode.getOrdinal() > 0) {
                     // Depend on any previous producer ordinal nodes (i.e. any producer ordinal nodes with a lower
@@ -415,8 +414,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             } else if (taskClassifier.isProducer()) {
                 // Create (or get) a producer ordinal node that depends on the dependencies of this task node
                 Node ordinalNode = ordinalNodeAccess.getOrCreateOutputLocationNode(taskNode.getOrdinal());
-                taskNode.getDependencySuccessors().forEach(ordinalNode::addDependencySuccessor);
-                taskNode.getFinalizingSuccessors().forEach(ordinalNode::addDependencySuccessor);
+                taskNode.getHardSuccessors().forEach(ordinalNode::addDependencySuccessor);
 
                 if (taskNode.getOrdinal() > 0) {
                     // Depend on any previous destroyer ordinal nodes (i.e. any destroyer ordinal nodes with a lower

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -401,21 +401,26 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             ((TaskLocalStateInternal)taskNode.getTask().getLocalState()).visitRegisteredProperties(taskClassifier);
 
             if (taskClassifier.isDestroyer()) {
+                // Create (or get) a destroyer ordinal node that depends on the dependencies of this task node
                 Node ordinalNode = ordinalNodeAccess.getOrCreateDestroyableLocationNode(taskNode.getOrdinal());
                 taskNode.getDependencySuccessors().forEach(ordinalNode::addDependencySuccessor);
                 taskNode.getFinalizingSuccessors().forEach(ordinalNode::addDependencySuccessor);
 
-
                 if (taskNode.getOrdinal() > 0) {
+                    // Depend on any previous producer ordinal nodes (i.e. any producer ordinal nodes with a lower
+                    // ordinal)
                     ordinalNodeAccess.getPrecedingProducerLocationNodes(taskNode.getOrdinal())
                         .forEach(taskNode::addDependencySuccessor);
                 }
             } else if (taskClassifier.isProducer()) {
+                // Create (or get) a producer ordinal node that depends on the dependencies of this task node
                 Node ordinalNode = ordinalNodeAccess.getOrCreateOutputLocationNode(taskNode.getOrdinal());
                 taskNode.getDependencySuccessors().forEach(ordinalNode::addDependencySuccessor);
                 taskNode.getFinalizingSuccessors().forEach(ordinalNode::addDependencySuccessor);
 
                 if (taskNode.getOrdinal() > 0) {
+                    // Depend on any previous destroyer ordinal nodes (i.e. any destroyer ordinal nodes with a lower
+                    // ordinal)
                     ordinalNodeAccess.getPrecedingDestroyerLocationNodes(taskNode.getOrdinal())
                         .forEach(taskNode::addDependencySuccessor);
                 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -78,6 +78,11 @@ public interface ExecutionPlan extends Describable {
         }
 
         @Override
+        public void addEntryTasks(Collection<? extends Task> tasks, int ordinal) {
+            throw new IllegalStateException();
+        }
+
+        @Override
         public void determineExecutionPlan() {
         }
 
@@ -157,6 +162,8 @@ public interface ExecutionPlan extends Describable {
     void addNodes(Collection<? extends Node> nodes);
 
     void addEntryTasks(Collection<? extends Task> tasks);
+
+    void addEntryTasks(Collection<? extends Task> tasks, int ordinal);
 
     void determineExecutionPlan();
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -18,11 +18,13 @@ package org.gradle.execution.plan;
 
 import org.gradle.api.Action;
 import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.properties.DefaultTaskProperties;
+import org.gradle.api.internal.tasks.properties.OutputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.api.tasks.TaskExecutionException;
@@ -49,7 +51,8 @@ public class LocalTaskNode extends TaskNode {
     private List<? extends ResourceLock> resourceLocks;
     private TaskProperties taskProperties;
 
-    public LocalTaskNode(TaskInternal task, WorkValidationContext workValidationContext) {
+    public LocalTaskNode(TaskInternal task, WorkValidationContext workValidationContext, int ordinal) {
+        super(ordinal);
         this.task = task;
         this.validationContext = workValidationContext;
     }
@@ -129,6 +132,10 @@ public class LocalTaskNode extends TaskNode {
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
         for (Node targetNode : getDependencies(dependencyResolver)) {
             addDependencySuccessor(targetNode);
+            if (targetNode instanceof TaskNode) {
+                // if the dependency doesn't already have an ordinal assigned, then inherit the ordinal from this node
+                ((TaskNode) targetNode).maybeSetOrdinal(getOrdinal());
+            }
             processHardSuccessor.execute(targetNode);
         }
 
@@ -191,6 +198,30 @@ public class LocalTaskNode extends TaskNode {
         return task.getIdentityPath().toString();
     }
 
+    private void addOutputFilesToMutations(Set<OutputFilePropertySpec> outputFilePropertySpecs) {
+        final MutationInfo mutations = getMutationInfo();
+        outputFilePropertySpecs.forEach(spec -> {
+            File outputLocation = spec.getOutputFile();
+            if (outputLocation != null) {
+                mutations.outputPaths.add(outputLocation.getAbsolutePath());
+            }
+            mutations.hasOutputs = true;
+        });
+    }
+
+    private void addLocalStateFilesToMutations(FileCollection localStateFiles) {
+        final MutationInfo mutations = getMutationInfo();
+        localStateFiles.forEach(file -> {
+            mutations.outputPaths.add(file.getAbsolutePath());
+            mutations.hasLocalState = true;
+        });
+    }
+
+    private void addDestroyablesToMutations(FileCollection destroyables) {
+        destroyables
+            .forEach(file -> getMutationInfo().destroyablePaths.add(file.getAbsolutePath()));
+    }
+
     @Override
     public void resolveMutations() {
         final LocalTaskNode taskNode = this;
@@ -202,19 +233,11 @@ public class LocalTaskNode extends TaskNode {
         PropertyWalker propertyWalker = serviceRegistry.get(PropertyWalker.class);
         try {
             taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
-            taskProperties.getOutputFileProperties().forEach(spec -> {
-                File outputLocation = spec.getOutputFile();
-                if (outputLocation != null) {
-                    mutations.outputPaths.add(outputLocation.getAbsolutePath());
-                }
-                mutations.hasOutputs = true;
-            });
-            taskProperties.getLocalStateFiles().forEach(file -> {
-                mutations.outputPaths.add(file.getAbsolutePath());
-                mutations.hasLocalState = true;
-            });
-            taskProperties.getDestroyableFiles()
-                .forEach(file -> mutations.destroyablePaths.add(file.getAbsolutePath()));
+
+            addOutputFilesToMutations(taskProperties.getOutputFileProperties());
+            addLocalStateFilesToMutations(taskProperties.getLocalStateFiles());
+            addDestroyablesToMutations(taskProperties.getDestroyableFiles());
+
             mutations.hasFileInputs = !taskProperties.getInputFileProperties().isEmpty();
         } catch (Exception e) {
             throw new TaskExecutionException(task, e);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -132,10 +132,6 @@ public class LocalTaskNode extends TaskNode {
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
         for (Node targetNode : getDependencies(dependencyResolver)) {
             addDependencySuccessor(targetNode);
-            if (targetNode instanceof TaskNode) {
-                // if the dependency doesn't already have an ordinal assigned, then inherit the ordinal from this node
-                ((TaskNode) targetNode).maybeSetOrdinal(getOrdinal());
-            }
             processHardSuccessor.execute(targetNode);
         }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.NodeExecutionContext;
+import org.gradle.internal.resources.ResourceLock;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class OrdinalNode extends Node implements SelfExecutingNode {
+    public enum Type { DESTROYER, PRODUCER }
+
+    private final Type type;
+    private final int ordinal;
+
+    public OrdinalNode(Type type, int ordinal) {
+        this.type = type;
+        this.ordinal = ordinal;
+    }
+
+    @Nullable
+    @Override
+    public Throwable getNodeFailure() {
+        return null;
+    }
+
+    @Override
+    public void rethrowNodeFailure() { }
+
+    @Override
+    public void prepareForExecution() { }
+
+    @Override
+    public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) { }
+
+    @Override
+    public Set<Node> getFinalizers() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void resolveMutations() { }
+
+    @Override
+    public boolean isPublicNode() {
+        return false;
+    }
+
+    @Override
+    public boolean requiresMonitoring() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public ResourceLock getProjectToLock() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal getOwningProject() {
+        return null;
+    }
+
+    @Override
+    public List<? extends ResourceLock> getResourcesToLock() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() {
+        return type.name().toLowerCase() + " locations for task group " + ordinal;
+    }
+
+    @Override
+    public int compareTo(Node o) {
+        return -1;
+    }
+
+    @Override
+    public void execute(NodeExecutionContext context) { }
+
+    public Type getType() {
+        return type;
+    }
+
+    public int getOrdinal() {
+        return ordinal;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
@@ -26,6 +26,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Represents a node in the graph that controls ordinality of destroyers and producers as they are
+ * added to the task graph.  For example "clean build" on the command line implies that the user wants
+ * to run the clean tasks of each project before the build tasks of each project.  Ordinal nodes ensure
+ * this order by tracking the dependencies of destroyers and producers in each group of tasks added to
+ * the task graph and prevents producers of a higher ordinality to run before the destroyers of a lower
+ * ordinality even if the destroyers are delayed waiting on dependencies (and vice versa).
+ */
 public class OrdinalNode extends Node implements SelfExecutingNode {
     public enum Type { DESTROYER, PRODUCER }
 
@@ -88,6 +96,7 @@ public class OrdinalNode extends Node implements SelfExecutingNode {
     }
 
     @Override
+    // TODO is there a better term to use here than "task group"
     public String toString() {
         return type.name().toLowerCase() + " locations for task group " + ordinal;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+/**
+ * A factory for creating and accessing ordinal nodes
+ */
 public class OrdinalNodeAccess {
     TreeMap<Integer, Node> destroyerLocationNodes = Maps.newTreeMap();
     TreeMap<Integer, Node> producerLocationNodes = Maps.newTreeMap();
@@ -48,6 +51,11 @@ public class OrdinalNodeAccess {
         return Streams.concat(destroyerLocationNodes.values().stream(), producerLocationNodes.values().stream()).collect(Collectors.toList());
     }
 
+    /**
+     * Create relationships between the ordinal nodes such that destroyer ordinals cannot complete until all preceding producer
+     * ordinals have completed (and vice versa).  This ensures that an ordinal does not complete early simply because the nodes in
+     * the ordinal group it represents have no explicit dependencies.
+     */
     void createInterNodeRelationships() {
         destroyerLocationNodes.forEach((ordinal, destroyer) -> getPrecedingProducerLocationNodes(ordinal).forEach(destroyer::addDependencySuccessor));
         producerLocationNodes.forEach((ordinal, producer) -> getPrecedingDestroyerLocationNodes(ordinal).forEach(producer::addDependencySuccessor));

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+public class OrdinalNodeAccess {
+    TreeMap<Integer, Node> destroyerLocationNodes = Maps.newTreeMap();
+    TreeMap<Integer, Node> producerLocationNodes = Maps.newTreeMap();
+
+    Node getOrCreateDestroyableLocationNode(int ordinal) {
+        return destroyerLocationNodes.computeIfAbsent(ordinal, this::createDestroyerLocationNode);
+    }
+
+    Node getOrCreateOutputLocationNode(int ordinal) {
+        return producerLocationNodes.computeIfAbsent(ordinal, this::createProducerLocationNode);
+    }
+
+    Collection<Node> getPrecedingDestroyerLocationNodes(int from) {
+        return destroyerLocationNodes.headMap(from).values();
+    }
+
+    Collection<Node> getPrecedingProducerLocationNodes(int from) {
+        return producerLocationNodes.headMap(from).values();
+    }
+
+    List<Node> getAllNodes() {
+        return Streams.concat(destroyerLocationNodes.values().stream(), producerLocationNodes.values().stream()).collect(Collectors.toList());
+    }
+
+    void createInterNodeRelationships() {
+        destroyerLocationNodes.forEach((ordinal, destroyer) -> getPrecedingProducerLocationNodes(ordinal).forEach(destroyer::addDependencySuccessor));
+        producerLocationNodes.forEach((ordinal, producer) -> getPrecedingDestroyerLocationNodes(ordinal).forEach(producer::addDependencySuccessor));
+    }
+
+    private Node createDestroyerLocationNode(int ordinal) {
+        return createOrdinalNode(OrdinalNode.Type.DESTROYER, ordinal);
+    }
+
+    private Node createProducerLocationNode(int ordinal) {
+        return createOrdinalNode(OrdinalNode.Type.PRODUCER, ordinal);
+    }
+
+    private Node createOrdinalNode(OrdinalNode.Type type, int ordinal) {
+        Node ordinalNode = new OrdinalNode(type, ordinal);
+        ordinalNode.require();
+        return ordinalNode;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.composite.internal.IncludedBuildTaskResource;
+import org.gradle.composite.internal.TaskIdentifier;
 import org.gradle.internal.Actions;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
@@ -34,21 +35,25 @@ import java.util.List;
 public class TaskInAnotherBuild extends TaskNode {
     public static TaskInAnotherBuild of(
         TaskInternal task,
-        BuildTreeWorkGraphController taskGraph
+        BuildTreeWorkGraphController taskGraph,
+        int ordinal
     ) {
         BuildIdentifier targetBuild = buildIdentifierOf(task);
-        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, task);
-        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(task, ordinal);
+        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, taskIdentifier);
+        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource, ordinal);
     }
 
     public static TaskInAnotherBuild of(
         String taskPath,
         BuildIdentifier targetBuild,
-        BuildTreeWorkGraphController taskGraph
+        BuildTreeWorkGraphController taskGraph,
+        int ordinal
     ) {
-        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, taskPath);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(taskPath, ordinal);
+        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, taskIdentifier);
         Path taskIdentityPath = Path.path(targetBuild.getName()).append(Path.path(taskPath));
-        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource);
+        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource, ordinal);
     }
 
     protected IncludedBuildTaskResource.State state = IncludedBuildTaskResource.State.Waiting;
@@ -57,7 +62,8 @@ public class TaskInAnotherBuild extends TaskNode {
     private final BuildIdentifier targetBuild;
     private final IncludedBuildTaskResource target;
 
-    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild, IncludedBuildTaskResource target) {
+    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild, IncludedBuildTaskResource target, int ordinal) {
+        super(ordinal);
         this.taskIdentityPath = taskIdentityPath;
         this.taskPath = taskPath;
         this.targetBuild = targetBuild;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -39,8 +39,8 @@ public class TaskInAnotherBuild extends TaskNode {
         int ordinal
     ) {
         BuildIdentifier targetBuild = buildIdentifierOf(task);
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(task, ordinal);
-        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, taskIdentifier);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task, ordinal);
+        IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource, ordinal);
     }
 
@@ -50,8 +50,8 @@ public class TaskInAnotherBuild extends TaskNode {
         BuildTreeWorkGraphController taskGraph,
         int ordinal
     ) {
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(taskPath, ordinal);
-        IncludedBuildTaskResource taskResource = taskGraph.locateTask(targetBuild, taskIdentifier);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, taskPath, ordinal);
+        IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         Path taskIdentityPath = Path.path(targetBuild.getName()).append(Path.path(taskPath));
         return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource, ordinal);
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -30,12 +30,18 @@ import java.util.Set;
 
 public abstract class TaskNode extends Node {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskNode.class);
+    public static final int UNKNOWN_ORDINAL = -1;
 
     private final NavigableSet<Node> mustSuccessors = Sets.newTreeSet();
     private final Set<Node> mustPredecessors = Sets.newHashSet();
     private final NavigableSet<Node> shouldSuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> finalizers = Sets.newTreeSet();
     private final NavigableSet<Node> finalizingSuccessors = Sets.newTreeSet();
+    private int ordinal;
+
+    public TaskNode(int ordinal) {
+        this.ordinal = ordinal;
+    }
 
     @Override
     public boolean doCheckDependenciesComplete() {
@@ -175,4 +181,13 @@ public abstract class TaskNode extends Node {
         }
     }
 
+    public int getOrdinal() {
+        return ordinal;
+    }
+
+    public void maybeSetOrdinal(int ordinal) {
+        if (this.ordinal == UNKNOWN_ORDINAL || this.ordinal > ordinal) {
+            this.ordinal = ordinal;
+        }
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
@@ -36,7 +36,6 @@ public class TaskNodeDependencyResolver implements DependencyResolver {
     public boolean resolve(Task task, Object node, final Action<? super Node> resolveAction) {
         TaskNode taskNode = taskNodeFactory.getNode(task);
         int ordinal = taskNode != null ? taskNode.getOrdinal() : TaskNode.UNKNOWN_ORDINAL;
-        // TODO should this use getNode()?
         return TASK_AS_TASK.resolve(task, node, resolved -> resolveAction.execute(taskNodeFactory.getOrCreateNode(resolved, ordinal)));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
@@ -34,7 +34,10 @@ public class TaskNodeDependencyResolver implements DependencyResolver {
 
     @Override
     public boolean resolve(Task task, Object node, final Action<? super Node> resolveAction) {
-        return TASK_AS_TASK.resolve(task, node, resolved -> resolveAction.execute(taskNodeFactory.getOrCreateNode(resolved)));
+        TaskNode taskNode = taskNodeFactory.getNode(task);
+        int ordinal = taskNode != null ? taskNode.getOrdinal() : TaskNode.UNKNOWN_ORDINAL;
+        // TODO should this use getNode()?
+        return TASK_AS_TASK.resolve(task, node, resolved -> resolveAction.execute(taskNodeFactory.getOrCreateNode(resolved, ordinal)));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -64,13 +64,18 @@ public class TaskNodeFactory {
         return nodes.keySet();
     }
 
-    public TaskNode getOrCreateNode(Task task) {
+    @Nullable
+    public TaskNode getNode(Task task) {
+        return nodes.get(task);
+    }
+
+    public TaskNode getOrCreateNode(Task task, int ordinal) {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
+                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)), ordinal);
             } else {
-                node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController);
+                node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController, ordinal);
             }
             nodes.put(task, node);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraphController.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.build;
 
-import org.gradle.api.internal.TaskInternal;
+import org.gradle.composite.internal.TaskIdentifier;
 
 import java.util.Collection;
 
@@ -29,14 +29,7 @@ public interface BuildWorkGraphController {
      *
      * <p>This method does not schedule the task for execution, use {@link BuildWorkGraph#schedule(Collection)} to schedule the task.
      */
-    ExportedTaskNode locateTask(TaskInternal task);
-
-    /**
-     * Locates a future task node in this build's work graph, for use from some other build's work graph.
-     *
-     * <p>This method does not schedule the task for execution, use {@link BuildWorkGraph#schedule(Collection)} to schedule the task.
-     */
-    ExportedTaskNode locateTask(String taskPath);
+    ExportedTaskNode locateTask(TaskIdentifier taskIdentifier);
 
     /**
      * Creates a new, empty work graph for this build.

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
@@ -26,4 +26,6 @@ public interface ExportedTaskNode {
     TaskInternal getTask();
 
     IncludedBuildTaskResource.State getTaskState();
+
+    int getOrdinal();
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -46,6 +46,7 @@ import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     FileSystem fs = NativeServicesTestFixture.instance.get(FileSystem)
+    int ordinal = 0
 
     DefaultExecutionPlan executionPlan
     def lease = Stub(WorkerLeaseRegistry.WorkerLease)
@@ -503,7 +504,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     }
 
     private void destroyerRunsFirst(Task producer, Task consumer, Task destroyer) {
-        addToGraphAndPopulate(destroyer)
+        addToGraph(destroyer)
         addToGraphAndPopulate(producer, consumer)
 
         def destroyerInfo = selectNextTaskNode()
@@ -559,6 +560,78 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         destroyerRunsFirst(a, c, b)
     }
 
+    def "a task that destroys the output of a task and has a dependency in another project runs first if it is ordered first"() {
+        given:
+        def projectA = project(project, "a")
+        Task producer = task("producer", project: projectA, type: AsyncWithOutputDirectory)
+        _ * producer.outputDirectory >> file("inputDir")
+        def projectC = project(project, "c")
+        Task dependency = task("dependency", project: projectC, type: AsyncWithDestroysFile)
+        _ * dependency.destroysFile >> file("someOtherDir")
+        def projectB = project(project, "b")
+        Task destroyer = task("destroyer", project: projectB, type: AsyncWithDestroysFile, dependsOn: [dependency])
+        _ * destroyer.destroysFile >> file("inputDir").file("inputSubdir").file("foo")
+
+        when:
+        addToGraph(destroyer)
+        addToGraphAndPopulate(producer)
+
+        then:
+        def dependencyNode = selectNextTaskNode()
+        dependencyNode.task == dependency
+        selectNextTaskNode() == null
+
+        when:
+        executionPlan.finishedExecuting(dependencyNode)
+
+        then:
+        def destroyerNode = selectNextTaskNode()
+        destroyerNode.task == destroyer
+        selectNextTaskNode() == null
+
+        when:
+        executionPlan.finishedExecuting(destroyerNode)
+
+        then:
+        selectNextTask() == producer
+    }
+
+    def "a task that produces an output and has a dependency in another project runs first if it is ordered first"() {
+        given:
+        def projectC = project(project, "c")
+        Task dependency = task("dependency", project: projectC, type: AsyncWithOutputDirectory)
+        _ * dependency.outputDirectory >> file("someOtherDir")
+        def projectA = project(project, "a")
+        Task producer = task("producer", project: projectA, type: AsyncWithOutputDirectory, dependsOn: [dependency])
+        _ * producer.outputDirectory >> file("inputDir")
+        def projectB = project(project, "b")
+        Task destroyer = task("destroyer", project: projectB, type: AsyncWithDestroysFile)
+        _ * destroyer.destroysFile >> file("inputDir").file("inputSubdir").file("foo")
+
+        when:
+        addToGraph(producer)
+        addToGraphAndPopulate(destroyer)
+
+        then:
+        def dependencyNode = selectNextTaskNode()
+        dependencyNode.task == dependency
+        selectNextTaskNode() == null
+
+        when:
+        executionPlan.finishedExecuting(dependencyNode)
+
+        then:
+        def producerNode = selectNextTaskNode()
+        producerNode.task == producer
+        selectNextTaskNode() == null
+
+        when:
+        executionPlan.finishedExecuting(producerNode)
+
+        then:
+        selectNextTask() == destroyer
+    }
+
     def "finalizer runs after the last task to be finalized"() {
         given:
         def projectA = project(project, "a")
@@ -601,9 +674,9 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         Task otherTaskWithDependency = task("otherTaskWithDependency", type: Async, dependsOn: [dependency])
 
         when:
-        executionPlan.addEntryTasks([finalized])
-        executionPlan.addEntryTasks([otherTaskWithDependency])
-        executionPlan.determineExecutionPlan()
+        addToGraph(finalized)
+        addToGraph(otherTaskWithDependency)
+        populateGraph()
 
         and:
         def finalizedNode = selectNextTaskNode()
@@ -646,9 +719,9 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         Task mustRunAfter = task("mustRunAfter", type: Async, mustRunAfter: [finalizer])
 
         when:
-        executionPlan.addEntryTasks([finalized])
-        executionPlan.addEntryTasks([mustRunAfter])
-        executionPlan.determineExecutionPlan()
+        addToGraph(finalized)
+        addToGraph(mustRunAfter)
+        populateGraph()
 
         and:
         def dependencyNode = selectNextTaskNode()
@@ -682,9 +755,9 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         Task mustRunAfter = task("mustRunAfter", type: Async, mustRunAfter: [finalizer])
 
         when:
-        executionPlan.addEntryTasks([finalized])
-        executionPlan.addEntryTasks([mustRunAfter])
-        executionPlan.determineExecutionPlan()
+        addToGraph(finalized)
+        addToGraph(mustRunAfter)
+        populateGraph()
 
         and:
         def dependencyNode = selectNextTaskNode()
@@ -864,8 +937,16 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assert tasks as Set == [first, second] as Set
     }
 
+    private void addToGraph(Task... tasks) {
+        executionPlan.addEntryTasks(Arrays.asList(tasks), ordinal++)
+    }
+
     private void addToGraphAndPopulate(Task... tasks) {
-        executionPlan.addEntryTasks(Arrays.asList(tasks))
+        addToGraph(tasks)
+        executionPlan.determineExecutionPlan()
+    }
+
+    private void populateGraph() {
         executionPlan.determineExecutionPlan()
     }
 
@@ -927,6 +1008,11 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         def nextTaskNode
         recordLocks {
             nextTaskNode = executionPlan.selectNext(lease, resourceLockState)
+        }
+        // ignore nodes that aren't tasks
+        if (nextTaskNode != null && !(nextTaskNode instanceof TaskNode)) {
+            executionPlan.finishedExecuting(nextTaskNode)
+            return selectNextTaskNode()
         }
         if (nextTaskNode?.task instanceof Async) {
             nextTaskNode.projectToLock.unlock()

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -39,6 +39,7 @@ import static org.gradle.util.internal.WrapUtil.toList
 class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     DefaultExecutionPlan executionPlan
     def workerLease = Mock(WorkerLeaseRegistry.WorkerLease)
+    int order = 0
 
     def setup() {
         def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController))
@@ -96,9 +97,9 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         Task d = task("d")
 
         when:
-        executionPlan.addEntryTasks(toList(c, b))
-        executionPlan.addEntryTasks(toList(d, a))
-        executionPlan.determineExecutionPlan()
+        addToGraph(toList(c, b))
+        addToGraph(toList(d, a))
+        populateGraph()
 
         then:
         executes(b, c, a, d)
@@ -129,9 +130,9 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         Task e = task("e", dependsOn: [b, d])
 
         when:
-        executionPlan.addEntryTasks(toList(c))
-        executionPlan.addEntryTasks(toList(e))
-        executionPlan.determineExecutionPlan()
+        addToGraph(toList(c))
+        addToGraph(toList(e))
+        populateGraph()
 
         then:
         executes(a, b, c, d, e)
@@ -156,9 +157,9 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         Task c = task("c", (orderingRule): [b])
 
         when:
-        executionPlan.addEntryTasks([c])
-        executionPlan.addEntryTasks([b])
-        executionPlan.determineExecutionPlan()
+        addToGraph([c])
+        addToGraph([b])
+        populateGraph()
 
         then:
         executes(a, b, c)
@@ -319,9 +320,8 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         Task finalized = task("finalized", finalizedBy: [finalizer], didWork: false)
 
         when:
-        executionPlan.addEntryTasks([finalized])
-        executionPlan.addEntryTasks([dependsOnFinalizer])
-        executionPlan.determineExecutionPlan()
+        addToGraph([finalized])
+        addToGraphAndPopulate([dependsOnFinalizer])
 
         then:
         executes(finalized, finalizerDependency, finalizer, dependsOnFinalizer)
@@ -485,11 +485,11 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         Task c = task("c", dependsOn: [b])
         Task d = task("d", dependsOn: [c])
         relationships(a, mustRunAfter: [c])
-        executionPlan.addEntryTasks([d])
+        addToGraph([d])
 
         when:
-        executionPlan.addEntryTasks([a])
-        executionPlan.determineExecutionPlan()
+        addToGraph([a])
+        populateGraph()
 
         then:
         def e = thrown CircularReferenceException
@@ -845,8 +845,16 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         return node
     }
 
+    private void addToGraph(List tasks) {
+        executionPlan.addEntryTasks(tasks, order++)
+    }
+
     private void addToGraphAndPopulate(List tasks) {
-        executionPlan.addEntryTasks(tasks)
+        addToGraph(tasks)
+        populateGraph()
+    }
+
+    private void populateGraph() {
         executionPlan.determineExecutionPlan()
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -51,7 +51,7 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'can create a node for a task'() {
         when:
-        def node = graph.getOrCreateNode(a)
+        def node = graph.getOrCreateNode(a, 0)
 
         then:
         !node.inKnownState
@@ -65,16 +65,16 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'caches node for a given task'() {
         when:
-        def node = graph.getOrCreateNode(a)
+        def node = graph.getOrCreateNode(a, 0)
 
         then:
-        graph.getOrCreateNode(a).is(node)
+        graph.getOrCreateNode(a, 0).is(node)
     }
 
     void 'can add multiple nodes'() {
         when:
-        graph.getOrCreateNode(a)
-        graph.getOrCreateNode(b)
+        graph.getOrCreateNode(a, 0)
+        graph.getOrCreateNode(b, 0)
 
         then:
         graph.tasks == [a, b] as Set
@@ -82,9 +82,9 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'clear'() {
         when:
-        graph.getOrCreateNode(a)
-        graph.getOrCreateNode(b)
-        graph.getOrCreateNode(c)
+        graph.getOrCreateNode(a, 0)
+        graph.getOrCreateNode(b, 0)
+        graph.getOrCreateNode(c, 0)
         graph.clear()
 
         then:

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -64,7 +64,7 @@ class TestExecutionBuildConfigurationAction implements BuildConfigurationAction 
         allTestTasksToRun.addAll(configureBuildForInternalJvmTestRequest(gradleInternal, testExecutionRequest));
         allTestTasksToRun.addAll(configureBuildForTestTasks(testExecutionRequest));
         configureTestTasks(allTestTasksToRun);
-        context.getExecutionPlan().addEntryTasks(allTestTasksToRun);
+        context.getExecutionPlan().addEntryTasks(allTestTasksToRun, 0);
     }
 
     private void configureTestTasks(Set<Test> allTestTasksToRun) {


### PR DESCRIPTION
Fixes #10889
Fixes #2488

### Context
This fixes ordering issues related to running both destroyers and producers on the same command line.  It addresses the problem by introducing "ordinal" nodes in the task graph which allow us to prevent producer tasks from executing before destroyer tasks that may be delayed by dependencies (and vice versa).

For instance, if I run "clean build" I expect all of the clean tasks from a project to run before the build tasks.  If my clean task has a dependency on a task in another project, it will be delayed until the dependency completes.  This allows a "build" task (a producer) to jump in and start executing, which delays the clean task until _after_ the build task.  

The ordinal nodes depend on any dependencies of the clean task and the succeeding producer tasks depend on the ordinal task, which means the producer cannot start until the dependencies of any preceeding destroyer tasks complete and normal task ordering and conflict management will dictate whether the destroyer or producer will run next.  

The same applies for destroyers.  They will depend on any preceding "producer" ordinal nodes and cannot run until the dependencies of any preceding producers are complete.

Tasks that are neither producers or destroyers will not have any relationships to ordinal nodes.