### PR TITLE
Ignore native directory in UndefinedBuildExecutionIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/UndefinedBuildExecutionIntegrationTest.groovy
@@ -93,7 +93,7 @@ class UndefinedBuildExecutionIntegrationTest extends AbstractIntegrationSpec {
     }
 
     private void assertNoProjectCaches(TestFile dir) {
-        assert !(dir.list()?.findAll { it != "caches" })
+        assert !(dir.list()?.findAll { !(it in ["caches", "native"]) })
     }
 
     def "fails when user home directory is used and Gradle has not been run before"() {


### PR DESCRIPTION
that is only in the Gradle user home directory and not in the project cache
directory.

Follow up to #18981, given that it still seems to be flaky: https://ge.gradle.org/s/awsv5styankxw/tests/:core:forkingIntegTest/org.gradle.api.UndefinedBuildExecutionIntegrationTest/fails%20when%20attempting%20to%20execute%20tasks%20%5Btasks%5D%20in%20directory%20with%20no%20settings%20or%20build%20file?anchor=e30&focused-exception-line=0-2&top-execution=1