### PR TITLE
Refactor DefaultRootComponentMetadataBuilder to use Factory Pattern

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/internal/NameValidatorTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeContainer
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectInternal
@@ -41,11 +42,15 @@ class NameValidatorTest extends Specification {
     static forbiddenCharacters = NameValidator.FORBIDDEN_CHARACTERS
     static forbiddenLeadingAndTrailingCharacter = NameValidator.FORBIDDEN_LEADING_AND_TRAILING_CHARACTER
     static invalidNames = forbiddenCharacters.collect { "a${it}b" } + ["${forbiddenLeadingAndTrailingCharacter}ab", "ab${forbiddenLeadingAndTrailingCharacter}", '']
+    @Shared
+    def rootComponentMetaDataBuilderFactory = Mock(DefaultRootComponentMetadataBuilder.Factory) {
+        create(_) >> Mock(DefaultRootComponentMetadataBuilder)
+    }
 
     @Shared
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, CollectionCallbackActionDecorator.NOOP, null, TestUtil.objectFactory(), null)],
+        ["configurations", new DefaultConfigurationContainer(TestUtil.instantiatorFactory().decorateLenient(), null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, CollectionCallbackActionDecorator.NOOP, null, TestUtil.objectFactory(), rootComponentMetaDataBuilderFactory, null)],
         ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
         ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -62,7 +62,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomM
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorFactory;
@@ -201,6 +201,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         void configure(ServiceRegistration registration) {
             registration.add(DefaultTransformedVariantFactory.class);
             registration.add(DefaultConfigurationFactory.class);
+            registration.add(DefaultRootComponentMetadataBuilder.Factory.class);
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
@@ -330,8 +331,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         ConfigurationContainerInternal createConfigurationContainer(
             Instantiator instantiator,
-            DependencyMetaDataProvider metaDataProvider,
-            LocalComponentMetadataBuilder metaDataBuilder,
             GlobalDependencyResolutionRules globalDependencyResolutionRules,
             VcsMappingsStore vcsMappingsStore,
             ComponentIdentifierFactory componentIdentifierFactory,
@@ -339,16 +338,14 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             ImmutableModuleIdentifierFactory moduleIdentifierFactory,
             ComponentSelectorConverter componentSelectorConverter,
             DependencyLockingProvider dependencyLockingProvider,
-            ProjectStateRegistry projectStateRegistry,
             CollectionCallbackActionDecorator callbackDecorator,
             NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
             ObjectFactory objectFactory,
+            DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
             DefaultConfigurationFactory defaultConfigurationFactory
         ) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 instantiator,
-                metaDataProvider,
-                metaDataBuilder,
                 globalDependencyResolutionRules.getDependencySubstitutionRules(),
                 vcsMappingsStore,
                 componentIdentifierFactory,
@@ -356,10 +353,10 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 moduleIdentifierFactory,
                 componentSelectorConverter,
                 dependencyLockingProvider,
-                projectStateRegistry,
                 callbackDecorator,
                 moduleSelectorNotationParser,
                 objectFactory,
+                rootComponentMetadataBuilderFactory,
                 defaultConfigurationFactory
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -31,14 +31,12 @@ import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder;
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.CapabilitiesResolutionInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultCapabilitiesResolution;
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.notations.ComponentIdentifierParserFactory;
-import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
@@ -60,8 +58,6 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
 
     public DefaultConfigurationContainer(
         Instantiator instantiator,
-        DependencyMetaDataProvider dependencyMetaDataProvider,
-        LocalComponentMetadataBuilder localComponentMetadataBuilder,
         DependencySubstitutionRules globalDependencySubstitutionRules,
         VcsMappingsStore vcsMappingsStore,
         ComponentIdentifierFactory componentIdentifierFactory,
@@ -69,10 +65,10 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
         ComponentSelectorConverter componentSelectorConverter,
         DependencyLockingProvider dependencyLockingProvider,
-        ProjectStateRegistry projectStateRegistry,
         CollectionCallbackActionDecorator callbackDecorator,
         NotationParser<Object, ComponentSelector> moduleSelectorNotationParser,
         ObjectFactory objectFactory,
+        DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory,
         DefaultConfigurationFactory defaultConfigurationFactory
     ) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
@@ -81,7 +77,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             CapabilitiesResolutionInternal capabilitiesResolutionInternal = instantiator.newInstance(DefaultCapabilitiesResolution.class, new CapabilityNotationParserFactory(false).create(), new ComponentIdentifierParserFactory().create());
             return instantiator.newInstance(DefaultResolutionStrategy.class, globalDependencySubstitutionRules, vcsMappingsStore, componentIdentifierFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, capabilitiesResolutionInternal, instantiator, objectFactory, attributesFactory, moduleSelectorNotationParser, dependencyCapabilityNotationParser);
         };
