### PR TITLE
Clarify settings.gradle preview flags for VERSION_CATALOG

### DIFF
--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -6,8 +6,11 @@
 
 [WARNING]
 ====
-Central declaration of dependencies is an incubating feature.
-It requires the activation of the `VERSION_CATALOGS` <<feature_lifecycle#feature_preview,feature preview>>.
+Central declaration of dependencies is an incubating feature which must be enabled explicitly as a <<feature_lifecycle#feature_preview,feature preview>>.
+To add support for version catalogs, add this to your `settings.gradle(.kts)` file:
+```
+enableFeaturePreview("VERSION_CATALOGS")
+```
 ====
 
 [[sub:version-catalog]]
@@ -307,6 +310,7 @@ For example, an organization may want to create a catalog of dependencies that d
 
 The link:{javadocPath}/org/gradle/api/initialization/dsl/VersionCatalogBuilder.html[version catalog builder API] supports including a model from an external file.
 This makes it possible to reuse the catalog of the main build for `buildSrc`, if needed.
+Note that you'll need to separately <<platforms.adoc#sec:central-declaration-of-dependencies, enable VERSION_CATALOGS preview feature>> in `buildSrc/settings.gradle(.kts)`.
 For example, the `buildSrc/settings.gradle(.kts)` file can include this file using:
 
 .Sharing the dependency catalog with buildSrc


### PR DESCRIPTION
No issue, but related to #18975. Not depending on the outcome of that, this may need to change. Only later I realized that command line works, it's only IntelliJ IDEA sync that fails.

### Context
I was using the [docs](https://docs.gradle.org/7.0/userguide/platforms.html#sec:sharing-catalogs) and I was getting errors that the declared `versionCatalogs { create("deps") { ...` was not found when using with `implementation(deps.foo.bar)`. I updated the docs to make it explicit that the VERSION_CATALOG preview needs to be enabled in every settings.gradle, buildSrc doesn't inherit things from the project's settings.gradle.

Also, while I was there I updated the the top warning to match this one:
https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors
It's much simpler to understand what to do.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
