### PR TITLE
Expose configuration to control test sources and test dependencies in Eclipse project generation

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java
@@ -161,10 +161,15 @@ public class EclipseClasspath {
 
     private final Property<Boolean> containsTestFixtures;
 
+    private final Property<String> testSourceSetNamePattern;
+    private final Property<String> testDependencyConfigurationNamePattern;
+
     @Inject
     public EclipseClasspath(org.gradle.api.Project project) {
         this.project = project;
         this.containsTestFixtures = project.getObjects().property(Boolean.class).convention(false);
+        this.testSourceSetNamePattern = project.getObjects().property(String.class).convention(".*[tT][eE][sS][tT].*");
+        this.testDependencyConfigurationNamePattern = project.getObjects().property(String.class).convention(".*[tT][eE][sS][tT].*");
     }
 
     /**
@@ -379,5 +384,35 @@ public class EclipseClasspath {
     @Incubating
     public Property<Boolean> getContainsTestFixtures() {
         return containsTestFixtures;
+    }
+
+    /**
+     * Returns the regular expression matching on test source sets.
+     * <p>
+     * If a source set name matches with the returned pattern then the contained source directories will be marked in Eclipse as it contains test sources
+     * (i.e. the test=true entry attribute will be present on the source directory classpath entry).
+     * <p>
+     * The default value is {@code .*test.*}
+     *
+     * @since 7.4
+     */
+    @Incubating
+    public Property<String> getTestSourceSetNamePattern() {
+        return testSourceSetNamePattern;
+    }
+
+    /**
+     * Returns the regular expression matching on test dependency configuration names.
+     * <p>
+     * If a dependency defined only in configurations that all match with the returned pattern then the dependency will be marked as test dependency on the eclipse classpath
+     * (i.e. the test=true entry attribute will be present on the library classpath entry).
+     * <p>
+     * The default value is {@code .*test.*}
+     *
+     * @since 7.4
+     */
+    @Incubating
+    public Property<String> getTestDependencyConfigurationNamePattern() {
+        return testDependencyConfigurationNamePattern;
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -74,7 +74,8 @@ public class EclipseDependenciesCreator {
 
     public List<AbstractClasspathEntry> createDependencyEntries() {
         EclipseDependenciesVisitor visitor = new EclipseDependenciesVisitor(classpath.getProject());
-        new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), inferModulePath, gradleApiSourcesResolver).visit(visitor);
+        String testConfigNamePattern = classpath.getTestDependencyConfigurationNamePattern().get();
+        new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class), classpath.getPlusConfigurations(), classpath.getMinusConfigurations(), inferModulePath, gradleApiSourcesResolver, testConfigNamePattern).visit(visitor);
         return visitor.getDependencies();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/WtpClasspathAttributeSupport.java
@@ -65,7 +65,7 @@ public class WtpClasspathAttributeSupport {
     private static Set<File> collectFilesFromConfigs(EclipseClasspath classpath, Set<Configuration> configs, Set<Configuration> minusConfigs) {
         WtpClasspathAttributeDependencyVisitor visitor = new WtpClasspathAttributeDependencyVisitor(classpath);
         new IdeDependencySet(classpath.getProject().getDependencies(), ((ProjectInternal) classpath.getProject()).getServices().get(JavaModuleDetector.class),
-            configs, minusConfigs, false, NullGradleApiSourcesResolver.INSTANCE).visit(visitor);
+            configs, minusConfigs, false, NullGradleApiSourcesResolver.INSTANCE, classpath.getTestDependencyConfigurationNamePattern().get()).visit(visitor);
         return visitor.getFiles();
     }
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -52,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_API;
 import static org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory.ClassPathNotation.GRADLE_TEST_KIT;