-        this.rootComponentMetadataBuilder = new DefaultRootComponentMetadataBuilder(dependencyMetaDataProvider, componentIdentifierFactory, moduleIdentifierFactory, localComponentMetadataBuilder, this, projectStateRegistry, dependencyLockingProvider);
+        this.rootComponentMetadataBuilder = rootComponentMetadataBuilderFactory.create(this);
         this.defaultConfigurationFactory = defaultConfigurationFactory;
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDepen
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
@@ -75,7 +76,9 @@ class DefaultConfigurationContainerSpec extends Specification {
         decorateSpec(_) >> { Spec spec -> spec }
     }
     def immutableAttributesFactory = AttributeTestUtil.attributesFactory()
-
+    private DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory = Mock(DefaultRootComponentMetadataBuilder.Factory) {
+        create(_) >> Mock(DefaultRootComponentMetadataBuilder)
+    }
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
         instantiator,
         resolver,
@@ -95,8 +98,6 @@ class DefaultConfigurationContainerSpec extends Specification {
     )
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(
         instantiator,
-        metaDataProvider,
-        metaDataBuilder,
         globalSubstitutionRules,
         vcsMappingsInternal,
         componentIdentifierFactory,
@@ -104,10 +105,10 @@ class DefaultConfigurationContainerSpec extends Specification {
         moduleIdentifierFactory,
         componentSelectorConverter,
         dependencyLockingProvider,
-        projectStateRegistry,
         domainObjectCollectionCallbackActionDecorator,
         Mock(NotationParser),
         TestUtil.objectFactory(),
+        rootComponentMetadataBuilderFactory,
         configurationFactory
     )
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.PublishArtifactNotationParserFactory
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules
-import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder
+import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultRootComponentMetadataBuilder
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
@@ -52,7 +52,6 @@ class DefaultConfigurationContainerTest extends Specification {
     private ConfigurationResolver resolver = Mock(ConfigurationResolver)
     private ListenerManager listenerManager = Stub(ListenerManager.class)
     private DependencyMetaDataProvider metaDataProvider = Mock(DependencyMetaDataProvider.class)
-    private LocalComponentMetadataBuilder metaDataBuilder = Mock(LocalComponentMetadataBuilder)
     private ComponentIdentifierFactory componentIdentifierFactory = Mock(ComponentIdentifierFactory)
     private DependencySubstitutionRules globalSubstitutionRules = Mock(DependencySubstitutionRules)
     private VcsMappingsStore vcsMappingsInternal = Mock(VcsMappingsStore)
@@ -73,6 +72,9 @@ class DefaultConfigurationContainerTest extends Specification {
     }
     private ComponentSelectorConverter componentSelectorConverter = Mock()
     private DomainObjectContext domainObjectContext = new RootScriptDomainObjectContext()
+    private DefaultRootComponentMetadataBuilder.Factory rootComponentMetadataBuilderFactory = Mock(DefaultRootComponentMetadataBuilder.Factory) {
+        create(_) >> Mock(DefaultRootComponentMetadataBuilder)
+    }
     private DefaultConfigurationFactory configurationFactory = new DefaultConfigurationFactory(
         instantiator,
         resolver,
@@ -96,8 +98,6 @@ class DefaultConfigurationContainerTest extends Specification {
     )
     private DefaultConfigurationContainer configurationContainer = instantiator.newInstance(DefaultConfigurationContainer.class,
         instantiator,
-        metaDataProvider,
-        metaDataBuilder,
         globalSubstitutionRules,
         vcsMappingsInternal,
         componentIdentifierFactory,
@@ -105,10 +105,10 @@ class DefaultConfigurationContainerTest extends Specification {
         moduleIdentifierFactory,
         componentSelectorConverter,
         lockingProvider,
-        projectStateRegistry,
         callbackActionDecorator,
         Mock(NotationParser),
         TestUtil.objectFactory(),
+        rootComponentMetadataBuilderFactory,
         configurationFactory
     )
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultRootComponentMetadataBuilderTest.groovy
@@ -44,14 +44,16 @@ class DefaultRootComponentMetadataBuilderTest extends Specification {
 
     def mid = DefaultModuleIdentifier.newId('foo', 'bar')
 
-    def builder = new DefaultRootComponentMetadataBuilder(
+    def builderFactory = new DefaultRootComponentMetadataBuilder.Factory(
         metaDataProvider,
         componentIdentifierFactory,
         moduleIdentifierFactory,
         configurationComponentMetaDataBuilder,
-        configurationsProvider,
         projectStateRegistry,
-        dependencyLockingProvider)
+        dependencyLockingProvider
+    )
+
+    def builder = builderFactory.create(configurationsProvider)
 
     def "caches root component metadata"() {
         componentIdentifierFactory.createComponentIdentifier(_) >> {


### PR DESCRIPTION
Application of the Dependency Inversion Principle against the `DefaultRootComponentMetadataBuilder`