### PR TITLE
Add BuildCache interface to DSL doc

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.caching.configuration.BuildCache.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.caching.configuration.BuildCache.xml
@@ -23,6 +23,12 @@
                     <td>Name</td>
                 </tr>
             </thead>
+            <tr>
+                <td>push</td>
+            </tr>
+            <tr>
+                <td>enabled</td>
+            </tr>
         </table>
     </section>
     <section>


### PR DESCRIPTION
So when clicking in the DSL doc on BuildCache we end up on the dsl doc again.