### PR TITLE
CC-compatible jacoco and test aggregation

### DIFF
--- a/subprojects/docs/src/docs/dsl/dsl.xml
+++ b/subprojects/docs/src/docs/dsl/dsl.xml
@@ -602,6 +602,12 @@
             <tr>
                 <td>org.gradle.api.reporting.ReportingExtension</td>
             </tr>
+            <tr>
+                <td>org.gradle.api.tasks.testing.AggregateTestReport</td>
+            </tr>
+            <tr>
+                <td>org.gradle.testing.jacoco.plugins.JacocoCoverageReport</td>
+            </tr>
         </table>
     </section>
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.AggregateTestReport.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.testing.AggregateTestReport.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>reportTask</td>
+            </tr>
+            <tr>
+                <td>testType</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoCoverageReport.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoCoverageReport.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>reportTask</td>
+            </tr>
+            <tr>
+                <td>testType</td>
+            </tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/userguide/jvm/jacoco_report_aggregation_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jacoco_report_aggregation_plugin.adoc
@@ -1,0 +1,23 @@
+// Copyright 2021 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[jacoco_report_aggregation_plugin]]
+= The JaCoCo Report Aggregation Plugin
+
+The JaCoCo Report Aggregation plugin (plugin id: `jacoco-report-aggregation`) provides the ability to aggregate the results of multiple JaCoCo code coverage reports into a single HTML report.  The binary data backing the coverage reports are produced by link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task invocations; see more at the <<jacoco_plugin#jacoco_plugin,JaCoCo Plugin>> chapter. This aggregation is done in a way that is compatible with the <<configuration_cache#config_cache,configuration cache>>.
+
+The plugin adds configurations and artifact views which collect variants exposed by the JaCoCo Plugin. More details TBD
+[[sec:test_report_aggregation_usage]]
+== Usage
+TBD

--- a/subprojects/docs/src/docs/userguide/jvm/test_report_aggregation_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/test_report_aggregation_plugin.adoc
@@ -1,0 +1,23 @@
+// Copyright 2021 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[test_report_aggregation_plugin]]
+= The Test Report Aggregation Plugin
+
+The Test Report Aggregation plugin (plugin id: `test-report-aggregation`) provides tasks and configurations which can be used to aggregate the results of multiple link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task invocations into a single HTML report.  This aggregation is done in a way that is compatible with the <<configuration_cache#config_cache,configuration cache>>.
+
+The plugin adds configurations and artifact views which collect variants exposed by the JVM Test Suite plugin. More details TBD
+[[sec:test_report_aggregation_usage]]
+== Usage
+TBD

--- a/subprojects/jacoco/build.gradle.kts
+++ b/subprojects/jacoco/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testFixturesImplementation(project(":core"))
     testFixturesImplementation(project(":internal-integ-testing"))
     testFixturesImplementation(libs.jsoup)