@@ -68,14 +69,20 @@ public class IdeDependencySet {
     private final Collection<Configuration> minusConfigurations;
     private final boolean inferModulePath;
     private final GradleApiSourcesResolver gradleApiSourcesResolver;
+    private final Pattern testConfigNamePattern;
 
-    public IdeDependencySet(DependencyHandler dependencyHandler, JavaModuleDetector javaModuleDetector, Collection<Configuration> plusConfigurations, Collection<Configuration> minusConfigurations,  boolean inferModulePath, GradleApiSourcesResolver gradleApiSourcesResolver) {
+    public IdeDependencySet(DependencyHandler dependencyHandler, JavaModuleDetector javaModuleDetector, Collection<Configuration> plusConfigurations, Collection<Configuration> minusConfigurations, boolean inferModulePath, GradleApiSourcesResolver gradleApiSourcesResolver) {
+        this(dependencyHandler, javaModuleDetector, plusConfigurations, minusConfigurations, inferModulePath, gradleApiSourcesResolver, ".*test.*");
+    }
+
+    public IdeDependencySet(DependencyHandler dependencyHandler, JavaModuleDetector javaModuleDetector, Collection<Configuration> plusConfigurations, Collection<Configuration> minusConfigurations, boolean inferModulePath, GradleApiSourcesResolver gradleApiSourcesResolver, String testConfigNamePattern) {
         this.dependencyHandler = dependencyHandler;
         this.javaModuleDetector = javaModuleDetector;
         this.plusConfigurations = plusConfigurations;
         this.minusConfigurations = minusConfigurations;
         this.inferModulePath = inferModulePath;
         this.gradleApiSourcesResolver = gradleApiSourcesResolver;
+        this.testConfigNamePattern = Pattern.compile(testConfigNamePattern);
     }
 
     public void visit(IdeDependencyVisitor visitor) {
@@ -262,7 +269,7 @@ public class IdeDependencySet {
 
         private boolean isTestConfiguration(Set<Configuration> configurations) {
             for (Configuration c : configurations) {
-                if (!c.getName().toLowerCase().contains("test")) {
+                if (!testConfigNamePattern.matcher(c.getName()).matches()) {
                     return false;
                 }
             }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreatorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.eclipse.model.internal
 
 import org.gradle.api.file.DirectoryTree
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
@@ -128,7 +129,7 @@ class SourceFoldersCreatorTest extends Specification {
         _ * resources.includes >> resourcesTree.patterns.includes
         _ * resources.srcDirTrees >> [resourcesTree]
         _ * allSource.getSrcDirTrees() >> [javaTree, resourcesTree]
-        return new SourceFoldersCreator().projectRelativeFolders([sourceSet], { File file -> file.path }, defaultOutputFolder)
+        return new SourceFoldersCreator().projectRelativeFolders([sourceSet], { File file -> file.path }, defaultOutputFolder, Mock(Property) { get() >> ".*test.*" })
     }
 
     private List<SourceFolder> externalSourceFolders(String... paths) {


### PR DESCRIPTION
Eclipse has a well-known limitation that it can only define one classpath per project. Because of this, it is difficult to map Gradle source sets to Eclipse projects. 

Eclipse 4.8 introduced a partial fix for the problem called [test sources](https://www.eclipse.org/eclipse/news/4.8/jdt.php#jdt-test-sources). Source directories can be marked with a `test` classpath attribute. Test source directories
- can reference jar files from the Eclipse classpath that have a `test` classpath attribute
- can be used from other source directories that have a `test` classpath attribute
- can be used in another project if the project dependency has the `without_test_code=false` classpath attribute

This makes the Eclipse-to-Gradle project mapping better, but it's still far from perfect. Ideally, there should be a separate classpath attribute corresponding to each source set. The existing solution has the following rules:
- project and jar dependencies have the `test` flag if they are declared in a test dependency configuration (i.e. the configuration name contains the `test` substring)
- an Eclipse source directory has the `test` classpath attribute if it's path contains the `test` substring (e.g. `src/main/integTest`)
- an Eclipse project dependency has the `without_test_code=false` classpath attribute if the target project applies the `java-test-fixtures` plugin

This covers the majority of the cases, can be frustrating for builds with custom source sets and dependency configurations. See a detailed discussion [here](https://github.com/gradle/gradle/issues/18138).

For those special cases we usually recommend adjusting the classpath attributes in the [`eclipse.classpath.file.whenMerged` ](https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.eclipse.model.EclipseClasspath.html) block. However, the callback is just a file transformation and provides no context about the dependency resolution. 

Moreover, as mentioned before, the calculation of test source directories and dependencies are hardcoded into the eclipse plugin implementation. To make the situation better, this PR exposes two properties on the `EclipseClasspath` DSL:
- `testSourceSetNamePattern` - if a source set name matches the pattern then all source directories from the source set will have the `test` classpath attribute in Eclipse
- `testDependencyConfigurationNamePattern` - if a dependency is declared in scopes with matching names then the dependency will have the `test` classpath attribute in Eclipse.

Note that the same dependency can be declared in multiple dependency scopes. In this case, the dependency will have the `test` classpath attribute if all of the container scopes' names match the pattern.
 
Also note that this PR changes the output of the `eclipseClasspath` task (defined in the built-in `eclipse` plugin), as well as the classpath of the projects created by Buildship.

Fixes #18138.


