### PR TITLE
Fix issues in flaky test quarantine builds

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -26,7 +26,8 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os) : BaseGradl
             StageNames.QUICK_FEEDBACK_LINUX_ONLY,
             StageNames.QUICK_FEEDBACK,
             StageNames.READY_FOR_MERGE,
-            StageNames.READY_FOR_NIGHTLY
+            StageNames.READY_FOR_NIGHTLY,
+            StageNames.READY_FOR_RELEASE,
         )
     }.flatMap { it.functionalTests }.filter { it.os == os }
 
@@ -40,7 +41,7 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os) : BaseGradl
             ).joinToString(separator = " ")
         steps {
             gradleWrapper {
-                name = "FLAKY_TEST_QUARANTINE_${testCoverage.testJvmVersion.name.uppercase()}"
+                name = "FLAKY_TEST_QUARANTINE_${testCoverage.testType.name.uppercase()}_${testCoverage.testJvmVersion.name.uppercase()}"
                 tasks = "${testCoverage.testType.name}Test"
                 gradleParams = parameters
                 executionMode = BuildStep.ExecutionMode.ALWAYS

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -16,6 +16,7 @@
 
 import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
 import gradlebuild.basics.BuildEnvironment
+import gradlebuild.basics.flakyTestQuarantine
 import gradlebuild.basics.isExperimentalTestFilteringEnabled
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionPartitionSecond
@@ -24,7 +25,6 @@ import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
 import gradlebuild.basics.testJavaVendor
 import gradlebuild.basics.testJavaVersion
-import gradlebuild.basics.flakyTestQuarantine
 import gradlebuild.filterEnvironmentVariables
 import gradlebuild.jvm.argumentproviders.CiEnvironmentProvider
 import gradlebuild.jvm.extension.UnitTestAndCompileExtension
@@ -230,9 +230,14 @@ fun Test.configureRerun() {
     }
 }
 
-fun Test.determineMaxRetry() = when {
+fun Test.determineMaxRetries() = when {
     project.flakyTestQuarantine.isPresent -> 4
     else -> 1
+}
+
+fun Test.determineMaxFailures() = when {
+    project.flakyTestQuarantine.isPresent -> Integer.MAX_VALUE
+    else -> 10
 }
 
 fun configureTests() {
@@ -257,8 +262,8 @@ fun configureTests() {
         if (BuildEnvironment.isCiServer) {
             configureRerun()
             retry {
-                maxRetries.convention(determineMaxRetry())
-                maxFailures.set(10)
+                maxRetries.convention(determineMaxRetries())
+                maxFailures.set(determineMaxFailures())
             }
             doFirst {
                 logger.lifecycle("maxParallelForks for '$path' is $maxParallelForks")


### PR DESCRIPTION
- Enable flaky test quarantine for ready for release, too.
- Display test type name in build step.
- Set max failures to Integer.MAX_VALUE for flaky test qurantine builds.
