### PR TITLE
Fix leftover operation files in CC tests

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -118,5 +118,3 @@ dependencies {
 classycle {
     excludePatterns.add("org/gradle/configurationcache/**")
 }
-
-testFilesCleanup.reportOnly.set(true)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiBackedGradleExecuter.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/fixtures/ToolingApiBackedGradleExecuter.groovy
@@ -18,7 +18,6 @@ package org.gradle.configurationcache.fixtures
 
 import org.apache.tools.ant.util.TeeOutputStream
 import org.gradle.api.Action
-import org.gradle.initialization.StartParameterBuildOptions
 import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
@@ -84,14 +83,17 @@ class ToolingApiBackedGradleExecuter extends AbstractGradleExecuter {
         toolingApi.withConnector {
             it.forProjectDirectory(workingDir)
         }
+
+        def systemPropertiesBeforeInvocation = new HashMap<String, Object>(System.getProperties())
+
         try {
             toolingApi.withConnection {
                 action.execute(it)
             }
         } finally {
             if (GradleContextualExecuter.embedded) {
-                System.clearProperty(StartParameterBuildOptions.ConfigurationCacheOption.PROPERTY_NAME)
-                System.clearProperty(StartParameterBuildOptions.IsolatedProjectsOption.PROPERTY_NAME)
+                System.getProperties().clear()
+                System.getProperties().putAll(systemPropertiesBeforeInvocation)
             }
         }
     }


### PR DESCRIPTION
[Original discussion](https://gradle.slack.com/archives/CH43P3A10/p1636104331055900)

We suspect that some build operation tracing system properties were set in test A but not cleaned up properly, resulting in test B generating leftover trace files. This PR captures all system properties before the invocation, and restore them after.