### PR TITLE
Input artifact should only be an incremental input

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -62,8 +62,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.INCREMENTAL;
 import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.NON_INCREMENTAL;
-import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.PRIMARY;
 import static org.gradle.internal.file.TreeType.DIRECTORY;
 import static org.gradle.internal.file.TreeType.FILE;
 
@@ -376,7 +376,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         @Override
         @OverridingMethodsMustInvokeSuper
         public void visitRegularInputs(InputVisitor visitor) {
-            visitor.visitInputFileProperty(INPUT_ARTIFACT_PROPERTY_NAME, PRIMARY,
+            visitor.visitInputFileProperty(INPUT_ARTIFACT_PROPERTY_NAME, INCREMENTAL,
                 new FileValueSupplier(
                     inputArtifactProvider,
                     transformer.getInputArtifactNormalizer(),

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -497,7 +497,7 @@ allprojects { p ->
                 output.convention(layout.buildDirectory.dir(providers.gradleProperty("\${project.name}DirName").orElse("\${project.name}-dir")))
                 def defaultContent = project.name
                 content.convention(providers.gradleProperty("\${project.name}Content").orElse(defaultContent))
-                def defaultNames = [project.name]
+                def defaultNames = providers.gradleProperty("\${project.name}EmptyDir").present ? [] : [project.name]
                 names.convention(providers.gradleProperty("\${project.name}Name").map { [it] }.orElse(defaultNames))
             """.stripIndent()
             producerConfigOverrides = """


### PR DESCRIPTION
but not a primary input. We don't know how to reconstruct the result when the input artifact is empty.

Fixes #19003