### PR TITLE
API for configuration cache friendly execution

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -40,6 +40,7 @@ import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource
 import org.gradle.api.internal.provider.sources.FileContentValueSource
 import org.gradle.api.internal.provider.sources.GradlePropertyValueSource
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource
+import org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.configurationcache.CoupledProjectsListener
@@ -217,6 +218,10 @@ class ConfigurationCacheFingerprintWriter(
             is EnvironmentVariableValueSource.Parameters -> {
                 envVariableRead(parameters.variableName.get(), obtainedValue.value.get() as? String, null)
             }
+            is ProcessOutputValueSource.Parameters -> {
+                sink().write(ValueSource(obtainedValue.uncheckedCast()))
+                reportExternalProcessOutputRead(ProcessOutputValueSource.Parameters.getExecutable(parameters))
+            }
             else -> {
                 captureValueSource(obtainedValue)
             }
@@ -336,6 +341,14 @@ class ConfigurationCacheFingerprintWriter(
         reportInput(consumer = null, documentationSection = null) {
             text("build logic input of type ")
             reference(valueSourceType.simpleName)
+        }
+    }
+
+    private
+    fun reportExternalProcessOutputRead(executable: String) {
+        reportInput(consumer = null, documentationSection = null) {
+            text("output of the external process ")
+            reference(executable)
         }
     }
 

--- a/subprojects/core-api/build.gradle.kts
+++ b/subprojects/core-api/build.gradle.kts
@@ -5,13 +5,14 @@ plugins {
 description = "Public and internal 'core' Gradle APIs that are required by other subprojects"
 
 dependencies {
+    api(project(":process-services"))
+
     implementation(project(":base-services"))
     implementation(project(":base-services-groovy"))
     implementation(project(":enterprise-operations"))
     implementation(project(":files"))
     implementation(project(":logging"))
     implementation(project(":persistent-cache"))
-    implementation(project(":process-services"))
     implementation(project(":resources"))
 
     implementation(libs.groovy)

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -27,6 +27,9 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.initialization.Settings;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.process.ExecOutput;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
 
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
@@ -139,6 +142,42 @@ public interface ProviderFactory {
      * @since 6.1
      */
     FileContents fileContents(Provider<RegularFile> file);
+
+    /**
+     * Allows lazy access to the output of the external process.
+     *
+     * When the process output is read at configuration time it is considered as an input to the
+     * configuration model. Consequent builds will re-execute the process to obtain the output and
+     * check if the cached model is still up-to-date.
+     *
+     * The process input and output streams cannot be configured.
+     *
+     *
+     * @param action the configuration of the external process with the output stream
+     * pre-configured.
+     * @return an interface that allows lazy access to the process' output.
+     * @since 7.4
+     */
+    @Incubating
+    ExecOutput exec(Action<? super ExecSpec> action);
+
+    /**
+     * Allows lazy access to the output of the external java process.
+     *
+     * When the process output is read at configuration time it is considered as an input to the
+     * configuration model. Consequent builds will re-execute the process to obtain the output and
+     * check if the cached model is still up-to-date.
+     *
+     * The process input and output streams cannot be configured.
+     *
+     * @param action the configuration of the external process with the output stream
+     * pre-configured.
+     * @return an interface that allows lazy access to the process' output.
+     *
+     * @since 7.4
+     */
+    @Incubating
+    ExecOutput javaexec(Action<? super JavaExecSpec> action);
 
     /**
      * Creates a {@link Provider} whose value is obtained from the given {@link ValueSource}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSource.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ValueSource.java
@@ -45,6 +45,25 @@ import javax.inject.Inject;
  * by build logic during the configuration phase, in which case the source would be automatically
  * considered as an input to the work graph cache.
  * </p>
+ * <p>
+ * It is possible to have some Gradle services to be injected into the implementation, similar to
+ * tasks and plugins. It can be done by adding a parameter to the constructor and annotating the
+ * constructor with the {@code @Inject} annotation:
+ * <pre>
+ * public class MyValueSource implements ValueSource&lt;...&gt; {
+ *     &#064;Inject
+ *     public MyValueSource(ExecOperations execOperations) {
+ *         ...
+ *     }
+ * }
+ * </pre>
+ * Currently, only a small subset of services is supported:
+ * <ul>
+ *     <li>{@link org.gradle.process.ExecOperations} provides means to execute external processes.
+ *     It is possible to use this service even during the configuration time. However, as the
+ *     returned value is used to check the configuration cache, the {@link #obtain()} method will
+ *     be called during each build. Calling slow commands here will slow things down.</li>
+ * </ul>
  *
  * <p>
  * A value source implementation will most likely take parameters. To do this create a

--- a/subprojects/core-api/src/main/java/org/gradle/process/ExecOutput.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/ExecOutput.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
+
+/**
+ * Provides lazy access to the output of the external process.
+ *
+ * @since 7.4
+ */
+@Incubating
+public interface ExecOutput {
+    /**
+     * Returns a provider of the execution result.
+     *
+     * <p>
+     * The external process is executed only once and only when the value is requested for the first
+     * time.
+     * </p>
+     * <p>
+     * If starting the process results in exception then the ensuing exception is permanently
+     * propagated to callers of {@link Provider#get}, {@link Provider#getOrElse},
+     * {@link Provider#getOrNull} and {@link Provider#isPresent}.
+     * </p>
+     *
+     * @return provider of the execution result.
+     */
+    Provider<ExecResult> getResult();
+
+    /**
+     * Gets a handle to the content of the process' standard output.
+     *
+     * @return handle of the standard output of the process.
+     */
+    StandardStreamContent getStandardOutput();
+
+    /**
+     * Gets a handle to the content of the process' standard error output.
+     *
+     * @return handle of the standard error output of the process.
+     */
+    StandardStreamContent getStandardError();
+
+    /**
+     * A handle to access content of the process' standard stream (the standard output of the
+     * standard error output).
+     *
+     * @since 7.4
+     */
+    @Incubating
+    interface StandardStreamContent {
+        /**
+         * Gets a provider for the standard stream's content that returns it as a String. The output
+         * is decoded using the default encoding of the JVM running the build.
+         *
+         * <p>
+         * The external process is executed only once and only when the value is requested for the
+         * first time.
+         * </p>
+         * <p>
+         * If starting the process results in exception then the ensuing exception is permanently
+         * propagated to callers of {@link Provider#get}, {@link Provider#getOrElse},
+         * {@link Provider#getOrNull} and {@link Provider#isPresent}.
+         * </p>
+         */
+        Provider<String> getAsText();
+
+        /**
+         * Gets a provider for the standard stream's content that returns it as a byte array.
+         *
+         * <p>
+         * The external process is executed only once and only when the value is requested for the
+         * first time.
+         * </p>
+         * <p>
+         * If starting the process results in exception then the ensuing exception is permanently
+         * propagated to callers of {@link Provider#get}, {@link Provider#getOrElse},
+         * {@link Provider#getOrNull} and {@link Provider#isPresent}.
+         * </p>
+         */
+        Provider<byte[]> getAsBytes();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -344,6 +344,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         IsolatableFactory isolatableFactory,
         ServiceRegistry services,
         GradleProperties gradleProperties,
+        ExecFactory execFactory,
         ListenerManager listenerManager
     ) {
         return new DefaultValueSourceProviderFactory(
@@ -351,6 +352,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             instantiatorFactory,
             isolatableFactory,
             gradleProperties,
+            new DefaultExecOperations(execFactory),
             services
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -65,6 +65,8 @@ import org.gradle.api.internal.properties.GradleProperties;
 import org.gradle.api.internal.provider.DefaultProviderFactory;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
 import org.gradle.api.internal.provider.ValueSourceProviderFactory;
+import org.gradle.api.internal.provider.sources.process.ExecSpecFactory;
+import org.gradle.api.internal.provider.sources.process.ProcessOutputProviderFactory;
 import org.gradle.api.internal.resources.ApiTextResourceAdapter;
 import org.gradle.api.internal.resources.DefaultResourceHandler;
 import org.gradle.api.internal.tasks.TaskStatistics;
@@ -197,6 +199,8 @@ import org.gradle.model.internal.inspect.ModelRuleSourceDetector;
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedPluginHandler;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
 import org.gradle.process.internal.DefaultExecOperations;
+import org.gradle.process.internal.DefaultExecSpecFactory;
+import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecFactory;
 import org.gradle.tooling.provider.model.internal.BuildScopeToolingModelBuilderRegistryAction;
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry;
@@ -357,12 +361,21 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         );
     }
 
+    protected ExecSpecFactory createExecSpecFactory(ExecActionFactory execActionFactory) {
+        return new DefaultExecSpecFactory(execActionFactory);
+    }
+
+    protected ProcessOutputProviderFactory createProcessOutputProviderFactory(Instantiator instantiator, ExecSpecFactory execSpecFactory) {
+        return new ProcessOutputProviderFactory(instantiator, execSpecFactory);
+    }
+
     protected ProviderFactory createProviderFactory(
         Instantiator instantiator,
         ValueSourceProviderFactory valueSourceProviderFactory,
+        ProcessOutputProviderFactory processOutputProviderFactory,
         ListenerManager listenerManager
     ) {
-        return instantiator.newInstance(DefaultProviderFactory.class, valueSourceProviderFactory, listenerManager);
+        return instantiator.newInstance(DefaultProviderFactory.class, valueSourceProviderFactory, processOutputProviderFactory, listenerManager);
     }
 
     protected ActorFactory createActorFactory() {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecSpecFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal;
+
+import org.gradle.api.internal.provider.sources.process.ExecSpecFactory;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
+
+public class DefaultExecSpecFactory implements ExecSpecFactory {
+    private final ExecActionFactory execActionFactory;
+
+    public DefaultExecSpecFactory(ExecActionFactory execActionFactory) {
+        this.execActionFactory = execActionFactory;
+    }
+
+    @Override
+    public ExecSpec newExecSpec() {
+        return execActionFactory.newExecAction();
+    }
+
+    @Override
+    public JavaExecSpec newJavaExecSpec() {
+        return execActionFactory.newJavaExecAction();
+    }
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/ShellScript.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/ShellScript.groovy
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.process
+
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.test.fixtures.file.TestFile;
+
+/**
+ * The cross-platform builder of shell scripts that can be used to verify correctness of the
+ * invocation of an executable. It uses "sh" syntax on POSIX platforms and batch files on Windows.
+ */
+abstract class ShellScript {
+    protected final TestFile scriptFile
+
+    protected ShellScript(TestFile scriptFile) {
+        this.scriptFile = scriptFile
+    }
+
+    List<String> getCommandLine() {
+        return getCommandLineWithArguments()
+    }
+
+    abstract List<String> getCommandLineWithArguments(String... args)
+
+    private static class WindowsScript extends ShellScript {
+        private WindowsScript(TestFile scriptFile) {
+            super(scriptFile)
+        }
+
+        List<String> getCommandLineWithArguments(String... args) {
+            return [scriptFile.path] + args.toList()
+        }
+    }
+
+    private static class PosixScript extends ShellScript {
+        private PosixScript(TestFile scriptFile) {
+            super(scriptFile)
+        }
+
+        List<String> getCommandLineWithArguments(String... args) {
+            return ["/bin/sh", scriptFile.path] + args.toList()
+        }
+    }
+
+    static abstract class Builder {
+        private final StringBuilder scriptCommands = new StringBuilder()
+
+        protected Builder() {}
+
+        abstract Builder printArguments();
+
+        abstract Builder printText(String text);
+
+        abstract Builder printEnvironmentVariable(String variableName)
+
+        abstract Builder withExitValue(int exitValue)
+
+        protected Builder addLine(String line) {
+            scriptCommands.append(line).append('\n')
+            return this
+        }
+
+        ShellScript writeTo(TestFile baseDir, String basename) {
+            def scriptFile = baseDir.file(basename + scriptExtension)
+            scriptFile.write(scriptCommands.toString())
+            return build(scriptFile)
+        }
+
+        protected abstract ShellScript build(TestFile scriptFile)
+
+        protected abstract String getScriptExtension();
+    }
+
+    private static class PosixBuilder extends Builder {
+        @Override
+        protected ShellScript build(TestFile scriptFile) {
+            return new PosixScript(scriptFile)
+        }
+
+        @Override
+        Builder printArguments() {
+            return addLine('echo "$*"')
+        }
+
+        @Override
+        Builder printText(String text) {
+            return addLine("echo '$text'")
+        }
+
+        @Override
+        Builder printEnvironmentVariable(String variableName) {
+            return addLine("echo $variableName=\$$variableName")
+        }
+
+        @Override
+        Builder withExitValue(int exitValue) {
+            return addLine("exit $exitValue")
+        }
+
+        @Override
+        protected String getScriptExtension() {
+            return ".sh"
+        }
+    }
+
+    private static class WindowsBuilder extends Builder {
+        WindowsBuilder() {
+            addLine("@echo off")
+        }
+
+        @Override
+        Builder printArguments() {
+            return addLine("echo %*")
+        }
+
+        @Override
+        Builder printText(String text) {
+            return addLine("echo \"$text\"")
+        }
+
+        @Override
+        Builder printEnvironmentVariable(String variableName) {
+            return addLine("echo $variableName=%$variableName%")
+        }
+
+        @Override
+        Builder withExitValue(int exitValue) {
+            return addLine("exit $exitValue")
+        }
+
+        @Override
+        protected ShellScript build(TestFile scriptFile) {
+            return new WindowsScript(scriptFile)
+        }
+
+        @Override
+        protected String getScriptExtension() {
+            return ".bat"
+        }
+    }
+
+    static Builder builder() {
+        if (OperatingSystem.current().windows) {
+            return new WindowsBuilder()
+        }
+        return new PosixBuilder()
+    }
+
+}

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/process/TestJavaMain.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.Comparator;
+import java.util.Map;
+
+/**
+ * An executable Java class that can be used standalone to verify javaexec routines.
+ */
+public class TestJavaMain {
+    public static String getClassLocation() {
+        try {
+            return new File(TestJavaMain.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        if (args.length > 0) {
+            System.out.println("ARGUMENTS: " + String.join(" ", args));
+        }
+        System.out.println("ENVIRONMENT:");
+        printMap(System.getenv(), "TEST_");
+
+        System.out.println("PROPERTIES:");
+        printMap(System.getProperties(), "test.");
+    }
+
+    private static void printMap(Map<?, ?> items, String prefix) {
+        items.entrySet().stream().filter(e -> String.valueOf(e.getKey()).startsWith(prefix)).sorted(comparingByStringifiedKey()).forEach(e -> {
+            System.out.printf("   %s=%s\n", e.getKey(), e.getValue());
+        });
+    }
+
+    private static Comparator<Map.Entry<?, ?>> comparingByStringifiedKey() {
+        return Comparator.comparing(entry -> String.valueOf(entry.getKey()));
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -37,6 +37,7 @@ import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.isolation.TestIsolatableFactory
 import org.gradle.internal.management.VersionCatalogBuilderInternal
 import org.gradle.internal.service.scopes.Scopes
+import org.gradle.process.ExecOperations
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Rule
@@ -62,6 +63,7 @@ class LibrariesSourceGeneratorTest extends Specification implements VersionCatal
             TestUtil.instantiatorFactory(),
             new TestIsolatableFactory(),
             Stub(GradleProperties),
+            Stub(ExecOperations),
             TestUtil.services()
         ),
         null

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/catalog/LibrariesSourceGeneratorTest.groovy
@@ -66,6 +66,7 @@ class LibrariesSourceGeneratorTest extends Specification implements VersionCatal
             Stub(ExecOperations),
             TestUtil.services()
         ),
+        null,
         null
     )
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -806,6 +806,41 @@ For example a `BuildListener` or a `TaskExecutionListener`.
 
 These should be replaced by <<build_services#build_services,build services>>, registered to receive information about <<build_services#operation_listener, task execution>> if needed.
 
+[[config_cache:requirements:external_processes]]
+=== Running external processes
+
+Plugin and build scripts should avoid running external processes at configuration time.
+In general, it is preferred to run external processes in tasks with properly declared inputs and outputs to avoid unnecessary work when the task is up-to-date.
+If necessary, only configuration-cache-compatible APIs should be used instead of Java and Groovy standard APIs or existing `ExecOperations`,
+`Project.exec`, `Project.javaexec`, and their likes in settings and init scripts.
+For simpler cases, when grabbing the output of the process is enough,
+link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec-org.gradle.api.Action-[providers.exec()] and
+link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec-org.gradle.api.Action-[providers.javaExec()] can be used:
+
+====
+include::sample[dir="snippets/valueProviders/externalProcessProvider/groovy",files="build.gradle[]"]
+include::sample[dir="snippets/valueProviders/externalProcessProvider/kotlin",files="build.gradle.kts[]"]
+====
+
+For more complex cases a custom link:{javadocPath}/org/gradle/api/provider/ValueSource.html[ValueSource] implementation with injected `ExecOperations` can be used.
+This `ExecOperations` instance can be used at configuration time without restrictions.
+
+====
+include::sample[dir="snippets/valueProviders/externalProcessValueSource/groovy",files="build.gradle[tags=value-source]"]
+include::sample[dir="snippets/valueProviders/externalProcessValueSource/kotlin",files="build.gradle.kts[tags=value-source]"]
+====
+
+The `ValueSource` implementation can then be used to create a provider with link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#of-java.lang.Class-org.gradle.api.Action-[providers.of]:
+
+====
+include::sample[dir="snippets/valueProviders/externalProcessValueSource/groovy",files="build.gradle[tags=create-provider]"]
+include::sample[dir="snippets/valueProviders/externalProcessValueSource/kotlin",files="build.gradle.kts[tags=create-provider]"]
+====
+
+In both approaches, if the value of the provider is used at configuration time then it will become a build configuration input.
+The external process will be executed for every build to determine if the configuration cache is up-to-date, so it is recommended to only call fast-running processes at configuration time.
+If the value changes then the cache is invalidated and the process will be run again during this build as part of the configuration phase.
+
 [[config_cache:requirements:undeclared_gradle_prop_read]]
 === Undeclared reading of Gradle properties
 

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/groovy/build.gradle
@@ -1,0 +1,3 @@
+def gitVersion = providers.exec {
+    commandLine("git", "--version")
+}.standardOutput.asText.get()

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'external-process-provider'

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/kotlin/build.gradle.kts
@@ -1,0 +1,3 @@
+val gitVersion = providers.exec {
+    commandLine("git", "--version")
+}.standardOutput.asText.get()

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessProvider/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "external-process-provider"

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/groovy/build.gradle
@@ -1,0 +1,24 @@
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import java.nio.charset.Charset
+
+// tag::value-source[]
+abstract class GitVersionValueSource implements ValueSource<String, ValueSourceParameters.None> {
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    String obtain() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream()
+        execOperations.exec {
+            it.commandLine "git", "--version"
+            it.standardOutput = output
+        }
+        return output.toString(Charset.defaultCharset())
+    }
+}
+// end::value-source[]
+
+// tag::create-provider[]
+def gitVersionProvider = providers.of(GitVersionValueSource.class) {}
+def gitVersion = gitVersionProvider.get()
+// end::create-provider[]

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'external-process-value-source'

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/kotlin/build.gradle.kts
@@ -1,0 +1,25 @@
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import java.io.ByteArrayOutputStream
+import java.nio.charset.Charset
+
+// tag::value-source[]
+abstract class GitVersionValueSource : ValueSource<String, ValueSourceParameters.None> {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    override fun obtain(): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            commandLine("git", "--version")
+            standardOutput = output
+        }
+        return output.toString(Charset.defaultCharset())
+    }
+}
+// end::value-source[]
+
+// tag::create-provider[]
+val gitVersionProvider = providers.of(GitVersionValueSource::class) {}
+val gitVersion = gitVersionProvider.get()
+// end::create-provider[]

--- a/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/valueProviders/externalProcessValueSource/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "external-process-value-source"

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/ProcessOutputProviderIntegrationTest.groovy
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.provider
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.process.ShellScript
+import org.gradle.process.TestJavaMain
+import org.gradle.util.internal.TextUtil
+
+class ProcessOutputProviderIntegrationTest extends AbstractIntegrationSpec {
+    def "providers.exec can be used during configuration time"() {
+        given:
+        def testScript = ShellScript.builder()
+            .printArguments()
+            .printEnvironmentVariable("TEST_FOO")
+            .writeTo(testDirectory, "script")
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.getCommandLineWithArguments("--some-arg"))}
+                environment("TEST_FOO", "fooValue")
+            }
+
+            execProvider.result.get().assertNormalExitValue()
+            println(execProvider.standardOutput.asText.get())
+
+            task empty() {}
+        """
+
+        when:
+        run("-q", ":empty")
+
+        then:
+        outputContains("--some-arg")
+        outputContains("TEST_FOO=fooValue")
+    }
+
+    def "providers.javaexec can be used during configuration time"() {
+        given:
+        def testClasspath = TestJavaMain.classLocation
+        def testClass = TestJavaMain.class.name
+
+        buildFile """
+            def execProvider = providers.javaexec {
+                classpath("${TextUtil.escapeString(testClasspath)}")
+                mainClass = "$testClass"
+                args("--some-arg")
+                environment("TEST_FOO", "fooValue")
+                systemProperty("test.foo", "fooValue")
+            }
+
+            execProvider.result.get().assertNormalExitValue()
+            println(execProvider.standardOutput.asText.get())
+
+            task empty() {}
+        """
+
+        when:
+        run("-q", ":empty")
+
+        then:
+        outputContains("--some-arg")
+        outputContains("TEST_FOO=fooValue")
+        outputContains("test.foo=fooValue")
+    }
+
+    def "providers.exec returns a provider that throws if execution fails"() {
+        given:
+        def testScript = ShellScript.builder()
+            .withExitValue(42)
+            .writeTo(testDirectory, "script")
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.commandLine)}
+            }
+
+            println("exit value = " + execProvider.result.get().exitValue)
+            println(execProvider.standardOutput.asText.get())
+
+            task empty() {}
+        """
+
+        when:
+        runAndFail("-q", ":empty")
+
+        then:
+        result.assertHasErrorOutput("finished with non-zero exit value 42")
+    }
+
+    def "providers.exec provides exit value if exit value is ignored"() {
+        given:
+        def testScript = ShellScript.builder()
+            .withExitValue(1)
+            .writeTo(testDirectory, "script")
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.commandLine)}
+                setIgnoreExitValue(true)
+            }
+
+            println("exit value = " + execProvider.result.get().exitValue)
+            println(execProvider.standardOutput.asText.get())
+
+            task empty() {}
+        """
+
+        when:
+        run("-q", ":empty")
+
+        then:
+        outputContains("exit value = 1")
+    }
+
+    def "providers.exec provider can be wired to the task"() {
+        given:
+        def testScript = ShellScript.builder()
+            .printText("Script output")
+            .writeTo(testDirectory, "script")
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.commandLine)}
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract Property<String> getScriptOutput()
+                @TaskAction
+                def action() {
+                    println(scriptOutput.get())
+                }
+            }
+            tasks.register("printScriptOutput", MyTask) {
+                scriptOutput = execProvider.standardOutput.asText
+            }
+        """
+
+        when:
+        run("-q", ":printScriptOutput")
+
+        then:
+        outputContains("Script output")
+    }
+
+    def "task with providers.exec provider input is up to date for second run"() {
+        given:
+        def testScript = ShellScript.builder()
+            .printText("Script output")
+            .writeTo(testDirectory, "script")
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.commandLine)}
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract Property<String> getScriptOutput()
+
+                MyTask() {
+                    outputs.upToDateWhen { true }
+                }
+                @TaskAction
+                def action() {
+                    println(scriptOutput.get())
+                }
+            }
+            tasks.register("printScriptOutput", MyTask) {
+                scriptOutput = execProvider.standardOutput.asText
+            }
+        """
+
+        when:
+        run("-q", ":printScriptOutput")
+        def result = run(":printScriptOutput")
+
+        then:
+        result.assertTaskSkipped(":printScriptOutput")
+    }
+
+    def "task with providers.exec provider input is not up to date if script output changes"() {
+        given:
+        def testScriptName = "script"
+        def testScript = ShellScript.builder()
+            .printText("Script output")
+            .writeTo(testDirectory, testScriptName)
+
+        buildFile """
+            def execProvider = providers.exec {
+                ${cmdToExecConfig(testScript.commandLine)}
+            }
+
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract Property<String> getScriptOutput()
+
+                MyTask() {
+                    outputs.upToDateWhen { true }
+                }
+                @TaskAction
+                def action() {
+                    println(scriptOutput.get())
+                }
+            }
+            tasks.register("printScriptOutput", MyTask) {
+                scriptOutput = execProvider.standardOutput.asText
+            }
+        """
+
+        when:
+        run("-q", ":printScriptOutput")
+
+        // Overwrite script file with a new text
+        ShellScript.builder().printText("Other script output").writeTo(testDirectory, testScriptName)
+
+        def result = run(":printScriptOutput")
+
+        then:
+        outputContains("Other script output")
+        result.assertTaskExecuted(":printScriptOutput")
+    }
+
+    static String cmdToExecConfig(List<String> args) {
+        def argsString = args.collect { "'${TextUtil.escapeString(it)}'" }.join(", ")
+        return """
+            commandLine($argsString)
+        """
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultValueSourceProviderFactory.java
@@ -36,6 +36,7 @@ import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceLookup;
+import org.gradle.process.ExecOperations;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -45,6 +46,7 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
     private final InstantiatorFactory instantiatorFactory;
     private final IsolatableFactory isolatableFactory;
     private final GradleProperties gradleProperties;
+    private final ExecOperations execOperations;
     private final AnonymousListenerBroadcast<Listener> broadcaster;
     private final IsolationScheme<ValueSource, ValueSourceParameters> isolationScheme = new IsolationScheme<>(ValueSource.class, ValueSourceParameters.class, ValueSourceParameters.None.class);
     private final InstanceGenerator paramsInstantiator;
@@ -55,12 +57,14 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
         InstantiatorFactory instantiatorFactory,
         IsolatableFactory isolatableFactory,
         GradleProperties gradleProperties,
+        ExecOperations execOperations,
         ServiceLookup services
     ) {
         this.broadcaster = listenerManager.createAnonymousBroadcaster(ValueSourceProviderFactory.Listener.class);
         this.instantiatorFactory = instantiatorFactory;
         this.isolatableFactory = isolatableFactory;
         this.gradleProperties = gradleProperties;
+        this.execOperations = execOperations;
         // TODO - dedupe logic copied from DefaultBuildServicesRegistry
         this.paramsInstantiator = instantiatorFactory.decorateScheme().withServices(services).instantiator();
         this.specInstantiator = instantiatorFactory.decorateLenientScheme().withServices(services).instantiator();
@@ -115,6 +119,7 @@ public class DefaultValueSourceProviderFactory implements ValueSourceProviderFac
     ) {
         DefaultServiceRegistry services = new DefaultServiceRegistry();
         services.add(GradleProperties.class, gradleProperties);
+        services.add(ExecOperations.class, execOperations);
         if (isolatedParameters != null) {
             services.add(parametersType, isolatedParameters);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DefaultExecOutput.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DefaultExecOutput.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.api.internal.provider.sources.process.ProcessOutputValueSource.ExecOutputData;
+import org.gradle.api.provider.Provider;
+import org.gradle.process.ExecOutput;
+import org.gradle.process.ExecResult;
+
+import java.nio.charset.Charset;
+
+public class DefaultExecOutput implements ExecOutput {
+    private final Provider<ExecOutputData> dataProvider;
+
+    public DefaultExecOutput(Provider<ExecOutputData> dataProvider) {
+        this.dataProvider = dataProvider;
+    }
+
+    @Override
+    public Provider<ExecResult> getResult() {
+        return dataProvider.map(ExecOutputData::getResult);
+    }
+
+    @Override
+    public StandardStreamContent getStandardOutput() {
+        return new DefaultStandardStreamContent(dataProvider.map(ExecOutputData::getOutput));
+    }
+
+    @Override
+    public StandardStreamContent getStandardError() {
+        return new DefaultStandardStreamContent(dataProvider.map(ExecOutputData::getError));
+    }
+
+    private static class DefaultStandardStreamContent implements StandardStreamContent {
+        private final Provider<byte[]> bytesProvider;
+
+        public DefaultStandardStreamContent(Provider<byte[]> bytesProvider) {
+            this.bytesProvider = bytesProvider;
+        }
+
+        @Override
+        public Provider<String> getAsText() {
+            return getAsBytes().map(bytes -> new String(bytes, Charset.defaultCharset()));
+        }
+
+        @Override
+        public Provider<byte[]> getAsBytes() {
+            return bytesProvider;
+        }
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingBaseExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingBaseExecSpec.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.process.BaseExecSpec;
+import org.gradle.process.ProcessForkOptions;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Just the wrapper that delegates all calls to what {@link #getDelegate()} returns.
+ */
+interface DelegatingBaseExecSpec extends BaseExecSpec {
+    @Override
+    default BaseExecSpec setIgnoreExitValue(boolean ignoreExitValue) {
+        getDelegate().setIgnoreExitValue(ignoreExitValue);
+        return this;
+    }
+
+    @Override
+    default boolean isIgnoreExitValue() {
+        return getDelegate().isIgnoreExitValue();
+    }
+
+    @Override
+    default BaseExecSpec setStandardInput(InputStream inputStream) {
+        getDelegate().setStandardInput(inputStream);
+        return this;
+    }
+
+    @Override
+    default InputStream getStandardInput() {
+        return getDelegate().getStandardInput();
+    }
+
+    @Override
+    default BaseExecSpec setStandardOutput(OutputStream outputStream) {
+        getDelegate().setStandardOutput(outputStream);
+        return this;
+    }
+
+    @Override
+    default OutputStream getStandardOutput() {
+        return getDelegate().getStandardOutput();
+    }
+
+    @Override
+    default BaseExecSpec setErrorOutput(OutputStream outputStream) {
+        getDelegate().setErrorOutput(outputStream);
+        return this;
+    }
+
+    @Override
+    default OutputStream getErrorOutput() {
+        return getDelegate().getErrorOutput();
+    }
+
+    @Override
+    default List<String> getCommandLine() {
+        return getDelegate().getCommandLine();
+    }
+
+    @Override
+    default String getExecutable() {
+        return getDelegate().getExecutable();
+    }
+
+    @Override
+    default void setExecutable(String executable) {
+        getDelegate().setExecutable(executable);
+    }
+
+    @Override
+    default void setExecutable(Object executable) {
+        getDelegate().setExecutable(executable);
+    }
+
+    @Override
+    default ProcessForkOptions executable(Object executable) {
+        getDelegate().executable(executable);
+        return this;
+    }
+
+    @Override
+    default File getWorkingDir() {
+        return getDelegate().getWorkingDir();
+    }
+
+    @Override
+    default void setWorkingDir(File dir) {
+        getDelegate().setWorkingDir(dir);
+    }
+
+    @Override
+    default void setWorkingDir(Object dir) {
+        getDelegate().setWorkingDir(dir);
+    }
+
+    @Override
+    default ProcessForkOptions workingDir(Object dir) {
+        getDelegate().workingDir(dir);
+        return this;
+    }
+
+    @Override
+    default Map<String, Object> getEnvironment() {
+        return getDelegate().getEnvironment();
+    }
+
+    @Override
+    default void setEnvironment(Map<String, ?> environmentVariables) {
+        getDelegate().setEnvironment(environmentVariables);
+    }
+
+    @Override
+    default ProcessForkOptions environment(Map<String, ?> environmentVariables) {
+        getDelegate().environment(environmentVariables);
+        return this;
+    }
+
+    @Override
+    default ProcessForkOptions environment(String name, Object value) {
+        getDelegate().environment(name, value);
+        return this;
+    }
+
+    @Override
+    default ProcessForkOptions copyTo(ProcessForkOptions options) {
+        getDelegate().copyTo(options);
+        return this;
+    }
+
+    BaseExecSpec getDelegate();
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingExecSpec.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.ExecSpec;
+
+import java.util.List;
+
+interface DelegatingExecSpec extends DelegatingBaseExecSpec, ExecSpec {
+    @Override
+    default void setCommandLine(List<String> args) {
+        getDelegate().setCommandLine(args);
+    }
+
+    @Override
+    default void setCommandLine(Object... args) {
+        getDelegate().setCommandLine(args);
+    }
+
+    @Override
+    default void setCommandLine(Iterable<?> args) {
+        getDelegate().setCommandLine(args);
+    }
+
+    @Override
+    default ExecSpec commandLine(Object... args) {
+        getDelegate().commandLine(args);
+        return this;
+    }
+
+    @Override
+    default ExecSpec commandLine(Iterable<?> args) {
+        getDelegate().commandLine(args);
+        return this;
+    }
+
+    @Override
+    default ExecSpec args(Object... args) {
+        getDelegate().args(args);
+        return this;
+    }
+
+    @Override
+    default ExecSpec args(Iterable<?> args) {
+        getDelegate().args(args);
+        return this;
+    }
+
+    @Override
+    default ExecSpec setArgs(List<String> args) {
+        getDelegate().setArgs(args);
+        return this;
+    }
+
+    @Override
+    default ExecSpec setArgs(Iterable<?> args) {
+        getDelegate().setArgs(args);
+        return this;
+    }
+
+    @Override
+    default List<String> getArgs() {
+        return getDelegate().getArgs();
+    }
+
+    @Override
+    default List<CommandLineArgumentProvider> getArgumentProviders() {
+        return getDelegate().getArgumentProviders();
+    }
+
+    @Override
+    ExecSpec getDelegate();
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/DelegatingJavaExecSpec.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.api.Action;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.jvm.ModularitySpec;
+import org.gradle.api.provider.Property;
+import org.gradle.process.CommandLineArgumentProvider;
+import org.gradle.process.JavaDebugOptions;
+import org.gradle.process.JavaExecSpec;
+import org.gradle.process.JavaForkOptions;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+interface DelegatingJavaExecSpec extends DelegatingBaseExecSpec, JavaExecSpec {
+    @Override
+    default Property<String> getMainModule() {
+        return getDelegate().getMainModule();
+    }
+
+    @Override
+    default Property<String> getMainClass() {
+        return getDelegate().getMainClass();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Nullable
+    @Override
+    default String getMain() {
+        return getDelegate().getMain();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    default JavaExecSpec setMain(@Nullable String main) {
+        getDelegate().setMain(main);
+        return this;
+    }
+
+    @Nullable
+    @Override
+    default List<String> getArgs() {
+        return getDelegate().getArgs();
+    }
+
+    @Override
+    default JavaExecSpec args(Object... args) {
+        getDelegate().args(args);
+        return this;
+    }
+
+    @Override
+    default JavaExecSpec args(Iterable<?> args) {
+        getDelegate().args(args);
+        return this;
+    }
+
+    @Override
+    default JavaExecSpec setArgs(@Nullable List<String> args) {
+        getDelegate().setArgs(args);
+        return this;
+    }
+
+    @Override
+    default JavaExecSpec setArgs(@Nullable Iterable<?> args) {
+        getDelegate().setArgs(args);
+        return this;
+    }
+
+    @Override
+    default List<CommandLineArgumentProvider> getArgumentProviders() {
+        return getDelegate().getArgumentProviders();
+    }
+
+    @Override
+    default JavaExecSpec classpath(Object... paths) {
+        getDelegate().classpath(paths);
+        return this;
+    }
+
+    @Override
+    default FileCollection getClasspath() {
+        return getDelegate().getClasspath();
+    }
+
+    @Override
+    default JavaExecSpec setClasspath(FileCollection classpath) {
+        getDelegate().setClasspath(classpath);
+        return this;
+    }
+
+    @Override
+    default ModularitySpec getModularity() {
+        return getDelegate().getModularity();
+    }
+
+    @Override
+    default Map<String, Object> getSystemProperties() {
+        return getDelegate().getSystemProperties();
+    }
+
+    @Override
+    default void setSystemProperties(Map<String, ?> properties) {
+        getDelegate().setSystemProperties(properties);
+    }
+
+    @Override
+    default JavaForkOptions systemProperties(Map<String, ?> properties) {
+        getDelegate().systemProperties(properties);
+        return this;
+    }
+
+    @Override
+    default JavaForkOptions systemProperty(String name, Object value) {
+        getDelegate().systemProperty(name, value);
+        return this;
+    }
+
+    @Nullable
+    @Override
+    default String getDefaultCharacterEncoding() {
+        return getDelegate().getDefaultCharacterEncoding();
+    }
+
+    @Override
+    default void setDefaultCharacterEncoding(@Nullable String defaultCharacterEncoding) {
+        getDelegate().setDefaultCharacterEncoding(defaultCharacterEncoding);
+    }
+
+    @Nullable
+    @Override
+    default String getMinHeapSize() {
+        return getDelegate().getMinHeapSize();
+    }
+
+    @Override
+    default void setMinHeapSize(@Nullable String heapSize) {
+        getDelegate().setMinHeapSize(heapSize);
+    }
+
+    @Nullable
+    @Override
+    default String getMaxHeapSize() {
+        return getDelegate().getMaxHeapSize();
+    }
+
+    @Override
+    default void setMaxHeapSize(@Nullable String heapSize) {
+        getDelegate().setMaxHeapSize(heapSize);
+    }
+
+    @Nullable
+    @Override
+    default List<String> getJvmArgs() {
+        return getDelegate().getJvmArgs();
+    }
+
+    @Override
+    default void setJvmArgs(@Nullable List<String> arguments) {
+        getDelegate().setJvmArgs(arguments);
+    }
+
+    @Override
+    default void setJvmArgs(@Nullable Iterable<?> arguments) {
+        getDelegate().setJvmArgs(arguments);
+    }
+
+    @Override
+    default JavaForkOptions jvmArgs(Iterable<?> arguments) {
+        getDelegate().jvmArgs(arguments);
+        return this;
+    }
+
+    @Override
+    default JavaForkOptions jvmArgs(Object... arguments) {
+        getDelegate().jvmArgs(arguments);
+        return this;
+    }
+
+    @Override
+    default List<CommandLineArgumentProvider> getJvmArgumentProviders() {
+        return getDelegate().getJvmArgumentProviders();
+    }
+
+    @Override
+    default FileCollection getBootstrapClasspath() {
+        return getDelegate().getBootstrapClasspath();
+    }
+
+    @Override
+    default void setBootstrapClasspath(FileCollection classpath) {
+        getDelegate().setBootstrapClasspath(classpath);
+    }
+
+    @Override
+    default JavaForkOptions bootstrapClasspath(Object... classpath) {
+        getDelegate().bootstrapClasspath(classpath);
+        return this;
+    }
+
+    @Override
+    default boolean getEnableAssertions() {
+        return getDelegate().getEnableAssertions();
+    }
+
+    @Override
+    default void setEnableAssertions(boolean enabled) {
+        getDelegate().setEnableAssertions(enabled);
+    }
+
+    @Override
+    default boolean getDebug() {
+        return getDelegate().getDebug();
+    }
+
+    @Override
+    default void setDebug(boolean enabled) {
+        getDelegate().setDebug(enabled);
+    }
+
+    @Override
+    default JavaDebugOptions getDebugOptions() {
+        return getDelegate().getDebugOptions();
+    }
+
+    @Override
+    default void debugOptions(Action<JavaDebugOptions> action) {
+        getDelegate().debugOptions(action);
+    }
+
+    @Override
+    default List<String> getAllJvmArgs() {
+        return getDelegate().getAllJvmArgs();
+    }
+
+    @Override
+    default void setAllJvmArgs(List<String> arguments) {
+        getDelegate().setAllJvmArgs(arguments);
+    }
+
+    @Override
+    default void setAllJvmArgs(Iterable<?> arguments) {
+        getDelegate().setAllJvmArgs(arguments);
+    }
+
+    @Override
+    default JavaForkOptions copyTo(JavaForkOptions options) {
+        getDelegate().copyTo(options);
+        return this;
+    }
+
+    @Override
+    JavaExecSpec getDelegate();
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ExecSpecFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ExecSpecFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.process.BaseExecSpec;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
+
+/**
+ * The factory to build appropriate ExecSpec and JavaExecSpec instances. The returned
+ * instances, especially JavaExecSpec, must conform to the {@link BaseExecSpec#getCommandLine()} contract.
+ *
+ * These instances will not be exposed to the user code directly, so there is no need of decoration.
+ */
+@ServiceScope(Scopes.Build.class)
+public interface ExecSpecFactory {
+    ExecSpec newExecSpec();
+
+    JavaExecSpec newJavaExecSpec();
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputProviderFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.api.Action;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+import org.gradle.process.ExecSpec;
+import org.gradle.process.JavaExecSpec;
+
+@ServiceScope(Scopes.Build.class)
+public class ProcessOutputProviderFactory {
+    private final Instantiator instantiator;
+    private final ExecSpecFactory execSpecFactory;
+
+    public ProcessOutputProviderFactory(Instantiator instantiator, ExecSpecFactory execSpecFactory) {
+        this.instantiator = instantiator;
+        this.execSpecFactory = execSpecFactory;
+    }
+
+    public void configureParametersForExec(ProcessOutputValueSource.Parameters parameters, Action<? super ExecSpec> action) {
+        configureParameters(parameters, instantiator.newInstance(ProviderCompatibleExecSpec.class, execSpecFactory.newExecSpec()), action);
+    }
+
+    public void configureParametersForJavaExec(ProcessOutputValueSource.Parameters parameters, Action<? super JavaExecSpec> action) {
+        configureParameters(parameters, instantiator.newInstance(ProviderCompatibleJavaExecSpec.class, execSpecFactory.newJavaExecSpec()), action);
+    }
+
+    private <T extends ProviderCompatibleBaseExecSpec> void configureParameters(ProcessOutputValueSource.Parameters parameters, T spec, Action<? super T> action) {
+        action.execute(spec);
+        spec.copyToParameters(parameters);
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProcessOutputValueSource.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.api.Describable;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class ProcessOutputValueSource implements ValueSource<ProcessOutputValueSource.ExecOutputData, ProcessOutputValueSource.Parameters>, Describable {
+    public interface Parameters extends ValueSourceParameters {
+        /**
+         * The full command line of the process to be executed, including all parameters and
+         * executable name. This is a mandatory property.
+         *
+         * @return the command line property
+         */
+        ListProperty<String> getCommandLine();
+
+        // The ExecSpec's environment can be configured in two ways. First is to append some
+        // variables to the current environment. We don't want to freeze the whole environment as an
+        // input in this case to mimic the behavior with configuration cache being disabled. Thus,
+        // there are two properties on these Parameters: full environment is used when the caller
+        // sets the complete environment explicitly (with setEnvironment) and additional environment
+        // variables are used when the caller specifies additions only.
+
+        /**
+         * The full environment to use when running a process. If not set then a current environment
+         * of the Gradle process is used as a base and variables from the
+         * {@link #getAdditionalEnvironmentVariables()} are added to it. It is an error to specify
+         * both full environment and additional variables.
+         *
+         * @return the full environment property, can be not set
+         * @see org.gradle.process.BaseExecSpec#setEnvironment(Map)
+         */
+        MapProperty<String, Object> getFullEnvironment();
+
+        /**
+         * The additional environment variables to be applied on top of the current environment when
+         * running the process. Use {@link #getFullEnvironment()} to completely replace the
+         * environment.
+         *
+         * @return the additional environment variables property, can be not set
+         * @see org.gradle.process.BaseExecSpec#environment(String, Object)
+         * @see org.gradle.process.BaseExecSpec#environment(Map)
+         */
+        MapProperty<String, Object> getAdditionalEnvironmentVariables();
+
+        /**
+         * Whether the exception should be thrown if the process has non-successful exit code.
+         *
+         * @return the property to ignore exit value
+         * @see org.gradle.process.BaseExecSpec#setIgnoreExitValue(boolean)
+         */
+        Property<Boolean> getIgnoreExitValue();
+
+        static String getExecutable(Parameters p) {
+            List<String> command = p.getCommandLine().get();
+            return !command.isEmpty() ? command.get(0) : "";
+        }
+    }
+
+    private final ExecOperations execOperations;
+
+    @Inject
+    public ProcessOutputValueSource(ExecOperations execOperations) {
+        this.execOperations = execOperations;
+
+        if (hasFullEnvironment() && hasAdditionalEnvVars()) {
+            throw new IllegalArgumentException(
+                "Providing both full environment and additional environment variables isn't supported");
+        }
+    }
+
+    private boolean hasAdditionalEnvVars() {
+        return getParameters().getAdditionalEnvironmentVariables().isPresent();
+    }
+
+    private boolean hasFullEnvironment() {
+        return getParameters().getFullEnvironment().isPresent();
+    }
+
+    @Nullable
+    @Override
+    public ExecOutputData obtain() {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+        ExecResult r = execOperations.exec(spec -> {
+            spec.commandLine(getParameters().getCommandLine().get());
+            spec.setIgnoreExitValue(getParameters().getIgnoreExitValue().getOrElse(false));
+
+            if (hasFullEnvironment()) {
+                spec.setEnvironment(getParameters().getFullEnvironment().get());
+            } else if (hasAdditionalEnvVars()) {
+                spec.environment(getParameters().getAdditionalEnvironmentVariables().get());
+            }
+            spec.setStandardOutput(stdout);
+            spec.setErrorOutput(stderr);
+        });
+        return new ExecOutputData(r, stdout.toByteArray(), stderr.toByteArray());
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "output of the external process '" + Parameters.getExecutable(getParameters()) + "'";
+    }
+
+    public static class ExecOutputData {
+        private final ExecResult result;
+        private final byte[] output;
+        private final byte[] error;
+
+        public ExecOutputData(ExecResult result, byte[] output, byte[] error) {
+            this.result = result;
+            this.output = output;
+            this.error = error;
+        }
+
+        public ExecResult getResult() {
+            return result;
+        }
+
+        public byte[] getOutput() {
+            return output.clone();
+        }
+
+        public byte[] getError() {
+            return error.clone();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExecOutputData that = (ExecOutputData) o;
+            return result.getExitValue() == that.result.getExitValue() && Arrays.equals(output, that.output) && Arrays.equals(error, that.error);
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = Objects.hash(result);
+            hash = 31 * hash + Arrays.hashCode(output);
+            hash = 31 * hash + Arrays.hashCode(error);
+            return hash;
+        }
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpec.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.process.BaseExecSpec;
+import org.gradle.process.ProcessForkOptions;
+
+import javax.annotation.Nullable;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+abstract class ProviderCompatibleBaseExecSpec implements DelegatingBaseExecSpec {
+    private final Map<String, Object> additionalEnvVars = new HashMap<>();
+    @Nullable
+    private Map<String, Object> fullEnvironment;
+
+    @Override
+    public BaseExecSpec setStandardInput(InputStream inputStream) {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public InputStream getStandardInput() {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public BaseExecSpec setStandardOutput(OutputStream outputStream) {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public OutputStream getStandardOutput() {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public BaseExecSpec setErrorOutput(OutputStream outputStream) {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public OutputStream getErrorOutput() {
+        throw new UnsupportedOperationException("Standard streams cannot be configured for exec output provider");
+    }
+
+    @Override
+    public void setEnvironment(Map<String, ?> environmentVariables) {
+        fullEnvironment = new HashMap<>(environmentVariables);
+        // We are replacing the environment completely, there is no need to keep previous additions.
+        additionalEnvVars.clear();
+        // Keep the delegate's view of environment consistent to make sure getEnvironment and
+        // copyTo work properly.
+        DelegatingBaseExecSpec.super.setEnvironment(fullEnvironment);
+    }
+
+    @Override
+    public ProcessForkOptions environment(Map<String, ?> environmentVariables) {
+        getMapForAppends().putAll(environmentVariables);
+        // Keep the delegate's view of environment consistent to make sure getEnvironment and
+        // copyTo work properly.
+        DelegatingBaseExecSpec.super.environment(environmentVariables);
+        return this;
+    }
+
+    @Override
+    public ProcessForkOptions environment(String name, Object value) {
+        getMapForAppends().put(name, value);
+        // Keep the delegate's view of environment consistent to make sure getEnvironment and
+        // copyTo work properly.
+        DelegatingBaseExecSpec.super.environment(name, value);
+        return this;
+    }
+
+    private Map<String, Object> getMapForAppends() {
+        // If the full environment is specified then additionalEnvVars isn't used, all
+        // additions go into the full map directly.
+        return (fullEnvironment != null) ? fullEnvironment : additionalEnvVars;
+    }
+
+    @Override
+    public ProcessForkOptions copyTo(ProcessForkOptions options) {
+        return DelegatingBaseExecSpec.super.copyTo(options);
+    }
+
+    public void copyToParameters(ProcessOutputValueSource.Parameters parameters) {
+        parameters.getCommandLine().set(getCommandLine());
+        parameters.getFullEnvironment().set(fullEnvironment);
+        parameters.getAdditionalEnvironmentVariables().set(additionalEnvVars.isEmpty() ? null : additionalEnvVars);
+        parameters.getIgnoreExitValue().set(isIgnoreExitValue());
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.process.ExecSpec;
+
+class ProviderCompatibleExecSpec extends ProviderCompatibleBaseExecSpec implements DelegatingExecSpec {
+    private final ExecSpec execSpec;
+
+    public ProviderCompatibleExecSpec(ExecSpec execSpec) {
+        this.execSpec = execSpec;
+    }
+
+    @Override
+    public ExecSpec getDelegate() {
+        return execSpec;
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpec.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process;
+
+import org.gradle.process.JavaExecSpec;
+
+class ProviderCompatibleJavaExecSpec extends ProviderCompatibleBaseExecSpec implements DelegatingJavaExecSpec {
+    private final JavaExecSpec execSpec;
+
+    public ProviderCompatibleJavaExecSpec(JavaExecSpec execSpec) {
+        this.execSpec = execSpec;
+    }
+
+    @Override
+    public JavaExecSpec getDelegate() {
+        return execSpec;
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/ValueSourceBasedSpec.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.provider.ValueSourceSpec
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.snapshot.impl.DefaultValueSnapshotter
+import org.gradle.process.ExecOperations
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -36,11 +37,13 @@ abstract class ValueSourceBasedSpec extends Specification {
         TestUtil.managedFactoryRegistry()
     )
     def configurationTimeBarrier = Mock(ConfigurationTimeBarrier)
+    def execOperations = Mock(ExecOperations)
     def valueSourceProviderFactory = new DefaultValueSourceProviderFactory(
         listenerManager,
         TestUtil.instantiatorFactory(),
         isolatableFactory,
         Mock(GradleProperties),
+        execOperations,
         TestUtil.services()
     )
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProcessOutputValueSourceTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProcessOutputValueSourceTest.groovy
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process
+
+import org.gradle.api.Action
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.internal.provider.ValueSourceBasedSpec
+import org.gradle.api.reflect.ObjectInstantiationException
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+
+import java.nio.charset.Charset
+
+class ProcessOutputValueSourceTest extends ValueSourceBasedSpec {
+    def specFactory = TestFiles.execActionFactory()
+
+    def "command line is propagated to execOperations"() {
+        given:
+        def spec = specFactory.newExecAction()
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withDefaultEnvironment(it)
+            }
+        }.get()
+
+        then:
+        1 * execOperations.exec(_) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+        spec.getCommandLine() == ["echo", "hello"]
+        spec.environment == System.getenv()
+    }
+
+    def "full environment is propagated to execOperations"() {
+        given:
+        def spec = specFactory.newExecAction()
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withFullEnvironment(it, [FOO: "BAR"])
+            }
+        }.get()
+
+        then:
+        1 * execOperations.exec(_) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+        spec.environment == [FOO: "BAR"]
+    }
+
+    def "additional environment is propagated to execOperations"() {
+        given:
+        def spec = specFactory.newExecAction()
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withAdditionalEnvironment(it, [FOO: "BAR"])
+            }
+        }.get()
+
+        then:
+        1 * execOperations.exec(_) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+        spec.environment == System.getenv() + [FOO: "BAR"]
+    }
+
+    def "specifying both full and additional environment is an error"() {
+        given:
+        def spec = specFactory.newExecAction()
+        execOperations.exec(_ as Action<? super ExecSpec>) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                it.fullEnvironment = [FOO: "BAR"]
+                it.additionalEnvironmentVariables = [BAR: "BAZ"]
+            }
+        }.get()
+
+        then:
+        def e = thrown ObjectInstantiationException
+        e.getCause() instanceof IllegalArgumentException
+    }
+
+    def "ignoreReturnValue is false by default"() {
+        given:
+        def spec = specFactory.newExecAction()
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withDefaultEnvironment(it)
+            }
+        }.get()
+
+        then:
+        1 * execOperations.exec(_) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+        !spec.isIgnoreExitValue()
+    }
+
+    def "ignoreReturnValue is propagated to execOperations"() {
+        given:
+        def spec = specFactory.newExecAction()
+
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                it.ignoreExitValue = true
+                withDefaultEnvironment(it)
+            }
+        }.get()
+
+        then:
+        1 * execOperations.exec(_) >> { Action<? super ExecSpec> action -> action.execute(spec) }
+        spec.isIgnoreExitValue()
+    }
+
+    def "execution result is available from the provider"() {
+        given:
+        execOperations.exec(_ as Action<? super ExecSpec>) >> { Action<? super ExecSpec> action ->
+            def spec = specFactory.newExecAction()
+            action.execute(spec)
+            spec.standardOutput.write("output".getBytes(Charset.defaultCharset()))
+            spec.standardOutput.close()
+            spec.errorOutput.write("error".getBytes(Charset.defaultCharset()))
+            spec.errorOutput.close()
+            return Stub(ExecResult) {
+                getExitValue() >> 0
+            }
+        }
+
+        when:
+        def provider = createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withDefaultEnvironment(it)
+            }
+        }
+        def result = provider.get()
+
+        then:
+        result.getResult().getExitValue() == 0
+        new String(result.getOutput(), Charset.defaultCharset()) == "output"
+        new String(result.getError(), Charset.defaultCharset()) == "error"
+    }
+
+    def "execOperations are not called if provider is not queried"() {
+        when:
+        createProviderOf(ProcessOutputValueSource.class) {
+            it.parameters {
+                it.commandLine = ["echo", "hello"]
+                withDefaultEnvironment(it)
+            }
+        }
+
+        then:
+        0 * execOperations._
+    }
+
+    private static void withDefaultEnvironment(ProcessOutputValueSource.Parameters parameters) {
+        // Properties of parameters of the ValueSource are already present at the moment of creation,
+        // so we have to unset them explicitly here.
+        parameters.fullEnvironment = null
+        parameters.additionalEnvironmentVariables = null
+    }
+
+    private static void withFullEnvironment(ProcessOutputValueSource.Parameters parameters, Map<String, Object> environment) {
+        parameters.fullEnvironment = environment
+        parameters.additionalEnvironmentVariables = null
+    }
+
+    private static void withAdditionalEnvironment(ProcessOutputValueSource.Parameters parameters, Map<String, Object> environment) {
+        parameters.fullEnvironment = null
+        parameters.additionalEnvironmentVariables = environment
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpecTestBase.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleBaseExecSpecTestBase.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process
+
+
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+abstract class ProviderCompatibleBaseExecSpecTestBase extends Specification {
+
+    ProviderCompatibleBaseExecSpec specUnderTest
+
+    void setup() {
+        specUnderTest = createSpecUnderTest()
+    }
+
+    def "setting an environment overwrites added variables"() {
+        given:
+        specUnderTest.environment("SOMEVAR", "someval")
+
+        when:
+        specUnderTest.setEnvironment(OTHERVAR: "otherval")
+
+        then:
+        specUnderTest.getEnvironment() == [OTHERVAR: "otherval"]
+    }
+
+    def "adding variables after setting environment is working"() {
+        given:
+        specUnderTest.setEnvironment(SOMEVAR: "someval")
+
+        when:
+        specUnderTest.environment(OTHERVAR: "otherval")
+        specUnderTest.environment("ADDEDVAR", "addedval")
+
+        then:
+        specUnderTest.getEnvironment() == [OTHERVAR: "otherval", SOMEVAR: "someval", ADDEDVAR: "addedval"]
+    }
+
+    def "spec without environment doesn't set environment properties on parameters"() {
+        given:
+        def parameters = newParameters()
+
+        when:
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        !parameters.fullEnvironment.isPresent()
+        !parameters.additionalEnvironmentVariables.isPresent()
+    }
+
+    def "spec with additional environment sets only additionalEnvironmentVariables on parameters"() {
+        given:
+        def parameters = newParameters()
+
+        when:
+        specUnderTest.environment("FOO", "bar")
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        !parameters.fullEnvironment.isPresent()
+        parameters.additionalEnvironmentVariables.isPresent()
+        parameters.additionalEnvironmentVariables.get() == [FOO: "bar"]
+    }
+
+    def "spec with full environment sets only fullEnvironment on parameters"() {
+        given:
+        def parameters = newParameters()
+
+        when:
+        specUnderTest.setEnvironment(FOO: "bar")
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        parameters.fullEnvironment.isPresent()
+        !parameters.additionalEnvironmentVariables.isPresent()
+        parameters.fullEnvironment.get() == [FOO: "bar"]
+    }
+
+    def "spec with full environment sets only fullEnvironment on parameters even after appends"() {
+        given:
+        def parameters = newParameters()
+
+        when:
+        specUnderTest.setEnvironment(FOO: "bar")
+        specUnderTest.environment("OTHER", "value")
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        parameters.fullEnvironment.isPresent()
+        !parameters.additionalEnvironmentVariables.isPresent()
+        parameters.fullEnvironment.get() == [FOO: "bar", OTHER: "value"]
+    }
+
+    def "spec sets ignoreExitValue on parameters"(boolean ignoreExitValue) {
+        given:
+        def parameters = newParameters()
+
+        when:
+        specUnderTest.setIgnoreExitValue(ignoreExitValue)
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        parameters.ignoreExitValue.get() == ignoreExitValue
+
+        where:
+        ignoreExitValue << [true, false]
+    }
+
+    def "setting input stream is forbidden"() {
+        when:
+        specUnderTest.setStandardInput(new ByteArrayInputStream())
+        then:
+        thrown UnsupportedOperationException
+    }
+
+    def "setting output stream is forbidden"() {
+        when:
+        specUnderTest.setStandardOutput(new ByteArrayOutputStream())
+        then:
+        thrown UnsupportedOperationException
+    }
+
+    def "setting error stream is forbidden"() {
+        when:
+        specUnderTest.setErrorOutput(new ByteArrayOutputStream())
+        then:
+        thrown UnsupportedOperationException
+    }
+
+    protected abstract ProviderCompatibleBaseExecSpec createSpecUnderTest()
+
+    static ProcessOutputValueSource.Parameters newParameters() {
+        return TestUtil.objectFactory().newInstance(ProcessOutputValueSource.Parameters.class)
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleExecSpecTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process
+
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.process.internal.DefaultExecSpec
+
+class ProviderCompatibleExecSpecTest extends ProviderCompatibleBaseExecSpecTestBase {
+    def "spec sets commandLine on parameters"() {
+        given:
+        def parameters = newParameters()
+        def command = ["some", "command", "with", "arguments"]
+
+        when:
+        specUnderTest.commandLine = command
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        parameters.commandLine.get() == command
+    }
+
+    @Override
+    protected ProviderCompatibleExecSpec createSpecUnderTest() {
+        return new ProviderCompatibleExecSpec(new DefaultExecSpec(TestFiles.pathToFileResolver()))
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpecTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/sources/process/ProviderCompatibleJavaExecSpecTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources.process
+
+import org.gradle.api.internal.file.TestFiles
+import org.gradle.process.JavaExecSpec
+
+class ProviderCompatibleJavaExecSpecTest extends ProviderCompatibleBaseExecSpecTestBase {
+    def "spec sets commandLine on parameters"() {
+        given:
+        def parameters = newParameters()
+        def command = ["some", "arguments"]
+
+        when:
+        (specUnderTest as JavaExecSpec).args(command)
+        specUnderTest.copyToParameters(parameters)
+
+        then:
+        getSuffix(parameters.commandLine.get(), command.size()) == command
+    }
+
+    @Override
+    protected ProviderCompatibleJavaExecSpec createSpecUnderTest() {
+        def spec = new ProviderCompatibleJavaExecSpec(TestFiles.execActionFactory().newJavaExecAction())
+        spec.mainClass.set("org.example.Main")  // This is mandatory to operate on the JavaExecSpec implementation
+        return spec
+    }
+
+    private static List<String> getSuffix(List<String> src, int length) {
+        return src.subList(src.size() - length, src.size())
+    }
+}


### PR DESCRIPTION
This PR provides configuration cache-friendly APIs to execute processes during the configuration phase. There are two options:
- The build author can provide a `ValueSource` implementation that receives `ExecOperations` instance and uses it to execute whatever is necessary. As for every `ValueSource`, its value becomes part of the configuration cache's fingerprint; the value is obtained for each build execution to check the validity of the cache. It is the build author's responsibility to ensure that the value is computed fast, computation doesn't invalidate the cache when not necessary and no unwanted side effects happen
- For simpler cases, two new methods are added to `providers`: `exec` and `javaexec`. Both allow specifying a command, similar to existing `Project.exec` and `Project.javaexec` tasks, but instead of running the command right away lazy providers of the command's exit code and outputs are returned. The providers can be used during configuration (so they become inputs of the configuration cache) or can be wired to task inputs as usual (so they become inputs of the execution phase). Again, the build author has to ensure that the command runs fast and produces no unwanted side effects

Other ways to run external processes during the configuration phase will eventually become configuration cache errors.