### PR TITLE
Spike saving time unpacking cache entries 

### DIFF
--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -43,7 +43,7 @@ abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
     def fileSystemSupport = new DefaultTarPackerFileSystemSupport(deleter)
     def streamHasher = new DefaultStreamHasher()
     def stringInterner = new StringInterner()
-    def packer = new TarBuildCacheEntryPacker(fileSystemSupport, filePermissionAccess, streamHasher, stringInterner)
+    def packer = new TarBuildCacheEntryPacker(fileSystemSupport, filePermissionAccess, stringInterner)
     def fileSystemAccess = TestFiles.fileSystemAccess()
 
     abstract protected FilePermissionAccess createFilePermissionAccess()

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/BuildCacheServices.java
@@ -42,7 +42,6 @@ import org.gradle.internal.SystemProperties;
 import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.FileException;
 import org.gradle.internal.hash.ChecksumService;
-import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.nativeintegration.network.HostnameLookup;
@@ -114,13 +113,12 @@ public final class BuildCacheServices extends AbstractPluginServiceRegistry {
             }
 
             BuildCacheEntryPacker createResultPacker(
-                TarPackerFileSystemSupport fileSystemSupport,
-                FileSystem fileSystem,
-                StreamHasher fileHasher,
-                StringInterner stringInterner
+                    TarPackerFileSystemSupport fileSystemSupport,
+                    FileSystem fileSystem,
+                    StringInterner stringInterner
             ) {
                 return new GZipBuildCacheEntryPacker(
-                    new TarBuildCacheEntryPacker(fileSystemSupport, new FilePermissionsAccessAdapter(fileSystem), fileHasher, stringInterner));
+                    new TarBuildCacheEntryPacker(fileSystemSupport, new FilePermissionsAccessAdapter(fileSystem), stringInterner));
             }
 
             OriginMetadataFactory createOriginMetadataFactory(

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
@@ -167,6 +167,12 @@ class HashCodeTest extends Specification {
         thrown Exception
     }
 
+    def "can parse hash through roundtrip"() {
+        expect:
+        def originalHash = Hashing.md5().hashString("asdf")
+        originalHash == HashCode.fromString(originalHash.toString())
+    }
+
     def "can create compact string representation"() {
         expect:
         Hashing.md5().hashString("").toCompactString() == "ck2u8j60r58fu0sgyxrigm3cu"


### PR DESCRIPTION
I was looking to save time in this failing performance test due to changes we made in the Java plugin:
https://builds.gradle.org/repository/download/Gradle_Master_Check_PerformanceTestTestLinux_Trigger/47375550:id/performance-test-results.zip%21/report/tests/clean-assemble-with-local-cache---largeJavaMultiProject---TaskOutputCachingJavaPerformanceTest.html?redirectSupported=false

This reports about ~100ms regression, which we think is driven by adding two configurations to every subproject at c4fe8a. 

This spike saves time when loading cache entries by saving the hash from the producer build in a special header in the cache entry.

When unpacking the cache entry, we then skip calculating the size and hash of the new file by pulling that information out of the tar entry.

https://builds.gradle.org/repository/download/Gradle_Master_Util_Performance_AdHocPerformanceScenarioLinux/47377214:id/results/performance/build/test-results-largeJavaMultiProjectPerformanceAdHocTest.zip!/clean-assemble-with-local-cache/benchmark.html

This appears to save ~38ms.