### PR TITLE
Pass -PcommitId=HEAD when installing dogfood-second

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -66,7 +66,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
                 name = "BUILD_WITH_BUILT_GRADLE"
                 tasks = "clean :distributions-full:install"
                 gradleHome = "%teamcity.build.checkoutDir%/dogfood-first"
-                gradleParams = "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
+                gradleParams = "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PpromotionCommitId=HEAD -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
             }
 
             localGradle {


### PR DESCRIPTION
We need to use unified commitId for gradleception distribution
because when `gradle-api.jar` will contain `build-receipt.properties`.


https://ge.gradle.org/c/xgbypu6avn2ru/fqufsr5mf5e2m/task-inputs?expanded=WyJtaTJpejRzYW42MmZ3LWNsYXNzcGF0aGZpbGVzIiwiZ2p2cW5pN25xNWJrby1jbGFzc3BhdGhmaWxlcyIsInljeWxhcjNqMmZ4ZHMtc291cmNlZmlsZXMiLCJ5Y3lsYXIzajJmeGRzLXNvdXJjZUZpbGVzLTEtMCIsInljeWxhcjNqMmZ4ZHMtc291cmNlRmlsZXMtMS0wLTAiLCJxM2FxNGthcXhsZHNzLWNsYXNzcGF0aGZpbGVzIiwicTNhcTRrYXF4bGRzcy1jb21waWxlZHBsdWdpbnNibG9ja3NkaXIiLCJxM2FxNGthcXhsZHNzLXJ1bnRpbWVjbGFzc3BhdGhmaWxlcyIsInEzYXE0a2FxeGxkc3MtY29tcGlsZWRQbHVnaW5zQmxvY2tzRGlyLTEtMCIsInEzYXE0a2FxeGxkc3MtY29tcGlsZWRQbHVnaW5zQmxvY2tzRGlyLTEtMC0wIiwidTdjMnVscjRhc2FrYy1zb3VyY2VmaWxlcyIsInU3YzJ1bHI0YXNha2Mtc291cmNlRmlsZXMtMS0wLTAiLCJ1N2MydWxyNGFzYWtjLXNvdXJjZUZpbGVzLTEtMCJd#change-mi2iz4san62fw-classPathFiles-0-0

![image](https://user-images.githubusercontent.com/12689835/143517792-622da042-f591-4a36-a1bb-1e12c0df0707.png)
