### PR TITLE
Eagerly create the backing configurations of aggregation reports

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -324,6 +324,64 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassCoverage("transitive.Powerize")
     }
 
+    def 'can apply custom attributes to refine coverage results'() {
+        setup:
+        file('application/build.gradle') << '''
+            // add a additional Attribute to the execution data results for the application unit-test suite
+            configurations.coverageDataElementsForTest.attributes {
+              attribute(Attribute.of('customAttribute', String), 'foo')
+            }
+        '''
+        file('transitive/build.gradle') << '''
+            // add a additional Attribute to the execution data results for the transitive unit-test suite
+            configurations.coverageDataElementsForTest.attributes {
+              attribute(Attribute.of('customAttribute', String), 'bar')
+            }
+        '''
+        buildFile << '''
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+
+            dependencies {
+                jacocoAggregation project(":application")
+                jacocoAggregation project(":direct")
+            }
+
+            reporting {
+                reports {
+                    testCodeCoverageReport(JacocoCoverageReport) {
+                        testType = TestSuiteType.UNIT_TEST
+                    }
+                }
+            }
+
+            // add an Attribute to the configuration tasked with collecting results
+            // as a result, variant selection should exclude the transitive project
+            reporting {
+                reports.withType(JacocoCoverageReport).configureEach { report ->
+                    Configuration reportConf = configurations.getByName("${report.name}ExecutionData")
+                    reportConf.attributes {
+                        attribute(Attribute.of('customAttribute', String), 'foo')
+                    }
+                }
+            }
+        '''
+
+        when:
+        succeeds(":testCodeCoverageReport")
+
+        then:
+        file("transitive/build/jacoco/test.exec").assertDoesNotExist()
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("application.Adder")
+        report.assertHasClassCoverage("direct.Multiplier")
+        report.assertHasClassButNoCoverage("transitive.Powerize") // the class is still in the results since we collect class dirs and source elements; but excluded binary execution data
+    }
+
     def 'test verification failure prevents creation of aggregated report'() {
         given:
         file("application/build.gradle") << """

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -95,20 +95,20 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
 
         // iterate and configure each user-specified report, creating a <reportName>ExecutionData configuration for each
         reporting.getReports().withType(JacocoCoverageReport.class).configureEach(report -> {
-            report.getReportTask().configure(task -> {
-                // A resolvable configuration to collect JaCoCo coverage data; typically named "testCodeCoverageReportExecutionData"
-                Configuration executionDataConf = project.getConfigurations().create(report.getName() + "ExecutionData");
-                executionDataConf.extendsFrom(jacocoAggregation);
-                executionDataConf.setDescription(String.format("Supplies JaCoCo coverage data to the %s.  External library dependencies may appear as resolution failures, but this is expected behavior.", report.getName()));
-                executionDataConf.setVisible(false);
-                executionDataConf.setCanBeConsumed(false);
-                executionDataConf.setCanBeResolved(true);
-                executionDataConf.attributes(attributes -> {
-                    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
-                    attributes.attributeProvider(TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestSuiteType.class, tt)));
-                    attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.class, VerificationType.JACOCO_RESULTS));
-                });
+            // A resolvable configuration to collect JaCoCo coverage data; typically named "testCodeCoverageReportExecutionData"
+            Configuration executionDataConf = project.getConfigurations().create(report.getName() + "ExecutionData");
+            executionDataConf.extendsFrom(jacocoAggregation);
+            executionDataConf.setDescription(String.format("Supplies JaCoCo coverage data to the %s.  External library dependencies may appear as resolution failures, but this is expected behavior.", report.getName()));
+            executionDataConf.setVisible(false);
+            executionDataConf.setCanBeConsumed(false);
+            executionDataConf.setCanBeResolved(true);
+            executionDataConf.attributes(attributes -> {
+                attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.VERIFICATION));
+                attributes.attributeProvider(TestSuiteType.TEST_SUITE_TYPE_ATTRIBUTE, report.getTestType().map(tt -> objects.named(TestSuiteType.class, tt)));
+                attributes.attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.class, VerificationType.JACOCO_RESULTS));
+            });
 
+            report.getReportTask().configure(task -> {
                 Callable<FileCollection> executionData = () ->
                     executionDataConf.getIncoming().artifactView(view -> {
                         view.componentFilter(id -> id instanceof ProjectComponentIdentifier);

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/TestReportAggregationPluginIntegrationTest.groovy
@@ -317,6 +317,64 @@ class TestReportAggregationPluginIntegrationTest extends AbstractIntegrationSpec
         aggregatedTestResults.assertTestClassesExecuted('application.AdderTest', 'direct.MultiplierTest', 'transitive.PowerizeTest')
     }
 
+    def 'can apply custom attributes to refine test results'() {
+        setup:
+        file('application/build.gradle') << '''
+            // add a additional Attribute to the test results for the application unit-test suite
+            configurations.testResultsElementsForTest.attributes {
+              attribute(Attribute.of('customAttribute', String), 'foo')
+            }
+        '''
+        file('transitive/build.gradle') << '''
+            // add a additional Attribute to the test results for the transitive unit-test suite
+            configurations.testResultsElementsForTest.attributes {
+              attribute(Attribute.of('customAttribute', String), 'bar')
+            }
+        '''
+        buildFile << '''
+            apply plugin: 'org.gradle.test-report-aggregation'
+
+            dependencies {
+                testReportAggregation project(":application")
+                testReportAggregation project(":direct")
+            }
+
+            reporting {
+                reports {
+                    testAggregateTestReport(AggregateTestReport) {
+                        testType = TestSuiteType.UNIT_TEST
+                    }
+                }
+            }
+
+            // add an Attribute to the configuration tasked with collecting results
+            // as a result, variant selection should exclude the transitive project
+            reporting {
+                reports.withType(AggregateTestReport).configureEach { report ->
+                    Configuration reportConf = configurations.getByName("${report.name}Results")
+                    reportConf.attributes {
+                        attribute(Attribute.of('customAttribute', String), 'foo')
+                    }
+                }
+            }
+        '''
+
+        when:
+        succeeds(':testAggregateTestReport')
+
+        then:
+        result.assertTaskNotExecuted(':transitive:test')
+
+        def directTestResults = new HtmlTestExecutionResult(testDirectory.file('direct'))
+        directTestResults.assertTestClassesExecuted('direct.MultiplierTest')
+
+        def applicationTestResults = new HtmlTestExecutionResult(testDirectory.file('application'))
+        applicationTestResults.assertTestClassesExecuted('application.AdderTest')
+
+        def aggregatedTestResults = new HtmlTestExecutionResult(testDirectory, 'build/reports/tests/unit-test/aggregated-results')
+        aggregatedTestResults.assertTestClassesExecuted('application.AdderTest', 'direct.MultiplierTest')
+    }
+
     def 'test verification failure prevents creation of aggregated report'() {
         given:file("application/build.gradle") << """
             apply plugin: 'org.gradle.test-report-aggregation'


### PR DESCRIPTION
Eagerly create the backing configurations of AggregateTestReport and JacocoCoverageReport
    
 - Allows customization/filtering by specifying additional Attributes

--

This change is necessary for Android compatibility, where two variants containing test results from the `debug` and `release` buildtypes are indistinguishable. In order to allow adding the BuildType attribute to the consumer configurations, we need to create the configuration slightly earlier. Previously the configuration was created in a task configuration action and not accessible.