### PR TITLE
Rename ReadyForMerge and move Linux performance test out

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -19,19 +19,19 @@ import configurations.TestPerformanceTest
 import projects.DEFAULT_FUNCTIONAL_TEST_BUCKET_SIZE
 import projects.DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE
 
-enum class StageNames(override val stageName: String, override val description: String, override val uuid: String) : StageName {
-    QUICK_FEEDBACK_LINUX_ONLY("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer, Linux)", "QuickFeedbackLinuxOnly"),
-    QUICK_FEEDBACK("Quick Feedback", "Run checks and functional tests (embedded executer, Windows)", "QuickFeedback"),
-    READY_FOR_MERGE("Pull Request Feedback", "Run vairous functional tests against distribution", "BranchBuildAccept") {
+enum class StageNames(override val stageName: String, override val description: String) : StageName {
+    QUICK_FEEDBACK_LINUX_ONLY("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer, Linux)"),
+    QUICK_FEEDBACK("Quick Feedback", "Run checks and functional tests (embedded executer, Windows)"),
+    READY_FOR_MERGE("Pull Request Feedback", "Run vairous functional tests against distribution") {
         override val id: String = "ReadyforMerge"
     },
-    READY_FOR_NIGHTLY("Ready for Nightly", "Rerun tests in different environments / 3rd party components", "MasterAccept"),
-    READY_FOR_RELEASE("Ready for Release", "Once a day: Rerun tests in more environments", "ReleaseAccept"),
-    HISTORICAL_PERFORMANCE("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions", "HistoricalPerformance"),
-    EXPERIMENTAL("Experimental", "On demand: Run experimental tests", "Experimental"),
-    EXPERIMENTAL_VFS_RETENTION("Experimental FS Watching", "On demand checks to run tests with file system watching enabled", "ExperimentalVfsRetention"),
-    EXPERIMENTAL_JDK("Experimental JDK", "On demand checks to run tests with latest experimental JDK", "ExperimentalJDK"),
-    EXPERIMENTAL_PERFORMANCE("Experimental Performance", "Try out new performance test running", "ExperimentalPerformance")
+    READY_FOR_NIGHTLY("Ready for Nightly", "Rerun tests in different environments / 3rd party components"),
+    READY_FOR_RELEASE("Ready for Release", "Once a day: Rerun tests in more environments"),
+    HISTORICAL_PERFORMANCE("Historical Performance", "Once a week: Run performance tests for multiple Gradle versions"),
+    EXPERIMENTAL("Experimental", "On demand: Run experimental tests"),
+    EXPERIMENTAL_VFS_RETENTION("Experimental FS Watching", "On demand checks to run tests with file system watching enabled"),
+    EXPERIMENTAL_JDK("Experimental JDK", "On demand checks to run tests with latest experimental JDK"),
+    EXPERIMENTAL_PERFORMANCE("Experimental Performance", "Try out new performance test running")
 }
 
 private val performanceRegressionTestCoverages = listOf(
@@ -229,8 +229,7 @@ data class GradleSubproject(val name: String, val unitTests: Boolean = true, val
 interface StageName {
     val stageName: String
     val description: String
-    val uuid: String
-        get() = id
+
     val id: String
         get() = stageName.replace(" ", "").replace("-", "")
 }

--- a/.teamcity/src/main/kotlin/model/PerformanceTestSpec.kt
+++ b/.teamcity/src/main/kotlin/model/PerformanceTestSpec.kt
@@ -37,6 +37,12 @@ interface PerformanceTestProjectSpec {
     fun channel(): String
 }
 
+data class PerformanceTestPartialTrigger(
+    val triggerName: String,
+    val triggerId: String,
+    val dependencies: List<PerformanceTestCoverage>
+)
+
 data class PerformanceTestCoverage(
     private val uuid: Int,
     override val type: PerformanceTestType,
@@ -106,8 +112,10 @@ data class FlameGraphGeneration(
     ) : PerformanceTestBuildSpec {
         override
         val type: PerformanceTestType = PerformanceTestType.adHoc
+
         override
         val withoutDependencies: Boolean = true
+
         override
         fun asConfigurationId(model: CIBuildModel, bucket: String): String =
             "${this@FlameGraphGeneration.asConfigurationId(model)}$bucket"

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -1,6 +1,7 @@
 package projects
 
 import common.failedTestArtifactDestination
+import configurations.PerformanceTestsPass
 import configurations.StagePasses
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.Project
@@ -43,12 +44,15 @@ class CheckProject(
     }
 
     var prevStage: Stage? = null
+    val previousPerformanceTestPasses: MutableList<PerformanceTestsPass> = mutableListOf()
     model.stages.forEach { stage ->
-        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage)
+        val stageProject = StageProject(model, functionalTestBucketProvider, performanceTestBucketProvider, stage, previousPerformanceTestPasses)
         val stagePasses = StagePasses(model, stage, prevStage, stageProject)
         buildType(stagePasses)
         subProject(stageProject)
+
         prevStage = stage
+        previousPerformanceTestPasses.addAll(stageProject.performanceTests)
     }
 
     buildTypesOrder = buildTypes

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -26,7 +26,13 @@ import model.StageNames
 import model.TestCoverage
 import model.TestType
 
-class StageProject(model: CIBuildModel, functionalTestBucketProvider: FunctionalTestBucketProvider, performanceTestBucketProvider: PerformanceTestBucketProvider, stage: Stage) : Project({
+class StageProject(
+    model: CIBuildModel,
+    functionalTestBucketProvider: FunctionalTestBucketProvider,
+    performanceTestBucketProvider: PerformanceTestBucketProvider,
+    stage: Stage,
+    previousPerformanceTestPasses: List<PerformanceTestsPass>
+) : Project({
     this.id("${model.projectId}_Stage_${stage.stageName.id}")
     this.name = stage.stageName.stageName
     this.description = stage.stageName.description
@@ -107,6 +113,18 @@ class StageProject(model: CIBuildModel, functionalTestBucketProvider: Functional
             if (performanceTests.size > 1) {
                 buildType(PartialTrigger("All Performance Tests for ${stage.stageName.stageName}", "Stage_${stage.stageName.id}_PerformanceTests", model, performanceTests))
             }
+        }
+
+        stage.performanceTestPartialTriggers.forEach { trigger ->
+            buildType(
+                PartialTrigger(
+                    trigger.triggerName, trigger.triggerId, model,
+                    trigger.dependencies.map { performanceTestCoverage ->
+                        val targetPerformanceTestPassBuildTypeId = "${performanceTestCoverage.asConfigurationId(model)}_Trigger"
+                        (performanceTests + previousPerformanceTestPasses).first { it.id.toString().endsWith(targetPerformanceTestPassBuildTypeId) }
+                    }
+                )
+            )
         }
     }
 


### PR DESCRIPTION
1. Rename "Ready for Merge" to "Pull Request Feedback" to avoid confusion.
2. Move Linux performance tests to ReadyForNightly stage.
3. Add composite builds for AllPerformanceTests.
