### PR TITLE
Replay ignored hierarchies when enabling watching

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -55,7 +55,6 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
 
     @Override
     public final SnapshotHierarchy updateVfsOnBuildStarted(SnapshotHierarchy root, WatchMode watchMode) {
-        watchableHierarchies.updateUnsupportedFileSystems(watchMode);
         SnapshotHierarchy newRoot = watchableHierarchies.removeUnwatchableContentOnBuildStart(root, createInvalidator(), watchMode);
         newRoot = doUpdateVfsOnBuildStarted(newRoot);
         if (root != newRoot) {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -122,6 +122,7 @@ public class WatchableHierarchies {
         return newRoot;
     }
 
+    @CheckReturnValue
     private SnapshotHierarchy removeUnwatchedSnapshots(SnapshotHierarchy root, Invalidator invalidator) {
         RemoveUnwatchedFiles removeUnwatchedFilesVisitor = new RemoveUnwatchedFiles(root, invalidator);
         root.rootSnapshots()
@@ -129,6 +130,7 @@ public class WatchableHierarchies {
         return removeUnwatchedFilesVisitor.getRootWithUnwatchedFilesRemoved();
     }
 
+    @CheckReturnValue
     private SnapshotHierarchy removeWatchedHierarchiesOverLimit(SnapshotHierarchy root, Predicate<File> isWatchedHierarchy, int maximumNumberOfWatchedHierarchies, Invalidator invalidator) {
         hierarchies.removeIf(hierarchy -> !isWatchedHierarchy.test(hierarchy));
         SnapshotHierarchy result = root;
@@ -153,6 +155,7 @@ public class WatchableHierarchies {
             .reduce(FileHierarchySet.empty(), FileHierarchySet::plus, Combiners.nonCombining());
     }
 
+    @CheckReturnValue
     private SnapshotHierarchy removeUnwatchableFileSystems(SnapshotHierarchy root, Invalidator invalidator) {
         SnapshotHierarchy invalidatedRoot = invalidateUnsupportedFileSystems(root, invalidator);
         if (invalidatedRoot != root) {
@@ -163,6 +166,7 @@ public class WatchableHierarchies {
         return invalidatedRoot;
     }
 
+    @CheckReturnValue
     public SnapshotHierarchy removeUnwatchableContentOnBuildStart(SnapshotHierarchy root, Invalidator invalidator, WatchMode watchMode) {
         SnapshotHierarchy newRoot = root;
         newRoot = removeUnprovenHierarchies(newRoot, invalidator, watchMode);
@@ -183,6 +187,7 @@ public class WatchableHierarchies {
             }, nonCombining());
     }
 
+    @CheckReturnValue
     private SnapshotHierarchy invalidateUnsupportedFileSystems(SnapshotHierarchy root, Invalidator invalidator) {
         try {
             return watchableFileSystemDetector.detectUnsupportedFileSystems()

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -34,6 +34,7 @@ import javax.annotation.CheckReturnValue;
 import java.io.File;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.function.Predicate;
@@ -146,12 +147,12 @@ public class WatchableHierarchies {
                 result = invalidator.invalidate(locationToRemove.toString(), result);
             }
         }
-        rebuildWatchableFiles();
+        watchableFiles = buildWatchableFilesFromHierarchies(hierarchies);
         return result;
     }
 
-    private void rebuildWatchableFiles() {
-        this.watchableFiles = hierarchies.stream()
+    private static FileHierarchySet buildWatchableFilesFromHierarchies(Collection<File> hierarchies) {
+        return hierarchies.stream()
             .reduce(FileHierarchySet.empty(), FileHierarchySet::plus, Combiners.nonCombining());
     }
 
@@ -217,7 +218,7 @@ public class WatchableHierarchies {
             newRoot = invalidateUnwatchableHierarchies(newRoot, invalidator, unwatchableFiles);
 
             hierarchies.removeIf(unwatchableFiles::contains);
-            rebuildWatchableFiles();
+            watchableFiles = buildWatchableFilesFromHierarchies(hierarchies);
 
             // Replay the watchable hierarchies since the end of last build, since they have become watchable.
             for (File watchableHierarchy : watchableHierarchiesSinceLastBuildFinish) {

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
@@ -205,6 +205,25 @@ public abstract class FileHierarchySet {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            PrefixFileSet that = (PrefixFileSet) o;
+
+            return rootNode.equals(that.rootNode);
+        }
+
+        @Override
+        public int hashCode() {
+            return rootNode.hashCode();
+        }
+
+        @Override
         public String toString() {
             final StringBuilder builder = new StringBuilder();
             rootNode.visitHierarchy(0, new NodeVisitor() {
@@ -334,6 +353,30 @@ public abstract class FileHierarchySet {
             for (Node child : children) {
                 child.visitHierarchy(depth + 1, visitor);
             }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Node node = (Node) o;
+
+            if (!prefix.equals(node.prefix)) {
+                return false;
+            }
+            return children.equals(node.children);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = prefix.hashCode();
+            result = 31 * result + children.hashCode();
+            return result;
         }
 
         @Override


### PR DESCRIPTION
So we watch hierarchies which have been ignored when switching from watch mode `DEFAULT` to `ENABLED`. Note that the registration of the hierarchy comes in before we do the watchable hierarchy bookkeeping at the start of the build.

I ran into this when using the continuous build spike for tests, since the tests have their project home on `tmpfs`, which isn't supported. Though when I did turn on file system watching explicitly, the first build didn't start watching the project directory since the hierarchy was still ignored, causing the test to fail since it didn't start a rebuild.

This is the case where the current behavior causes problems:
- Run a build on `/tmp` with the unsupported `tmpfs` file system with watch mode `DEFAULT` -> unsupported file system `/tmp`, nothing is watched. This is from some other test which runs a regular build. `unwatchableFiles` is set to `/tmp`.
- Run a build on the same daemon with watch mode `ENABLED`. This is executed from a test for continuous build.
  - The project root of the new project comes in `registerWatchableHierarchy`, though is ignored since `unwatchableFiles` still contains `/tmp`.
  - We run `updateVfsOnBuildStarted`, see that the watch mode is `ENABLED` and set `unwatchableFiles` to empty.
  - We now don't watch anything in the project root, since there isn't another call to `registerWatchableHierarchy`.
  - The build doesn't receive any file system events and the continuous build isn't triggered.
- Run another build on the same daemon with watch mode `ENABLED`.
  - The project root of the new project comes in `registerWatchableHierarchy`, and now it is added to the watchable hierarchies since `unwatchableFiles` is empty.
  - Everything works now and we register watchers for files in the project dir, the continuous build triggers.