### PR TITLE
Remove timeout limitation for FlakyTest build

### DIFF
--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -42,7 +42,7 @@ class RerunFlakyTest(os: Os) : BuildType({
     val testNameParameterName = "testName"
     val testTaskOptionsParameterName = "testTaskOptions"
     val daemon = true
-    applyDefaultSettings(os, BuildToolBuildJvm, 30)
+    applyDefaultSettings(os, BuildToolBuildJvm, 0)
     val extraParameters = functionalTestExtraParameters("RerunFlakyTest", os, "%$testJvmVersionParameter%", "%$testJvmVendorParameter%")
     val parameters = (
         buildToolGradleParameters(daemon) +


### PR DESCRIPTION
30 min is usually not enough for reproducing a flaky test,
sometimes we need it to run hours.
