### PR TITLE
Flaky test quarantine: first step

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -29,6 +29,7 @@ import gradlebuild.basics.BuildParams.BUILD_SERVER_URL
 import gradlebuild.basics.BuildParams.BUILD_TIMESTAMP
 import gradlebuild.basics.BuildParams.BUILD_VCS_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_VERSION_QUALIFIER
+import gradlebuild.basics.BuildParams.FLAKY_TEST_QUARANTINE
 import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
 import gradlebuild.basics.BuildParams.INCLUDE_PERFORMANCE_TEST_SCENARIOS
@@ -71,6 +72,7 @@ object BuildParams {
     const val BUILD_VERSION_QUALIFIER = "versionQualifier"
     const val CI_ENVIRONMENT_VARIABLE = "CI"
     const val GRADLE_INSTALL_PATH = "gradle_installPath"
+    const val FLAKY_TEST_QUARANTINE = "flakyTestQuarantine"
     const val INCLUDE_PERFORMANCE_TEST_SCENARIOS = "includePerformanceTestScenarios"
     const val MAX_PARALLEL_FORKS = "maxParallelForks"
     const val PERFORMANCE_BASELINES = "performanceBaselines"
@@ -178,6 +180,10 @@ val Project.buildTimestamp: Provider<String>
 
 val Project.buildVersionQualifier: Provider<String>
     get() = gradleProperty(BUILD_VERSION_QUALIFIER)
+
+
+val Project.flakyTestQuarantine: Provider<String>
+    get() = gradleProperty(FLAKY_TEST_QUARANTINE)
 
 
 val Project.ignoreIncomingBuildReceipt: Provider<Boolean>

--- a/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
+++ b/build-logic/dependency-modules/src/main/kotlin/gradlebuild/modules/extension/ExternalModulesExtension.kt
@@ -95,6 +95,7 @@ abstract class ExternalModulesExtension {
     val julToSlf4j = "org.slf4j:jul-to-slf4j"
     val junit = "junit:junit"
     val junit5Vintage = "org.junit.vintage:junit-vintage-engine"
+    val junit5JupiterApi = "org.junit.jupiter:junit-jupiter-api"
     val junitPlatform = "org.junit.platform:junit-platform-launcher"
     val jzlib = "com.jcraft:jzlib"
     val kryo = "com.esotericsoftware.kryo:kryo"
@@ -229,6 +230,7 @@ abstract class ExternalModulesExtension {
         julToSlf4j to License.MIT,
         junit to License.EPL,
         junit5Vintage to License.EPL,
+        junit5JupiterApi to License.EPL,
         junitPlatform to License.EPL,
         jzlib to License.BSDStyle,
         kryo to License.BSD3,

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.operations.BuildOperationRef
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLockCoordinationService
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RELEASE_AND_REACQUIRE_PROJECT_LOCKS
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RELEASE_PROJECT_LOCKS
@@ -102,7 +102,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
         instant.waitFinished >= instant.completeWorker1
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3461")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3461")
     def "work can be submitted to one operation while another operation is being waited on"() {
         def operation1 = Mock(BuildOperationRef)
         def operation2 = Mock(BuildOperationRef)
@@ -219,7 +219,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
         e.causes.get(0).message == "BOOM!"
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3461")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3461")
     def "an error is thrown when work is submitted while being waited on"() {
         def operation1 = Mock(BuildOperationRef)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
+import org.gradle.test.fixtures.Flaky
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Requires
@@ -40,7 +41,7 @@ import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServi
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 import static org.hamcrest.Matchers.containsString
 
-@Issue("https://github.com/gradle/gradle-private/issues/3413")
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/3413")
 @Requires({ !GradleContextualExecuter.configCache })
 class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture, ValidationMessageChecker {
     private final static long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
         api(libs.jsr305)                { version { strictly("3.0.2") }}
         api(libs.julToSlf4j)            { version { strictly(slf4jVersion) }}
         api(libs.junit)                 { version { strictly("4.13.2") }}
+        api(libs.junit5JupiterApi)      { version { strictly("5.7.2") }}
         api(libs.junit5Vintage)         { version { strictly("5.7.2") }}
         api(libs.junitPlatform)         { version { strictly("1.7.2") }}
         api(libs.jzlib)                 { version { strictly("1.1.3") }}

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m3/ToolingApiEclipseModelCrossVersionSpec.groovy
@@ -20,11 +20,11 @@ import org.gradle.integtests.tooling.fixture.WithOldConfigurationsSupport
 import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.HierarchicalEclipseProject
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 class ToolingApiEclipseModelCrossVersionSpec extends ToolingApiSpecification implements WithOldConfigurationsSupport {
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3439')
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3439')
     def "can build the eclipse model for a java project"() {
 
         projectDir.file('build.gradle').text = '''
@@ -167,7 +167,7 @@ dependencies {
 
         eclipseProject.classpath.size() == 2
         eclipseProject.classpath.every { it instanceof ExternalDependency }
-        eclipseProject.classpath.collect { it.file.name } as Set == ['commons-lang-2.5.jar', 'commons-io-1.4.jar' ] as Set
+        eclipseProject.classpath.collect { it.file.name } as Set == ['commons-lang-2.5.jar', 'commons-io-1.4.jar'] as Set
         eclipseProject.classpath.collect { it.source?.name } as Set == ['commons-lang-2.5-sources.jar', 'commons-io-1.4-sources.jar'] as Set
         eclipseProject.classpath.collect { it.javadoc?.name } as Set == [null, null] as Set
     }
@@ -190,7 +190,7 @@ dependencies {
         minimalProject != null
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3439')
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3439')
     def "can build the eclipse project dependencies for a java project"() {
         projectDir.file("gradle.properties") << """
             org.gradle.parallel=$parallel
@@ -265,14 +265,14 @@ project(':c') {
         EclipseProject rootProject = loadToolingModel(EclipseProject)
 
         then:
-        def projectC = rootProject.children.find { it.name == 'c'}
-        def projectA = rootProject.children.find { it.name == 'a'}
+        def projectC = rootProject.children.find { it.name == 'c' }
+        def projectA = rootProject.children.find { it.name == 'a' }
 
-        projectC.projectDependencies.any {it.path == 'b'}
+        projectC.projectDependencies.any { it.path == 'b' }
 
-        projectA.projectDependencies.any {it.path == 'b'}
-        projectA.projectDependencies.any {it.path == 'c'}
-        projectA.projectDependencies.any {it.path == 'root'}
+        projectA.projectDependencies.any { it.path == 'b' }
+        projectA.projectDependencies.any { it.path == 'c' }
+        projectA.projectDependencies.any { it.path == 'root' }
     }
 
     def "can build the eclipse project hierarchy for a multi-project build"() {
@@ -351,7 +351,7 @@ configure(project(':bar')) {
         when:
         HierarchicalEclipseProject rootProject = loadToolingModel(HierarchicalEclipseProject)
         then:
-        rootProject.children.any { it.name == 'foo'}
-        rootProject.children.any { it.name == 'customized-bar'}
+        rootProject.children.any { it.name == 'foo' }
+        rootProject.children.any { it.name == 'customized-bar' }
     }
 }

--- a/subprojects/internal-testing/build.gradle.kts
+++ b/subprojects/internal-testing/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.asm)
     implementation(libs.asmTree)
     implementation(libs.junit)
+    implementation(libs.junit5JupiterApi)
     implementation(libs.spock)
     implementation(libs.spockJUnit4)
     implementation(libs.jsoup)

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/Flaky.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/Flaky.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures
+
+import org.junit.jupiter.api.Tag
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Marks a test as flaky. The flaky tests are quarantined to run
+ * at a special stage so it won't interrupt normal build pipeline.
+ *
+ * For Spock tests, including/excluding tests annotated by this annotation is handled by `SpockConfig.groovy` in classpath.
+ * For JUnit Jupiter tests, because it's a <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-meta-annotations">Meta-Annotation</a>,
+ *   tests annotated by this is handled by `JUnitPlatformOptions.includeTags/excludeTags`.
+ * For JUnit 4 tests, because we run them in Vintage engine, we have to annotate the tests with `@Category(Flaky.class)` so it can be transparently
+ *   recognized by `JUnitPlatformOptions.includeTags/excludeTags` (<a href="https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4-categories-support">Categories Support</a>).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@Tag("org.gradle.test.fixtures.Flaky")
+@interface Flaky {
+    /**
+     * Description or issue tracker link.
+     */
+    String because()
+}

--- a/subprojects/internal-testing/src/main/resources/FlakyTestQuarantineSpockConfig.groovy
+++ b/subprojects/internal-testing/src/main/resources/FlakyTestQuarantineSpockConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling
-
-import org.gradle.api.JavaVersion
 import org.gradle.test.fixtures.Flaky
 
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3430")
-class ToolingApiClientMinJdkCompatibilityTest extends ToolingApiClientJdkCompatibilityTest {
-    JavaVersion getClientJdkVersion() {
-        return JavaVersion.VERSION_1_8
+runner {
+    include {
+        annotation Flaky
     }
 }
+

--- a/subprojects/internal-testing/src/main/resources/SpockConfig.groovy
+++ b/subprojects/internal-testing/src/main/resources/SpockConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.tooling
-
-import org.gradle.api.JavaVersion
 import org.gradle.test.fixtures.Flaky
 
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3430")
-class ToolingApiClientMinJdkCompatibilityTest extends ToolingApiClientJdkCompatibilityTest {
-    JavaVersion getClientJdkVersion() {
-        return JavaVersion.VERSION_1_8
+runner {
+    exclude {
+        annotation Flaky
     }
 }
+

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -17,26 +17,22 @@
 package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import groovy.transform.CompileStatic
-
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
-import org.gradle.test.fixtures.file.LeaksFileHandles
-
 import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-
+import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.test.fixtures.Flaky
 import org.hamcrest.Matcher
-import spock.lang.Ignore
 
 import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.hasItems
+import static org.hamcrest.CoreMatchers.not
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.Assert.assertTrue
 
-
 @TargetGradleVersion(">=5.4")
-@Ignore('https://github.com/gradle/gradle-private/issues/3414')
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     def "can fetch buildSrc classpath in face of compilation errors"() {

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
@@ -17,18 +17,17 @@
 package org.gradle.kotlin.dsl.tooling.builders.r54
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
-
-import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVersionTest
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.startsWith
 import static org.hamcrest.MatcherAssert.assertThat
 
 @TargetGradleVersion(">=5.4")
-@Ignore('https://github.com/gradle/gradle-private/issues/3414')
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptModelCrossVersionTest {
 
     @LeaksFileHandles("Kotlin Compiler Daemon working directory")

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -18,11 +18,11 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Ignore('https://github.com/gradle/gradle-private/issues/3414')
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
 

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -18,11 +18,11 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Ignore('https://github.com/gradle/gradle-private/issues/3414')
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "can fetch model for a given set of scripts"() {

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -20,14 +20,13 @@ import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 import java.lang.reflect.Proxy
 
-
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Ignore('https://github.com/gradle/gradle-private/issues/3414')
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "single request models equal multi requests models"() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -20,8 +20,8 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.archives.TestReproducibleArchives
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.test.fixtures.Flaky
 import org.gradle.util.TestPrecondition
-import spock.lang.Ignore
 import spock.lang.Retry
 
 import static org.gradle.integtests.fixtures.RetryConditions.cleanProjectDir
@@ -83,7 +83,7 @@ jar.dependsOn postCompile
         assert classloader.loadClass('Thing').getDeclaredFields()*.name == ["CHANGED"]
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3460")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3460")
     @UnsupportedWithConfigurationCache(because = "taskGraph.afterTask")
     def "new build should be triggered when input files to tasks are changed after each task has been executed, but before the build has completed"(changingInput) {
         given:
@@ -132,7 +132,7 @@ jar.dependsOn postCompile
         changingInput << ['a', 'b', 'c', 'd']
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3460")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3460")
     def "new build should be triggered when input files to tasks are changed during the task is executing"(changingInput) {
         given:
         ['a', 'b', 'c', 'd'].each { file(it).createDir() }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.TestFile
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 import static org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory.QUIET_PERIOD_SYSPROP
 import static org.gradle.internal.filewatch.DefaultFileWatcherEventListener.SHOW_INDIVIDUAL_CHANGES_LIMIT
@@ -122,7 +122,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         changesCount << [1, changesLimit, 11]
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3205')
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3205')
     def "should report the changes when directories are created #changesCount"(changesCount) {
         given:
         def inputDirectories = (1..changesCount).collect { inputDir.file("input${it}Directory") }
@@ -141,7 +141,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         changesCount << [1, changesLimit, 11]
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3205')
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3205')
     def "should report the changes when directories are deleted #changesCount"(changesCount) {
         given:
         def inputDirectories = (1..changesCount).collect { inputDir.file("input${it}Directory").createDir() }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPlugin3Test.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaPlugin3Test.groovy
@@ -22,10 +22,11 @@ import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.scala.ScalaDoc
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.test.fixtures.Flaky
 import org.gradle.util.TestUtil
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import spock.lang.Issue
 
 import static org.gradle.api.tasks.TaskDependencyMatchers.dependsOn
@@ -33,19 +34,18 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.instanceOf
 import static org.hamcrest.MatcherAssert.assertThat
 
-@Ignore
 @Issue("https://github.com/gradle/gradle-private/issues/3440")
+@Category(Flaky)
 class ScalaPlugin3Test {
     @Rule
     public TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
 
-    private final Project project = TestUtil.create(temporaryFolder).rootProject()
-
-    private final ScalaPlugin scalaPlugin = new ScalaPlugin()
-
     @LeaksFileHandles
     @Test
     void addsScalaDoc3TasksToTheProject() {
+        Project project = TestUtil.create(temporaryFolder).rootProject()
+        ScalaPlugin scalaPlugin = new ScalaPlugin()
+
         scalaPlugin.apply(project)
         temporaryFolder.createFile('libs/scala3-library_3-3.0.1.jar)')
         project.dependencies.add('implementation', project.files('libs/scala3-library_3-3.0.1.jar)'))

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/ClientShutdownCrossVersionSpec.groovy
@@ -20,8 +20,8 @@ import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.tooling.model.gradle.GradleBuild
+import org.gradle.test.fixtures.Flaky
 import org.junit.Rule
-import spock.lang.Ignore
 
 class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
     private static final JVM_OPTS = ["-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError"] + NORMALIZED_BUILD_JVM_OPTS
@@ -49,7 +49,7 @@ class ClientShutdownCrossVersionSpec extends ToolingApiSpecification {
         thrown(IllegalStateException)
     }
 
-    @Ignore('https://github.com/gradle/gradle-private/issues/3477')
+    @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3477')
     def "cleans up idle daemons when tooling API session is shutdown"() {
         withConnection { connection ->
             connection.model(GradleBuild).setJvmArguments(buildJvmArguments).get()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ContinuousBuildProgressEventsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ContinuousBuildProgressEventsCrossVersionSpec.groovy
@@ -19,7 +19,7 @@ package org.gradle.integtests.tooling.r25
 import org.gradle.integtests.tooling.fixture.ContinuousBuildToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.tooling.BuildLauncher
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
 class ContinuousBuildProgressEventsCrossVersionSpec extends ContinuousBuildToolingApiSpecification {
 
@@ -29,7 +29,7 @@ class ContinuousBuildProgressEventsCrossVersionSpec extends ContinuousBuildTooli
         launcher.addProgressListener(events)
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3462")
+    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3462")
     def "client can receive appropriate logging and progress events for subsequent builds"() {
         when:
         def javaSrcFile = sourceDir.file("Thing.java") << 'public class Thing {}'

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientCurrentJdkCompatibilityTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClientCurrentJdkCompatibilityTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.integtests.tooling
 
 import org.gradle.api.JavaVersion
-import spock.lang.Ignore
+import org.gradle.test.fixtures.Flaky
 
-@Ignore("https://github.com/gradle/gradle-private/issues/3430")
+@Flaky(because = "https://github.com/gradle/gradle-private/issues/3430")
 class ToolingApiClientCurrentJdkCompatibilityTest extends ToolingApiClientJdkCompatibilityTest {
     JavaVersion getClientJdkVersion() {
         return JavaVersion.current()


### PR DESCRIPTION
In the past we use `@Ignore` to ignore flaky tests, which results in lost history. This PR introduces a `@FlakyTest` annotation, tests marked by this annotation will be ignored in normal build pipeline but executed in flaky quarantine build.