### PR TITLE
Use command files for invocations of the ar static library archiver

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCommandLineLengthLimitIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCommandLineLengthLimitIntegrationTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Issue
+
+class CppCommandLineLengthLimitIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+
+    /*
+     * The windows command line length limit is 32767 characters according to https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553.
+     * This test builds a cpp library with 330 generated source files where each file path is more than 100 characters long.
+     * This could cause the command line for the compiler, linker or archiver to exceed that limit.
+     * Fewer source files may already cause this problem depending on the path length of the files.
+     */
+    @Requires(TestPrecondition.WINDOWS)
+    @Issue("gradle/gradle-native#1028")
+    def "can build libraries where the source file paths collectively exceed the windows command line length limit"() {
+        when:
+        buildFile << '''
+            plugins {
+                id "cpp-library"
+            }
+
+            tasks.register("generateSource") {
+                ext.sourceDir = layout.buildDirectory.dir("src-gen")
+                outputs.dir sourceDir
+                doLast {
+                    def srcGen = sourceDir.get()
+                    mkdir srcGen
+                    (1..330).each {
+                        srcGen.file("this_file_name_is_more_than_one_hundred_characters_long_to_exceed_the_windows_command_line_length_limit_${it}.cpp").asFile
+                            .text = "int foo${it}() { return ${it}; }"
+                    }
+                }
+            }
+
+            library {
+                source.from generateSource
+                linkage = [Linkage.STATIC, Linkage.SHARED]
+            }
+        '''
+        then:
+        succeeds "assembleDebugStatic", "assembleDebugShared"
+    }
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ArStaticLibraryArchiver.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ArStaticLibraryArchiver.java
@@ -28,6 +28,7 @@ import org.gradle.nativeplatform.toolchain.internal.ArgsTransformer;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocation;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolInvocationWorker;
+import org.gradle.nativeplatform.toolchain.internal.OptionsFileArgsWriter;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -37,8 +38,8 @@ import java.util.List;
  * A static library archiver based on the GNU 'ar' utility
  */
 public class ArStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchiverSpec> {
-    public ArStaticLibraryArchiver(BuildOperationExecutor buildOperationExecutor, CommandLineToolInvocationWorker commandLineToolInvocationWorker, CommandLineToolContext invocationContext, WorkerLeaseService workerLeaseService) {
-        super(buildOperationExecutor, commandLineToolInvocationWorker, invocationContext, new ArchiverSpecToArguments(), false, workerLeaseService);
+    public ArStaticLibraryArchiver(BuildOperationExecutor buildOperationExecutor, CommandLineToolInvocationWorker commandLineToolInvocationWorker, CommandLineToolContext invocationContext, boolean useCommandFile, WorkerLeaseService workerLeaseService) {
+        super(buildOperationExecutor, commandLineToolInvocationWorker, invocationContext, new ArchiverSpecToArguments(), useCommandFile, workerLeaseService);
     }
 
     @Override
@@ -74,7 +75,9 @@ public class ArStaticLibraryArchiver extends AbstractCompiler<StaticLibraryArchi
 
     @Override
     protected void addOptionsFileArgs(List<String> args, File tempDir) {
-        // No support for command file
+        OptionsFileArgsWriter writer = new GccOptionsFileArgsWriter(tempDir);
+        // modifies args in place
+        writer.execute(args);
     }
 
     private static class ArchiverSpecToArguments implements ArgsTransformer<StaticLibraryArchiverSpec> {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
@@ -186,7 +186,7 @@ class GccPlatformToolProvider extends AbstractPlatformToolProvider {
     @Override
     protected Compiler<StaticLibraryArchiverSpec> createStaticLibraryArchiver() {
         GccCommandLineToolConfigurationInternal staticLibArchiverTool = toolRegistry.getTool(ToolType.STATIC_LIB_ARCHIVER);
-        return new ArStaticLibraryArchiver(buildOperationExecutor, commandLineTool(staticLibArchiverTool), context(staticLibArchiverTool), workerLeaseService);
+        return new ArStaticLibraryArchiver(buildOperationExecutor, commandLineTool(staticLibArchiverTool), context(staticLibArchiverTool), useCommandFile, workerLeaseService);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftPlatformToolProvider.java
@@ -107,7 +107,7 @@ class SwiftPlatformToolProvider extends AbstractPlatformToolProvider {
     @Override
     protected Compiler<StaticLibraryArchiverSpec> createStaticLibraryArchiver() {
         CommandLineToolConfigurationInternal staticLibArchiverTool = (CommandLineToolConfigurationInternal) toolRegistry.getStaticLibArchiver();
-        return new ArStaticLibraryArchiver(buildOperationExecutor, commandLineTool(ToolType.STATIC_LIB_ARCHIVER, "ar"), context(staticLibArchiverTool), workerLeaseService);
+        return new ArStaticLibraryArchiver(buildOperationExecutor, commandLineTool(ToolType.STATIC_LIB_ARCHIVER, "ar"), context(staticLibArchiverTool), false, workerLeaseService);
     }
 
     @Override


### PR DESCRIPTION
Fixes gradle/gradle-native#1028

### Context
When building static native libraries with the gcc toolchain, Gradle does not use a command file for the call to the `ar` static archiver. Therefore it is impossible to build static libraries for projects with many source files on windows because of its command line length limit.
This pull requests activates the usage of command files for `ar` as proposed by @lacasseio in the issue linked above and adds an integration test.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