+    testFixturesImplementation(libs.groovyXml)
 
     testImplementation(project(":internal-testing"))
     testImplementation(project(":resources"))

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
+
+class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        multiProjectBuild("root", ["application", "direct", "transitive"]) {
+            buildFile << """
+                allprojects {
+                    repositories {
+                        ${mavenCentralRepository()}
+                    }
+                }
+                subprojects {
+                    plugins.withId('java') {
+                        testing {
+                            suites {
+                                test {
+                                    useJUnit()
+                                }
+                            }
+                        }
+                    }
+                }
+            """
+            file("application/build.gradle") << """
+                plugins {
+                    id 'java'
+                    id 'jacoco'
+                }
+
+                dependencies {
+                    implementation project(":direct")
+                }
+            """
+            file("application/src/main/java/application/Adder.java").java """
+                package application;
+
+                public class Adder {
+                    int add(int x, int y) {
+                        return x+y;
+                    }
+                }
+            """
+            file("application/src/test/java/application/AdderTest.java").java """
+                package application;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class AdderTest {
+                    @Test
+                    public void testAdd() {
+                        Adder adder = new Adder();
+                        Assert.assertEquals(2, adder.add(1, 1));
+                        Assert.assertEquals(4, adder.add(2, 2));
+                        Assert.assertEquals(3, adder.add(1, 2));
+                    }
+                }
+            """
+
+            file("direct/build.gradle") << """
+                plugins {
+                    id 'java'
+                    id 'jacoco'
+                }
+
+                dependencies {
+                    implementation project(":transitive")
+                }
+            """
+            file("direct/src/main/java/direct/Multiplier.java").java """
+                package direct;
+
+                public class Multiplier {
+                    int multiply(int x, int y) {
+                        return x*y;
+                    }
+                }
+            """
+            file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Multiplier multiplier = new Multiplier();
+                        Assert.assertEquals(1, multiplier.multiply(1, 1));
+                        Assert.assertEquals(4, multiplier.multiply(2, 2));
+                        Assert.assertEquals(2, multiplier.multiply(1, 2));
+                    }
+                }
+            """
+            file("transitive/build.gradle") << """
+                plugins {
+                    id 'java'
+                    id 'jacoco'
+                }
+            """
+            file("transitive/src/main/java/transitive/Powerize.java").java """
+                package transitive;
+
+                public class Powerize {
+                    int pow(int x, int y) {
+                        return (int)Math.pow(x, y);
+                    }
+                }
+            """
+            file("transitive/src/test/java/transitive/PowerizeTest.java").java """
+                package transitive;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class PowerizeTest {
+                    @Test
+                    public void testPow() {
+                        Powerize powerize = new Powerize();
+                        Assert.assertEquals(1, powerize.pow(1, 1));
+                        Assert.assertEquals(4, powerize.pow(2, 2));
+                        Assert.assertEquals(1, powerize.pow(1, 2));
+                    }
+                }
+            """
+        }
+    }
+
+    def "can aggregate jacoco execution data from subprojects"() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+
+        when:
+        succeeds(":application:testCodeCoverageReport")
+
+        then:
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("application.Adder")
+        report.assertHasClassCoverage("direct.Multiplier")
+        report.assertHasClassCoverage("transitive.Powerize")
+    }
+
+    def "aggregated report does not contain external dependencies"() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+        file("transitive/build.gradle") << """
+            dependencies {
+                implementation 'org.apache.commons:commons-io:1.3.2'
+            }
+        """
+
+        when:
+        succeeds(":application:testCodeCoverageReport")
+
+        then:
+        def report = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
+    }
+
+    def 'multiple test suites create multiple aggregation tasks'() {
+        given:
+        file("transitive/build.gradle") << """
+            testing {
+                suites {
+                    integTest(JvmTestSuite) {
+                        testType = TestType.INTEGRATION_TESTS
+                        useJUnit()
+                        dependencies {
+                          implementation project
+                        }
+                    }
+                }
+            }
+        """
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+
+            testing {
+                suites {
+                    integTest(JvmTestSuite) {
+                        testType = TestType.INTEGRATION_TESTS
+                        useJUnit()
+                        dependencies {
+                            implementation project(':transitive') // necessary to access Divisor when compiling test
+                        }
+                    }
+                }
+            }
+        """
+
+        file("transitive/src/main/java/transitive/Divisor.java").java """
+                package transitive;
+
+                public class Divisor {
+                    public int div(int x, int y) {
+                        return x / y;
+                    }
+                    public int mod(int x, int y) {
+                        return x % y;
+                    }
+                }
+            """
+
+        file("application/src/integTest/java/application/DivTest.java").java """
+                package application;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+                import transitive.Divisor;
+
+                public class DivTest {
+                    @Test
+                    public void testDiv() {
+                        Divisor divisor = new Divisor();
+                        Assert.assertEquals(2, divisor.div(4, 2));
+                    }
+                }
+            """
+        file("transitive/src/integTest/java/transitive/ModTest.java").java """
+                package transitive;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class ModTest {
+                    @Test
+                    public void testMod() {
+                        Divisor divisor = new Divisor();
+                        Assert.assertEquals(1, divisor.mod(5, 2));
+                    }
+                }
+            """
+
+        when:
+        succeeds(":application:testCodeCoverageReport", ":application:integTestCodeCoverageReport")
+
+        then:
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("transitive/build/jacoco/integTest.exec").assertExists()
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("direct/build/jacoco/integTest.exec").assertDoesNotExist()
+        file("application/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/integTest.exec").assertExists()
+
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+        file("application/build/reports/jacoco/integTestCodeCoverageReport/html/index.html").assertExists()
+
+        def testReport = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        testReport.assertHasClassCoverage("application.Adder")
+        testReport.assertHasClassCoverage("direct.Multiplier")
+        testReport.assertHasClassCoverage("transitive.Powerize")
+        testReport.assertHasClassButNoCoverage("transitive.Divisor")
+
+        def integTestReport = new JacocoReportXmlFixture(file("application/build/reports/jacoco/integTestCodeCoverageReport/integTestCodeCoverageReport.xml"))
+        integTestReport.assertHasClassButNoCoverage("application.Adder")
+        integTestReport.assertHasClassButNoCoverage("direct.Multiplier")
+        integTestReport.assertHasClassButNoCoverage("transitive.Powerize")
+        integTestReport.assertHasClassCoverage("transitive.Divisor")
+    }
+
+    def "can aggregate jacoco reports from root project"() {
+        given:
+        buildFile << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+
+            dependencies {
+                jacocoAggregation project(":application")
+                jacocoAggregation project(":direct")
+            }
+
+            reporting {
+                reports {
+                    testCodeCoverageReport(JacocoCoverageReport) {
+                        testType = TestType.UNIT_TESTS
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds(":testCodeCoverageReport")
+
+        then:
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("application.Adder")
+        report.assertHasClassCoverage("direct.Multiplier")
+        report.assertHasClassCoverage("transitive.Powerize")
+    }
+
+    def 'test verification failure prevents creation of aggregated report'() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Assert.fail("intentional failure to test jacoco coverage figures");
+                        Multiplier multiplier = new Multiplier();
+                        Assert.assertEquals(1, multiplier.multiply(1, 1));
+                        Assert.assertEquals(4, multiplier.multiply(2, 2));
+                        Assert.assertEquals(2, multiplier.multiply(1, 2));
+                    }
+                }
+            """
+
+        when:
+        def result = fails(":application:testCodeCoverageReport")
+
+        then:
+        result.assertTaskNotExecuted(':transitive:test')
+        result.assertTaskNotExecuted(':application:testCodeCoverageReport"')
+
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("transitive/build/jacoco/test.exec").assertDoesNotExist()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertDoesNotExist()
+        file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").assertDoesNotExist()
+    }
+
+    def 'test verification failure creates aggregated report with --continue flag'() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Assert.fail("intentional failure to test jacoco coverage figures");
+                    }
+                }
+            """
+
+        when:
+        def result = fails(":application:testCodeCoverageReport", "--continue")
+
+        then:
+        result.assertTaskExecuted(':direct:test')
+        result.assertTaskExecuted(':transitive:test')
+        result.assertTaskExecuted(':application:test')
+        result.assertTaskExecuted(':application:testCodeCoverageReport')
+
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+        file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("application.Adder")
+        report.assertHasClassButNoCoverage("direct.Multiplier") // direct will _not_ have coverage as its test task has a verification failure
+        report.assertHasClassCoverage("transitive.Powerize")
+    }
+
+    def 'catastrophic failure of single test prevents creation of aggregated report'() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        System.exit(42); // prematurely exit the testing VM
+                    }
+                }
+            """
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        def result = fails(":application:testCodeCoverageReport", "--continue")
+
+        then:
+        result.assertTaskExecuted(':direct:test')
+        result.assertTaskExecuted(':transitive:test')
+        result.assertTaskExecuted(':application:test')
+        result.assertTaskNotExecuted(':application:testCodeCoverageReport')
+
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        // despite --continue flag, :application:testCodeCoverageReport will not execute due to catastrophic failure in :direct:test
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertDoesNotExist()
+        file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").assertDoesNotExist()
+    }
+
+    def 'catastrophic failure of every test task prevents creation of aggregated report'() {
+        given:
+        // prevent all test VMs from starting
+        buildFile << '''
+                subprojects {
+                    plugins.withId('java') {
+                        testing {
+                            suites {
+                                test {
+                                    useJUnit()
+                                    jvmArgs '-XX:UnknownArgument'
+                                }
+                            }
+                        }
+                    }
+                }
+
+        '''
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+
+        when:
+        def result = fails(":application:testCodeCoverageReport", "--continue")
+
+        then:
+        result.assertTaskNotExecuted(':direct:test')
+        result.assertTaskNotExecuted(':transitive:test')
+        result.assertTaskNotExecuted(':application:test')
+        result.assertTaskNotExecuted(':application:testCodeCoverageReport')
+
+        file("direct/build/jacoco/test.exec").assertDoesNotExist()
+        file("transitive/build/jacoco/test.exec").assertDoesNotExist()
+        file("application/build/jacoco/test.exec").assertDoesNotExist()
+
+        // despite --continue flag, :application:testCodeCoverageReport will not execute due to catastrophic failures
+        file("application/build/reports/jacoco/testCodeCoverageReport/html/index.html").assertDoesNotExist()
+        file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml").assertDoesNotExist()
+    }
+
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -238,9 +238,16 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
                 coverageData project
             }
 
+            // Extract the artifact view for cc compatibility by providing it as an explicit task input
+            def artifactView = coverageDataConfig.incoming.artifactView { view ->
+                                   view.componentFilter { it in ProjectComponentIdentifier }
+                                   view.lenient = true
+                               }
+
             def testResolve = tasks.register('testResolve') {
+                inputs.files(artifactView.files)
                 doLast {
-                    assert coverageDataConfig.resolvedConfiguration.files*.name == [test.jacoco.destinationFile.name]
+                    assert inputs.files.singleFile.name == 'jacocoData.exec'
                 }
             }
             """.stripIndent()
