### PR TITLE
Deprecate creating a tar tree without a backing file

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/SkipWhenEmptyIntegrationTest.groovy
@@ -27,7 +27,6 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         emptyDirectory.zipTo(emptyZip)
         emptyDirectory.tarTo(emptyTar)
         buildFile << sourceTask
-        buildFile << getInputTarResource("emptyTar.tar")
         buildFile << """
             tasks.register("sourceTask", MySourceTask) {
                 sources.setFrom(${inputDeclaration})
@@ -46,7 +45,6 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         "empty directory as file tree"        | "fileTree(file('emptyDir'))"
         "empty zip tree"                      | "zipTree(file('emptyZip.zip'))"
         "empty tar tree"                      | "tarTree(file('emptyTar.tar'))"
-        "empty tar tree without backing file" | "tarTree(inputTarResource)"
         "empty directory"                     | "files('emptyDir')"
     }
 
@@ -58,7 +56,6 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         inputDirectory.zipTo(inputZip)
         inputDirectory.tarTo(inputTar)
         buildFile << sourceTask
-        buildFile << inputTarResource
         buildFile << """
             tasks.register("sourceTask", MySourceTask) {
                 sources.setFrom(${inputDeclaration})
@@ -77,7 +74,6 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
         "directory containing files as file tree"       | "fileTree(file('inputDir'))"
         "zip tree with files"                           | "zipTree(file('inputZip.zip'))"
         "tar tree with files"                           | "tarTree(file('inputTar.tar'))"
-        "tar tree without backing file with files"      | "tarTree(inputTarResource)"
     }
 
     def "emit a deprecation warning when file tree source does not ignore directories"() {
@@ -119,18 +115,6 @@ class SkipWhenEmptyIntegrationTest extends AbstractIntegrationSpec {
                     println("Running...")
                     outputFile.get().asFile.text = "executed"
                 }
-            }
-        """
-    }
-
-    private String getInputTarResource(String fileName = "inputTar.tar") {
-        """
-            def inputTarFile = file("${fileName}")
-            def inputTarResource = new ReadableResource() {
-                InputStream read() { Files.newInputStream(inputTarFile.toPath()) }
-                String displayName = "readable resource"
-                URI URI = uri("https://test.com")
-                String baseName = "base name"
             }
         """
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -238,6 +238,9 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             }
 '''
         when:
+        executer.expectDeprecationWarning(
+            "Creating a tarTree from a resource without a backing file has been deprecated. " +
+            "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file.")
         run 'copy'
         then:
         file('dest').assertHasDescendants('someDir/1.txt')

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -239,8 +239,9 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
 '''
         when:
         executer.expectDocumentedDeprecationWarning(
-            "Creating a tarTree from a resource without a backing file has been deprecated. " +
-                "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file. " +
+            "Using tarTree() on a resource without a backing file has been deprecated. " +
+                "This will fail with an error in Gradle 8.0. " +
+                "Convert the resource to a file and then pass this file to tarTree(). For converting the resource to a file you can use a custom task or declare a dependency. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#tar_tree_no_backing_file"
         )
         run 'copy'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/bundling/ArchiveIntegrationTest.groovy
@@ -238,9 +238,11 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
             }
 '''
         when:
-        executer.expectDeprecationWarning(
+        executer.expectDocumentedDeprecationWarning(
             "Creating a tarTree from a resource without a backing file has been deprecated. " +
-            "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file.")
+                "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#tar_tree_no_backing_file"
+        )
         run 'copy'
         then:
         file('dest').assertHasDescendants('someDir/1.txt')

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -198,7 +198,7 @@ public class DefaultFileOperations implements FileOperations {
                 DeprecationLogger.deprecateAction("Creating a tarTree from a resource without a backing file")
                     .withAdvice("Use a task or declare a dependency to create the tar file.")
                     .willBecomeAnErrorInGradle8()
-                    .undocumented()
+                    .withUpgradeGuideSection(7, "tar_tree_no_backing_file")
                     .nagUser();
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileOperations.java
@@ -195,8 +195,8 @@ public class DefaultFileOperations implements FileOperations {
             boolean hasBackingFile = tarPath instanceof ReadableResourceInternal
                 && ((ReadableResourceInternal) tarPath).getBackingFile() != null;
             if (!hasBackingFile) {
-                DeprecationLogger.deprecateAction("Creating a tarTree from a resource without a backing file")
-                    .withAdvice("Use a task or declare a dependency to create the tar file.")
+                DeprecationLogger.deprecateAction("Using tarTree() on a resource without a backing file")
+                    .withAdvice("Convert the resource to a file and then pass this file to tarTree(). For converting the resource to a file you can use a custom task or declare a dependency.")
                     .willBecomeAnErrorInGradle8()
                     .withUpgradeGuideSection(7, "tar_tree_no_backing_file")
                     .nagUser();

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -73,12 +73,13 @@ Finally, using `@link:{javadocPath}/org/gradle/api/tasks/InputDirectory.html[Inp
 The same is true for `@link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#dir-java.lang.Object-[inputs.dir()]` when registering an input directory via the runtime API.
 
 [[tar_tree_no_backing_file]]
-==== Tar trees from resources without backing files
+==== TAR trees from resources without backing files
 
-It is possible to create tar trees from arbitrary resources.
+It is possible to create TAR trees from arbitrary resources.
 If the resource is not created via `project.resources`, then it may not have a backing file.
-Creating a tar tree from a resource with no backing file has been deprecated.
-Instead of using a resource without a backing file it seems to be better to have a task to download or create the tar file or use dependency management to download the file from an URL.
+Creating a TAR tree from a resource with no backing file has been deprecated.
+Instead, convert the resource to a file and use `project.tarTree()` on the file.
+To convert the resource to a file you can use a custom task or use dependency management to download the file via a URL.
 This way, Gradle is able to apply optimizations like up-to-date checks instead of re-running the logic to create the resource every time.
 
 [[changes_7.3]]

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -72,6 +72,15 @@ To ignore directories in Gradle 8.0 and later, the input property needs to be an
 Finally, using `@link:{javadocPath}/org/gradle/api/tasks/InputDirectory.html[InputDirectory]` implies `@IgnoreEmptyDirectories`, so no changes are necessary when using this annotation.
 The same is true for `@link:{javadocPath}/org/gradle/api/tasks/TaskInputs.html#dir-java.lang.Object-[inputs.dir()]` when registering an input directory via the runtime API.
 
+[[tar_tree_no_backing_file]]
+==== Tar trees from resources without backing files
+
+It is possible to create tar trees from arbitrary resources.
+If the resource is not created via `project.resources`, then it may not have a backing file.
+Creating a tar tree from a resource with no backing file has been deprecated.
+Instead of using a resource without a backing file it seems to be better to have a task to download or create the tar file or use dependency management to download the file from an URL.
+This way, Gradle is able to apply optimizations like up-to-date checks instead of re-running the logic to create the resource every time.
+
 [[changes_7.3]]
 == Upgrading from 7.2 and earlier
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -472,6 +472,10 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                 }))
             }
         """
+        executer.expectDeprecationWarning(
+            "Creating a tarTree from a resource without a backing file has been deprecated. " +
+            "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file."
+        )
 
         expect:
         fails("taskWithInvalidOutput")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -472,9 +472,10 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                 }))
             }
         """
-        executer.expectDeprecationWarning(
+        executer.expectDocumentedDeprecationWarning(
             "Creating a tarTree from a resource without a backing file has been deprecated. " +
-            "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file."
+                "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file. " +
+                "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#tar_tree_no_backing_file"
         )
 
         expect:

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -473,8 +473,9 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         executer.expectDocumentedDeprecationWarning(
-            "Creating a tarTree from a resource without a backing file has been deprecated. " +
-                "This will fail with an error in Gradle 8.0. Use a task or declare a dependency to create the tar file. " +
+            "Using tarTree() on a resource without a backing file has been deprecated. " +
+                "This will fail with an error in Gradle 8.0. " +
+                "Convert the resource to a file and then pass this file to tarTree(). For converting the resource to a file you can use a custom task or declare a dependency. " +
                 "Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#tar_tree_no_backing_file"
         )
 


### PR DESCRIPTION
Having tar tree without a backing file doesn't seem super useful and makes our code much more complex.

Fixes #18854