### PR TITLE
Invalidate the cached state of coupled projects when project isolation is enabled

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -76,8 +76,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model2[3].message == "project :d classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle") << """

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsAccessFromGroovyDslIntegrationTest.groovy
@@ -121,13 +121,13 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         }
     }
 
-    def "reports problem when build script uses #method method to apply plugins to another project"() {
+    def "reports problem when root project build script uses #expression method to apply plugins to another project"() {
         settingsFile << """
             include("a")
             include("b")
         """
         buildFile << """
-            $method(':a').plugins.apply('java-library')
+            ${expression}.plugins.apply('java-library')
         """
 
         when:
@@ -140,9 +140,35 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         }
 
         where:
-        method        | _
-        "project"     | _
-        "findProject" | _
+        expression          | _
+        "project(':a')"     | _
+        "findProject(':a')" | _
+    }
+
+    def "reports problem when child project build script uses #expression method to apply plugins to sibling project"() {
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        file("a/build.gradle") << """
+            ${expression}.plugins.apply('java-library')
+        """
+
+        when:
+        configurationCacheFails("assemble")
+
+        then:
+        fixture.assertStateStoreFailed {
+            projectsConfigured(":", ":a", ":b")
+            problem("Build file 'a/build.gradle': Cannot access project '$target' from project ':a'")
+        }
+
+        where:
+        expression          | target
+        "project(':b')"     | ":b"
+        "findProject(':b')" | ":b"
+        "rootProject"       | ":"
+        "parent"            | ":"
     }
 
     def "reports problem when root project build script uses chain of methods #chain { } to apply plugins to other projects"() {
@@ -177,7 +203,7 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         "findProject('b').findProject(':').subprojects" | _
     }
 
-    def "reports problem when project build script uses chain of methods #chain { } to apply plugins to sibling projects"() {
+    def "reports problem when project build script uses chain of methods #chain { } to apply plugins to other projects"() {
         settingsFile << """
             include("a")
             include("b")
@@ -192,14 +218,17 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         then:
         fixture.assertStateStoreFailed {
             projectsConfigured(":", ":a", ":b")
-            problem("Build file 'a${File.separator}build.gradle': Cannot access project ':b' from project ':a'")
+            problem("Build file 'a/build.gradle': Cannot access project ':b' from project ':a'")
         }
 
         where:
         chain                                    | _
         "project(':').subprojects"               | _
         "project(':').subprojects.each"          | _
+        "rootProject.subprojects"                | _
+        "parent.subprojects"                     | _
         "project(':b').project(':').subprojects" | _
+        "project(':b').parent.subprojects"       | _
         "project(':').project('b')"              | _
         "findProject(':').findProject('b').with" | _
     }
@@ -219,8 +248,8 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         then:
         fixture.assertStateStoreFailed {
             projectsConfigured(":", ":a", ":b")
-            problem("Build file 'a${File.separator}build.gradle': Cannot access project ':' from project ':a'")
-            problem("Build file 'a${File.separator}build.gradle': Cannot access project ':b' from project ':a'")
+            problem("Build file 'a/build.gradle': Cannot access project ':' from project ':a'")
+            problem("Build file 'a/build.gradle': Cannot access project ':b' from project ':a'")
         }
 
         where:
@@ -261,5 +290,26 @@ class IsolatedProjectsAccessFromGroovyDslIntegrationTest extends AbstractIsolate
         outputContains("project name = root")
         outputContains("project name = a")
         outputContains("project name = b")
