### PR TITLE
Add other possible solution for OUTPUT_FILE_VALIDATOR

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -726,7 +726,7 @@ task someTask(type: SomeTask) {
 
         expect:
         fails "test"
-        failureDescriptionContains(cannotWriteToFile {
+        failureDescriptionContains(cannotWriteFileToDirectory {
             property('output')
                 .file(outputDir)
                 .isNotFile()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -458,7 +458,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         then:
         def e = thrown WorkValidationException
-        validateException(task, e, cannotWriteToFile {
+        validateException(task, e, cannotWriteFileToDirectory {
             property('outputFile')
                 .file(task.outputFile)
                 .isNotFile()
@@ -478,7 +478,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         then:
         def e = thrown WorkValidationException
-        validateException(task, e, cannotWriteToFile {
+        validateException(task, e, cannotWriteFileToDirectory {
             property('outputFiles')
                 .file(task.outputFiles[0])
                 .isNotFile()
@@ -499,7 +499,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         then:
         def e = thrown WorkValidationException
-        validateException(task, e, cannotWriteToFile {
+        validateException(task, e, cannotCreateParentDirectories {
             property('outputFile')
                 .file(task.outputFile)
                 .ancestorIsNotDirectory(task.outputFile.parentFile)
@@ -520,7 +520,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec imp
 
         then:
         def e = thrown WorkValidationException
-        validateException(task, e, cannotWriteToFile {
+        validateException(task, e, cannotCreateParentDirectories {
             property('outputFiles')
                 .file(task.outputFiles[0])
                 .ancestorIsNotDirectory(task.outputFiles[0].parentFile)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/validation/ValidationMessageCheckerTest.groovy
@@ -563,7 +563,7 @@ Please refer to https://docs.gradle.org/current/userguide/validation_problems.ht
         def ancestor = dummyLocation('/tmp/foo')
 
         when:
-        render cannotWriteToFile {
+        render cannotWriteFileToDirectory {
             type('Writer').property('output')
             file(location)
             isNotFile()
@@ -576,13 +576,15 @@ Type 'Writer' property 'output' is not writable because '${location}' is not a f
 
 Reason: Cannot write a file to a location pointing at a directory.
 
-Possible solution: Configure 'output' to point to a file, not a directory.
+Possible solutions:
+  1. Configure 'output' to point to a file, not a directory.
+  2. Annotate 'output' with @OutputDirectory instead of @OutputFiles.
 
 Please refer to https://docs.gradle.org/current/userguide/validation_problems.html#cannot_write_output for more details about this problem.
 """
 
         when:
-        render cannotWriteToFile {
+        render cannotCreateParentDirectories {
             type('Writer').property('output')
             file(location)
             ancestorIsNotDirectory(ancestor)
@@ -593,9 +595,9 @@ Please refer to https://docs.gradle.org/current/userguide/validation_problems.ht
         outputEquals """
 Type 'Writer' property 'output' is not writable because '${location}' ancestor '${ancestor}' is not a directory.
 
-Reason: Cannot write a file to a location pointing at a directory.
+Reason: Cannot create parent directories that are existing as file.
 
-Possible solution: Configure 'output' to point to a file, not a directory.
+Possible solution: Configure 'output' to point to the correct location.
 
 Please refer to https://docs.gradle.org/current/userguide/validation_problems.html#cannot_write_output for more details about this problem.
 """

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -259,12 +259,26 @@ trait ValidationMessageChecker {
     @ValidationTestFor(
         ValidationProblemId.CANNOT_WRITE_OUTPUT
     )
-    String cannotWriteToFile(@DelegatesTo(value = CannotWriteToFile, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+    String cannotWriteFileToDirectory(@DelegatesTo(value = CannotWriteToFile, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
         def config = display(CannotWriteToFile, 'cannot_write_output', spec)
-        config.description("is not writable because '${config.file}' ${config.reason}")
+
+        def cannotWriteToFile = config.description("is not writable because '${config.file}' ${config.reason}")
             .reason("Cannot write a file to a location pointing at a directory")
             .solution("Configure '${config.property}' to point to a file, not a directory")
-            .render()
+            .solution("Annotate '${config.property}' with @OutputDirectory instead of @OutputFiles.")
+        cannotWriteToFile.render()
+    }
+
+    @ValidationTestFor(
+        ValidationProblemId.CANNOT_WRITE_OUTPUT
+    )
+    String cannotCreateParentDirectories(@DelegatesTo(value = CannotWriteToFile, strategy = Closure.DELEGATE_FIRST) Closure<?> spec = {}) {
+        def config = display(CannotWriteToFile, 'cannot_write_output', spec)
+
+        def cannotWriteToFile = config.description("is not writable because '${config.file}' ${config.reason}")
+            .reason("Cannot create parent directories that are existing as file")
+            .solution("Configure '${config.property}' to point to the correct location")
+        cannotWriteToFile.render()
     }
 
     @ValidationTestFor(


### PR DESCRIPTION
### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
