### PR TITLE
Fix checking Kotlin APIs with JApiCmp

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -23,38 +23,6 @@
             "changes": [
                 "org.gradle.kotlin.dsl.support.delegates.SettingsDelegate.include(java.lang.String[])"
             ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
-            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.ProviderConvertible,kotlin.jvm.functions.Function1)",
-            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
-            "changes": [
-                "METHOD_ADDED_TO_PUBLIC_CLASS"
-            ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
-            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(org.gradle.api.artifacts.Configuration,org.gradle.api.provider.ProviderConvertible)",
-            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
-            "changes": [
-                "METHOD_ADDED_TO_PUBLIC_CLASS"
-            ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
-            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.ProviderConvertible,kotlin.jvm.functions.Function1)",
-            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
-            "changes": [
-                "METHOD_ADDED_TO_PUBLIC_CLASS"
-            ]
-        },
-        {
-            "type": "org.gradle.kotlin.dsl.DependencyHandlerScope",
-            "member": "Method org.gradle.kotlin.dsl.DependencyHandlerScope.invoke(java.lang.String,org.gradle.api.provider.ProviderConvertible)",
-            "acceptation": "Support ProviderConvertible in some places where Provider is accepted",
-            "changes": [
-                "METHOD_ADDED_TO_PUBLIC_CLASS"
-            ]
         }
     ]
 }


### PR DESCRIPTION
As pondered in https://github.com/gradle/gradle/pull/18812#discussion_r738569605, and fully revealed in https://github.com/gradle/gradle/pull/18865, there is a bug with how the Kotlin API is checked with JApiCmp. Methods marked with `@since` and `@Incubating` still need to be "accepted", even though they _were_ accepted by the `@since` and `@Incubating`. This is because the original check for "matching Kotlin method" was over-general, and included too many functions. I have written a new check that isn't 100% perfect, but should improve the reliability of matching methods. In particular, it allowed me to revert the changes to `accepted-public-api-changes.json` from #18812 and #18865 (not yet merged or pushed as of writing).