### PR TITLE
Don't collect configuration cache diagnostics after the report has been written

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -44,7 +44,7 @@ public class Instrumented {
     }
 
     public static void discardListener() {
-        LISTENER.set(NO_OP);
+        setListener(NO_OP);
     }
 
     // Called by generated code
@@ -82,7 +82,7 @@ public class Instrumented {
     // Called by generated code.
     public static String systemProperty(String key, @Nullable String defaultValue, String consumer) {
         String value = System.getProperty(key);
-        LISTENER.get().systemPropertyQueried(key, value, consumer);
+        listener().systemPropertyQueried(key, value, consumer);
         if (value == null) {
             return defaultValue;
         }
@@ -92,62 +92,66 @@ public class Instrumented {
     // Called by generated code.
     public static Properties systemProperties(String consumer) {
         return new AccessTrackingProperties(System.getProperties(), (k, v) -> {
-            LISTENER.get().systemPropertyQueried(convertToString(k), convertToString(v), consumer);
+            listener().systemPropertyQueried(convertToString(k), convertToString(v), consumer);
         });
     }
 
     // Called by generated code.
     public static Integer getInteger(String key, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Integer.getInteger(key);
     }
 
     // Called by generated code.
     public static Integer getInteger(String key, int defaultValue, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Integer.getInteger(key, defaultValue);
     }
 
     // Called by generated code.
     public static Integer getInteger(String key, Integer defaultValue, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Integer.getInteger(key, defaultValue);
     }
 
     // Called by generated code.
     public static Long getLong(String key, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Long.getLong(key);
     }
 
     // Called by generated code.
     public static Long getLong(String key, long defaultValue, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Long.getLong(key, defaultValue);
     }
 
     // Called by generated code.
     public static Long getLong(String key, Long defaultValue, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Long.getLong(key, defaultValue);
     }
 
     // Called by generated code.
     public static boolean getBoolean(String key, String consumer) {
-        LISTENER.get().systemPropertyQueried(key, System.getProperty(key), consumer);
+        listener().systemPropertyQueried(key, System.getProperty(key), consumer);
         return Boolean.getBoolean(key);
     }
 
     // Called by generated code.
     public static String getenv(String key, String consumer) {
         String value = System.getenv(key);
-        LISTENER.get().envVariableQueried(key, value, consumer);
+        listener().envVariableQueried(key, value, consumer);
         return value;
+    }
+
+    private static Listener listener() {
+        return LISTENER.get();
     }
 
     // Called by generated code.
     public static Map<String, String> getenv(String consumer) {
-        return new AccessTrackingEnvMap((key, value) -> LISTENER.get().envVariableQueried(convertToString(key), value, consumer));
+        return new AccessTrackingEnvMap((key, value) -> listener().envVariableQueried(convertToString(key), value, consumer));
     }
 
     private static Object unwrap(Object obj) {


### PR DESCRIPTION
As the `gradle-enterprise` plugin might cause diagnostics to be emitted after the report has already been written.
