### PR TITLE
Fix SnapshotTaskInputsBuildOperationResult.visitInputFileProperties

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -247,6 +247,9 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
 
         private void visitUnvisitedDirectories() {
             DirectorySnapshot unvisited = unvisitedDirectories.poll();
+            String previousPath = this.path;
+            String previousName = this.name;
+            HashCode previousHash = this.hash;
             while (unvisited != null) {
                 this.path = unvisited.getAbsolutePath();
                 this.name = unvisited.getName();
@@ -254,6 +257,9 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
                 visitor.preDirectory(this);
                 unvisited = unvisitedDirectories.poll();
             }
+            this.path = previousPath;
+            this.name = previousName;
+            this.hash = previousHash;
         }
     }
 


### PR DESCRIPTION
for ignored root directories.

`visitUnvisitedDirectories` didn't reset the state, so the root directory was reported twice instead of reporting the subdirectory. This is only a problem now since we changed relative path normalization to always ignore the root directory, so we have a situation where only some directories are ignored and not all of them.

The change to relative path normalization was done in #17837.