### PR TITLE
Do not make pending when edge is being removed anyway

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -1233,9 +1233,12 @@ public class NodeState implements DependencyGraphNode {
     }
 
     void makePending(EdgeState edgeState) {
-        outgoingEdges.remove(edgeState);
-        edgeState.markUnused();
-        edgeState.getSelector().release();
+        if (!removingOutgoingEdges) {
+            // We can ignore if we are already removing edges anyway
+            outgoingEdges.remove(edgeState);
+            edgeState.markUnused();
+            edgeState.getSelector().release();
+        }
     }
 
     ImmutableAttributes desugar(ImmutableAttributes attributes) {


### PR DESCRIPTION
This prevents a `ConcurrentModificationException` in some resolution cases.