### PR TITLE
Use unified commit id for all Gradleception builds

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -40,12 +40,17 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
     val buildScanTagForType = buildScanTag("Gradleception")
     val defaultParameters = (buildToolGradleParameters() + listOf(buildScanTagForType) + "-Porg.gradle.java.installations.auto-download=false").joinToString(separator = " ")
 
+    params {
+        // Override the default commit id so the build steps produce reproducible distribution
+        param("env.BUILD_COMMIT_ID", "HEAD")
+    }
+
     applyDefaults(
         model,
         this,
         ":distributions-full:install",
         notQuick = true,
-        extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PpromotionCommitId=HEAD -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType",
+        extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType",
         extraSteps = {
             script {
                 name = "CALCULATE_MD5_VERSION_FOR_DOGFOODING_DISTRIBUTION"
@@ -66,7 +71,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
                 name = "BUILD_WITH_BUILT_GRADLE"
                 tasks = "clean :distributions-full:install"
                 gradleHome = "%teamcity.build.checkoutDir%/dogfood-first"
-                gradleParams = "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PpromotionCommitId=HEAD -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
+                gradleParams = "-Pgradle_installPath=dogfood-second -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp2 $defaultParameters"
             }
 
             localGradle {


### PR DESCRIPTION
We found that Gradleception builds are not reproducible because of
`commitId` in `build-receipt.properties` (generated API jars are used
as runtime classpath). Now let's unify it.
