### PR TITLE
Don't delegate visitCollection -> visitGenericFileTree

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/AbstractArchiveFileTree.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/AbstractArchiveFileTree.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.file.archive;
 
-import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -35,7 +34,7 @@ public abstract class AbstractArchiveFileTree implements FileSystemMirroringFile
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
+    public void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner) {
         File backingFile = getBackingFile();
         if (backingFile != null) {
             visitor.visitFileTreeBackedByFile(backingFile, owner, this);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/AbstractArchiveFileTreeTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.file.archive
 
 import org.gradle.api.file.FileVisitor
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.collections.DirectoryFileTree
+import org.gradle.api.internal.file.collections.MinimalFileTree
 import org.gradle.api.provider.Provider
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
@@ -32,7 +32,7 @@ class AbstractArchiveFileTreeTest extends Specification {
 
     def "visits structure when backing file is known"() {
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
         def backingFile = tmpDir.createFile("thing.bin")
 
         def fileTree = new TestArchiveFileTree(backingFile: backingFile)
@@ -47,7 +47,7 @@ class AbstractArchiveFileTreeTest extends Specification {
 
     def "visits structure when backing file is not known"() {
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
 
         def fileTree = new TestArchiveFileTree()
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/DirectoryFileTree.java
@@ -24,7 +24,6 @@ import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.file.ReproducibleFileVisitor;
 import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.util.PatternFilterable;
@@ -103,7 +102,7 @@ public class DirectoryFileTree implements MinimalFileTree, PatternFilterableFile
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
+    public void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner) {
         visitor.visitFileTree(dir, patternSet, owner);
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FileTreeAdapter.java
@@ -104,6 +104,21 @@ public final class FileTreeAdapter extends AbstractFileTree {
 
     @Override
     protected void visitContents(FileCollectionStructureVisitor visitor) {
-        tree.visitStructure(visitor, this);
+        tree.visitStructure(new MinimalFileTree.MinimalFileTreeStructureVisitor() {
+            @Override
+            public void visitGenericFileTree(FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
+                visitor.visitGenericFileTree(fileTree, sourceTree);
+            }
+
+            @Override
+            public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
+                visitor.visitFileTree(root, patterns, fileTree);
+            }
+
+            @Override
+            public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
+                visitor.visitFileTreeBackedByFile(file, fileTree, sourceTree);
+            }
+        }, this);
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
@@ -74,7 +74,8 @@ public class FilteredMinimalFileTree implements MinimalFileTree, FileSystemMirro
 
             @Override
             public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
-                visitor.visitGenericFileTree(owner, FilteredMinimalFileTree.this);
+                // No need to filter the contents here, since only `GeneratedSingletonFileTree` which uses the call provides an empty list here.
+                visitor.visitCollection(source, contents);
             }
 
             @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
@@ -74,8 +74,7 @@ public class FilteredMinimalFileTree implements MinimalFileTree, FileSystemMirro
 
             @Override
             public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
-                // No need to filter the contents here, since only `GeneratedSingletonFileTree` which uses the call provides an empty list here.
-                visitor.visitCollection(source, contents);
+                throw new IllegalStateException("A minimal file tree shouldn't call visitCollection");
             }
 
             @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
@@ -60,21 +60,11 @@ public class FilteredMinimalFileTree implements MinimalFileTree, FileSystemMirro
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
-        tree.visitStructure(new FileCollectionStructureVisitor() {
+    public void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner) {
+        tree.visitStructure(new MinimalFileTreeStructureVisitor() {
             @Override
-            public boolean startVisit(FileCollectionInternal.Source source, FileCollectionInternal fileCollection) {
-                throw new IllegalStateException();
-            }
-
-            @Override
-            public VisitType prepareForVisit(FileCollectionInternal.Source source) {
+            public FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
                 return visitor.prepareForVisit(source);
-            }
-
-            @Override
-            public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
-                throw new IllegalStateException("A minimal file tree shouldn't call visitCollection");
             }
 
             @Override

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
-import java.util.Collections;
 
 /**
  * A generated file tree which is composed using a mapping from relative path to file source.
@@ -104,7 +103,7 @@ public class GeneratedSingletonFileTree implements FileSystemMirroringFileTree, 
     public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
         if (visitor.prepareForVisit(this) == FileCollectionStructureVisitor.VisitType.NoContents) {
             // Visit metadata but not contents
-            visitor.visitCollection(this, Collections.emptyList());
+            throw new IllegalStateException("Cannot visit a GeneratedSingletonFileTree without the contents");
         } else {
             visitor.visitFileTree(getFile(), new PatternSet(), owner);
         }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -101,10 +101,8 @@ public class GeneratedSingletonFileTree implements FileSystemMirroringFileTree, 
 
     @Override
     public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
-        if (visitor.prepareForVisit(this) == FileCollectionStructureVisitor.VisitType.NoContents) {
-            // Visit metadata but not contents
-            throw new IllegalStateException("Cannot visit a GeneratedSingletonFileTree without the contents");
-        } else {
+        if (visitor.prepareForVisit(this) != FileCollectionStructureVisitor.VisitType.NoContents) {
+            // TODO: Fail when using NoContents when we moved to using the new file system watching infrastructure for continuous build.
             visitor.visitFileTree(getFile(), new PatternSet(), owner);
         }
     }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/GeneratedSingletonFileTree.java
@@ -100,7 +100,7 @@ public class GeneratedSingletonFileTree implements FileSystemMirroringFileTree, 
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
+    public void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner) {
         if (visitor.prepareForVisit(this) != FileCollectionStructureVisitor.VisitType.NoContents) {
             // TODO: Fail when using NoContents when we moved to using the new file system watching infrastructure for continuous build.
             visitor.visitFileTree(getFile(), new PatternSet(), owner);

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/MinimalFileTree.java
@@ -15,9 +15,14 @@
  */
 package org.gradle.api.internal.file.collections;
 
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitor;
+import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
+import org.gradle.api.tasks.util.PatternSet;
+
+import java.io.File;
 
 /**
  * A minimal file tree implementation. An implementation can optionally also implement the following interfaces:
@@ -34,5 +39,37 @@ public interface MinimalFileTree extends MinimalFileCollection {
      */
     void visit(FileVisitor visitor);
 
-    void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner);
+    void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner);
+
+    interface MinimalFileTreeStructureVisitor {
+
+        /**
+         * Called prior to visiting a file source with the given spec, and allows this visitor to skip these files.
+         * A "file source" is some opaque source of files that is not a full {@link FileCollection}.
+         *
+         * <p>Note that this method is not necessarily called immediately before one of the visit methods, as some collections may be
+         * resolved in parallel. However, all visiting is performed sequentially and in order.
+         * This method is also called sequentially and in order.
+         *
+         * @return how should the collection be visited?
+         */
+        default FileCollectionStructureVisitor.VisitType prepareForVisit(FileCollectionInternal.Source source) {
+            return FileCollectionStructureVisitor.VisitType.Visit;
+        }
+
+        /**
+         * Visits a file tree whose content is generated from some opaque source.
+         */
+        void visitGenericFileTree(FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree);
+
+        /**
+         * Visits a file tree at a root file on the file system (potentially filtered).
+         */
+        void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree);
+
+        /**
+         * Visits a file tree whose content is generated from the contents of a file.
+         */
+        void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree);
+    }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/SingleIncludePatternFileTree.java
@@ -22,7 +22,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.DefaultFileVisitDetails;
-import org.gradle.api.internal.file.FileCollectionStructureVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.pattern.PatternStep;
 import org.gradle.api.internal.file.pattern.PatternStepFactory;
@@ -76,7 +75,7 @@ public class SingleIncludePatternFileTree implements MinimalFileTree, LocalFileT
     }
 
     @Override
-    public void visitStructure(FileCollectionStructureVisitor visitor, FileTreeInternal owner) {
+    public void visitStructure(MinimalFileTreeStructureVisitor visitor, FileTreeInternal owner) {
         visitor.visitFileTree(baseDir, getPatterns(), owner);
     }
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/DirectoryFileTreeTest.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.file.collections
 
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.ReproducibleFileVisitor
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.specs.Spec
@@ -30,7 +29,7 @@ class DirectoryFileTreeTest extends AbstractProjectBuilderSpec {
         def root = temporaryFolder.createDir("root")
         def patterns = new PatternSet()
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
 
         def fileTree = new DirectoryFileTree(root, patterns, TestFiles.fileSystem(), false)
 

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FilteredMinimalFileTreeTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/FilteredMinimalFileTreeTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.file.collections
 
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
@@ -78,13 +77,13 @@ class FilteredMinimalFileTreeTest extends Specification {
         def owner = Stub(FileTreeInternal)
         def sourcePatterns = Mock(PatternSet)
         def intersectPatterns = Mock(PatternSet)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
 
         when:
         tree.visitStructure(visitor, owner)
 
         then:
-        1 * source.visitStructure(_, _) >> { FileCollectionStructureVisitor nestedVisitor, FileTreeInternal o ->
+        1 * source.visitStructure(_, _) >> { MinimalFileTree.MinimalFileTreeStructureVisitor nestedVisitor, FileTreeInternal o ->
             nestedVisitor.visitFileTree(dir, sourcePatterns, o)
         }
         1 * sourcePatterns.intersect() >> intersectPatterns

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
@@ -81,7 +81,7 @@ class GeneratedSingletonFileTreeSpec extends Specification {
 
     def "visiting structure eagerly generates content when listener requests content but does not use it"() {
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
         def tmpDir = tmpDir.createDir("dir")
         def generatedFile = tmpDir.file("file.bin")
         def generationListener = Mock(Action)
@@ -108,7 +108,7 @@ class GeneratedSingletonFileTreeSpec extends Specification {
 
     def "visiting structure does not generate content when listener does not need it"() {
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
         def tmpDir = tmpDir.createDir("dir")
         def contentWriter = Mock(Action)
         def generationListener = Mock(Action)

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/GeneratedSingletonFileTreeSpec.groovy
@@ -120,7 +120,6 @@ class GeneratedSingletonFileTreeSpec extends Specification {
 
         then:
         1 * visitor.prepareForVisit(fileTree) >> FileCollectionStructureVisitor.VisitType.NoContents
-        1 * visitor.visitCollection(fileTree, [])
         0 * _
     }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/collections/SingleIncludePatternFileTreeSpec.groovy
@@ -17,7 +17,6 @@ package org.gradle.api.internal.file.collections
 
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.file.FileVisitor
-import org.gradle.api.internal.file.FileCollectionStructureVisitor
 import org.gradle.api.internal.file.FileTreeInternal
 import org.gradle.api.specs.Spec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -67,7 +66,7 @@ class SingleIncludePatternFileTreeSpec extends Specification {
     def "visits structure"() {
         def spec = Stub(Spec)
         def owner = Stub(FileTreeInternal)
-        def visitor = Mock(FileCollectionStructureVisitor)
+        def visitor = Mock(MinimalFileTree.MinimalFileTreeStructureVisitor)
 
         fileTree = new SingleIncludePatternFileTree(tempDir.testDirectory, "pattern", spec)
 


### PR DESCRIPTION
in FilteredMinimalFileTree.

This came up in https://github.com/gradle/gradle/issues/19158 when I tried to remove `visitGenericFileTree()`. Actually, it seems like it is impossible to get to the call of the method, since
- Only `GeneratedSingletonFileTree` calls `visitCollection()` when `prepareForVisit` returns `FileCollectionStructureVisitor.VisitType.NoContents`.
- Only [`CollectingVisitor`](https://github.com/gradle/gradle/blob/b7e1a80ddd35b0c17177a103d9ce63e11fa6ce48/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt#L163) uses `NoContents`, though that already returns early since `startVisit` there will end up in the branch for [`FileTreeInternal`](https://github.com/gradle/gradle/blob/b7e1a80ddd35b0c17177a103d9ce63e11fa6ce48/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/FileCollectionCodec.kt#L143-L146), aborting the visiting.