### PR TITLE
Fix DependencyVerifier verification-metadata key comparison

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
@@ -17,11 +17,12 @@ package org.gradle.api.internal.artifacts.verification.verifier;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.bouncycastle.openpgp.PGPPublicKey;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation;
 import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
 import org.gradle.api.internal.artifacts.verification.model.Checksum;
@@ -40,18 +41,22 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DependencyVerifier {
-    private final Map<ComponentIdentifier, ComponentVerificationMetadata> verificationMetadata;
+    private static final Comparator<ModuleComponentIdentifier> MODULE_COMPONENT_IDENTIFIER_COMPARATOR = Comparator.comparing(ModuleComponentIdentifier::getGroup)
+        .thenComparing(ModuleComponentIdentifier::getModule)
+        .thenComparing(ModuleComponentIdentifier::getVersion);
+    private final Map<ModuleComponentIdentifier, ComponentVerificationMetadata> verificationMetadata;
     private final DependencyVerificationConfiguration config;
     private final List<String> topLevelComments;
 
-    DependencyVerifier(Map<ComponentIdentifier, ComponentVerificationMetadata> verificationMetadata, DependencyVerificationConfiguration config, List<String> topLevelComments) {
-        this.verificationMetadata = ImmutableMap.copyOf(verificationMetadata);
+    DependencyVerifier(Map<ModuleComponentIdentifier, ComponentVerificationMetadata> verificationMetadata, DependencyVerificationConfiguration config, List<String> topLevelComments) {
+        this.verificationMetadata = ImmutableSortedMap.copyOf(verificationMetadata, MODULE_COMPONENT_IDENTIFIER_COMPARATOR);
         this.config = config;
         this.topLevelComments = topLevelComments;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.verification.DependencyVerificationException;
 import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
@@ -42,9 +42,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DependencyVerifierBuilder {
-    private static final Comparator<ModuleComponentIdentifier> MODULE_COMPONENT_IDENTIFIER_COMPARATOR = Comparator.comparing(ModuleComponentIdentifier::getGroup)
-        .thenComparing(ModuleComponentIdentifier::getModule)
-        .thenComparing(ModuleComponentIdentifier::getVersion);
     private final Map<ModuleComponentIdentifier, ComponentVerificationsBuilder> byComponent = Maps.newHashMap();
     private final List<DependencyVerificationConfiguration.TrustedArtifact> trustedArtifacts = Lists.newArrayList();
     private final Set<DependencyVerificationConfiguration.TrustedKey> trustedKeys = Sets.newLinkedHashSet();
@@ -131,11 +128,8 @@ public class DependencyVerifierBuilder {
     }
 
     public DependencyVerifier build() {
-        ImmutableMap.Builder<ComponentIdentifier, ComponentVerificationMetadata> builder = ImmutableMap.builderWithExpectedSize(byComponent.size());
-        byComponent.entrySet()
-            .stream()
-            .sorted(Map.Entry.comparingByKey(MODULE_COMPONENT_IDENTIFIER_COMPARATOR))
-            .forEachOrdered(entry -> builder.put(entry.getKey(), entry.getValue().build()));
+        ImmutableMap.Builder<ModuleComponentIdentifier, ComponentVerificationMetadata> builder = ImmutableMap.builderWithExpectedSize(byComponent.size());
+        byComponent.forEach((key, value) -> builder.put(key, value.build()));
         return new DependencyVerifier(builder.build(), new DependencyVerificationConfiguration(isVerifyMetadata, isVerifySignatures, trustedArtifacts, useKeyServers, ImmutableList.copyOf(keyServers), ImmutableSet.copyOf(ignoredKeys), ImmutableList.copyOf(trustedKeys)), topLevelComments);
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierTest.groovy
@@ -17,14 +17,21 @@
 package org.gradle.api.internal.artifacts.verification.verifier
 
 import org.bouncycastle.openpgp.PGPPublicKey
+import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation
+import org.gradle.api.internal.artifacts.verification.model.Checksum
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
+import org.gradle.api.internal.artifacts.verification.model.ImmutableArtifactVerificationMetadata
+import org.gradle.api.internal.artifacts.verification.model.ImmutableComponentVerificationMetadata
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationResultBuilder
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationService
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier
 import org.gradle.internal.hash.ChecksumService
+import org.gradle.internal.hash.HashCode
 import org.gradle.security.internal.PublicKeyService
 import spock.lang.Issue
 import spock.lang.Specification
@@ -66,6 +73,26 @@ class DependencyVerifierTest extends Specification {
         0 * _
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/19089")
+    def "should not fail when custom implementation of ModuleComponentIdentifier is verified"() {
+        def defaultModuleComponentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org", "foo"), "1.0")
+        def checksum = new Checksum(ChecksumKind.md5, "my-checksum", [] as Set<String>, "")
+        def verificationMetadata = new ImmutableComponentVerificationMetadata(defaultModuleComponentIdentifier, [new ImmutableArtifactVerificationMetadata("foo-1.0.jar", [checksum], [] as Set, [] as Set)])
+        verifier = new DependencyVerifier([(defaultModuleComponentIdentifier): verificationMetadata], new DependencyVerificationConfiguration(true, false, [], true, [], [] as Set, []), [])
+        def hashCode = Mock(HashCode) { toString() >> "my-checksum" }
+
+        when:
+        artifactFile.exists() >> true
+        def myModuleComponentIdentifier = new MyModuleComponentIdentifier("org", "foo", "1.0")
+        def artifact = new ModuleComponentFileArtifactIdentifier(myModuleComponentIdentifier, "foo-1.0.jar")
+        verifier.verify(checksumService, signatureVerificationService, kind, artifact, artifactFile, null, result)
+
+        then:
+        1 * checksumService.md5(artifactFile) >> hashCode
+        1 * signatureVerificationService.getPublicKeyService()
+        0 * result.failWith(_)
+    }
+
     private void artifact(String group, String name, String version) {
         artifact = new ModuleComponentFileArtifactIdentifier(
             DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId(group, name), version),
@@ -75,5 +102,52 @@ class DependencyVerifierTest extends Specification {
 
     private verify() {
         verifier.verify(checksumService, signatureVerificationService, kind, artifact, artifactFile, signatureFile, result)
+    }
+
+    class MyModuleComponentIdentifier implements ModuleComponentIdentifier {
+        private String group
+        private String module
+        private String version
+
+        MyModuleComponentIdentifier(String group, String module, String version) {
+            this.group = group
+            this.module = module
+            this.version = version
+        }
+
+        @Override
+        String getDisplayName() {
+            return "$group:$module:$version"
+        }
+
+        @Override
+        String getGroup() {
+            return group
+        }
+
+        @Override
+        String getModule() {
+            return module
+        }
+
+        @Override
+        String getVersion() {
+            return version
+        }
+
+        @Override
+        ModuleIdentifier getModuleIdentifier() {
+            return new ModuleIdentifier() {
+                @Override
+                String getGroup() {
+                    return group
+                }
+
+                @Override
+                String getName() {
+                    return module
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
This was reported in one of my PRs for dependency verification so I took a stab.

Fixes #19089

DependencyVerifier has a map ` Map<ComponentIdentifier, ComponentVerificationMetadata> verificationMetadata` and it looks like somehow IntelliJ's implementation is passed to `DependencyVerifier#verify` method, so verificationMetada is not found since comparison methods are different from our`ComponentIdentifier` implementation. This fixes it.

<img width="1364" alt="Screenshot 2021-11-23 at 15 50 23" src="https://user-images.githubusercontent.com/3939893/143070858-243e505f-fe55-4d26-8293-5b10e3cf75e2.png">

I wasn't sure how to reproduce that with integration tests, but I checked it with a reproducer from  #19089 and it fixes it.



