### PR TITLE
Tag CodeQL Builds with `CODEQL` Build Scan Tag

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -90,7 +90,7 @@ object BuildEnvironment {
     /**
      * A selection of environment variables injected into the enviroment by the `codeql-env.sh` script.
      */
-    private const val CODEQL_ENVIRONMENT_VARIABLES = [
+    private val CODEQL_ENVIRONMENT_VARIABLES = arrayOf(
         "CODEQL_JAVA_HOME",
         "CODEQL_EXTRACTOR_JAVA_SCRATCH_DIR",
         "CODEQL_ACTION_RUN_MODE",
@@ -98,7 +98,7 @@ object BuildEnvironment {
         "CODEQL_DIST",
         "CODEQL_PLATFORM",
         "CODEQL_RUNNER"
-    ]
+    )
     const val CI_ENVIRONMENT_VARIABLE = "CI"
     const val BUILD_BRANCH = "BUILD_BRANCH"
     const val BUILD_COMMIT_ID = "BUILD_COMMIT_ID"

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -90,7 +90,8 @@ object BuildEnvironment {
     /**
      * A selection of environment variables injected into the enviroment by the `codeql-env.sh` script.
      */
-    private val CODEQL_ENVIRONMENT_VARIABLES = arrayOf(
+    private
+    val CODEQL_ENVIRONMENT_VARIABLES = arrayOf(
         "CODEQL_JAVA_HOME",
         "CODEQL_EXTRACTOR_JAVA_SCRATCH_DIR",
         "CODEQL_ACTION_RUN_MODE",

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -97,6 +97,11 @@ object BuildEnvironment {
     val isTravis = "TRAVIS" in System.getenv()
     val isJenkins = "JENKINS_HOME" in System.getenv()
     val isGhActions = "GITHUB_ACTIONS" in System.getenv()
+    val isCodeQl: Boolean by lazy {
+        // This logic is kept here instead of `codeql-analysis.init.gradle` because that file will hopefully be removed in the future.
+        // Removing that file is waiting on the GitHub team fixing an issue in Autobuilder logic.
+        System.getenv().keys.any { it.startsWith("CODEQL_") }
+    }
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()
     val isWindows = OperatingSystem.current().isWindows

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -87,6 +87,18 @@ fun toPreTestedCommitBaseBranch(actualBranch: String): String = when {
 
 object BuildEnvironment {
 
+    /**
+     * A selection of environment variables injected into the enviroment by the `codeql-env.sh` script.
+     */
+    private const val CODEQL_ENVIRONMENT_VARIABLES = [
+        "CODEQL_JAVA_HOME",
+        "CODEQL_EXTRACTOR_JAVA_SCRATCH_DIR",
+        "CODEQL_ACTION_RUN_MODE",
+        "CODEQL_ACTION_VERSION",
+        "CODEQL_DIST",
+        "CODEQL_PLATFORM",
+        "CODEQL_RUNNER"
+    ]
     const val CI_ENVIRONMENT_VARIABLE = "CI"
     const val BUILD_BRANCH = "BUILD_BRANCH"
     const val BUILD_COMMIT_ID = "BUILD_COMMIT_ID"
@@ -100,7 +112,7 @@ object BuildEnvironment {
     val isCodeQl: Boolean by lazy {
         // This logic is kept here instead of `codeql-analysis.init.gradle` because that file will hopefully be removed in the future.
         // Removing that file is waiting on the GitHub team fixing an issue in Autobuilder logic.
-        System.getenv().keys.any { it.startsWith("CODEQL_") }
+        CODEQL_ENVIRONMENT_VARIABLES.any { it in System.getenv() }
     }
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -16,6 +16,7 @@
 
 import com.gradle.scan.plugin.BuildScanExtension
 import gradlebuild.basics.BuildEnvironment.isCiServer
+import gradlebuild.basics.BuildEnvironment.isCodeQl
 import gradlebuild.basics.BuildEnvironment.isGhActions
 import gradlebuild.basics.BuildEnvironment.isJenkins
 import gradlebuild.basics.BuildEnvironment.isTravis
@@ -185,6 +186,11 @@ fun Project.extractCiData() {
                 value(tcBuildTypeName, buildType)
                 link("Build Type Scans", customValueSearchUrl(mapOf(tcBuildTypeName to buildType)))
             }
+        }
+    }
+    if (isCodeQl) {
+        buildScan {
+            tag("CODEQL")
         }
     }
 }


### PR DESCRIPTION
### Context

This will make it easier to identify CodeQL builds in build scans