### PR TITLE
Disable stacktrace checking for TestVerificationFailureHandlingIntegr…

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestVerificationFailureHandlingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestVerificationFailureHandlingIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.testing
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.Matchers
 
 class TestVerificationFailureHandlingIntegrationTest extends AbstractIntegrationSpec {
@@ -124,9 +123,7 @@ class TestVerificationFailureHandlingIntegrationTest extends AbstractIntegration
      * Cause the test VM to fail at startup by providing an invalid JVM argument.
      */
     def withFatalTestExecutionError() {
-        if (OperatingSystem.current().windows) {
-            executer.withStackTraceChecksDisabled() // ignore additional ST only seen on Windows
-        }
+        executer.withStackTraceChecksDisabled() // ignore additional ST
         withPassingTest()
         buildFile << '''
             tasks.named('test', Test).configure {


### PR DESCRIPTION
…ationTest

Otherwise it's flaky because of the IOException stacktrace. e.g: https://ge.gradle.org/s/axa4pkgduy3nc/tests/:testing-jvm:noDaemonIntegTest/org.gradle.testing.TestVerificationFailureHandlingIntegrationTest/task%20does%20not%20execute%20when%20it%20has%20a%20test%20task%20output%20dependency%20and%20VM%20exits%20unexpectedly?top-execution=1