### PR TITLE
Monitor Gradleception cache mission on master/release

### DIFF
--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -20,6 +20,7 @@ import gradlebuild.basics.BuildEnvironment.isCodeQl
 import gradlebuild.basics.BuildEnvironment.isGhActions
 import gradlebuild.basics.BuildEnvironment.isJenkins
 import gradlebuild.basics.BuildEnvironment.isTravis
+import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildConfigurationId
 import gradlebuild.basics.buildId
 import gradlebuild.basics.buildServerUrl
@@ -136,9 +137,10 @@ fun isExpectedCompileCacheMiss() =
     isInBuild(
         "Check_CompileAllBuild",
         "Component_GradlePlugin_Performance_PerformanceLatestMaster",
-        "Component_GradlePlugin_Performance_PerformanceLatestReleased",
-        "Check_Gradleception"
-    )
+        "Component_GradlePlugin_Performance_PerformanceLatestReleased"
+    ) || (isInBuild("Check_Gradleception") && !isOnBranch("master", "release"))
+
+fun Project.isOnBranch(vararg branches: String) = buildBranch.orNull in branches
 
 fun isInBuild(vararg buildTypeIds: String) = buildConfigurationId.orNull?.let { currentBuildTypeId ->
     buildTypeIds.any { currentBuildTypeId.endsWith(it) }


### PR DESCRIPTION
After the optimization we made, the cache misses on master
and release should be monitored now.
