### PR TITLE
Update wrapper to latest nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.4-20211105135452+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.4-20211201142612+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
For the fix to still generate build scans when there's an exception during taskGraph.whenReady with the configuration cache.
