### PR TITLE
Re-enable ArtifactTransformCachingIntegrationTest for configuration caching

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -28,10 +28,8 @@ import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.gradle.test.fixtures.Flaky
 import org.junit.Rule
 import spock.lang.Issue
-import spock.lang.Requires
 
 import java.util.regex.Pattern
 
@@ -41,8 +39,6 @@ import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServi
 import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 import static org.hamcrest.Matchers.containsString
 
-@Flaky(because = "https://github.com/gradle/gradle-private/issues/3413")
-@Requires({ !GradleContextualExecuter.configCache })
 class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyResolutionTest implements FileAccessTimeJournalFixture, ValidationMessageChecker {
     private final static long MAX_CACHE_AGE_IN_DAYS = LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES
 


### PR DESCRIPTION
I wasn't able to reproduce the original problem. I tried running the test multiple times: https://ge.gradle.org/scans/tests?search.names=gitBranchName&search.relativeStartTime=P90D&search.tasks=configCacheIntegTest&search.timeZoneId=Europe/Berlin&search.values=wolfs/flaky/artifact-transform&tests.container=org.gradle.integtests.resolve.transform.ArtifactTransformCachingIntegrationTest&tests.sortField=FAILED&tests.unstableOnly=true

So maybe the problem has been fixed in the meantime?

Fixes https://github.com/gradle/gradle-private/issues/3413.