### PR TITLE
Notify VFS when creating manifest

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -144,6 +144,7 @@ public class GeneratedSingletonFileTree implements FileSystemMirroringFileTree, 
             if (file == null) {
                 file = createFileInstance(fileName);
                 if (!file.exists()) {
+                    fileGenerationListener.execute(file);
                     copyTo(file);
                 } else {
                     updateFileOnlyWhenGeneratedContentChanges();

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
@@ -52,6 +52,7 @@ class GeneratedSingletonFileTreeSpec extends Specification {
             assert details.file == generatedFile
             assert generatedFile.text == "contents!"
         }
+        1 * generationListener.execute(generatedFile)
         1 * contentWriter.execute(_) >> { OutputStream outputStream ->
             outputStream << "contents!"
         }
@@ -98,6 +99,7 @@ class GeneratedSingletonFileTreeSpec extends Specification {
             assert generatedFile.isFile()
             assert generatedFile.text == "contents!"
         }
+        1 * generationListener.execute(generatedFile)
         1 * contentWriter.execute(_) >> { OutputStream outputStream ->
             outputStream << "contents!"
         }


### PR DESCRIPTION
So we ignore late events and make sure we don't miss the modification.

I saw this pop up when implementing #18930, since continuous build picked up the modification of the newly created manifest and re-triggered a build.