### PR TITLE
Centralize & cleanup DefaultConfiguration creation logic

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
@@ -18,18 +18,15 @@ package org.gradle.util.internal
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
-import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.taskfactory.TaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
-import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.instantiation.InstantiationScheme
 import org.gradle.nativeplatform.internal.DefaultFlavorContainer
 import org.gradle.util.AttributeTestUtil
@@ -48,7 +45,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-        ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, null, TestUtil.domainObjectCollectionFactory(), null, TestUtil.objectFactory())],
+        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, CollectionCallbackActionDecorator.NOOP, null, TestUtil.objectFactory(), null)],
         ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
         ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
+import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationFactory;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler;
@@ -95,7 +96,6 @@ import org.gradle.api.internal.attributes.AttributeDesugaring;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileLookup;
@@ -108,7 +108,6 @@ import org.gradle.api.internal.provider.PropertyFactory;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.internal.InternalBuildFinishedListener;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildState;
@@ -142,7 +141,6 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.vfs.FileSystemAccess;
-import org.gradle.internal.work.WorkerThreadRegistry;
 import org.gradle.util.internal.SimpleMapInterner;
 import org.gradle.vcs.internal.VcsMappingsStore;
 
@@ -202,6 +200,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         void configure(ServiceRegistration registration) {
             registration.add(DefaultTransformedVariantFactory.class);
+            registration.add(DefaultConfigurationFactory.class);
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
@@ -300,28 +299,28 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 ProviderFactory providerFactory
         ) {
             return new DefaultBaseRepositoryFactory(
-                    localMavenRepositoryLocator,
-                    fileResolver,
-                    fileCollectionFactory,
-                    repositoryTransportFactory,
-                    locallyAvailableResourceFinder,
-                    fileStoreAndIndexProvider.getArtifactIdentifierFileStore(),
-                    fileStoreAndIndexProvider.getExternalResourceFileStore(),
-                    new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository, metadataFactory),
-                    new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, instantiator),
-                    authenticationSchemeRegistry,
-                    ivyContextManager,
-                    moduleIdentifierFactory,
-                    instantiatorFactory,
-                    fileResourceRepository,
-                    metadataFactory,
-                    ivyMetadataFactory,
-                    isolatableFactory,
-                    objectFactory,
-                    callbackDecorator,
-                    urlArtifactRepositoryFactory,
-                    checksumService,
-                    providerFactory
+                localMavenRepositoryLocator,
+                fileResolver,
+                fileCollectionFactory,
+                repositoryTransportFactory,
+                locallyAvailableResourceFinder,
+                fileStoreAndIndexProvider.getArtifactIdentifierFileStore(),
+                fileStoreAndIndexProvider.getExternalResourceFileStore(),
+                new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository, metadataFactory),
+                new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, instantiator),
+                authenticationSchemeRegistry,
+                ivyContextManager,
+                moduleIdentifierFactory,
+                instantiatorFactory,
+                fileResourceRepository,
+                metadataFactory,
+                ivyMetadataFactory,
+                isolatableFactory,
+                objectFactory,
+                callbackDecorator,
+                urlArtifactRepositoryFactory,
+                checksumService,
+                providerFactory
             );
         }
 
@@ -329,49 +328,51 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultRepositoryHandler.class, baseRepositoryFactory, instantiator, callbackDecorator);
         }
 
