### PR TITLE
Change to ADOPTIUM vendor for JDK

### DIFF
--- a/.teamcity/src/main/kotlin/common/Jvm.kt
+++ b/.teamcity/src/main/kotlin/common/Jvm.kt
@@ -30,5 +30,5 @@ object BuildToolBuildJvm : Jvm {
     override val version: JvmVersion
         get() = JvmVersion.java11
     override val vendor: JvmVendor
-        get() = JvmVendor.openjdk
+        get() = JvmVendor.adoptiumopenjdk
 }

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -21,7 +21,7 @@ enum class JvmCategory(
     override val version: JvmVersion
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.oracle, JvmVersion.java17),
-    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.openjdk, JvmVersion.java11),
-    EXPERIMENTAL_VERSION(JvmVendor.oracle, JvmVersion.java18)
+    MAX_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java17),
+    SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java11),
+    EXPERIMENTAL_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18)
 }

--- a/.teamcity/src/main/kotlin/common/JvmVendor.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVendor.kt
@@ -17,5 +17,5 @@
 package common
 
 enum class JvmVendor {
-    oracle, openjdk
+    oracle, openjdk, adoptiumopenjdk
 }

--- a/.teamcity/src/main/kotlin/common/JvmVersion.kt
+++ b/.teamcity/src/main/kotlin/common/JvmVersion.kt
@@ -19,8 +19,6 @@ package common
 enum class JvmVersion(val major: Int) {
     java8(8),
     java11(11),
-    java15(15),
-    java16(16),
     java17(17),
     java18(18)
 }

--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -91,7 +91,7 @@ enum class Os(
 
     fun javaInstallationLocations(): String {
         val paths = enumValues<JvmVersion>().joinToString(",") { version ->
-            val vendor = if (version.major >= 11) JvmVendor.openjdk else JvmVendor.oracle
+            val vendor = if (version.major >= 11) JvmVendor.adoptiumopenjdk else JvmVendor.oracle
             javaHome(DefaultJvm(version, vendor), this)
         }
         return """"-Porg.gradle.java.installations.paths=$paths""""

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -143,8 +143,8 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
-        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java18.openjdk.64bit%"
-        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.openjdk.64bit%,%windows.java15.openjdk.64bit%,%windows.java16.openjdk.64bit%,%windows.java17.openjdk.64bit%,%windows.java18.openjdk.64bit%"
+        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.adoptiumopenjdk.64bit%"
+        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.adoptiumopenjdk.64bit%,%windows.java17.adoptiumopenjdk.64bit%,%windows.java18.adoptiumopenjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
         return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -65,7 +65,7 @@ class PerformanceTestBuildTypeTest {
                 ),
                 functionalTests = listOf(
                     TestCoverage(1, TestType.platform, Os.LINUX, JvmVersion.java8),
-                    TestCoverage(2, TestType.platform, Os.WINDOWS, JvmVersion.java11, vendor = JvmVendor.openjdk)
+                    TestCoverage(2, TestType.platform, Os.WINDOWS, JvmVersion.java11, vendor = JvmVendor.adoptiumopenjdk)
                 ),
                 performanceTests = listOf(PerformanceTestCoverage(1, PerformanceTestType.per_commit, Os.LINUX))
             ),
@@ -91,7 +91,7 @@ class PerformanceTestBuildTypeTest {
             "-PtestJavaVersion=8",
             "-PtestJavaVendor=oracle",
             "-Porg.gradle.java.installations.auto-download=false",
-            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.openjdk.64bit%,%linux.java15.openjdk.64bit%,%linux.java16.openjdk.64bit%,%linux.java17.openjdk.64bit%,%linux.java18.openjdk.64bit%\"",
+            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.adoptiumopenjdk.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -55,9 +55,9 @@ tasks.registerCITestDistributionLifecycleTasks()
 fun configureCompile() {
     java.toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        // Do not force AdoptOpenJDK vendor for M1 Macs
+        // Do not force Adoptium vendor for M1 Macs
         if (!OperatingSystem.current().toString().contains("aarch64")) {
-            vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+            vendor.set(JvmVendorSpec.ADOPTIUM)
         }
     }
 


### PR DESCRIPTION
The `ADOPTOPENJDK` vendor is deprecated by us, and causes issues with provisioning because of changes to the AdoptOpenJDK APIs. This changes to the new `ADOPTIUM` vendor instead.

This does not remove the M1 restriction, as the 11 builds do not currently produce M1 artifacts.