### PR TITLE
Fix broken link in userguide

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/06-publishing/publishing_maven.adoc
@@ -193,7 +193,7 @@ The Maven Publish Plugin makes this easy to do by automatically creating a link:
 
 When a project changes the `groupId` or `artifactId` (the _coordinates_) of an artifact it publishes, it is important to let users know where the new artifact can be found. Maven can help with that through the _relocation_ feature. The way this works is that a project publishes an additional artifact under the old coordinates consisting only of a minimal _relocation POM_; that POM file specifies where the new artifact can be found. Maven repository browsers and build tools can then inform the user that the coordinates of an artifact have changed.
 
-For this, a project adds an additional `MavenPublication` specifying a link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPomRelocation[MavenPomRelocation]:
+For this, a project adds an additional `MavenPublication` specifying a link:{groovyDslPath}/org.gradle.api.publish.maven.MavenPomRelocation.html[MavenPomRelocation]:
 
 .Specifying a relocation POM
 ====


### PR DESCRIPTION
### Context
Fixes a broken link I accidentally introduced in #17852.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
