### PR TITLE
Let Gradle create a "mirror" directory with downloaded artifacts

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -473,14 +473,19 @@ class DependencyManagementBuildScopeServices {
             externalResourceFileStore, artifactIdentifierFileStore);
     }
 
-    private ByUrlCachedExternalResourceIndex prepareArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceFileStore externalResourceFileStore, ArtifactCacheMetadata artifactCacheMetadata) {
-        return new ByUrlCachedExternalResourceIndex(
+    private CachedExternalResourceIndex<String> prepareArtifactUrlCachedResolutionIndex(BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, ExternalResourceFileStore externalResourceFileStore, ArtifactCacheMetadata artifactCacheMetadata) {
+        ByUrlCachedExternalResourceIndex byUrlCachedExternalResourceIndex = new ByUrlCachedExternalResourceIndex(
             "resource-at-url",
             timeProvider,
             artifactCacheLockingManager,
             externalResourceFileStore.getFileAccessTracker(),
             artifactCacheMetadata.getCacheDir().toPath()
         );
+        String mirrorDirectory = System.getProperty("org.gradle.download.mirror.directory", null);
+        if (mirrorDirectory != null) {
+            return byUrlCachedExternalResourceIndex.withMirrorDirectory(new File(mirrorDirectory));
+        }
+        return byUrlCachedExternalResourceIndex;
     }
 
     TextUriResourceLoader.Factory createTextUrlResourceLoaderFactory(FileStoreAndIndexProvider fileStoreAndIndexProvider, RepositoryTransportFactory repositoryTransportFactory, RelativeFilePathResolver resolver) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/cached/ByUrlCachedExternalResourceIndex.java
@@ -18,13 +18,85 @@ package org.gradle.internal.resource.cached;
 
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.internal.file.FileAccessTracker;
+import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.serialize.BaseSerializerFactory;
 import org.gradle.util.internal.BuildCommencedTimeProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ByUrlCachedExternalResourceIndex extends DefaultCachedExternalResourceIndex<String> {
+    private final static Logger LOGGER = LoggerFactory.getLogger(ByUrlCachedExternalResourceIndex.class);
+
     public ByUrlCachedExternalResourceIndex(String persistentCacheFile, BuildCommencedTimeProvider timeProvider, ArtifactCacheLockingManager artifactCacheLockingManager, FileAccessTracker fileAccessTracker, Path commonRootPath) {
         super(persistentCacheFile, BaseSerializerFactory.STRING_SERIALIZER, timeProvider, artifactCacheLockingManager, fileAccessTracker, commonRootPath);
+    }
+
+    /**
+     * Creates a resource index which will mirror every download to a local
+     * directory.
+     */
+    public CachedExternalResourceIndex<String> withMirrorDirectory(File path) {
+        return new FileMirroringExternalResourceIndex(path);
+    }
+
+    private class FileMirroringExternalResourceIndex implements CachedExternalResourceIndex<String> {
+        private final File mirrorDirectory;
+
+        public FileMirroringExternalResourceIndex(File path) {
+            this.mirrorDirectory = path;
+        }
+
+        @Override
+        public void store(String key, File artifactFile, @Nullable ExternalResourceMetaData metaData) {
+            ByUrlCachedExternalResourceIndex.this.store(key, artifactFile, metaData);
+            writeArtifactToMirrorDirectory(artifactFile, metaData);
+        }
+
+        private void writeArtifactToMirrorDirectory(File artifactFile, @Nullable ExternalResourceMetaData metaData) {
+            if (metaData != null) {
+                URI location = metaData.getLocation();
+                File repoDir = new File(mirrorDirectory, location.getHost());
+                File filePath = new File(repoDir, location.getPath()).getAbsoluteFile();
+                if (!filePath.exists()) {
+                    File parentDir = filePath.getParentFile();
+                    if (parentDir.isDirectory() || parentDir.mkdirs()) {
+                        try {
+                            Files.copy(artifactFile.toPath(), filePath.toPath());
+                        } catch (IOException e) {
+                            LOGGER.warn("Unable to copy file {} to {}", artifactFile, filePath);
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void storeMissing(String key) {
+            ByUrlCachedExternalResourceIndex.this.storeMissing(key);
+        }
+
+        @Nullable
+        @Override
+        public CachedExternalResource lookup(String key) {
+            CachedExternalResource lookup = ByUrlCachedExternalResourceIndex.this.lookup(key);
+            if (lookup != null) {
+                File cachedFile = lookup.getCachedFile();
+                ExternalResourceMetaData externalResourceMetaData = lookup.getExternalResourceMetaData();
+                writeArtifactToMirrorDirectory(cachedFile, externalResourceMetaData);
+            }
+            return lookup;
+        }
+
+        @Override
+        public void clear(String key) {
+            ByUrlCachedExternalResourceIndex.this.clear(key);
+        }
     }
 }


### PR DESCRIPTION
### Context

This commit introduces a system property, `org.gradle.download.mirror.directory`,
which, when set, would make Gradle copy all resources which it downloads during
the build into a local directory, in addition to its internal cache.

The rationale is to make it easier for external tooling to create mirrors of
repositories which are used during a build. Indeed, unlike Maven, Gradle copies
downloaded resources into an opaque cache directory structure (for good reasons),
but making it difficult to create a repository from scratch which would include
all the required dependencies.

The goal is slightly different from the 2-level dependency cache for CI: in this
case the goal is NOT to create an environment cache, but to create a trusted
repository that an organization can verify independently, track every single
dependency or file being downloaded and mirror into, say, an Artifactory or
Nexus server, which would then be used on _different_ builds.

There were several attempts in doing so. For example:

- https://github.com/uklance/gradle-dependency-export which cannot handle plugins
and has to deal with parent POMs/BOMs in a special manner since those are not
accessible via standard Gradle APIs
- https://github.com/melix/gradle-download-helper which does something similar
using the tooling API but has to download files by itself in a separate context,
while having the same problem with parent POMs and BOMs

This commit provides a _simple_ solution to this problem, which, while not perfect,
makes it much easier to create such a layout:

- you would run a build with a fresh Gradle home (-g newhome)
- and pass the `org.gradle.download.mirror.directory` property to a local directory

As soon as a file is downloaded, it would automatically be copied into that directory.
At the end of the build, you get a "local mirror" which could potentially be used
as a file repository or used as a source for uploading to a mirror.

If the Gradle team considers this as useful, I can add some integration tests to make sure it works as expected (I already successfully tested it for a couple projects).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