+    }
+
+    def "project can access itself"() {
+        settingsFile << """
+            rootProject.name = "root"
+            include("a")
+            include("b")
+        """
+        buildFile << """
+            rootProject.plugins.apply('java-library')
+            project(':').plugins.apply('java-library')
+            project(':a').parent.plugins.apply('java-library')
+        """
+
+        when:
+        configurationCacheRun("assemble")
+
+        then:
+        fixture.assertStateStored {
+            projectsConfigured(":", ":a", ":b")
+        }
     }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -81,7 +81,9 @@ class IsolatedProjectsFixture {
 
         spec.problems.assertResultHasProblems(spec.result) {
             withTotalProblemsCount(totalProblems)
-            withUniqueProblems(details.problems.collect { it.message })
+            withUniqueProblems(details.problems.collect {
+                it.message.replace('/', File.separator)
+            })
         }
 
         assertProjectsConfigured(details)
@@ -113,7 +115,9 @@ class IsolatedProjectsFixture {
 
         spec.problems.assertFailureHasProblems(spec.failure) {
             withTotalProblemsCount(totalProblems)
-            withUniqueProblems(details.problems.collect { it.message })
+            withUniqueProblems(details.problems.collect {
+                it.message.replace('/', File.separator)
+            })
         }
 
         assertProjectsConfigured(details)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -41,7 +41,7 @@ class IsolatedProjectsFixture {
      * Also asserts that the expected set of projects is configured, the expected models are queried
      * and the appropriate console logging, reports and build operations are generated.
      */
-    void assertStateStored(@DelegatesTo(StoreDetails) Closure closure = {}) {
+    void assertStateStored(@DelegatesTo(StoreDetails) Closure closure) {
         def details = new StoreDetails()
         closure.delegate = details
         closure()
@@ -62,7 +62,7 @@ class IsolatedProjectsFixture {
      * Also asserts that the expected set of projects is configured, the expected models are queried
      * and the appropriate console logging, reports and build operations are generated.
      */
-    void assertStateStoredWithProblems(@DelegatesTo(StoreWithProblemsDetails) Closure closure = {}) {
+    void assertStateStoredWithProblems(@DelegatesTo(StoreWithProblemsDetails) Closure closure) {
         def details = new StoreWithProblemsDetails()
         closure.delegate = details
         closure()
@@ -70,21 +70,12 @@ class IsolatedProjectsFixture {
         def totalProblems = details.problems.inject(0) { a, b -> a + b.count }
 
         assertHasStoreReason(details)
-        if (totalProblems == 1) {
-            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with 1 problem.")
-        } else {
-            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with ${totalProblems} problems.")
-        }
+        assertHasStoreMessage(totalProblems)
         assertHasWarningThatIncubatingFeatureUsed()
 
         configurationCacheBuildOperations.assertStateStored()
 
-        spec.problems.assertResultHasProblems(spec.result) {
-            withTotalProblemsCount(totalProblems)
-            withUniqueProblems(details.problems.collect {
-                it.message.replace('/', File.separator)
-            })
-        }
+        assertHasProblems(totalProblems, details.problems)
 
         assertProjectsConfigured(details)
         assertModelsQueried(details)
@@ -96,7 +87,7 @@ class IsolatedProjectsFixture {
      * Also asserts that the expected set of projects is configured, the expected models are queried
      * and the appropriate console logging, reports and build operations are generated.
      */
-    void assertStateStoreFailed(@DelegatesTo(StoreWithProblemsDetails) Closure closure = {}) {
+    void assertStateStoreFailed(@DelegatesTo(StoreWithProblemsDetails) Closure closure) {
         def details = new StoreWithProblemsDetails()
         closure.delegate = details
         closure()
@@ -130,11 +121,47 @@ class IsolatedProjectsFixture {
      * Also asserts that the expected set of projects is configured, the expected models are queried
      * and the appropriate console logging, reports and build operations are generated.
      */
-    void assertStateRecreated(@DelegatesTo(StoreRecreatedDetails) Closure closure = {}) {
+    void assertStateRecreated(@DelegatesTo(StoreRecreatedDetails) Closure closure) {
         def details = new StoreRecreatedDetails()
         closure.delegate = details
         closure()
 
+        assertHasRecreateReason(details)
+        spec.postBuildOutputContains("Configuration cache entry stored.")
+        assertHasWarningThatIncubatingFeatureUsed()
+
+        configurationCacheBuildOperations.assertStateStored()
+
+        assertProjectsConfigured(details)
+        assertModelsQueried(details)
+    }
+
+    /**
+     * Asserts that the cache entry is discarded and stored with the expected problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateRecreatedWithProblems(@DelegatesTo(StoreRecreatedWithProblemsDetails) Closure closure) {
+        def details = new StoreRecreatedWithProblemsDetails()
+        closure.delegate = details
+        closure()
+
+        def totalProblems = details.problems.inject(0) { a, b -> a + b.count }
+
+        assertHasRecreateReason(details)
+        assertHasStoreMessage(totalProblems)
+        assertHasWarningThatIncubatingFeatureUsed()
+
+        configurationCacheBuildOperations.assertStateStored()
+
+        assertHasProblems(totalProblems, details.problems)
+
+        assertProjectsConfigured(details)
+        assertModelsQueried(details)
+    }
+
+    private void assertHasRecreateReason(StoreRecreatedDetails details) {
         // Inputs can be discovered in parallel, so required that any one of the changed inputs is reported
         def reasons = []
         details.changedFiles.each { file ->
@@ -151,7 +178,7 @@ class IsolatedProjectsFixture {
         }
 
         def messages = reasons.collect { reason ->
-            if (details.models.isEmpty()) {
+            if (details.runsTasks) {
                 "Creating task graph as configuration cache cannot be reused because $reason has changed."
             } else {
                 "Creating tooling model as configuration cache cannot be reused because $reason has changed."
@@ -160,13 +187,6 @@ class IsolatedProjectsFixture {
 
         def found = messages.any { message -> spec.output.contains(message) }
         assert found: "could not find expected invalidation reason in output. expected: ${messages}"
-        spec.postBuildOutputContains("Configuration cache entry stored.")
-        assertHasWarningThatIncubatingFeatureUsed()
-
-        configurationCacheBuildOperations.assertStateStored()
-
-        assertProjectsConfigured(details)
-        assertModelsQueried(details)
     }
 
     /**
@@ -190,10 +210,28 @@ class IsolatedProjectsFixture {
     }
 
     private void assertHasStoreReason(StoreDetails details) {
-        if (details.models.isEmpty() && details.buildModelQueries == 0) {
+        if (details.runsTasks) {
             spec.outputContains("Calculating task graph as no configuration cache is available for tasks:")
         } else {
             spec.outputContains("Creating tooling model as no configuration cache is available for the requested model")
+        }
+    }
+
+    private void assertHasStoreMessage(int totalProblems) {
+        assert totalProblems > 0
+        if (totalProblems == 1) {
+            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with 1 problem.")
+        } else {
+            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with ${totalProblems} problems.")
+        }
+    }
+
+    private assertHasProblems(int totalProblems, List<ProblemDetails> problems) {
+        spec.problems.assertResultHasProblems(spec.result) {
+            withTotalProblemsCount(totalProblems)
+            withUniqueProblems(problems.collect {
+                it.message.replace('/', File.separator)
+            })
         }
     }
 
@@ -262,6 +300,7 @@ class IsolatedProjectsFixture {
         final projects = new HashSet<String>()
         final List<ModelDetails> models = []
         int buildModelQueries
+        boolean runsTasks = true
 
         void projectConfigured(String path) {
             projects.add(path)
@@ -275,6 +314,7 @@ class IsolatedProjectsFixture {
          * The given number of build scoped models are created.
          */
         void buildModelCreated(int count = 1) {
+            runsTasks = false
             buildModelQueries += count
         }
 
@@ -283,6 +323,7 @@ class IsolatedProjectsFixture {
          */
         void modelsCreated(String... paths) {
             projectsConfigured(paths)
+            runsTasks = false
             models.addAll(paths.collect { new ModelDetails(it, 1) })
         }
 
@@ -291,6 +332,7 @@ class IsolatedProjectsFixture {
          */
         void modelsCreated(String path, int count) {
             projectsConfigured(path)
+            runsTasks = false
             models.add(new ModelDetails(path, count))
         }
     }
@@ -323,6 +365,14 @@ class IsolatedProjectsFixture {
 
         void systemPropertyChanged(String name) {
             changedSystemProperty = name
+        }
+    }
+
+    static class StoreRecreatedWithProblemsDetails extends StoreRecreatedDetails {
+        final List<ProblemDetails> problems = []
+
+        void problem(String message, int count = 1) {
+            problems.add(new ProblemDetails(message, count))
         }
     }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.isolated
+
+class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractIsolatedProjectsToolingApiIntegrationTest {
+    def "projects are treated as coupled when parent mutates child project"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("build.gradle") << """
+            project(":a") {
+                plugins.apply(my.MyPlugin)
+            }
+            project(":b") {
+                plugins.apply(my.MyPlugin)
+            }
+        """
+        file("a/build.gradle") << """
+            myExtension.message = "project a"
+        """
+        file("b/build.gradle") << """
+            myExtension.message = "project b"
+        """
+        file("c/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 3
+        model[0].message == "project a"
+        model[1].message == "project b"
+        model[2].message == "It works from project :c"
+
+        and:
+        fixture.assertStateStoredWithProblems {
+            projectConfigured(":buildSrc")
+            projectsConfigured(":")
+            buildModelCreated()
+            modelsCreated(":a", ":b", ":c")
+            problem("Build file 'build.gradle': Cannot access project ':a' from project ':'")
+            problem("Build file 'build.gradle': Cannot access project ':b' from project ':'")
+        }
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 3
+        model2[0].message == "project a"
+        model2[1].message == "project b"
+        model2[2].message == "It works from project :c"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("build.gradle") << """
+            project(":a") {
+                afterEvaluate {
+                    myExtension.message = "new project a"
+                }
+            }
+        """
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 3
+        // TODO - should use the updated message
+        model3[0].message == "project a"
+        model3[1].message == "project b"
+        model3[2].message == "It works from project :c"
+
+        and:
+        fixture.assertStateRecreatedWithProblems {
+            fileChanged("build.gradle")
+            projectConfigured(":buildSrc")
+            projectConfigured(":")
+            // TODO - should invalidate the model for projects a and b
+            modelsCreated()
+            problem("Build file 'build.gradle': Cannot access project ':a' from project ':'", 2)
+            problem("Build file 'build.gradle': Cannot access project ':b' from project ':'")
+        }
+    }
+
+    def "projects are treated as coupled when child mutates parent project"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+        """
+        file("a/build.gradle") << """
+            parent.plugins.apply(my.MyPlugin)
+            parent.myExtension.message = "root project"
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        // TODO - should include model from root
+        model.size() == 1
+        model[0].message == "It works from project :b"
+
+        and:
+        fixture.assertStateStoredWithProblems {
+            projectConfigured(":buildSrc")
+            projectsConfigured(":", ":a")
+            buildModelCreated()
+            // TODO - should create model for root
+            modelsCreated(":b")
+            problem("Build file 'a/build.gradle': Cannot access project ':' from project ':a'", 2)
+        }
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 1
+        model2[0].message == "It works from project :b"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("a/build.gradle") << """
+            // Some change
+        """
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 1
+        model3[0].message == "It works from project :b"
+
+        and:
+        fixture.assertStateRecreatedWithProblems {
+            fileChanged("a/build.gradle")
+            projectConfigured(":buildSrc")
+            projectsConfigured(":", ":a")
+            // TODO - should invalidate the model for root
+            modelsCreated()
+            problem("Build file 'a/build.gradle': Cannot access project ':' from project ':a'", 2)
+        }
+    }
+
+    def "projects are treated as coupled when project queries a sibling project"() {
+        given:
+        withSomeToolingModelBuilderPluginInBuildSrc()
+        settingsFile << """
+            include("a")
+            include("b")
+            include("c")
+        """
+        file("a/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            myExtension.message = "the message"
+        """
+        file("b/build.gradle") << """
+            plugins.apply(my.MyPlugin)
+            def otherProject = project(':a')
+            myExtension.message = otherProject.myExtension.message
+        """
+
+        when:
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model.size() == 2
+        model[0].message == "the message"
+        model[1].message == "the message"
+
+        and:
+        fixture.assertStateStoredWithProblems {
+            projectConfigured(":buildSrc")
+            projectsConfigured(":", ":c")
+            buildModelCreated()
+            modelsCreated(":a", ":b")
+            problem("Build file 'b/build.gradle': Cannot access project ':a' from project ':b'")
+        }
+
+        when:
+        executer.withArguments(ENABLE_CLI)
+        def model2 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model2.size() == 2
+        model2[0].message == "the message"
+        model2[1].message == "the message"
+
+        and:
+        fixture.assertStateLoaded()
+
+        when:
+        file("b/build.gradle") << """
+            // some change
+        """
+        executer.withArguments(ENABLE_CLI, WARN_PROBLEMS_CLI_OPT)
+        def model3 = runBuildAction(new FetchCustomModelForEachProject())
+
+        then:
+        model3.size() == 2
+        model3[0].message == "the message"
+        model3[1].message == "the message"
+
+        and:
+        fixture.assertStateRecreatedWithProblems {
+            fileChanged("b/build.gradle")
+            projectConfigured(":buildSrc")
+            projectConfigured(":")
+            // TODO - should invalidate the model for project a
+            projectConfigured(":a")
+            modelsCreated(":b")
+            problem("Build file 'b/build.gradle': Cannot access project ':a' from project ':b'")
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -16,11 +16,11 @@
 
 package org.gradle.configurationcache
 
-import org.gradle.api.Project
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
+import org.gradle.api.internal.project.ProjectState
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
@@ -92,6 +92,7 @@ interface ConfigurationCacheStateFile {
     fun outputStream(): OutputStream
     fun inputStream(): InputStream
     fun delete()
+
     // Replace the contents of this state file, by moving the given file to the location of this state file
     fun moveFrom(file: File)
     fun stateFileForIncludedBuild(build: BuildDefinition): ConfigurationCacheStateFile
@@ -275,11 +276,11 @@ class ConfigurationCacheState(
     }
 
     private
-    suspend fun DefaultWriteContext.writeProjectStates(gradle: GradleInternal, relevantProjects: List<Project>) {
+    suspend fun DefaultWriteContext.writeProjectStates(gradle: GradleInternal, relevantProjects: List<ProjectState>) {
         withGradleIsolate(gradle, userTypesCodec) {
             // Do not serialize trivial states to speed up deserialization.
             val nonTrivialProjectStates = relevantProjects.asSequence()
-                .map { project -> project.computeCachedState() }
+                .map { project -> project.mutableModel.computeCachedState() }
                 .filterNotNull()
                 .toList()
 
@@ -571,16 +572,17 @@ class ConfigurationCacheState(
     }
 
     private
-    fun getRelevantProjectsFor(nodes: List<Node>, relevantProjectsRegistry: RelevantProjectsRegistry): List<Project> {
+    fun getRelevantProjectsFor(nodes: List<Node>, relevantProjectsRegistry: RelevantProjectsRegistry): List<ProjectState> {
         return fillTheGapsOf(relevantProjectsRegistry.relevantProjects(nodes))
     }
 
     private
-    fun Encoder.writeRelevantProjects(relevantProjects: List<Project>) {
+    fun Encoder.writeRelevantProjects(relevantProjects: List<ProjectState>) {
         writeCollection(relevantProjects) { project ->
-            writeString(project.path)
-            writeFile(project.projectDir)
-            writeFile(project.buildDir)
+            val mutableModel = project.mutableModel
+            writeString(mutableModel.path)
+            writeFile(mutableModel.projectDir)
+            writeFile(mutableModel.buildDir)
         }
     }
 
@@ -702,8 +704,8 @@ interface StoredBuilds {
 
 
 internal
-fun fillTheGapsOf(projects: Collection<Project>): List<Project> {
-    val projectsWithoutGaps = ArrayList<Project>(projects.size)
+fun fillTheGapsOf(projects: Collection<ProjectState>): List<ProjectState> {
+    val projectsWithoutGaps = ArrayList<ProjectState>(projects.size)
     var index = 0
     projects.forEach { project ->
         var parent = project.parent

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CoupledProjectsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/CoupledProjectsListener.kt
@@ -14,25 +14,17 @@
  * limitations under the License.
  */
 
-package org.gradle.configurationcache.fingerprint
+package org.gradle.configurationcache
 
-import org.gradle.util.Path
+import org.gradle.api.internal.project.ProjectState
+import org.gradle.internal.service.scopes.EventScope
+import org.gradle.internal.service.scopes.Scopes
 
 
-internal
-sealed class ProjectSpecificFingerprint {
-    data class ProjectFingerprint(
-        val projectPath: Path,
-        val value: ConfigurationCacheFingerprint
-    ) : ProjectSpecificFingerprint()
-
-    data class ProjectDependency(
-        val consumingProject: Path,
-        val targetProject: Path
-    ) : ProjectSpecificFingerprint()
-
-    data class CoupledProjects(
-        val referringProject: Path,
-        val targetProject: Path
-    ) : ProjectSpecificFingerprint()
+@EventScope(Scopes.Build::class)
+interface CoupledProjectsListener {
+    /**
+     * Notified when the build logic for a project accesses the mutable state of some other project.
+     */
+    fun onProjectReference(referrer: ProjectState, target: ProjectState)
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -54,6 +54,7 @@ import org.gradle.internal.build.BuildModelController
 import org.gradle.internal.build.BuildModelControllerServices
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.buildtree.BuildModelParameters
+import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.model.CalculatedValueContainerFactory
 import org.gradle.internal.model.StateTransitionControllerFactory
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -151,10 +152,11 @@ class DefaultBuildModelControllerServices(
         fun createCrossProjectModelAccess(
             projectRegistry: ProjectRegistry<ProjectInternal>,
             problemsListener: ProblemsListener,
-            userCodeApplicationContext: UserCodeApplicationContext
+            userCodeApplicationContext: UserCodeApplicationContext,
+            listenerManager: ListenerManager
         ): CrossProjectModelAccess {
             val delegate = VintageIsolatedProjectsProvider().createCrossProjectModelAccess(projectRegistry)
-            return ProblemReportingCrossProjectModelAccess(delegate, problemsListener, userCodeApplicationContext)
+            return ProblemReportingCrossProjectModelAccess(delegate, problemsListener, listenerManager.getBroadcaster(CoupledProjectsListener::class.java), userCodeApplicationContext)
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -100,6 +100,7 @@ import java.util.concurrent.Callable
 class ProblemReportingCrossProjectModelAccess(
     private val delegate: CrossProjectModelAccess,
     private val problems: ProblemsListener,
+    private val coupledProjectsListener: CoupledProjectsListener,
     private val userCodeContext: UserCodeApplicationContext
 ) : CrossProjectModelAccess {
     override fun findProject(referrer: ProjectInternal, relativeTo: ProjectInternal, path: String): ProjectInternal? {
@@ -123,7 +124,7 @@ class ProblemReportingCrossProjectModelAccess(
         return if (this == referrer) {
             this
         } else {
-            ProblemReportingProject(this, referrer, problems, userCodeContext)
+            ProblemReportingProject(this, referrer, problems, coupledProjectsListener, userCodeContext)
         }
     }
 
@@ -132,6 +133,7 @@ class ProblemReportingCrossProjectModelAccess(
         val delegate: ProjectInternal,
         val referrer: ProjectInternal,
         val problems: ProblemsListener,
+        val coupledProjectsListener: CoupledProjectsListener,
         val userCodeContext: UserCodeApplicationContext
     ) : ProjectInternal, GroovyObjectSupport() {
 
@@ -978,6 +980,7 @@ class ProblemReportingCrossProjectModelAccess(
             problems.onProblem(
                 PropertyProblem(location, message, exception, null)
             )
+            coupledProjectsListener.onProjectReference(referrer.owner, delegate.owner)
             // Configure the target project, if it would normally be configured before the referring project
             if (delegate.compareTo(referrer) < 0) {
                 delegate.owner.ensureConfigured()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -146,11 +146,10 @@ class ProblemReportingCrossProjectModelAccess(
             if (result.isFound) {
                 return result.value
             }
+            onAccess()
             val delegateBean = (delegate as DynamicObjectAware).asDynamicObject
             val delegateResult = delegateBean.tryGetProperty(propertyName)
             if (delegateResult.isFound) {
-                // Only report properties that exist
-                onAccess()
                 return delegateResult.value
             }
             throw thisBean.getMissingProperty(propertyName)
@@ -164,11 +163,10 @@ class ProblemReportingCrossProjectModelAccess(
             if (result.isFound) {
                 return result.value
             }
+            onAccess()
             val delegateBean = (delegate as DynamicObjectAware).asDynamicObject
             val delegateResult = delegateBean.tryInvokeMethod(name, *varargs)
             if (delegateResult.isFound) {
-                // Only report methods that exist
-                onAccess()
                 return delegateResult.value
             }
             throw thisBean.methodMissingException(name, args)
@@ -980,6 +978,10 @@ class ProblemReportingCrossProjectModelAccess(
             problems.onProblem(
                 PropertyProblem(location, message, exception, null)
             )
+            // Configure the target project, if it would normally be configured before the referring project
+            if (delegate.compareTo(referrer) < 0) {
+                delegate.owner.ensureConfigured()
+            }
         }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ProblemReportingCrossProjectModelAccess.kt
@@ -106,6 +106,10 @@ class ProblemReportingCrossProjectModelAccess(
         return delegate.findProject(referrer, relativeTo, path)?.wrap(referrer)
     }
 
+    override fun access(referrer: ProjectInternal, project: ProjectInternal): ProjectInternal {
+        return project.wrap(referrer)
+    }
+
     override fun getSubprojects(referrer: ProjectInternal, relativeTo: ProjectInternal): MutableSet<out ProjectInternal> {
         return delegate.getSubprojects(referrer, relativeTo).mapTo(LinkedHashSet()) { it.wrap(referrer) }
     }
@@ -811,11 +815,19 @@ class ProblemReportingCrossProjectModelAccess(
         }
 
         override fun getParent(): ProjectInternal? {
-            return delegate.parent
+            return delegate.getParent(referrer)
+        }
+
+        override fun getParent(referrer: ProjectInternal): ProjectInternal? {
+            return delegate.getParent(referrer)
         }
 
         override fun getRootProject(): ProjectInternal {
-            return delegate.rootProject
+            return delegate.getRootProject(referrer)
+        }
+
+        override fun getRootProject(referrer: ProjectInternal): ProjectInternal {
+            return delegate.getRootProject(referrer)
         }
 
         override fun evaluate(): Project {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/RelevantProjectsRegistry.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/RelevantProjectsRegistry.kt
@@ -19,7 +19,6 @@ package org.gradle.configurationcache
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.internal.artifacts.configurations.ProjectDependencyObservedListener
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.execution.plan.Node
 import org.gradle.internal.service.scopes.Scopes
@@ -29,15 +28,15 @@ import org.gradle.internal.service.scopes.ServiceScope
 @ServiceScope(Scopes.Build::class)
 class RelevantProjectsRegistry : ProjectDependencyObservedListener {
     private
-    val targetProjects = mutableSetOf<ProjectInternal>()
+    val targetProjects = mutableSetOf<ProjectState>()
 
-    fun relevantProjects(nodes: List<Node>): Set<ProjectInternal> =
+    fun relevantProjects(nodes: List<Node>): Set<ProjectState> =
         targetProjects +
             nodes.mapNotNullTo(mutableListOf()) { node ->
-                node.owningProject
+                node.owningProject?.owner
             }
 
     override fun dependencyObserved(consumingProject: ProjectState?, targetProject: ProjectState, requestedState: ConfigurationInternal.InternalState, target: ResolvedProjectConfiguration) {
-        targetProjects.add(targetProject.mutableModel)
+        targetProjects.add(targetProject)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -92,6 +92,12 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                     val target = projects.entryFor(input.targetProject)
                     target.consumedBy(consumer)
                 }
+                is ProjectSpecificFingerprint.CoupledProjects -> {
+                    val referrer = projects.entryFor(input.referringProject)
+                    val target = projects.entryFor(input.targetProject)
+                    target.consumedBy(referrer)
+                    referrer.consumedBy(target)
+                }
                 else -> throw IllegalStateException("Unexpected configuration cache fingerprint: $input")
             }
         }
@@ -112,6 +118,10 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                     }
                 is ProjectSpecificFingerprint.ProjectDependency ->
                     if (reusedProjects.contains(input.consumingProject)) {
+                        consumer.accept(input)
+                    }
+                is ProjectSpecificFingerprint.CoupledProjects ->
+                    if (reusedProjects.contains(input.referringProject)) {
                         consumer.accept(input)
                     }
             }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/FillTheProjectGapsTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/FillTheProjectGapsTest.kt
@@ -17,7 +17,7 @@
 package org.gradle.configurationcache
 
 import com.nhaarman.mockitokotlin2.mock
-import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectState
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -115,12 +115,12 @@ class FillTheProjectGapsTest {
 
     @Suppress("ClassName")
     private
-    class projectMock(private val parent: Project?) {
+    class projectMock(private val parent: ProjectState?) {
 
         private
-        lateinit var memoizedMock: Project
+        lateinit var memoizedMock: ProjectState
 
-        operator fun getValue(thisRef: Project?, property: KProperty<*>): Project {
+        operator fun getValue(thisRef: ProjectState?, property: KProperty<*>): ProjectState {
             if (!this::memoizedMock.isInitialized) {
                 memoizedMock = mock {
                     on(mock.parent).thenReturn(parent)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/CrossProjectModelAccess.java
@@ -28,12 +28,26 @@ import java.util.Set;
 @ServiceScope(Scopes.Build.class)
 public interface CrossProjectModelAccess {
     /**
+     * Locates the given project relative to some project.
+     *
+     * @param referrer The project from which the return value will be used.
      * @param path absolute path
      */
     @Nullable
     ProjectInternal findProject(ProjectInternal referrer, ProjectInternal relativeTo, String path);
 
+    /**
+     * @param referrer The project from which the return value will be used.
+     */
+    ProjectInternal access(ProjectInternal referrer, ProjectInternal project);
+
+    /**
+     * @param referrer The project from which the return value will be used.
+     */
     Set<? extends ProjectInternal> getSubprojects(ProjectInternal referrer, ProjectInternal relativeTo);
 
+    /**
+     * @param referrer The project from which the return value will be used.
+     */
     Set<? extends ProjectInternal> getAllprojects(ProjectInternal referrer, ProjectInternal relativeTo);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultCrossProjectModelAccess.java
@@ -27,6 +27,11 @@ public class DefaultCrossProjectModelAccess implements CrossProjectModelAccess {
     }
 
     @Override
+    public ProjectInternal access(ProjectInternal referrer, ProjectInternal project) {
+        return project;
+    }
+
+    @Override
     public ProjectInternal findProject(ProjectInternal referrer, ProjectInternal relativeTo, String path) {
         return projectRegistry.getProject(relativeTo.absoluteProjectPath(path));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -367,7 +367,12 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getRootProject() {
-        return rootProject;
+        return getRootProject(this);
+    }
+
+    @Override
+    public ProjectInternal getRootProject(ProjectInternal referrer) {
+        return getCrossProjectModelAccess().access(referrer, rootProject);
     }
 
     @Override
@@ -405,7 +410,16 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public ProjectInternal getParent() {
-        return parent;
+        return getParent(this);
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal getParent(ProjectInternal referrer) {
+        if (parent == null) {
+            return null;
+        }
+        return getCrossProjectModelAccess().access(referrer, parent);
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -66,8 +66,13 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     @Override
     ProjectInternal getParent();
 
+    @Nullable
+    ProjectInternal getParent(ProjectInternal referrer);
+
     @Override
     ProjectInternal getRootProject();
+
+    ProjectInternal getRootProject(ProjectInternal referrer);
 
     Project evaluate();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -52,6 +52,7 @@ import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.api.internal.project.DefaultAntBuilderFactory;
 import org.gradle.api.internal.project.DeferredProjectConfiguration;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.project.ant.DefaultAntLoggingAdapterFactory;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
@@ -123,10 +124,11 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
 
     protected PluginRegistry createPluginRegistry(PluginRegistry rootRegistry) {
         PluginRegistry parentRegistry;
-        if (project.getParent() == null) {
+        ProjectState parent = project.getOwner().getBuildParent();
+        if (parent == null) {
             parentRegistry = rootRegistry.createChild(project.getBaseClassLoaderScope());
         } else {
-            parentRegistry = project.getParent().getServices().get(PluginRegistry.class);
+            parentRegistry = parent.getMutableModel().getServices().get(PluginRegistry.class);
         }
         return parentRegistry.createChild(project.getClassLoaderScope());
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -149,7 +149,7 @@ class DefaultProjectSpec extends Specification {
         nestedChild2.identityPath == Path.path(":nested:child1:child2")
     }
 
-    def project(String name, ProjectInternal parent, GradleInternal build) {
+    ProjectInternal project(String name, ProjectInternal parent, GradleInternal build) {
         def serviceRegistryFactory = Stub(ServiceRegistryFactory)
         def serviceRegistry = Stub(ServiceRegistry)
 
@@ -176,6 +176,7 @@ class DefaultProjectSpec extends Specification {
         return Spy(DefaultProject, constructorArgs: [name, parent, projectDir, new File("build file"), Stub(ScriptSource), build, container, serviceRegistryFactory, Stub(ClassLoaderScope), Stub(ClassLoaderScope)]) {
             getFileOperations() >> fileOperations
             getObjects() >> objectFactory
+            getCrossProjectModelAccess() >> Stub(CrossProjectModelAccess)
         }
     }
 }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultKotlinScriptBasePluginsApplicator.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/DefaultKotlinScriptBasePluginsApplicator.kt
@@ -18,14 +18,14 @@ package org.gradle.kotlin.dsl.provider.plugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
-import org.gradle.kotlin.dsl.accessors.warnAboutDiscontinuedJsonProjectSchema
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.kotlin.dsl.accessors.tasks.PrintAccessors
+import org.gradle.kotlin.dsl.accessors.warnAboutDiscontinuedJsonProjectSchema
 import org.gradle.kotlin.dsl.provider.KotlinScriptBasePluginsApplicator
 
 
 class DefaultKotlinScriptBasePluginsApplicator : KotlinScriptBasePluginsApplicator {
-    override fun apply(project: Project) {
+    override fun apply(project: ProjectInternal) {
         project.plugins.apply(KotlinScriptBasePlugin::class.java)
     }
 }
@@ -33,7 +33,8 @@ class DefaultKotlinScriptBasePluginsApplicator : KotlinScriptBasePluginsApplicat
 
 class KotlinScriptBasePlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
-        rootProject.plugins.apply(KotlinScriptRootPlugin::class.java)
+        // Currently, there is no public API to do this in a project isolation safe way. Instead, do this in a non-safe way for now
+        (project as ProjectInternal).owner.owner.projects.rootProject.mutableModel.plugins.apply(KotlinScriptRootPlugin::class.java)
         tasks.register("kotlinDslAccessorsReport", PrintAccessors::class.java)
     }
 }

--- a/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
+++ b/subprojects/kotlin-dsl-tooling-builders/src/main/kotlin/org/gradle/kotlin/dsl/tooling/builders/KotlinBuildScriptModelBuilder.kt
@@ -127,7 +127,7 @@ object KotlinBuildScriptModelBuilder : ToolingModelBuilder {
             ?: return projectScriptModelBuilder(null, modelRequestProject)
 
         modelRequestProject.findProjectWithBuildFile(scriptFile)?.let { buildFileProject ->
-            return projectScriptModelBuilder(scriptFile, buildFileProject)
+            return projectScriptModelBuilder(scriptFile, buildFileProject as ProjectInternal)
         }
 
         modelRequestProject.enclosingSourceSetOf(scriptFile)?.let { enclosingSourceSet ->
@@ -241,7 +241,7 @@ fun hashOf(scriptFile: File) =
 private
 fun projectScriptModelBuilder(
     scriptFile: File?,
-    project: Project
+    project: ProjectInternal
 ) = KotlinScriptTargetModelBuilder(
     scriptFile = scriptFile,
     project = project,

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluatorTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluatorTest.kt
@@ -20,13 +20,11 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
-
-import org.gradle.api.Project
 import org.gradle.api.initialization.IncludedBuild
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.plugins.ExtensionContainerInternal
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
-import org.gradle.api.plugins.ExtensionContainer
-
 import org.junit.Test
 
 
@@ -75,8 +73,8 @@ class SimplifiedKotlinScriptEvaluatorTest : TestWithTempFiles() {
     }
 
     private
-    fun project() = mock<Project> {
-        on { extensions } doReturn mock<ExtensionContainer>()
+    fun project() = mock<ProjectInternal> {
+        on { extensions } doReturn mock<ExtensionContainerInternal>()
     }
 
     private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -93,7 +93,7 @@ class PluginAccessorClassPathGenerator @Inject constructor(
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider
 ) {
-    fun pluginSpecBuildersClassPath(project: Project): AccessorsClassPath = project.rootProject.let { rootProject ->
+    fun pluginSpecBuildersClassPath(project: ProjectInternal): AccessorsClassPath = project.owner.owner.projects.rootProject.mutableModel.let { rootProject ->
 
         rootProject.getOrCreateProperty("gradleKotlinDsl.pluginAccessorsClassPath") {
             val buildSrcClassLoaderScope = baseClassLoaderScopeOf(rootProject)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/execution/Interpreter.kt
@@ -25,6 +25,7 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.GeneratedSubclass
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.classpath.ClassPath
@@ -122,7 +123,7 @@ class Interpreter(val host: Host) {
             pluginRequests: PluginRequests
         )
 
-        fun applyBasePluginsTo(project: Project)
+        fun applyBasePluginsTo(project: ProjectInternal)
 
         fun setupEmbeddedKotlinFor(scriptHost: KotlinScriptHost<*>)
 
@@ -398,7 +399,7 @@ class Interpreter(val host: Host) {
         }
 
         override fun applyBasePluginsTo(project: Project) {
-            host.applyBasePluginsTo(project)
+            host.applyBasePluginsTo(project as ProjectInternal)
         }
 
         override fun handleScriptException(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePluginsApplicator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptBasePluginsApplicator.kt
@@ -16,10 +16,10 @@
 
 package org.gradle.kotlin.dsl.provider
 
-import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
 
 
 interface KotlinScriptBasePluginsApplicator {
 
-    fun apply(project: Project)
+    fun apply(project: ProjectInternal)
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -22,6 +22,7 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.plugins.PluginAwareInternal
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.cache.CacheOpenException
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
@@ -158,7 +159,7 @@ class StandardKotlinScriptEvaluator(
     inner class InterpreterHost : Interpreter.Host {
 
         override fun pluginAccessorsFor(scriptHost: KotlinScriptHost<*>): ClassPath =
-            (scriptHost.target as? Project)?.let {
+            (scriptHost.target as? ProjectInternal)?.let {
                 val pluginAccessorClassPathGenerator = it.serviceOf<PluginAccessorClassPathGenerator>()
                 pluginAccessorClassPathGenerator.pluginSpecBuildersClassPath(it).bin
             } ?: ClassPath.EMPTY
@@ -209,7 +210,7 @@ class StandardKotlinScriptEvaluator(
             )
         }
 
-        override fun applyBasePluginsTo(project: Project) {
+        override fun applyBasePluginsTo(project: ProjectInternal) {
             kotlinScriptBasePluginsApplicator
                 .apply(project)
         }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/accessors/ProjectAccessorsClassPathTest.kt
@@ -23,13 +23,11 @@ import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
 import kotlinx.metadata.jvm.KmModuleVisitor
-
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
 import org.gradle.api.Task
-
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraint
@@ -37,34 +35,30 @@ import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.internal.plugins.ExtensionContainerInternal
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.plugins.Convention
-import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.reflect.TypeOf.parameterizedTypeOf
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
-
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-
+import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.concurrent.withSynchronousIO
 import org.gradle.kotlin.dsl.fixtures.AbstractDslTest
 import org.gradle.kotlin.dsl.fixtures.eval
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
-import org.gradle.kotlin.dsl.project
 import org.gradle.kotlin.dsl.support.compileToDirectory
 import org.gradle.kotlin.dsl.support.loggerFor
-import org.gradle.kotlin.dsl.typeOf
-
 import org.gradle.nativeplatform.BuildType
 import org.junit.Assert.assertEquals
 import org.junit.Test
-
 import org.mockito.ArgumentMatchers.anyMap
-
 import java.io.File
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier.PUBLIC
@@ -93,12 +87,12 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         val function0 = mock<() -> Unit>()
         val function1 = mock<(String) -> Unit>()
         val function2 = mock<(Int, Double) -> Boolean>()
-        val extensions = mock<ExtensionContainer> {
+        val extensions = mock<ExtensionContainerInternal> {
             on { getByName("function0") } doReturn function0
             on { getByName("function1") } doReturn function1
             on { getByName("function2") } doReturn function2
         }
-        val project = mock<Project> {
+        val project = mock<ProjectInternal> {
             on { getExtensions() } doReturn extensions
         }
 
@@ -299,7 +293,7 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
         val sourceSets = mock<SourceSetContainer> {
             on { named(any<String>(), eq(SourceSet::class.java)) } doReturn sourceSet
         }
-        val extensions = mock<ExtensionContainer> {
+        val extensions = mock<ExtensionContainerInternal> {
             on { getByName(any()) } doReturn sourceSets
         }
         val constraint = mock<DependencyConstraint>()
@@ -315,14 +309,14 @@ class ProjectAccessorsClassPathTest : AbstractDslTest() {
             on { project(anyMap<String, Any?>()) } doReturn projectDependency
         }
         val clean = mock<TaskProvider<Delete>>()
-        val tasks = mock<TaskContainer> {
+        val tasks = mock<TaskContainerInternal> {
             on { named(any<String>(), eq(Delete::class.java)) } doReturn clean
         }
         val applicationPluginConvention = mock<@Suppress("deprecation") org.gradle.api.plugins.ApplicationPluginConvention>()
         val convention = mock<Convention> {
             on { plugins } doReturn mapOf("application" to applicationPluginConvention)
         }
-        val project = mock<Project> {
+        val project = mock<ProjectInternal> {
             on { getConfigurations() } doReturn configurations
             on { getExtensions() } doReturn extensions
             on { getDependencies() } doReturn dependencies

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -18,9 +18,9 @@ package org.gradle.kotlin.dsl.fixtures
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
-import org.gradle.api.Project
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.configuration.DefaultImportsReader
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.Describables
@@ -183,7 +183,7 @@ class SimplifiedKotlinScriptEvaluator(
 
         override fun applyPluginsTo(scriptHost: KotlinScriptHost<*>, pluginRequests: PluginRequests) = Unit
 
-        override fun applyBasePluginsTo(project: Project) = Unit
+        override fun applyBasePluginsTo(project: ProjectInternal) = Unit
 
         override fun setupEmbeddedKotlinFor(scriptHost: KotlinScriptHost<*>) = Unit
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

When the build logic of a project accesses the mutable state of another project, treat those projects as "coupled". When an input of a project changes, then invalidate the cached state of all projects that are coupled with it.

Also generate a configuration cache problem when the state of another project is accessed via `Project.parent` and `Project.rootProject`.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
