### PR TITLE
Fix multiple annotation processing issues discovered by Micronaut

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.integtests.fixtures.CompilationOutputsFixture
 import org.gradle.language.fixtures.AnnotationProcessorFixture
 import org.gradle.language.fixtures.CompileJavaBuildOperationsFixture
 import org.gradle.test.fixtures.file.TestFile
+import org.intellij.lang.annotations.Language
 
 abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
 
@@ -53,6 +54,9 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
             dependencies {
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")
+
+                testCompileOnly project(":annotation")
+                testAnnotationProcessor project(":processor")
             }
         """
 
@@ -70,7 +74,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
         processor.writeAnnotationProcessorTo(processorProjectDir)
     }
 
-    protected final File java(String... classBodies) {
+    protected final File java(@Language("java") String... classBodies) {
         javaInPackage('', classBodies)
     }
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -436,7 +436,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         succeeds "compileJava"
     }
 
-    @Issue("https://https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6536")
     def "does not reprocess if nothing in the current sourceSet changed"() {
         given:
         withProcessor(new AnnotatedGeneratedClassProcessorFixture())

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -436,6 +436,23 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         succeeds "compileJava"
     }
 
+    @Issue("https://https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    def "does not reprocess if nothing in the current sourceSet changed"() {
+        given:
+        withProcessor(new AnnotatedGeneratedClassProcessorFixture())
+        javaTestSourceFile "@Bean class Test {}"
+        outputs.snapshot { succeeds "compileTestJava" }
+
+        when:
+        java "class Unrelated {}"
+
+        then:
+        succeeds "compileTestJava"
+
+        and:
+        outputs.recompiledClasses("Unrelated")
+    }
+
     private boolean serviceRegistryReferences(String... services) {
         def registry = file("build/classes/java/main/ServiceRegistryResource.txt").text
         services.every() {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -61,7 +61,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
-    @Issue("https://https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    @Issue("https://github.com/micronaut-projects/micronaut-core/issues/6536")
     def "remembers generated files across multiple compilations"() {
         given:
         def a = java "@Helper class A {}"

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -61,6 +61,25 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.recompiledFiles("A", "AHelper", "AHelperResource.txt")
     }
 
+    @Issue("https://https://github.com/micronaut-projects/micronaut-core/issues/6536")
+    def "remembers generated files across multiple compilations"() {
+        given:
+        def a = java "@Helper class A {}"
+        def b = java "@Helper class B {}"
+        java "class Unrelated {}"
+        run "compileJava"
+        a.text = "@Helper class A { public void foo() {} }"
+        outputs.snapshot { run "compileJava" }
+
+        when:
+        b.text = " class B { }"
+        run "compileJava"
+
+        then:
+        outputs.deletedFiles("BHelper", "BHelperResource")
+        outputs.recompiledFiles("B")
+    }
+
     def "generated files are recompiled when annotated file is affected by a change"() {
         given:
         def util = java "class Util {}"

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysis.java
@@ -157,6 +157,9 @@ public class ClassSetAnalysis {
      * - the originating types of generated classes that need to be recompiled, since they wouldn't exist if the originating type is not reprocessed
      */
     public Set<String> getTypesToReprocess(Set<String> compiledClasses) {
+        if (compiledClasses.isEmpty()) {
+            return Collections.emptySet();
+        }
         Set<String> typesToReprocess = new HashSet<>(annotationProcessingData.getAggregatedTypes());
         for (Map.Entry<String, Set<String>> entry : annotationProcessingData.getGeneratedTypesByOrigin().entrySet()) {
             if (entry.getValue().stream().anyMatch(compiledClasses::contains)) {


### PR DESCRIPTION
- Don't reprocess types when there is nothing to compile
- Merge annotation processing data across subsequent compilations

Fixes https://github.com/micronaut-projects/micronaut-core/issues/6536

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
