### PR TITLE
Ignore the JAVA_VERSION env variable when looking for JVM's on macOS

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -16,7 +16,8 @@ Include only their name, impactful features should be called out separately belo
 [Róbert Papp](https://github.com/TWiStErRob),
 [Piyush Mor](https://github.com/piyushmor),
 [Ned Twigg](https://github.com/nedtwigg),
-[Nikolas Grottendieck](https://github.com/Okeanos).
+[Nikolas Grottendieck](https://github.com/Okeanos),
+[Lars Grefer](https://github.com/larsgrefer).
 
 ## Upgrade instructions
 

--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
@@ -79,6 +79,7 @@ public class OsXInstallationSupplier extends AutoDetectingInstallationSupplier {
         ExecHandleBuilder execHandleBuilder = execHandleFactory.newExec();
         execHandleBuilder.workingDir(new File(".").getAbsoluteFile());
         execHandleBuilder.commandLine("/usr/libexec/java_home", "-V");
+        execHandleBuilder.getEnvironment().remove("JAVA_VERSION");
         // verbose output is written to stderr
         execHandleBuilder.setErrorOutput(outputStream);
         execHandleBuilder.setStandardOutput(new ByteArrayOutputStream());

--- a/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/jvm/toolchain/internal/OsXInstallationSupplier.java
@@ -79,9 +79,8 @@ public class OsXInstallationSupplier extends AutoDetectingInstallationSupplier {
         ExecHandleBuilder execHandleBuilder = execHandleFactory.newExec();
         execHandleBuilder.workingDir(new File(".").getAbsoluteFile());
         execHandleBuilder.commandLine("/usr/libexec/java_home", "-V");
-        execHandleBuilder.getEnvironment().remove("JAVA_VERSION");
-        // verbose output is written to stderr
-        execHandleBuilder.setErrorOutput(outputStream);
+        execHandleBuilder.getEnvironment().remove("JAVA_VERSION"); //JAVA_VERSION filters the content of java_home's output
+        execHandleBuilder.setErrorOutput(outputStream); // verbose output is written to stderr
         execHandleBuilder.setStandardOutput(new ByteArrayOutputStream());
         execHandleBuilder.build().start().waitForFinish().assertNormalExitValue();
     }


### PR DESCRIPTION
fixes #19117

### Context

The `JAVA_VERSION` environment variable can be used on macOS to filter the output of `/usr/libexec/java_home`.
This can be useful to quickly select which java version will be used by `/usr/bin/java` on the command line.

When searching for JVM's for the toolchain support, this environment variable prevents Gradle from finding all installed JVM's.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
