### PR TITLE
Use relative path sensitivity for Scala sources

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -194,7 +194,8 @@ public class GroovyCompile extends AbstractCompile implements HasCompileOptions 
      */
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
-    @PathSensitive(PathSensitivity.RELATIVE) // Java source files are supported, too. Therefore we should care about the relative path.
+    // Java source files are supported, too. Therefore, we should care about the relative path.
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     protected FileCollection getStableSources() {
         return stableSources;

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -253,7 +253,8 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
      * {@inheritDoc}
      */
     @Override
-    @PathSensitive(PathSensitivity.NAME_ONLY)
+    // Java source files are supported, too. Therefore, we should care about the relative path.
+    @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getSource() {
         return super.getSource();
     }


### PR DESCRIPTION
so it is in-line with the other JVM compilation tasks we have.
We also want to phase-out using `NAME_ONLY` on directory inputs.