### PR TITLE
Try to fix LocaleSupportDaemonIntegrationTest flakiness

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -98,6 +98,7 @@ import static org.gradle.integtests.fixtures.executer.OutputScrapingExecutionRes
 import static org.gradle.internal.service.scopes.DefaultGradleUserHomeScopeServiceRegistry.REUSE_USER_HOME_SERVICES;
 import static org.gradle.util.internal.CollectionUtils.collect;
 import static org.gradle.util.internal.CollectionUtils.join;
+import static org.gradle.util.internal.DefaultGradleVersion.VERSION_OVERRIDE_VAR;
 
 public abstract class AbstractGradleExecuter implements GradleExecuter, ResettableExpectations {
 
@@ -183,9 +184,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private final MutableActionSet<GradleExecuter> beforeExecute = new MutableActionSet<>();
     private ImmutableActionSet<GradleExecuter> afterExecute = ImmutableActionSet.empty();
 
-    protected final TestDirectoryProvider testDirectoryProvider;
     protected final GradleVersion gradleVersion;
+    protected final TestDirectoryProvider testDirectoryProvider;
     protected final GradleDistribution distribution;
+    private GradleVersion gradleVersionOverride;
 
     private boolean debug = Boolean.getBoolean(DEBUG_SYSPROP);
     private boolean debugLauncher = Boolean.getBoolean(LAUNCHER_DEBUG_SYSPROP);
@@ -395,6 +397,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         if (!checkDaemonCrash) {
             executer.noDaemonCrashChecks();
         }
+        if (gradleVersionOverride != null) {
+            executer.withGradleVersionOverride(gradleVersionOverride);
+        }
 
         executer.startBuildProcessInDebugger(debug);
         executer.startLauncherInDebugger(debugLauncher);
@@ -477,6 +482,12 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     @Override
+    public GradleExecuter withGradleVersionOverride(GradleVersion gradleVersion) {
+        this.gradleVersionOverride = gradleVersion;
+        return this;
+    }
+
+    @Override
     public GradleExecuter requireOwnGradleUserHomeDir() {
         return withGradleUserHomeDir(testDirectoryProvider.getTestDirectory().file("user-home"));
     }
@@ -490,6 +501,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
         GradleInvocation gradleInvocation = new GradleInvocation();
         gradleInvocation.environmentVars.putAll(environmentVars);
+        if (gradleVersionOverride != null) {
+            gradleInvocation.environmentVars.put(VERSION_OVERRIDE_VAR, gradleVersionOverride.getVersion());
+        }
         if (!useOnlyRequestedJvmOpts) {
             gradleInvocation.buildJvmArgs.addAll(getImplicitBuildJvmArgs());
         }
@@ -909,13 +923,18 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     private void cleanupIsolatedDaemons() {
         List<DaemonLogsAnalyzer> analyzers = new ArrayList<>();
+        List<GradleVersion> versions = (gradleVersionOverride != null)
+            ? ImmutableList.of(gradleVersion, gradleVersionOverride)
+            : ImmutableList.of(gradleVersion);
         for (File dir : isolatedDaemonBaseDirs) {
-            try {
-                DaemonLogsAnalyzer analyzer = new DaemonLogsAnalyzer(dir, gradleVersion.getVersion());
-                analyzers.add(analyzer);
-                analyzer.killAll();
-            } catch (Exception e) {
-                getLogger().warn("Problem killing isolated daemons of Gradle version " + gradleVersion + " in " + dir, e);
+            for (GradleVersion version : versions) {
+                try {
+                    DaemonLogsAnalyzer analyzer = new DaemonLogsAnalyzer(dir, version.getVersion());
+                    analyzers.add(analyzer);
+                    analyzer.killAll();
+                } catch (Exception e) {
+                    getLogger().warn("Problem killing isolated daemons of Gradle version " + version + " in " + dir, e);
+                }
             }
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -24,6 +24,7 @@ import org.gradle.integtests.fixtures.RichConsoleStyling;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.test.fixtures.file.TestDirectoryProvider;
 import org.gradle.test.fixtures.file.TestFile;
+import org.gradle.util.GradleVersion;
 import org.gradle.util.internal.TextUtil;
 
 import java.io.File;
@@ -105,6 +106,14 @@ public interface GradleExecuter extends Stoppable {
      * <p>Note: does not affect the daemon base dir.</p>
      */
     GradleExecuter withGradleUserHomeDir(File userHomeDir);
+
+    /**
+     * Sets the Gradle version for executing Gradle.
+     *
+     * This does not actually use a different gradle version,
+     * it just modifies result of DefaultGradleVersion.current() for the Gradle that is run by the executer.
+     */
+    GradleExecuter withGradleVersionOverride(GradleVersion gradleVersion);
 
     /**
      * Sets the java home dir. Setting to null requests that the executer use the real default java home dir rather than the default used for testing.

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/LocaleSupportDaemonIntegrationTest.groovy
@@ -101,11 +101,12 @@ class LocaleSupportDaemonIntegrationTest extends DaemonIntegrationSpec {
         """
 
         when:
-        executer.withEnvironmentVars(("${DefaultGradleVersion.VERSION_OVERRIDE_VAR}".toString()): overrideVersion)
+        executer.requireIsolatedDaemons()
+        executer.withGradleVersionOverride(DefaultGradleVersion.version(overrideVersion))
         runWithLocale(locale)
 
         then:
-        outputContains("GradleVersion: Gradle ${overrideVersion}")
+        outputContains("GradleVersion: Gradle ${overrideVersion}\ndefaultLocale")
 
         and:
         ranWithLocale(locale)


### PR DESCRIPTION
The problem for flakiness is that daemon with "release" version is still
alive and blocks deleting of logs file after tests on Windows platform.

The idea here is that we make daemon isolated and `AbstractGradleExecuter` aware of
the modified version. And with that daemon is hopefully killed successfully in
`AbstractGradleExecutor#cleanupIsolatedDaemons`, that is called from the `cleanup`
method at the end of the test.