### PR TITLE
Throw a more specific error when a JDK is needed

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/SimpleGeneratedJavaClassCompiler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/SimpleGeneratedJavaClassCompiler.java
@@ -44,6 +44,9 @@ class SimpleGeneratedJavaClassCompiler {
      */
     public static void compile(File srcDir, File dstDir, List<ClassSource> classes, ClassPath classPath) throws GeneratedClassCompilationException {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new GeneratedClassCompilationException("No Java compiler found, please ensure you are running Gradle with a JDK");
+        }
         DiagnosticCollector<JavaFileObject> ds = new DiagnosticCollector<>();
         try (StandardJavaFileManager mgr = compiler.getStandardFileManager(ds, null, null)) {
             List<String> options = buildOptions(dstDir, classPath);


### PR DESCRIPTION
Fixes #18018

I didn't add any tests as I imagine that would require provisioning a JRE somehow.