@@ -296,9 +303,16 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
+            // Extract the artifact view for cc compatibility by providing it as an explicit task input
+            def artifactView = coverageDataConfig.incoming.artifactView { view ->
+                                   view.componentFilter { it in ProjectComponentIdentifier }
+                                   view.lenient = true
+                               }
+
             def testResolve = tasks.register('testResolve') {
+                inputs.files(artifactView.files)
                 doLast {
-                    assert coverageDataConfig.getResolvedConfiguration().getFiles()*.getName() == ["subA.exec", "subB.exec"]
+                    assert inputs.files*.name == ["subA.exec", "subB.exec"]
                 }
             }
             """.stripIndent()
@@ -357,9 +371,17 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
+
+            // Extract the artifact view for cc compatibility by providing it as an explicit task input
+            def artifactView = coverageDataConfig.incoming.artifactView { view ->
+                                   view.componentFilter { it in ProjectComponentIdentifier }
+                                   view.lenient = true
+                               }
+
             def testResolve = tasks.register('testResolve') {
+                inputs.files(artifactView.files)
                 doLast {
-                    assert coverageDataConfig.getResolvedConfiguration().getFiles()*.getName() == ["direct.exec", "transitive.exec"]
+                    assert inputs.files*.name == ["direct.exec", "transitive.exec"]
                 }
             }
             """.stripIndent()

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/DefaultJacocoCoverageReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/DefaultJacocoCoverageReport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jacoco;
+
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.testing.jacoco.plugins.JacocoCoverageReport;
+import org.gradle.testing.jacoco.tasks.JacocoReport;
+
+import javax.inject.Inject;
+
+public abstract class DefaultJacocoCoverageReport implements JacocoCoverageReport {
+    private final String name;
+    private final TaskProvider<JacocoReport> reportTask;
+
+    @Inject
+    public DefaultJacocoCoverageReport(String name, TaskContainer tasks) {
+        this.name = name;
+        this.reportTask = tasks.register(name, JacocoReport.class, task -> {
+            task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+            task.setDescription("Generates aggregated code coverage report.");
+
+            task.reports(reports -> {
+                reports.getXml().getRequired().convention(true);
+                reports.getHtml().getRequired().convention(true);
+            });
+        });
+    }
+
+    @Override
+    public TaskProvider<JacocoReport> getReportTask() {
+        return reportTask;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoCoverageReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoCoverageReport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+import org.gradle.api.reporting.ReportSpec;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.testing.jacoco.tasks.JacocoReport;
+
+/**
+ * A container for the inputs of an aggregated JaCoCo code coverage report.
+ *
+ * @since 7.4
+ */
+@Incubating
+public interface JacocoCoverageReport extends ReportSpec {
+
+    /**
+     * Contains the {@link JacocoReport} task instance which produces this report
+     *
+     * @return the task instance
+     */
+    TaskProvider<JacocoReport> getReportTask();
+
+    /**
+     * Contains a value representing the type of test suite this task belongs to.  See static constants on {@link org.gradle.api.attributes.TestType} for examples.
+     *
+     * @return this report's test type
+     */
+    Property<String> getTestType();
+}

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -123,16 +123,17 @@ public class JacocoPlugin implements Plugin<Project> {
         variant.setVisible(false);
         variant.setCanBeResolved(false);
         variant.setCanBeConsumed(true);
-        variant.extendsFrom(project.getConfigurations().getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+        variant.extendsFrom(project.getConfigurations().getByName(suite.getSources().getImplementationConfigurationName()),
+                project.getConfigurations().getByName(suite.getSources().getRuntimeOnlyConfigurationName()));
 
         final ObjectFactory objects = project.getObjects();
         variant.attributes(attributes -> {
-            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
             attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
             attributes.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.JACOCO_COVERAGE));
-            attributes.attribute(Verification.TEST_SUITE_NAME_ATTRIBUTE, objects.named(Verification.class, suite.getName()));
             attributes.attribute(Verification.TARGET_NAME_ATTRIBUTE, objects.named(Verification.class, suite.getName()));
+            attributes.attribute(Verification.TEST_SUITE_NAME_ATTRIBUTE, objects.named(Verification.class, suite.getName()));
             attributes.attributeProvider(TestType.TEST_TYPE_ATTRIBUTE, suite.getTestType().map(tt -> objects.named(TestType.class, tt)));
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
         });
 
         variant.getOutgoing().artifact(target.getTestTask().map(task -> task.getExtensions().getByType(JacocoTaskExtension.class).getDestinationFile()), artifact -> {
@@ -210,7 +211,7 @@ public class JacocoPlugin implements Plugin<Project> {
 
     private void configureJacocoReportDefaults(final JacocoPluginExtension extension, final JacocoReport reportTask) {
         reportTask.getReports().all(action(report ->
-            report.getRequired().set(report.getName().equals("html"))
+            report.getRequired().convention(report.getName().equals("html"))
         ));
         DirectoryProperty reportsDir = extension.getReportsDirectory();
         reportTask.getReports().all(action(report -> {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins;
+
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.Sources;
+import org.gradle.api.attributes.TestType;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.internal.jacoco.DefaultJacocoCoverageReport;
+import org.gradle.testing.base.TestSuite;
+import org.gradle.testing.base.TestingExtension;
+import org.gradle.testing.jacoco.tasks.JacocoReport;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Adds configurations to for resolving variants containing JaCoCo code coverage results, which may span multiple subprojects.  Reacts to the presence of the jvm-test-suite plugin and creates
+ * tasks to collect code coverage results for each named test-suite.
+ *
+ * @since 7.4
+ * @see <a href="https://docs.gradle.org/current/userguide/jacoco_report_aggregation_plugin.html">JaCoCo Report Aggregation Plugin reference</a>
+ */
+@Incubating
+public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
+
+    public static final String JACOCO_AGGREGATION_CONFIGURATION_NAME = "jacocoAggregation";
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.gradle.reporting-base");
+        project.getPluginManager().apply("jacoco");
+
+        Configuration jacocoAggregation = project.getConfigurations().create(JACOCO_AGGREGATION_CONFIGURATION_NAME);
+        jacocoAggregation.setDescription("Collects project dependencies for purposes of JaCoCo coverage report aggregation");
+        jacocoAggregation.setVisible(false);
+        jacocoAggregation.setCanBeConsumed(false);
+        jacocoAggregation.setCanBeResolved(false);
+
+        ObjectFactory objects = project.getObjects();
+        Configuration sourceDirectoriesConf = project.getConfigurations().create("allCodeCoverageReportSourceDirectories");
+        sourceDirectoriesConf.setDescription("Supplies the source directories used to produce all aggregated JaCoCo coverage data reports");
+        sourceDirectoriesConf.extendsFrom(jacocoAggregation);
+        sourceDirectoriesConf.setVisible(false);
+        sourceDirectoriesConf.setCanBeConsumed(false);
+        sourceDirectoriesConf.setCanBeResolved(true);
+        sourceDirectoriesConf.attributes(attributes -> {
+            attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.SOURCES));
+            attributes.attribute(Sources.SOURCES_ATTRIBUTE, objects.named(Sources.class, Sources.ALL_SOURCE_DIRS));
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
+        });
+
+        ArtifactView sourceDirectories = sourceDirectoriesConf.getIncoming().artifactView(view -> {
+            view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+            view.lenient(true);
+        });
+
+        Configuration classDirectoriesConf = project.getConfigurations().create("allCodeCoverageReportClassDirectories");
+        classDirectoriesConf.extendsFrom(jacocoAggregation);
+        classDirectoriesConf.setDescription("Supplies the class directories used to produce all aggregated JaCoCo coverage data reports");
+        classDirectoriesConf.setVisible(false);
+        classDirectoriesConf.setCanBeConsumed(false);
+        classDirectoriesConf.setCanBeResolved(true);
+
+        ArtifactView classDirectories = classDirectoriesConf.getIncoming().artifactView(view -> {
+            view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+        });
+
+        ReportingExtension reporting = project.getExtensions().getByType(ReportingExtension.class);
+        reporting.getReports().registerBinding(JacocoCoverageReport.class, DefaultJacocoCoverageReport.class);
+
+        // iterate and configure each user-specified report, creating a <reportName>ExecutionData configuration for each
+        reporting.getReports().withType(JacocoCoverageReport.class).configureEach(report -> {
+            report.getReportTask().configure(task -> {
+                // A resolvable configuration to collect JaCoCo coverage data; typically named "testCodeCoverageReportExecutionData"
+                Configuration executionDataConf = project.getConfigurations().create(report.getName() + "ExecutionData");
+                executionDataConf.extendsFrom(jacocoAggregation);
+                executionDataConf.setDescription(String.format("Supplies JaCoCo coverage data to the %s.  External library dependencies may appear as resolution failures, but this is expected behavior.", report.getName()));
+                executionDataConf.setVisible(false);
+                executionDataConf.setCanBeConsumed(false);
+                executionDataConf.setCanBeResolved(true);
+                executionDataConf.attributes(attributes -> {
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+                    attributes.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.JACOCO_COVERAGE));
+                    attributes.attributeProvider(TestType.TEST_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestType.class, tt)));
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
+                });
+
+                Callable<FileCollection> executionData = () ->
+                    executionDataConf.getIncoming().artifactView(view -> {
+                        view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+                        view.lenient(true);
+                    }).getFiles();
+
+                configureReportTaskInputs(task, classDirectories, sourceDirectories, executionData);
+            });
+        });
+
+        // convention for synthesizing reports based on existing test suites in "this" project
+        project.getPlugins().withId("jvm-test-suite", plugin -> {
+            // Depend on this project for aggregation
+            project.getDependencies().add(JACOCO_AGGREGATION_CONFIGURATION_NAME, project);
+
+            TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
+            ExtensiblePolymorphicDomainObjectContainer<TestSuite> testSuites = testing.getSuites();
+            testSuites.withType(JvmTestSuite.class).configureEach(testSuite -> {
+                reporting.getReports().create(testSuite.getName() + "CodeCoverageReport", JacocoCoverageReport.class, report -> {
+                    report.getTestType().convention(testSuite.getTestType());
+                });
+            });
+        });
+    }
+
+    private void configureReportTaskInputs(JacocoReport task, ArtifactView classDirectories, ArtifactView sourceDirectories, Callable<FileCollection> executionData) {
+        task.getExecutionData().from(executionData);
+        task.getClassDirectories().from(classDirectories.getFiles());
+        task.getSourceDirectories().from(sourceDirectories.getFiles());
+    }
+}

--- a/subprojects/jacoco/src/main/resources/META-INF/gradle-plugins/org.gradle.jacoco-report-aggregation.properties
+++ b/subprojects/jacoco/src/main/resources/META-INF/gradle-plugins/org.gradle.jacoco-report-aggregation.properties
@@ -1,0 +1,1 @@
+implementation-class=org.gradle.testing.jacoco.plugins.JacocoReportAggregationPlugin

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoReportXmlFixture.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoReportXmlFixture.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins.fixtures
+
+import groovy.transform.Immutable
+import groovy.xml.XmlSlurper
+import org.gradle.test.fixtures.file.TestFile
+
+class JacocoReportXmlFixture {
+    private final xml
+    private final List<Coverage> classes
+
+    JacocoReportXmlFixture(TestFile reportXmlFile) {
+        reportXmlFile.assertIsFile()
+        def slurper = new XmlSlurper(false, false, true)
+        slurper.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        this.xml = slurper.parse(reportXmlFile)
+        this.classes = []
+        xml*.'package'.each { pkg ->
+            classes.addAll(pkg.'class'.collect {
+                def name = it.@name.toString()
+                def missed = 0
+                def covered = 0
+                if (it.counter.size() > 0) {
+                    def classCounter = it.counter.find { it.@type == "CLASS" }
+                    missed = Integer.parseInt(classCounter.@missed.toString())
+                    covered = Integer.parseInt(classCounter.@covered.toString())
+                }
+
+                return new Coverage(name, covered, missed)
+            })
+        }
+    }
+
+    void assertHasClassCoverage(String clazz, int covered=1) {
+        def coverage = findClass(clazz)
+        assert coverage
+        assert coverage.covered == covered
+    }
+
+    /**
+     * Verify that the argument was found and analyzed, but has a coverage rate of zero.
+     * @param clazz
+     */
+    void assertHasClassButNoCoverage(String clazz) {
+        assertHasClassCoverage(clazz, 0)
+    }
+
+    void assertDoesNotContainClass(String clazz) {
+        assert findClass(clazz) == null
+    }
+
+    Coverage findClass(String clazz) {
+        def searchFor = clazz.replace('.', '/')
+        return classes.find(candidate -> candidate.name == searchFor)
+    }
+
+    @Immutable
+    static class Coverage {
+        String name
+        int covered
+        int missed
+
+        boolean isCompleteCoverage() {
+            missed == 0
+        }
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.HtmlTestExecutionResult
+
+class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        multiProjectBuild("root", ["application", "direct", "transitive"]) {
+            buildFile << """
+                allprojects {
+                    repositories {
+                        ${mavenCentralRepository()}
+                    }
+                }
+                subprojects {
+                    plugins.withId('java') {
+                        testing {
+                            suites {
+                                test {
+                                    useJUnit()
+                                }
+                            }
+                        }
+                    }
+                }
+            """
+            file("application/build.gradle") << """
+                plugins {
+                    id 'java'
+                }
+
+                dependencies {
+                    implementation project(":direct")
+                }
+            """
+            file("application/src/main/java/application/Adder.java").java """
+                package application;
+
+                public class Adder {
+                    int add(int x, int y) {
+                        return x+y;
+                    }
+                }
+            """
+            file("application/src/test/java/application/AdderTest.java").java """
+                package application;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class AdderTest {
+                    @Test
+                    public void testAdd() {
+                        Adder adder = new Adder();
+                        Assert.assertEquals(2, adder.add(1, 1));
+                        Assert.assertEquals(4, adder.add(2, 2));
+                        Assert.assertEquals(3, adder.add(1, 2));
+                    }
+                }
+            """
+
+            file("direct/build.gradle") << """
+                plugins {
+                    id 'java'
+                }
+
+                dependencies {
+                    implementation project(":transitive")
+                }
+            """
+            file("direct/src/main/java/direct/Multiplier.java").java """
+                package direct;
+
+                public class Multiplier {
+                    int multiply(int x, int y) {
+                        return x*y;
+                    }
+                }
+            """
+            file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Multiplier multiplier = new Multiplier();
+                        Assert.assertEquals(1, multiplier.multiply(1, 1));
+                        Assert.assertEquals(4, multiplier.multiply(2, 2));
+                        Assert.assertEquals(2, multiplier.multiply(1, 2));
+                    }
+                }
+            """
+            file("transitive/build.gradle") << """
+                plugins {
+                    id 'java'
+                }
+            """
+            file("transitive/src/main/java/transitive/Powerize.java").java """
+                package transitive;
+
+                public class Powerize {
+                    int pow(int x, int y) {
+                        return (int)Math.pow(x, y);
+                    }
+                }
+            """
+            file("transitive/src/test/java/transitive/PowerizeTest.java").java """
+                package transitive;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class PowerizeTest {
+                    @Test
+                    public void testPow() {
+                        Powerize powerize = new Powerize();
+                        Assert.assertEquals(1, powerize.pow(1, 1));
+                        Assert.assertEquals(4, powerize.pow(2, 2));
+                        Assert.assertEquals(1, powerize.pow(1, 2));
+                    }
+                }
+            """
+        }
+    }
+
+    def 'can aggregate unit test results from subprojects'() {
+        given:
+        file('application/build.gradle') << '''
+            apply plugin: 'org.gradle.test-report-aggregation'
+        '''
+
+        when:
+        succeeds(':application:testAggregateTestReport')
+
+        then:
+        result.assertTaskExecuted(":application:test")
+        result.assertTaskExecuted(":direct:test")
+        result.assertTaskExecuted(":transitive:test")
+        result.assertTaskExecuted(":application:testAggregateTestReport")
+
+        def transitiveTestResults = new HtmlTestExecutionResult(testDirectory.file('transitive'))
+        transitiveTestResults.assertTestClassesExecuted('transitive.PowerizeTest')
+
+        def directTestResults = new HtmlTestExecutionResult(testDirectory.file('direct'))
+        directTestResults.assertTestClassesExecuted('direct.MultiplierTest')
+
+        def applicationTestResults = new HtmlTestExecutionResult(testDirectory.file('application'))
+        applicationTestResults.assertTestClassesExecuted('application.AdderTest')
+
+        def aggregatedResults = new HtmlTestExecutionResult(testDirectory, "application/build/reports/tests/unit-tests/aggregated-results")
+        aggregatedResults.assertTestClassesExecuted("application.AdderTest", "direct.MultiplierTest", "transitive.PowerizeTest")
+    }
+
+    def 'multiple test suites create multiple aggregation tasks'() {
+        given:
+        file("transitive/build.gradle") << """
+            testing {
+                suites {
+                    integTest(JvmTestSuite) {
+                        testType = TestType.INTEGRATION_TESTS
+                        useJUnit()
+                        dependencies {
+                          implementation project
+                        }
+                    }
+                }
+            }
+        """
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.test-report-aggregation'
+
+            testing {
+                suites {
+                    integTest(JvmTestSuite) {
+                        testType = TestType.INTEGRATION_TESTS
+                        useJUnit()
+                        dependencies {
+                            implementation project(':transitive') // necessary to access Divisor when compiling test
+                        }
+                    }
+                }
+            }
+        """
+
+        file("transitive/src/main/java/transitive/Divisor.java").java """
+                package transitive;
+
+                public class Divisor {
+                    public int div(int x, int y) {
+                        return x / y;
+                    }
+                    public int mod(int x, int y) {
+                        return x % y;
+                    }
+                }
+            """
+
+        file("application/src/integTest/java/application/DivTest.java").java """
+                package application;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+                import transitive.Divisor;
+
+                public class DivTest {
+                    @Test
+                    public void testDiv() {
+                        Divisor divisor = new Divisor();
+                        Assert.assertEquals(2, divisor.div(4, 2));
+                    }
+                }
+            """
+        file("transitive/src/integTest/java/transitive/ModTest.java").java """
+                package transitive;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class ModTest {
+                    @Test
+                    public void testMod() {
+                        Divisor divisor = new Divisor();
+                        Assert.assertEquals(1, divisor.mod(5, 2));
+                    }
+                }
+            """
+
+        when:
+        succeeds(":application:testAggregateTestReport", ":application:integTestAggregateTestReport")
+
+        then:
+        result.assertTaskExecuted(":transitive:test")
+        result.assertTaskExecuted(":direct:test")
+        result.assertTaskExecuted(":application:test")
+        result.assertTaskExecuted(":transitive:integTest")
+        result.assertTaskExecuted(":application:integTest")
+        result.assertTaskExecuted(":application:testAggregateTestReport")
+        result.assertTaskExecuted(":application:integTestAggregateTestReport")
+
+        def transitiveTestResults = new HtmlTestExecutionResult(testDirectory.file('transitive'))
+        transitiveTestResults.assertTestClassesExecuted('transitive.PowerizeTest')
+
+        def directTestResults = new HtmlTestExecutionResult(testDirectory.file('direct'))
+        directTestResults.assertTestClassesExecuted('direct.MultiplierTest')
+
+        def applicationTestResults = new HtmlTestExecutionResult(testDirectory.file('application'))
+        applicationTestResults.assertTestClassesExecuted('application.AdderTest')
+
+        def transitiveIntegTestResults = new HtmlTestExecutionResult(testDirectory.file('transitive'), 'build/reports/tests/integTest')
+        transitiveIntegTestResults.assertTestClassesExecuted('transitive.ModTest')
+
+        def applicationIntegTestResults = new HtmlTestExecutionResult(testDirectory.file('application'), 'build/reports/tests/integTest')
+        applicationIntegTestResults.assertTestClassesExecuted('application.DivTest')
+
+        def aggregatedTestResults = new HtmlTestExecutionResult(testDirectory, 'application/build/reports/tests/unit-tests/aggregated-results')
+        aggregatedTestResults.assertTestClassesExecuted('application.AdderTest', 'direct.MultiplierTest', 'transitive.PowerizeTest')
+
+        def aggregatedIntegTestResults = new HtmlTestExecutionResult(testDirectory, 'application/build/reports/tests/integration-tests/aggregated-results')
+        aggregatedIntegTestResults.assertTestClassesExecuted('transitive.ModTest', 'application.DivTest')
+    }
+
+    def 'can aggregate tests from root project'() {
+        given:
+        buildFile << '''
+            apply plugin: 'org.gradle.test-report-aggregation'
+
+            dependencies {
+                testReportAggregation project(":application")
+                testReportAggregation project(":direct")
+            }
+
+            reporting {
+                reports {
+                    testAggregateTestReport(AggregateTestReport) {
+                        testType = TestType.UNIT_TESTS
+                    }
+                }
+            }
+        '''
+
+        when:
+        succeeds(':testAggregateTestReport')
+
+        then:
+        def transitiveTestResults = new HtmlTestExecutionResult(testDirectory.file('transitive'))
+        transitiveTestResults.assertTestClassesExecuted('transitive.PowerizeTest')
+
+        def directTestResults = new HtmlTestExecutionResult(testDirectory.file('direct'))
+        directTestResults.assertTestClassesExecuted('direct.MultiplierTest')
+
+        def applicationTestResults = new HtmlTestExecutionResult(testDirectory.file('application'))
+        applicationTestResults.assertTestClassesExecuted('application.AdderTest')
+
+        def aggregatedTestResults = new HtmlTestExecutionResult(testDirectory, 'build/reports/tests/unit-tests/aggregated-results')
+        aggregatedTestResults.assertTestClassesExecuted('application.AdderTest', 'direct.MultiplierTest', 'transitive.PowerizeTest')
+    }
+
+    def 'test verification failure prevents creation of aggregated report'() {
+        given:file("application/build.gradle") << """
+            apply plugin: 'org.gradle.test-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Assert.fail("intentional failure");
+                    }
+                }
+            """
+
+        when:
+        fails(":application:testAggregateTestReport")
+
+        then:
+        result.assertTaskExecuted(":application:test")
+        result.assertTaskExecuted(":direct:test")
+        result.assertTaskNotExecuted(":transitive:test")
+        result.assertTaskNotExecuted(":application:testAggregateTestReport")
+
+        file("application/build/reports/tests/unit-tests/aggregated-results").assertDoesNotExist()
+    }
+
+    def 'test verification failure creates aggregated report with --continue flag'() {
+        given:file("application/build.gradle") << """
+            apply plugin: 'org.gradle.test-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Assert.fail("intentional failure");
+                    }
+                }
+            """
+
+        when:
+        fails(":application:testAggregateTestReport", "--continue")
+
+        then:
+        result.assertTaskExecuted(":application:test")
+        result.assertTaskExecuted(":direct:test")
+        result.assertTaskExecuted(":transitive:test")
+        result.assertTaskExecuted(":application:testAggregateTestReport")
+
+        def transitiveTestResults = new HtmlTestExecutionResult(testDirectory.file('transitive'))
+        transitiveTestResults.assertTestClassesExecuted('transitive.PowerizeTest')
+
+        def directTestResults = new HtmlTestExecutionResult(testDirectory.file('direct'))
+        directTestResults.assertTestClassesExecuted('direct.MultiplierTest')
+
+        def applicationTestResults = new HtmlTestExecutionResult(testDirectory.file('application'))
+        applicationTestResults.assertTestClassesExecuted('application.AdderTest')
+
+        def aggregatedResults = new HtmlTestExecutionResult(testDirectory, "application/build/reports/tests/unit-tests/aggregated-results")
+        aggregatedResults.assertTestClassesExecuted("application.AdderTest", "direct.MultiplierTest", "transitive.PowerizeTest")
+    }
+
+    def 'catastrophic failure of single test prevents creation of aggregated report'() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.test-report-aggregation'
+        """
+        file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                         System.exit(42); // prematurely exit the testing VM
+                    }
+                }
+            """
+
+        when:
+        executer.withStackTraceChecksDisabled()
+        fails(":application:testAggregateTestReport", "--continue")
+
+        then:
+        // despite --continue flag, :application:testAggregateTestReport will not execute due to catastrophic failure in :direct:test
+        result.assertTaskExecuted(":application:test")
+        result.assertTaskExecuted(":direct:test")
+        result.assertTaskExecuted(":transitive:test")
+        result.assertTaskNotExecuted(":application:testAggregateTestReport")
+
+        file("application/build/reports/tests/unit-tests/aggregated-results").assertDoesNotExist()
+
+    }
+
+    def 'catastrophic failure of every test task prevents creation of aggregated report'() {
+        given:
+        // prevent all test VMs from starting
+        buildFile << '''
+                subprojects {
+                    plugins.withId('java') {
+                        testing {
+                            suites {
+                                test {
+                                    useJUnit()
+                                    jvmArgs '-XX:UnknownArgument'
+                                }
+                            }
+                        }
+                    }
+                }
+        '''
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.test-report-aggregation'
+        """
+
+        when:
+        fails(":application:testAggregateTestReport", "--continue")
+
+        then:
+        // despite --continue flag, :application:testAggregateTestReport will not execute due to catastrophic failures
+        result.assertTaskNotExecuted(":application:test")
+        result.assertTaskNotExecuted(":direct:test")
+        result.assertTaskNotExecuted(":transitive:test")
+        result.assertTaskNotExecuted(":application:testAggregateTestReport")
+
+        file("application/build/reports/tests/unit-tests/aggregated-results").assertDoesNotExist()
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -439,9 +439,9 @@ public class JavaPlugin implements Plugin<Project> {
 
         final ObjectFactory objects = project.getObjects();
         variant.attributes(attributes -> {
-            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
             attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.SOURCES));
             attributes.attribute(Sources.SOURCES_ATTRIBUTE, objects.named(Sources.class, Sources.ALL_SOURCE_DIRS));
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
         });
 
         variant.getOutgoing().artifacts(mainSourceSet.getAllSource().getSourceDirectories().getElements().flatMap(e -> project.provider(() -> e)), artifact -> {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.plugins.jvm.JvmTestSuiteTarget;
 import org.gradle.api.plugins.jvm.internal.DefaultJvmTestSuite;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.testing.AbstractTestTask;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.testing.base.TestSuite;
 import org.gradle.testing.base.TestingExtension;
@@ -104,7 +105,9 @@ public class JvmTestSuitePlugin implements Plugin<Project> {
         variant.setVisible(false);
         variant.setCanBeResolved(false);
         variant.setCanBeConsumed(true);
-        variant.extendsFrom(project.getConfigurations().getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME));
+        variant.extendsFrom(project.getConfigurations().getByName(suite.getSources().getImplementationConfigurationName()),
+            project.getConfigurations().getByName(suite.getSources().getRuntimeOnlyConfigurationName()));
+
 
         final ObjectFactory objects = project.getObjects();
         variant.attributes(attributes -> {
@@ -117,8 +120,8 @@ public class JvmTestSuitePlugin implements Plugin<Project> {
         });
 
         variant.getOutgoing().artifact(
-            target.getTestTask().flatMap(task -> task.getBinaryResultsDirectory().file("results.bin")),
-            artifact -> artifact.setType(ArtifactTypeDefinition.BINARY_DATA_TYPE)
+            target.getTestTask().flatMap(AbstractTestTask::getBinaryResultsDirectory),
+            artifact -> artifact.setType(ArtifactTypeDefinition.DIRECTORY_TYPE)
         );
 
         return variant;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/TestReportAggregationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/TestReportAggregationPlugin.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.TestType;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.tasks.testing.DefaultAggregateTestReport;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.api.tasks.testing.AggregateTestReport;
+import org.gradle.testing.base.TestSuite;
+import org.gradle.testing.base.TestingExtension;
+import org.gradle.testing.base.plugins.TestingBasePlugin;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Adds configurations to for resolving variants containing test execution results, which may span multiple subprojects.  Reacts to the presence of the jvm-test-suite plugin and creates
+ * tasks to collect test results for each named test-suite.
+ *
+ * @since 7.4
+ * @see <a href="https://docs.gradle.org/current/userguide/test_report_aggregation_plugin.html">Test Report Aggregation Plugin reference</a>
+ */
+@Incubating
+public abstract class TestReportAggregationPlugin implements Plugin<Project> {
+
+    public static final String TEST_REPORT_AGGREGATION_CONFIGURATION_NAME = "testReportAggregation";
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.gradle.reporting-base");
+
+        final Configuration testAggregation = project.getConfigurations().create(TEST_REPORT_AGGREGATION_CONFIGURATION_NAME);
+        testAggregation.setDescription("A configuration to collect test execution results");
+        testAggregation.setVisible(false);
+        testAggregation.setCanBeConsumed(false);
+        testAggregation.setCanBeResolved(false);
+
+        ReportingExtension reporting = project.getExtensions().getByType(ReportingExtension.class);
+        reporting.getReports().registerBinding(AggregateTestReport.class, DefaultAggregateTestReport.class);
+
+        ObjectFactory objects = project.getObjects();
+
+        // prepare testReportDir with a reasonable default, but override with JavaPluginExtension#testReportDir if available
+        final DirectoryProperty testReportDir = objects.directoryProperty().convention(reporting.getBaseDirectory().dir(TestingBasePlugin.TESTS_DIR_NAME));
+        JavaPluginExtension javaPluginExtension = project.getExtensions().findByType(JavaPluginExtension.class);
+        if (javaPluginExtension != null) {
+            testReportDir.set(javaPluginExtension.getTestReportDir());
+        }
+
+        // iterate and configure each user-specified report, creating a <reportName>ExecutionData configuration for each
+        reporting.getReports().withType(AggregateTestReport.class).configureEach(report -> {
+            report.getReportTask().configure(task -> {
+
+                // A resolvable configuration to collect test results; typically named "testResults"
+                Configuration testResultsConf = project.getConfigurations().create(report.getName() + "Results");
+                testResultsConf.extendsFrom(testAggregation);
+                testResultsConf.setDescription(String.format("Supplies test result data to the %s.  External library dependencies may appear as resolution failures, but this is expected behavior.", report.getName()));
+                testResultsConf.setVisible(false);
+                testResultsConf.setCanBeConsumed(false);
+                testResultsConf.setCanBeResolved(true);
+                testResultsConf.attributes(attributes -> {
+                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+                    attributes.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.TEST_RESULTS));
+                    attributes.attributeProvider(TestType.TEST_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestType.class, tt)));
+                    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.VERIFICATION));
+                });
+
+                Callable<FileCollection> testResults = () ->
+                    testResultsConf.getIncoming().artifactView(view -> {
+                        view.componentFilter(id -> id instanceof ProjectComponentIdentifier);
+                        view.lenient(true);
+                    }).getFiles();
+
+                task.getTestResults().from(testResults);
+                task.getDestinationDirectory().convention(testReportDir.dir(report.getTestType().map(tt -> tt + "/aggregated-results")));
+            });
+        });
+
+        // convention for synthesizing reports based on existing test suites in "this" project
+        project.getPlugins().withId("jvm-test-suite", plugin -> {
+            // Depend on this project for aggregation
+            project.getDependencies().add(TEST_REPORT_AGGREGATION_CONFIGURATION_NAME, project);
+
+            TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
+            ExtensiblePolymorphicDomainObjectContainer<TestSuite> testSuites = testing.getSuites();
+
+            testSuites.withType(JvmTestSuite.class).configureEach(testSuite -> {
+                reporting.getReports().create(testSuite.getName() + "AggregateTestReport", AggregateTestReport.class, report -> {
+                    report.getTestType().convention(testSuite.getTestType());
+                });
+            });
+        });
+    }
+
+}

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.test-report-aggregation.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.test-report-aggregation.properties
@@ -1,0 +1,1 @@
+implementation-class=org.gradle.api.plugins.TestReportAggregationPlugin

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportSpec.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportSpec.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.reporting;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+/**
+ * Common parent for aggregation report types
+ *
+ * @since 7.4
+ */
+@Incubating
+public interface ReportSpec extends Named {
+}

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.reporting;
 
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
@@ -51,11 +53,12 @@ public class ReportingExtension {
 
     private final ProjectInternal project;
     private final DirectoryProperty baseDirectory;
-
+    private final ExtensiblePolymorphicDomainObjectContainer<ReportSpec> reports;
 
     public ReportingExtension(Project project) {
         this.project = (ProjectInternal)project;
         this.baseDirectory = project.getObjects().directoryProperty();
+        this.reports = project.getObjects().polymorphicDomainObjectContainer(ReportSpec.class);
         baseDirectory.set(project.getLayout().getBuildDirectory().dir(DEFAULT_REPORTS_DIR_NAME));
     }
 
@@ -129,4 +132,14 @@ public class ReportingExtension {
         }
     }
 
+    /**
+     * Container for aggregation reports, which may be configured automatically in reaction to the presence of the jvm-test-suite plugin.
+     *
+     * @return A container of known aggregation reports
+     * @since 7.4
+     */
+    @Incubating
+    public ExtensiblePolymorphicDomainObjectContainer<ReportSpec> getReports() {
+        return reports;
+    }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DefaultAggregateTestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/DefaultAggregateTestReport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import org.gradle.api.Action;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.AggregateTestReport;
+import org.gradle.api.tasks.testing.TestReport;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+
+import javax.inject.Inject;
+
+public abstract class DefaultAggregateTestReport implements AggregateTestReport {
+    private final String name;
+    private final TaskProvider<TestReport> reportTask;
+
+    @Inject
+    public DefaultAggregateTestReport(String name, TaskContainer tasks) {
+        this.name = name;
+        reportTask = tasks.register(name, TestReport.class, new Action<TestReport>() { // no lambdas; this module enforces language level 6
+            @Override
+            public void execute(TestReport task) {
+                task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+                task.setDescription("Generates aggregated test report.");
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public TaskProvider<TestReport> getReportTask() {
+        return reportTask;
+    }
+
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/AggregateTestReport.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/AggregateTestReport.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.testing;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Property;
+import org.gradle.api.reporting.ReportSpec;
+import org.gradle.api.tasks.TaskProvider;
+
+/**
+ * A container for the inputs of an aggregated test report.
+ *
+ * @since 7.4
+ */
+@Incubating
+public interface AggregateTestReport extends ReportSpec {
+
+    /**
+     * Contains the {@link TestReport} task instance which produces this report.
+     *
+     * @return the task instance
+     */
+    TaskProvider<TestReport> getReportTask();
+
+    /**
+     * Contains a value representing the type of test suite this task belongs to.  See static constants on {@link org.gradle.api.attributes.TestType} for examples.
+     *
+     * @return this report's test type
+     */
+    Property<String> getTestType();
+}


### PR DESCRIPTION
Working examples of test and jacoco aggregation.

Work to be done (not necessarily as part of this PR):

- [ ]  Complete user manual pages. The stubs are intentionally incomplete pending user feedback.
- [x]  Update the `jvm-multi-project-with-code-coverage` sample to use the aggregation plugin
- [x]  Create a similar sample to `jvm-multi-project-with-code-coverage` showing test aggregation

samples changes are coming in #19100 