-        ConfigurationContainerInternal createConfigurationContainer(Instantiator instantiator,
-                                                                    ConfigurationResolver configurationResolver, DomainObjectContext domainObjectContext,
-                                                                    ListenerManager listenerManager, DependencyMetaDataProvider metaDataProvider,
-                                                                    LocalComponentMetadataBuilder metaDataBuilder, FileCollectionFactory fileCollectionFactory,
-                                                                    GlobalDependencyResolutionRules globalDependencyResolutionRules, VcsMappingsStore vcsMappingsStore, ComponentIdentifierFactory componentIdentifierFactory,
-                                                                    BuildOperationExecutor buildOperationExecutor, ImmutableAttributesFactory attributesFactory,
-                                                                    ImmutableModuleIdentifierFactory moduleIdentifierFactory, ComponentSelectorConverter componentSelectorConverter,
-                                                                    DependencyLockingProvider dependencyLockingProvider,
-                                                                    ProjectStateRegistry projectStateRegistry,
-                                                                    CalculatedValueContainerFactory calculatedValueContainerFactory,
-                                                                    DocumentationRegistry documentationRegistry,
-                                                                    CollectionCallbackActionDecorator callbackDecorator,
-                                                                    UserCodeApplicationContext userCodeApplicationContext,
-                                                                    WorkerThreadRegistry workerThreadRegistry,
-                                                                    DomainObjectCollectionFactory domainObjectCollectionFactory,
-                                                                    NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
-                                                                    ObjectFactory objectFactory) {
+        ConfigurationContainerInternal createConfigurationContainer(
+            Instantiator instantiator,
+            DependencyMetaDataProvider metaDataProvider,
+            LocalComponentMetadataBuilder metaDataBuilder,
+            GlobalDependencyResolutionRules globalDependencyResolutionRules,
+            VcsMappingsStore vcsMappingsStore,
+            ComponentIdentifierFactory componentIdentifierFactory,
+            ImmutableAttributesFactory attributesFactory,
+            ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+            ComponentSelectorConverter componentSelectorConverter,
+            DependencyLockingProvider dependencyLockingProvider,
+            ProjectStateRegistry projectStateRegistry,
+            CollectionCallbackActionDecorator callbackDecorator,
+            NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
+            ObjectFactory objectFactory,
+            DefaultConfigurationFactory defaultConfigurationFactory
+        ) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
-                    configurationResolver,
-                    instantiator,
-                    domainObjectContext,
-                    listenerManager,
-                    metaDataProvider,
-                    metaDataBuilder,
-                    fileCollectionFactory,
-                    globalDependencyResolutionRules.getDependencySubstitutionRules(),
-                    vcsMappingsStore,
-                    componentIdentifierFactory,
-                    buildOperationExecutor,
-                    taskResolverFor(domainObjectContext),
-                    attributesFactory,
-                    moduleIdentifierFactory,
-                    componentSelectorConverter,
-                    dependencyLockingProvider,
-                    projectStateRegistry,
-                    calculatedValueContainerFactory,
-                    documentationRegistry,
-                    callbackDecorator,
-                    userCodeApplicationContext,
-                    workerThreadRegistry,
-                    domainObjectCollectionFactory,
-                    moduleSelectorNotationParser,
-                    objectFactory
+                instantiator,
+                metaDataProvider,
+                metaDataBuilder,
+                globalDependencyResolutionRules.getDependencySubstitutionRules(),
+                vcsMappingsStore,
+                componentIdentifierFactory,
+                attributesFactory,
+                moduleIdentifierFactory,
+                componentSelectorConverter,
+                dependencyLockingProvider,
+                projectStateRegistry,
+                callbackDecorator,
+                moduleSelectorNotationParser,
+                objectFactory,
+                defaultConfigurationFactory
+            );
+        }
+
+        PublishArtifactNotationParserFactory createPublishArtifactNotationParserFactory(
+            Instantiator instantiator,
+            DependencyMetaDataProvider metaDataProvider,
+            DomainObjectContext domainObjectContext
+        ) {
+            return new PublishArtifactNotationParserFactory(
+                instantiator,
+                metaDataProvider,
+                taskResolverFor(domainObjectContext)
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -111,7 +111,6 @@ import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.deprecation.DeprecationMessageBuilder;
 import org.gradle.internal.event.ListenerBroadcast;
-import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.model.CalculatedModelValue;
@@ -159,13 +158,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     };
 
     private final ConfigurationResolver resolver;
-    private final ListenerManager listenerManager;
     private final DependencyMetaDataProvider metaDataProvider;
     private final DefaultDependencySet dependencies;
     private final DefaultDependencyConstraintSet dependencyConstraints;
     private final DefaultDomainObjectSet<Dependency> ownDependencies;
     private final DefaultDomainObjectSet<DependencyConstraint> ownDependencyConstraints;
-    private final DomainObjectContext owner;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
     private final ProjectStateRegistry projectStateRegistry;
     private CompositeDomainObjectSet<Dependency> inheritedDependencies;
@@ -182,8 +179,6 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners;
     private final BuildOperationExecutor buildOperationExecutor;
     private final Instantiator instantiator;
-    private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
-    private final NotationParser<Object, Capability> capabilityNotationParser;
     private Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
     private ResolutionStrategyInternal resolutionStrategy;
     private final FileCollectionFactory fileCollectionFactory;
@@ -241,28 +236,33 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private ConfigurationInternal consistentResolutionSource;
     private String consistentResolutionReason;
     private ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory;
+    private final DefaultConfigurationFactory defaultConfigurationFactory;
 
-    public DefaultConfiguration(DomainObjectContext domainObjectContext,
-                                String name,
-                                ConfigurationsProvider configurationsProvider,
-                                ConfigurationResolver resolver,
-                                ListenerManager listenerManager,
-                                DependencyMetaDataProvider metaDataProvider,
-                                Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
-                                FileCollectionFactory fileCollectionFactory,
-                                BuildOperationExecutor buildOperationExecutor,
-                                Instantiator instantiator,
-                                NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
-                                NotationParser<Object, Capability> capabilityNotationParser,
-                                ImmutableAttributesFactory attributesFactory,
-                                RootComponentMetadataBuilder rootComponentMetadataBuilder,
-                                DocumentationRegistry documentationRegistry,
-                                UserCodeApplicationContext userCodeApplicationContext,
-                                DomainObjectContext owner,
-                                ProjectStateRegistry projectStateRegistry,
-                                WorkerThreadRegistry workerThreadRegistry,
-                                DomainObjectCollectionFactory domainObjectCollectionFactory,
-                                CalculatedValueContainerFactory calculatedValueContainerFactory
+    /**
+     * To create an instance, use {@link DefaultConfigurationFactory#create}.
+     */
+    public DefaultConfiguration(
+        DomainObjectContext domainObjectContext,
+        String name,
+        ConfigurationsProvider configurationsProvider,
+        ConfigurationResolver resolver,
+        ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners,
+        DependencyMetaDataProvider metaDataProvider,
+        Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
+        FileCollectionFactory fileCollectionFactory,
+        BuildOperationExecutor buildOperationExecutor,
+        Instantiator instantiator,
+        NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
+        NotationParser<Object, Capability> capabilityNotationParser,
+        ImmutableAttributesFactory attributesFactory,
+        RootComponentMetadataBuilder rootComponentMetadataBuilder,
+        DocumentationRegistry documentationRegistry,
+        UserCodeApplicationContext userCodeApplicationContext,
+        ProjectStateRegistry projectStateRegistry,
+        WorkerThreadRegistry workerThreadRegistry,
+        DomainObjectCollectionFactory domainObjectCollectionFactory,
+        CalculatedValueContainerFactory calculatedValueContainerFactory,
+        DefaultConfigurationFactory defaultConfigurationFactory
     ) {
         this.userCodeApplicationContext = userCodeApplicationContext;
         this.projectStateRegistry = projectStateRegistry;
@@ -273,15 +273,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         this.name = name;
         this.configurationsProvider = configurationsProvider;
         this.resolver = resolver;
-        this.listenerManager = listenerManager;
         this.metaDataProvider = metaDataProvider;
         this.resolutionStrategyFactory = resolutionStrategyFactory;
         this.fileCollectionFactory = fileCollectionFactory;
-        this.dependencyResolutionListeners = listenerManager.createAnonymousBroadcaster(DependencyResolutionListener.class);
+        this.dependencyResolutionListeners = dependencyResolutionListeners;
         this.buildOperationExecutor = buildOperationExecutor;
         this.instantiator = instantiator;
-        this.artifactNotationParser = artifactNotationParser;
-        this.capabilityNotationParser = capabilityNotationParser;
         this.attributesFactory = attributesFactory;
         this.configurationAttributes = attributesFactory.mutable();
         this.domainObjectContext = domainObjectContext;
@@ -306,9 +303,9 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory);
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilder;
-        this.owner = owner;
-        this.currentResolveState = owner.getModel().newCalculatedValue(ResolveState.NOT_RESOLVED);
-        path = domainObjectContext.projectPath(name);
+        this.currentResolveState = domainObjectContext.getModel().newCalculatedValue(ResolveState.NOT_RESOLVED);
+        this.path = domainObjectContext.projectPath(name);
+        this.defaultConfigurationFactory = defaultConfigurationFactory;
     }
 
     private static Action<Void> validateMutationType(final MutationValidator mutationValidator, final MutationType type) {
@@ -589,7 +586,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
             return currentState;
         }
 
-        if (!owner.getModel().hasMutableState()) {
+        if (!domainObjectContext.getModel().hasMutableState()) {
             if (!workerThreadRegistry.isWorkerThread()) {
                 // Error if we are executing in a user-managed thread.
                 throw new IllegalStateException("The configuration " + identityPath.toString() + " was resolved from a thread not managed by Gradle.");
@@ -599,7 +596,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                     .willBeRemovedInGradle8()
                     .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")
                     .nagUser();
-                return owner.getModel().fromMutableState(p -> resolveExclusively(requestedState));
+                return domainObjectContext.getModel().fromMutableState(p -> resolveExclusively(requestedState));
             }
         }
         return resolveExclusively(requestedState);
@@ -760,8 +757,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     private boolean ignoresSettingsRepositories() {
-        if (owner instanceof ProjectInternal) {
-            ProjectInternal project = (ProjectInternal) this.owner;
+        if (domainObjectContext instanceof ProjectInternal) {
+            ProjectInternal project = (ProjectInternal) this.domainObjectContext;
             return !project.getRepositories().isEmpty() &&
                 !project.getGradle().getSettings().getDependencyResolutionManagement().getRepositories().isEmpty();
         }
@@ -829,7 +826,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public ExtraExecutionGraphDependenciesResolverFactory getDependenciesResolver() {
         if (dependenciesResolverFactory == null) {
-            dependenciesResolverFactory = new DefaultExtraExecutionGraphDependenciesResolverFactory(new DefaultResolutionResultProvider(), owner, calculatedValueContainerFactory,
+            dependenciesResolverFactory = new DefaultExtraExecutionGraphDependenciesResolverFactory(new DefaultResolutionResultProvider(), domainObjectContext, calculatedValueContainerFactory,
                 (attributes, filter) -> new ConfigurationFileCollection(new SelectedArtifactsProvider(), Specs.satisfyAll(), attributes, filter, false, false, new DefaultResolutionHost()));
         }
         return dependenciesResolverFactory;
@@ -1162,10 +1159,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         String newName = getNameWithCopySuffix();
 
         Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
-        DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName, configurationsProvider, resolver, listenerManager,
-            metaDataProvider, childResolutionStrategy, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser,
-            attributesFactory, rootComponentMetadataBuilder, documentationRegistry, userCodeApplicationContext, owner, projectStateRegistry, workerThreadRegistry,
-            domainObjectCollectionFactory, calculatedValueContainerFactory);
+        DefaultConfiguration copiedConfiguration = defaultConfigurationFactory.create(
+            newName,
+            configurationsProvider,
+            childResolutionStrategy,
+            rootComponentMetadataBuilder
+        );
         configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
         return copiedConfiguration;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.UnknownDomainObjectException;
-import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.UnknownConfigurationException;
@@ -25,14 +24,10 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
-import org.gradle.api.internal.artifacts.ConfigurationResolver;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
-import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
@@ -42,20 +37,12 @@ import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.Capabilit
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCapabilitiesResolution;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
-import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.internal.Factory;
-import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.model.CalculatedValueContainerFactory;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
-import org.gradle.internal.work.WorkerThreadRegistry;
 import org.gradle.vcs.internal.VcsMappingsStore;
 
 import java.util.Collection;
@@ -66,75 +53,36 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     implements ConfigurationContainerInternal, ConfigurationsProvider {
     public static final String DETACHED_CONFIGURATION_DEFAULT_NAME = "detachedConfiguration";
 
-    private final ConfigurationResolver resolver;
-    private final Instantiator instantiator;
-    private final DomainObjectContext context;
-    private final ListenerManager listenerManager;
-    private final DependencyMetaDataProvider dependencyMetaDataProvider;
-    private final FileCollectionFactory fileCollectionFactory;
-    private final BuildOperationExecutor buildOperationExecutor;
-    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
-    private final UserCodeApplicationContext userCodeApplicationContext;
-    private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
-    private final NotationParser<Object, Capability> capabilityNotationParser;
-    private final ImmutableAttributesFactory attributesFactory;
-    private final ProjectStateRegistry projectStateRegistry;
-    private final DocumentationRegistry documentationRegistry;
-
     private final AtomicInteger detachedConfigurationDefaultNameCounter = new AtomicInteger(1);
     private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
     private final DefaultRootComponentMetadataBuilder rootComponentMetadataBuilder;
-    private final WorkerThreadRegistry workerThreadRegistry;
-    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
+    private final DefaultConfigurationFactory defaultConfigurationFactory;
 
-    public DefaultConfigurationContainer(ConfigurationResolver resolver,
-                                         Instantiator instantiator,
-                                         DomainObjectContext context,
-                                         ListenerManager listenerManager,
-                                         DependencyMetaDataProvider dependencyMetaDataProvider,
-                                         LocalComponentMetadataBuilder localComponentMetadataBuilder,
-                                         FileCollectionFactory fileCollectionFactory,
-                                         DependencySubstitutionRules globalDependencySubstitutionRules,
-                                         VcsMappingsStore vcsMappingsStore,
-                                         ComponentIdentifierFactory componentIdentifierFactory,
-                                         BuildOperationExecutor buildOperationExecutor,
-                                         TaskResolver taskResolver,
-                                         ImmutableAttributesFactory attributesFactory,
-                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
-                                         ComponentSelectorConverter componentSelectorConverter,
-                                         DependencyLockingProvider dependencyLockingProvider,
-                                         ProjectStateRegistry projectStateRegistry,
-                                         CalculatedValueContainerFactory calculatedValueContainerFactory,
-                                         DocumentationRegistry documentationRegistry,
-                                         CollectionCallbackActionDecorator callbackDecorator,
-                                         UserCodeApplicationContext userCodeApplicationContext,
-                                         WorkerThreadRegistry workerThreadRegistry,
-                                         DomainObjectCollectionFactory domainObjectCollectionFactory,
-                                         NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
-                                         ObjectFactory objectFactory) {
+    public DefaultConfigurationContainer(
+        Instantiator instantiator,
+        DependencyMetaDataProvider dependencyMetaDataProvider,
+        LocalComponentMetadataBuilder localComponentMetadataBuilder,
+        DependencySubstitutionRules globalDependencySubstitutionRules,
+        VcsMappingsStore vcsMappingsStore,
+        ComponentIdentifierFactory componentIdentifierFactory,
+        ImmutableAttributesFactory attributesFactory,
+        ImmutableModuleIdentifierFactory moduleIdentifierFactory,
+        ComponentSelectorConverter componentSelectorConverter,
+        DependencyLockingProvider dependencyLockingProvider,
+        ProjectStateRegistry projectStateRegistry,
+        CollectionCallbackActionDecorator callbackDecorator,
+        NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
+        ObjectFactory objectFactory,
+        DefaultConfigurationFactory defaultConfigurationFactory
+    ) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
-        this.resolver = resolver;
-        this.instantiator = instantiator;
-        this.context = context;
-        this.listenerManager = listenerManager;
-        this.dependencyMetaDataProvider = dependencyMetaDataProvider;
-        this.fileCollectionFactory = fileCollectionFactory;
-        this.buildOperationExecutor = buildOperationExecutor;
-        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
-        this.userCodeApplicationContext = userCodeApplicationContext;
-        this.workerThreadRegistry = workerThreadRegistry;
-        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
-        this.artifactNotationParser = new PublishArtifactNotationParserFactory(instantiator, dependencyMetaDataProvider, taskResolver).create();
-        this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
-        this.attributesFactory = attributesFactory;
-        this.projectStateRegistry = projectStateRegistry;
-        this.documentationRegistry = documentationRegistry;
         NotationParser<Object, Capability> dependencyCapabilityNotationParser = new CapabilityNotationParserFactory(false).create();
         resolutionStrategyFactory = () -> {
             CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class, new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create());
             return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, dependencyCapabilityNotationParser);
         };
         this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, localComponentMetadataBuilder, this, projectStateRegistry, dependencyLockingProvider);
+        this.defaultConfigurationFactory = defaultConfigurationFactory;
     }
 
     @Override
@@ -186,10 +134,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     }
 
     private DefaultConfiguration newConfiguration(String name, ConfigurationsProvider detachedConfigurationsProvider, RootComponentMetadataBuilder componentMetadataBuilder) {
-        return instantiator.newInstance(DefaultConfiguration.class, context, name, detachedConfigurationsProvider, resolver, listenerManager,
-            dependencyMetaDataProvider, resolutionStrategyFactory, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser,
-            capabilityNotationParser, attributesFactory, componentMetadataBuilder, documentationRegistry, userCodeApplicationContext,
-            context, projectStateRegistry, workerThreadRegistry, domainObjectCollectionFactory, calculatedValueContainerFactory);
+        return defaultConfigurationFactory.create(name, detachedConfigurationsProvider, resolutionStrategyFactory, componentMetadataBuilder);
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationFactory.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.configurations;
+
+import org.gradle.api.artifacts.ConfigurablePublishArtifact;
+import org.gradle.api.artifacts.DependencyResolutionListener;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.artifacts.ConfigurationResolver;
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
+import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.configuration.internal.UserCodeApplicationContext;
+import org.gradle.internal.Factory;
+import org.gradle.internal.event.ListenerBroadcast;
+import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.model.CalculatedValueContainerFactory;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.internal.work.WorkerThreadRegistry;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+
+/**
+ * Factory for creating {@link org.gradle.api.artifacts.Configuration} instances.
+ */
+@ThreadSafe
+public class DefaultConfigurationFactory {
+
+    private final Instantiator instantiator;
+    private final ConfigurationResolver resolver;
+    private final ListenerManager listenerManager;
+    private final DependencyMetaDataProvider metaDataProvider;
+    private final DomainObjectContext domainObjectContext;
+    private final FileCollectionFactory fileCollectionFactory;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final DocumentationRegistry documentationRegistry;
+    private final UserCodeApplicationContext userCodeApplicationContext;
+    private final ProjectStateRegistry projectStateRegistry;
+    private final WorkerThreadRegistry workerThreadRegistry;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
+    private final CalculatedValueContainerFactory calculatedValueContainerFactory;
+
+    @Inject
+    public DefaultConfigurationFactory(
+        Instantiator instantiator,
+        ConfigurationResolver resolver,
+        ListenerManager listenerManager,
+        DependencyMetaDataProvider metaDataProvider,
+        DomainObjectContext domainObjectContext,
+        FileCollectionFactory fileCollectionFactory,
+        BuildOperationExecutor buildOperationExecutor,
+        PublishArtifactNotationParserFactory artifactNotationParserFactory,
+        ImmutableAttributesFactory attributesFactory,
+        DocumentationRegistry documentationRegistry,
+        UserCodeApplicationContext userCodeApplicationContext,
+        ProjectStateRegistry projectStateRegistry,
+        WorkerThreadRegistry workerThreadRegistry,
+        DomainObjectCollectionFactory domainObjectCollectionFactory,
+        CalculatedValueContainerFactory calculatedValueContainerFactory
+    ) {
+        this.instantiator = instantiator;
+        this.resolver = resolver;
+        this.listenerManager = listenerManager;
+        this.metaDataProvider = metaDataProvider;
+        this.domainObjectContext = domainObjectContext;
+        this.fileCollectionFactory = fileCollectionFactory;
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.artifactNotationParser = artifactNotationParserFactory.create();
+        this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
+        this.attributesFactory = attributesFactory;
+        this.documentationRegistry = documentationRegistry;
+        this.userCodeApplicationContext = userCodeApplicationContext;
+        this.projectStateRegistry = projectStateRegistry;
+        this.workerThreadRegistry = workerThreadRegistry;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
+        this.calculatedValueContainerFactory = calculatedValueContainerFactory;
+    }
+
+    /**
+     * Creates a new {@link DefaultConfiguration} instance.
+     */
+    DefaultConfiguration create(
+        String name,
+        ConfigurationsProvider configurationsProvider,
+        Factory<ResolutionStrategyInternal> resolutionStrategyFactory,
+        RootComponentMetadataBuilder rootComponentMetadataBuilder
+    ) {
+        ListenerBroadcast<DependencyResolutionListener> dependencyResolutionListeners =
+            listenerManager.createAnonymousBroadcaster(DependencyResolutionListener.class);
+        return instantiator.newInstance(
+            DefaultConfiguration.class,
+            domainObjectContext,
+            name,
+            configurationsProvider,
+            resolver,
+            dependencyResolutionListeners,
+            metaDataProvider,
+            resolutionStrategyFactory,
+            fileCollectionFactory,
+            buildOperationExecutor,
+            instantiator,
+            artifactNotationParser,
+            capabilityNotationParser,
+            attributesFactory,
+            rootComponentMetadataBuilder,
+            documentationRegistry,
+            userCodeApplicationContext,
+            projectStateRegistry,
+            workerThreadRegistry,
+            domainObjectCollectionFactory,
+            calculatedValueContainerFactory,
+            this
+        );
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -25,13 +25,13 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
-import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.api.specs.Spec
 import org.gradle.configuration.internal.UserCodeApplicationContext
 import org.gradle.internal.event.ListenerManager
@@ -59,7 +59,6 @@ class DefaultConfigurationContainerSpec extends Specification {
     private DependencySubstitutionRules globalSubstitutionRules = Mock()
     private VcsMappingsStore vcsMappingsInternal = Mock()
     private BuildOperationExecutor buildOperationExecutor = Mock()
-    private TaskResolver taskResolver = Mock()
     private ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock() {
         module(_, _) >> { args ->
             DefaultModuleIdentifier.newId(*args)
@@ -77,10 +76,40 @@ class DefaultConfigurationContainerSpec extends Specification {
     }
     def immutableAttributesFactory = AttributeTestUtil.attributesFactory()
 
-    private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider,
-        metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
-        immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry, calculatedValueContainerFactory, documentationRegistry,
-        domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, Mock(WorkerThreadRegistry), TestUtil.domainObjectCollectionFactory(), Mock(NotationParser), TestUtil.objectFactory())
+    private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
+        instantiator,
+        resolver,
+        listenerManager,
+        metaDataProvider,
+        domainObjectContext,
+        fileCollectionFactory,
+        buildOperationExecutor,
+        Stub(PublishArtifactNotationParserFactory),
+        immutableAttributesFactory,
+        documentationRegistry,
+        userCodeApplicationContext,
+        projectStateRegistry,
+        Mock(WorkerThreadRegistry),
+        TestUtil.domainObjectCollectionFactory(),
+        calculatedValueContainerFactory
+    )
+    private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(
+        instantiator,
+        metaDataProvider,
+        metaDataBuilder,
+        globalSubstitutionRules,
+        vcsMappingsInternal,
+        componentIdentifierFactory,
+        immutableAttributesFactory,
+        moduleIdentifierFactory,
+        componentSelectorConverter,
+        dependencyLockingProvider,
+        projectStateRegistry,
+        domainObjectCollectionCallbackActionDecorator,
+        Mock(NotationParser),
+        TestUtil.objectFactory(),
+        configurationFactory
+    )
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.ConfigurationResolver
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
@@ -70,32 +72,44 @@ class DefaultConfigurationContainerTest extends Specification {
         }
     }
     private ComponentSelectorConverter componentSelectorConverter = Mock()
-    private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
-        resolver,
+    private DomainObjectContext domainObjectContext = new RootScriptDomainObjectContext()
+    private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
         instantiator,
-        new RootScriptDomainObjectContext(),
+        resolver,
         listenerManager,
         metaDataProvider,
-        metaDataBuilder,
+        domainObjectContext,
         TestFiles.fileCollectionFactory(),
+        buildOperationExecutor,
+        new PublishArtifactNotationParserFactory(
+            instantiator,
+            metaDataProvider,
+            taskResolver
+        ),
+        immutableAttributesFactory,
+        documentationRegistry,
+        userCodeApplicationContext,
+        projectStateRegistry,
+        Mock(WorkerThreadRegistry),
+        TestUtil.domainObjectCollectionFactory(),
+        calculatedValueContainerFactory
+    )
+    private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
+        instantiator,
+        metaDataProvider,
+        metaDataBuilder,
         globalSubstitutionRules,
         vcsMappingsInternal,
         componentIdentifierFactory,
-        buildOperationExecutor,
-        taskResolver,
         immutableAttributesFactory,
         moduleIdentifierFactory,
         componentSelectorConverter,
         lockingProvider,
         projectStateRegistry,
-        calculatedValueContainerFactory,
-        documentationRegistry,
         callbackActionDecorator,
-        userCodeApplicationContext,
-        Mock(WorkerThreadRegistry),
-        TestUtil.domainObjectCollectionFactory(),
         Mock(NotationParser),
-        TestUtil.objectFactory()
+        TestUtil.objectFactory(),
+        configurationFactory
     )
 
     def addsNewConfigurationWhenConfiguringSelf() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -46,6 +46,7 @@ import org.gradle.api.internal.artifacts.DefaultResolverResults
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.artifacts.ResolverResults
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
@@ -58,6 +59,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.configuration.internal.UserCodeApplicationContext
@@ -66,9 +68,8 @@ import org.gradle.internal.event.AnonymousListenerBroadcast
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.operations.TestBuildOperationExecutor
+import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.internal.reflect.Instantiator
-import org.gradle.internal.typeconversion.NotationParser
-import org.gradle.internal.typeconversion.NotationParserBuilder
 import org.gradle.internal.work.WorkerThreadRegistry
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.AttributeTestUtil
@@ -1763,11 +1764,30 @@ All Artifacts:
         _ * domainObjectContext.buildPath >> Path.path(buildPath)
         _ * domainObjectContext.model >> RootScriptDomainObjectContext.INSTANCE
 
-        def publishArtifactNotationParser = NotationParserBuilder.toType(ConfigurablePublishArtifact).toComposite()
-        new DefaultConfiguration(domainObjectContext, confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
-            Factories.constant(resolutionStrategy), TestFiles.fileCollectionFactory(), new TestBuildOperationExecutor(), instantiator,
-            publishArtifactNotationParser, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, Stub(DocumentationRegistry),
-            userCodeApplicationContext, domainObjectContext, projectStateRegistry, Stub(WorkerThreadRegistry), TestUtil.domainObjectCollectionFactory(), calculatedValueContainerFactory)
+        def publishArtifactNotationParser = new PublishArtifactNotationParserFactory(
+            instantiator,
+            metaDataProvider,
+            Mock(TaskResolver)
+        )
+        def defaultConfigurationFactory = new DefaultConfigurationFactory(
+            DirectInstantiator.INSTANCE,
+            resolver,
+            listenerManager,
+            metaDataProvider,
+            domainObjectContext,
+            TestFiles.fileCollectionFactory(),
+            new TestBuildOperationExecutor(),
+            publishArtifactNotationParser,
+            immutableAttributesFactory,
+            Stub(DocumentationRegistry),
+            userCodeApplicationContext
+            ,
+            projectStateRegistry,
+            Stub(WorkerThreadRegistry),
+            TestUtil.domainObjectCollectionFactory(),
+            calculatedValueContainerFactory
+        )
+        defaultConfigurationFactory.create(confName, configurationsProvider, Factories.constant(resolutionStrategy), rootComponentMetadataBuilder)
     }
 
     private DefaultPublishArtifact artifact(String name) {


### PR DESCRIPTION
### Context

This cleans up the creation of the `DefaultConfiguration` to use the Factory pattern. This centralizes the creation logic in a single location and is an application of the dependency inversion principle.


### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
