### PR TITLE
Support `:internal-integ-testing` to be used via included build

### DIFF
--- a/subprojects/internal-integ-testing/build.gradle.kts
+++ b/subprojects/internal-integ-testing/build.gradle.kts
@@ -10,11 +10,22 @@ dependencies {
     api(libs.jettyWebApp) {
         because("Part of the public API via HttpServer")
     }
+    api(libs.spock) {
+        because("Part of the public API")
+    }
+    api(project(":internal-testing")) {
+        because("Part of the public API")
+    }
+    api(libs.junit) {
+        because("Part of the public API, used by spock AST transformer")
+    }
+    api(project(":base-services")) {
+        because("Part of the public API, used by spock AST transformer")
+    }
     api(project(":jvm-services")) {
         because("Exposing jvm metadata via AvailableJavaHomes")
     }
 
-    implementation(project(":base-services"))
     implementation(project(":enterprise-operations"))
     implementation(project(":messaging"))
     implementation(project(":native"))
@@ -32,7 +43,6 @@ dependencies {
     implementation(project(":dependency-management"))
     implementation(project(":configuration-cache"))
     implementation(project(":launcher"))
-    implementation(project(":internal-testing"))
     implementation(project(":build-events"))
     implementation(project(":build-option"))
 
@@ -41,8 +51,6 @@ dependencies {
     implementation(libs.groovyDatetime)
     implementation(libs.groovyJson)
     implementation(libs.groovyXml)
-    implementation(libs.junit)
-    implementation(libs.spock)
     implementation(libs.nativePlatform)
     implementation(libs.commonsLang)
     implementation(libs.commonsIo)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -196,15 +196,15 @@ class AbstractIntegrationSpec extends Specification {
         return 'settings.gradle.kts'
     }
 
-    def singleProjectBuild(String projectName, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def singleProjectBuild(String projectName, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         buildTestFixture.singleProjectBuild(projectName, cl)
     }
 
-    def multiProjectBuild(String projectName, List<String> subprojects, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def multiProjectBuild(String projectName, List<String> subprojects, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         multiProjectBuild(projectName, subprojects, CompiledLanguage.JAVA, cl)
     }
 
-    def multiProjectBuild(String projectName, List<String> subprojects, CompiledLanguage language, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def multiProjectBuild(String projectName, List<String> subprojects, CompiledLanguage language, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         buildTestFixture.multiProjectBuild(projectName, subprojects, language, cl)
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFile.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFile.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.fixtures.build
 
+import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 import org.gradle.test.fixtures.file.TestFile
 
 class BuildTestFile extends TestFile {
@@ -32,6 +33,10 @@ class BuildTestFile extends TestFile {
 
     TestFile getBuildFile() {
         file("build.gradle")
+    }
+
+    void buildFile(@GroovyBuildScriptLanguage String script) {
+        buildFile << script
     }
 
     TestFile getSettingsFile() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/build/BuildTestFixture.groovy
@@ -49,7 +49,7 @@ class BuildTestFixture {
         this
     }
 
-    def populate(String projectName, @DelegatesTo(BuildTestFile) Closure cl) {
+    def populate(String projectName, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl) {
         def project = buildInRootDir ? new BuildTestFile(getRootDir(), projectName) : new BuildTestFile(getRootDir().file(projectName), projectName)
         project.settingsFile << """
                     rootProject.name = '${projectName}'
@@ -58,7 +58,7 @@ class BuildTestFixture {
         project
     }
 
-    def singleProjectBuild(String projectName, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def singleProjectBuild(String projectName, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         def project = populate(projectName) {
             buildFile << """
                     group = 'org.test'
@@ -70,11 +70,11 @@ class BuildTestFixture {
         return project
     }
 
-    def multiProjectBuild(String projectName, List<String> subprojects, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def multiProjectBuild(String projectName, List<String> subprojects, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         multiProjectBuild(projectName, subprojects, CompiledLanguage.JAVA, cl)
     }
 
-    def multiProjectBuild(String projectName, List<String> subprojects, CompiledLanguage language, @DelegatesTo(BuildTestFile) Closure cl = {}) {
+    def multiProjectBuild(String projectName, List<String> subprojects, CompiledLanguage language, @DelegatesTo(value = BuildTestFile, strategy = Closure.DELEGATE_FIRST) Closure cl = {}) {
         def rootMulti = populate(projectName) {
             subprojects.each {
                 settingsFile << "include '$it'\n"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileRepository.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileRepository.groovy
@@ -37,6 +37,3 @@ class MavenFileRepository implements MavenRepository {
         return new MavenFileModule(rootDir, artifactDir, groupId, artifactId, version as String)
     }
 }
-
-
-


### PR DESCRIPTION
This allows the `:internal-integ-testing` project to be depended upon in other repositories via included build.

This is required in order to allow the following build to execute:
https://github.com/gradle/github-dependency-extractor