### PR TITLE
Specify gradlew Linux start script line ending in generated .gitattributes

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitAttributesGenerator.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/GitAttributesGenerator.java
@@ -33,7 +33,10 @@ public class GitAttributesGenerator implements BuildContentGenerator {
                 writer.println("#");
                 writer.println("# https://help.github.com/articles/dealing-with-line-endings/");
                 writer.println("#");
-                writer.println("# These are explicitly windows files and should use crlf");
+                writer.println("# Linux start script should use lf");
+                writer.println("/gradlew        text eol=lf");
+                writer.println();
+                writer.println("# These are Windows script files and should use crlf");
                 writer.println("*.bat           text eol=crlf");
                 writer.println();
             }


### PR DESCRIPTION
### Context
The `gradlew` start script is a Linux script and should therefore use `\n` (LF) as line ending. However, when users on Windows check out a Git project with a `gradlew` script, or when they restore the file from index the line endings might be changed to CRLF. This depends on the Git config, but if I recall correctly `core.autocrlf` is by default set to `true` when Git for Windows is installed.
These changed line endings can cause issues when Windows users then want to execute `gradlew` using WSL or copy it into a Docker image.

This pull request adds an entry for `gradlew` in the `.gitattributes` to specify that LF should be used as line ending.

Relates to #9583 (for which the `.gitattributes` file was originally added)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
