### PR TITLE
Replace -highly experimental-  with -experimental- in CC doc warning

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -26,7 +26,7 @@ In other words, the configuration cache saves the output of the configuration ph
 
 [IMPORTANT]
 ====
-This feature is currently *_highly experimental_* and not enabled by default.
+This feature is currently *_experimental_* and not enabled by default.
 
 Not all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> are supported.
 Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.


### PR DESCRIPTION
Replace _highly experimental_ with _experimental_ in configuration-cache documentation warning admonition at https://docs.gradle.org/nightly/userguide/configuration_cache.html#config_cache:intro