### PR TITLE
Create build scans for kill process steps

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -209,10 +209,8 @@ fun BuildType.killProcessStep(stepName: String, daemon: Boolean) {
             name = stepName
             executionMode = BuildStep.ExecutionMode.ALWAYS
             tasks = "killExistingProcessesStartedByGradle"
-            gradleParams = (
-                buildToolGradleParameters(daemon) +
-                    "-DpublishStrategy=publishOnFailure" // https://github.com/gradle/gradle-enterprise-conventions-plugin/pull/8
-                ).joinToString(separator = " ")
+            gradleParams =
+                buildToolGradleParameters(daemon).joinToString(separator = " ")
         }
     }
 }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -20,7 +20,9 @@ import common.Os
 import common.VersionedSettingsBranch
 import configurations.BaseGradleBuildType
 import configurations.PerformanceTest
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import model.CIBuildModel
 import model.JsonBasedGradleSubprojectProvider
@@ -36,6 +38,12 @@ import org.junit.jupiter.api.Test
 import java.io.File
 
 class PerformanceTestBuildTypeTest {
+    init {
+        // Set the project id here, so we can use methods on the DslContext
+        DslContext.projectId = AbsoluteId("Gradle_Master")
+        DslContext.addParameters("Branch" to "master")
+    }
+
     private
     val buildModel = CIBuildModel(
         projectId = "Gradle_Check",


### PR DESCRIPTION
This step may be slow since it is the first step running on a
new build agent. So it would be better to get some insights
there why it is slow.

For example, the step took 3 minutes here, all configuration time: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_CompileAllBuild/47545463?showLog=47545463_675_407