### PR TITLE
Refine configuration-cache report after the addition of configuration inputs

### DIFF
--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -220,12 +220,10 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(
         attributes {
             className("group-selector")
-            if (problemsCount == 0) {
-                className("group-selector--disabled")
-            } else if (tab == activeTab) {
-                className("group-selector--active")
-            } else {
-                onClick { Intent.SetTab(tab) }
+            when {
+                problemsCount == 0 -> className("group-selector--disabled")
+                tab == activeTab -> className("group-selector--active")
+                else -> onClick { Intent.SetTab(tab) }
             }
         },
         span(

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -209,13 +209,17 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun Model.summary() =
         "$totalProblems ${problemOrProblems()} found $cacheAction the configuration cache".let {
-            if (totalProblems > reportedProblems) "$it, only the first $reportedProblems were included in this report"
+            if (totalProblems > reportedProblems) "$it, only the first $reportedProblems ${reportedWasOrWere()} included in this report"
             else it
         }
 
     private
     fun Model.problemOrProblems() =
         if (totalProblems == 1) "problem was" else "problems were"
+
+    private
+    fun Model.reportedWasOrWere() =
+        if (reportedProblems == 1) "was" else "were"
 
     private
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -22,7 +22,6 @@ import elmish.code
 import elmish.div
 import elmish.empty
 import elmish.h1
-import elmish.hr
 import elmish.ol
 import elmish.pre
 import elmish.small
@@ -105,6 +104,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     }
 
     enum class Tab(val text: String) {
+        Inputs("Build logic inputs"),
         ByMessage("Problems grouped by message"),
         ByLocation("Problems grouped by location")
     }
@@ -149,9 +149,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     override fun view(model: Model): View<Intent> = div(
         attributes { className("report-wrapper") },
         viewHeader(model),
-        viewProblems(model),
-        hr(),
-        viewInputs(model.inputTree)
+        viewProblems(model)
     )
 
     private
@@ -177,6 +175,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
         ),
         div(
             attributes { className("groups") },
+            displayTabButton(Tab.Inputs, model.tab, model.inputTree.problemCount),
             displayTabButton(Tab.ByMessage, model.tab, model.messageTree.problemCount),
             displayTabButton(Tab.ByLocation, model.tab, model.locationTree.problemCount)
         )
@@ -186,6 +185,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun viewProblems(model: Model) = div(
         attributes { className("content") },
         when (model.tab) {
+            Tab.Inputs -> viewInputs(model.inputTree)
             Tab.ByMessage -> viewTree(model.messageTree, Intent::MessageTreeIntent, model.displayFilter)
             Tab.ByLocation -> viewTree(model.locationTree, Intent::TaskTreeIntent, model.displayFilter)
         }

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -96,7 +96,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
         val locationTree: ProblemTreeModel,
         val inputTree: ProblemTreeModel,
         val displayFilter: DisplayFilter = DisplayFilter.All,
-        val tab: Tab = Tab.ByMessage
+        val tab: Tab = if (totalProblems == 0) Tab.Inputs else Tab.ByMessage
     )
 
     enum class DisplayFilter {

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -90,6 +90,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     data class Model(
         val cacheAction: String,
+        val requestedTasks: String,
         val documentationLink: String,
         val totalProblems: Int,
         val reportedProblems: Int,
@@ -180,7 +181,8 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     private
     fun displaySummary(model: Model): View<Intent> {
         return h1(
-            "${model.cacheAction.capitalize()} the configuration cache",
+            "${model.cacheAction.capitalize()} the configuration cache for ",
+            code(model.requestedTasks),
             br(),
             small(model.inputsSummary()),
             br(),

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -192,29 +192,38 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     fun Model.inputsSummary() =
-        "${inputTree.problemCount} build logic input ${wasOrWere(inputTree.problemCount)} found".let {
+        found(inputTree.problemCount, "build logic input").let {
             if (inputTree.problemCount > 0) "$it and will cause the cache to be discarded when ${itsOrTheir(inputTree.problemCount)} value change"
             else it
         }
 
     private
     fun Model.problemsSummary() =
-        "$totalProblems ${problemOrProblems()} ${wasOrWere((totalProblems))} found".let {
+        found(totalProblems, "problem").let {
             if (totalProblems > reportedProblems) "$it, only the first $reportedProblems ${wasOrWere(reportedProblems)} included in this report"
             else it
         }
 
     private
-    fun Model.problemOrProblems() =
-        if (totalProblems == 1) "problem" else "problems"
+    fun found(count: Int, what: String) =
+        "${count.toStringOrNo()} ${what.sIfPlural(count)} ${wasOrWere(count)} found"
+
+    private
+    fun Int.toStringOrNo() =
+        if (this != 0) toString()
+        else "No"
+
+    private
+    fun String.sIfPlural(count: Int) =
+        if (count < 2) this else "${this}s"
 
     private
     fun wasOrWere(count: Int) =
-        if (count == 1) "was" else "were"
+        if (count <= 1) "was" else "were"
 
     private
     fun itsOrTheir(count: Int) =
-        if (count == 1) "its" else "there"
+        if (count <= 1) "its" else "their"
 
     private
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -192,9 +192,8 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     )
 
     private
-    fun viewInputs(inputTree: ProblemTreeModel): View<Intent> = when (inputTree.problemCount) {
-        0 -> h1("No build logic inputs were detected.")
-        else -> div(
+    fun viewInputs(inputTree: ProblemTreeModel): View<Intent> =
+        div(
             div(
                 attributes { className("title") },
                 h1("The following build logic inputs were automatically detected and will cause the cache to be discarded when their value change:"),
@@ -204,7 +203,6 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
                 viewTree(inputTree.tree.focus().children, Intent::InputTreeIntent)
             )
         )
-    }
 
     private
     fun Model.summary() =
@@ -225,7 +223,9 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun displayTabButton(tab: Tab, activeTab: Tab, problemsCount: Int): View<Intent> = div(
         attributes {
             className("group-selector")
-            if (tab == activeTab) {
+            if (problemsCount == 0) {
+                className("group-selector--disabled")
+            } else if (tab == activeTab) {
                 className("group-selector--active")
             } else {
                 onClick { Intent.SetTab(tab) }

--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -101,7 +101,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     )
 
     enum class Tab(val text: String) {
-        Inputs("Build logic inputs"),
+        Inputs("Build configuration inputs"),
         ByMessage("Problems grouped by message"),
         ByLocation("Problems grouped by location")
     }
@@ -192,7 +192,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
 
     private
     fun Model.inputsSummary() =
-        found(inputTree.problemCount, "build logic input").let {
+        found(inputTree.problemCount, "build configuration input").let {
             if (inputTree.problemCount > 0) "$it and will cause the cache to be discarded when ${itsOrTheir(inputTree.problemCount)} value change"
             else it
         }

--- a/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
@@ -41,6 +41,7 @@ external val configurationCacheProblems: () -> JsModel
 private
 external interface JsModel {
     val cacheAction: String
+    val requestedTasks: String
     val documentationLink: String
     val totalProblemCount: Int
     val diagnostics: Array<JsDiagnostic>
@@ -123,6 +124,7 @@ fun reportPageModelFromJsModel(jsModel: JsModel): ConfigurationCacheReportPage.M
     val diagnostics = importDiagnostics(jsModel.diagnostics)
     return ConfigurationCacheReportPage.Model(
         cacheAction = jsModel.cacheAction,
+        requestedTasks = jsModel.requestedTasks,
         documentationLink = jsModel.documentationLink,
         totalProblems = jsModel.totalProblemCount,
         reportedProblems = diagnostics.problems.size,

--- a/subprojects/configuration-cache-report/src/main/kotlin/elmish/View.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/elmish/View.kt
@@ -62,6 +62,9 @@ val li = ViewFactory("li")
 val a = ViewFactory("a")
 
 
+val br = ViewFactory("br")
+
+
 fun <I> render(view: View<I>, into: Element, send: (I) -> Unit) {
     into.innerHTML = ""
     into.appendElementFor(view, send)

--- a/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
+++ b/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
@@ -293,6 +293,14 @@ h4, h5, h6 {
     font-size: 0.875rem;
 }
 
+h1 code {
+    font-weight: bold;
+}
+
+h1 small {
+    font-weight: normal;
+}
+
 ul, ol, dl {
     list-style-position: outside;
     line-height: 1.6;

--- a/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
+++ b/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
@@ -40,11 +40,6 @@
     flex: 1 0 100%;
 }
 
-.filters {
-    margin-left: auto;
-    font-size: 0.875rem;
-}
-
 .content {
     font-size: 0.875rem;
     padding: 192px 0 48px;
@@ -173,43 +168,6 @@ ul .tree-btn {
 
 .copy-button::selection {
     color: transparent;
-}
-
-.filters-group {
-    display: inline-flex;
-    background-color: #EDEEEF;
-    border-radius: 5px;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    height: 30px;
-    align-items: center;
-    padding: 0 3px;
-    margin-left: 8px;
-    line-height: 1rem;
-}
-
-.btn {
-    padding: 4px 10px;
-    border-radius: 3px;
-    cursor: pointer;
-    position: relative;
-    height: 24px;
-    min-width: 78px;
-    display: inline-block;
-    text-align: center;
-}
-
-.btn:hover {
-    color: #3cafc6;
-    background-color: #d8eff3;
-    box-shadow: none;
-}
-
-.btn-active {
-    cursor: default;
-    background: #fff;
 }
 
 .groups {

--- a/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
+++ b/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
@@ -244,6 +244,10 @@ ul .tree-btn {
     background-color: #686868;
 }
 
+.group-selector--disabled {
+    cursor: not-allowed;
+}
+
 .accordion-header {
     cursor: pointer;
 }

--- a/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
+++ b/subprojects/configuration-cache-report/src/main/resources/configuration-cache-report.css
@@ -42,7 +42,7 @@
 
 .content {
     font-size: 0.875rem;
-    padding: 192px 0 48px;
+    padding: 240px 0 48px;
     overflow-x: auto;
     white-space: nowrap;
 }

--- a/subprojects/configuration-cache-report/src/test/resources/configuration-cache-report-data.js
+++ b/subprojects/configuration-cache-report/src/test/resources/configuration-cache-report-data.js
@@ -3,6 +3,7 @@ function configurationCacheProblems() {
     return (
         {
             "cacheAction": "storing",
+            "requestedTasks": "clean build",
             "documentationLink": "https://docs.gradle.org/6.6-20200618155501+0000/userguide/configuration_cache.html",
             "totalProblemCount": 2,
             "diagnostics": [

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -118,8 +118,8 @@ class ConfigurationCacheProblems(
 
         val outputDirectory = outputDirectoryFor(reportDir)
         val cacheActionText = cacheAction.summaryText()
-        val requestedTasksText = startParameter.requestedTaskNames.joinToString(" ")
-        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, requestedTasksText, problemCount)
+        val requestedTasks = startParameter.requestedTasksOrDefault()
+        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, requestedTasks, problemCount)
         if (htmlReportFile == null) {
             // there was nothing to report
             require(!failed)
@@ -156,6 +156,10 @@ class ConfigurationCacheProblems(
             LOAD -> "reusing"
             STORE -> "storing"
         }
+
+    private
+    fun ConfigurationCacheStartParameter.requestedTasksOrDefault() =
+        requestedTaskNames.takeIf { it.isNotEmpty() }?.joinToString(" ") ?: "default tasks"
 
     private
     fun outputDirectoryFor(buildDir: File): File =

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -118,7 +118,8 @@ class ConfigurationCacheProblems(
 
         val outputDirectory = outputDirectoryFor(reportDir)
         val cacheActionText = cacheAction.summaryText()
-        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, problemCount)
+        val requestedTasksText = startParameter.requestedTaskNames.joinToString(" ")
+        val htmlReportFile = report.writeReportFileTo(outputDirectory, cacheActionText, requestedTasksText, problemCount)
         if (htmlReportFile == null) {
             // there was nothing to report
             require(!failed)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheReport.kt
@@ -53,6 +53,7 @@ class ConfigurationCacheReport(
         open fun commitReportTo(
             outputDirectory: File,
             cacheAction: String,
+            requestedTasks: String,
             totalProblemCount: Int
         ): Pair<State, File?> =
             illegalState()
@@ -75,6 +76,7 @@ class ConfigurationCacheReport(
             override fun commitReportTo(
                 outputDirectory: File,
                 cacheAction: String,
+                requestedTasks: String,
                 totalProblemCount: Int
             ): Pair<State, File?> =
                 this to null
@@ -130,10 +132,10 @@ class ConfigurationCacheReport(
                 return this
             }
 
-            override fun commitReportTo(outputDirectory: File, cacheAction: String, totalProblemCount: Int): Pair<State, File?> {
+            override fun commitReportTo(outputDirectory: File, cacheAction: String, requestedTasks: String, totalProblemCount: Int): Pair<State, File?> {
                 lateinit var reportFile: File
                 executor.submit {
-                    closeHtmlReport(cacheAction, totalProblemCount)
+                    closeHtmlReport(cacheAction, requestedTasks, totalProblemCount)
                     reportFile = moveSpoolFileTo(outputDirectory)
                 }
                 executor.shutdownAndAwaitTermination()
@@ -153,8 +155,8 @@ class ConfigurationCacheReport(
             }
 
             private
-            fun closeHtmlReport(cacheAction: String, totalProblemCount: Int) {
-                writer.endHtmlReport(cacheAction, totalProblemCount)
+            fun closeHtmlReport(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+                writer.endHtmlReport(cacheAction, requestedTasks, totalProblemCount)
                 writer.close()
             }
 
@@ -226,10 +228,10 @@ class ConfigurationCacheReport(
      * see [HtmlReportWriter].
      */
     internal
-    fun writeReportFileTo(outputDirectory: File, cacheAction: String, totalProblemCount: Int): File? {
+    fun writeReportFileTo(outputDirectory: File, cacheAction: String, requestedTasks: String, totalProblemCount: Int): File? {
         var reportFile: File?
         modifyState {
-            val (newState, outputFile) = commitReportTo(outputDirectory, cacheAction, totalProblemCount)
+            val (newState, outputFile) = commitReportTo(outputDirectory, cacheAction, requestedTasks, totalProblemCount)
             reportFile = outputFile
             newState
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/HtmlReportWriter.kt
@@ -40,8 +40,8 @@ class HtmlReportWriter(val writer: Writer) {
         jsonModelWriter.beginModel()
     }
 
-    fun endHtmlReport(cacheAction: String, totalProblemCount: Int) {
-        jsonModelWriter.endModel(cacheAction, totalProblemCount)
+    fun endHtmlReport(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
+        jsonModelWriter.endModel(cacheAction, requestedTasks, totalProblemCount)
         endReportData()
         writer.append(htmlTemplate.second)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -44,7 +44,7 @@ class JsonModelWriter(val writer: Writer) {
         beginArray()
     }
 
-    fun endModel(cacheAction: String, totalProblemCount: Int) {
+    fun endModel(cacheAction: String, requestedTasks: String, totalProblemCount: Int) {
         endArray()
 
         comma()
@@ -53,6 +53,8 @@ class JsonModelWriter(val writer: Writer) {
         }
         comma()
         property("cacheAction", cacheAction)
+        comma()
+        property("requestedTasks", requestedTasks)
         comma()
         property("documentationLink", documentationRegistry.getDocumentationFor("configuration_cache"))
 


### PR DESCRIPTION
Fix the report layout moving inputs into their own tab, remove now irrelevant filter buttons, rework the title/summary of the report to account for inputs, display the requested tasks for the report so they are easier to identify, plus various enhancements.

![image](https://user-images.githubusercontent.com/132773/143285836-a9ff4352-8376-477e-b92b-f836f38fea4a.png)
