### PR TITLE
Cleanup unreadable file in SyncTaskIntegrationTest

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -430,6 +430,9 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
         outputDirectory.list().contains input.name
         outputContains("Cannot access output property 'destinationDir' of task ':sync'")
         executedAndNotSkipped(":sync")
+
+        cleanup:
+        unreadableOutput.makeReadable()
     }
 
     @Issue("https://github.com/gradle/gradle/issues/9586")


### PR DESCRIPTION
this was missing from the original change and caused some build failures, for example https://ge.gradle.org/s/f7euj5ikd67pu.