### PR TITLE
Upgrade protobuf plugin smoke test version

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -129,7 +129,7 @@ abstract class AbstractSmokeTest extends Specification {
         static errorProne = "2.0.2"
 
         // https://plugins.gradle.org/plugin/com.google.protobuf
-        static protobufPlugin = "0.8.17"
+        static protobufPlugin = "0.8.18"
         static protobufTools = "3.17.1"
 
         // https://plugins.gradle.org/plugin/org.gradle.test-retry

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/ProtobufPluginSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-
 import spock.lang.Issue
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -61,19 +60,14 @@ class ProtobufPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
         """
 
         when:
-        def result = runner('compileJava').forwardOutput()
-            .expectDeprecationWarning(deprecationOfFileTreeForEmptySources("sourceFiles"), "https://github.com/google/protobuf-gradle-plugin/pull/530")
-            .build()
+        def result = runner('compileJava').forwardOutput().build()
 
         then:
         result.task(":generateProto").outcome == SUCCESS
         result.task(":compileJava").outcome == SUCCESS
 
         when:
-        result = runner('compileJava')
-            .forwardOutput()
-            .expectDeprecationWarning(deprecationOfFileTreeForEmptySources("sourceFiles"), "https://github.com/google/protobuf-gradle-plugin/pull/530")
-            .build()
+        result = runner('compileJava').forwardOutput().build()
 
         then:
         result.task(":generateProto").outcome == UP_TO_DATE


### PR DESCRIPTION
The new version doesn't emit the deprecation warning about file trees any more. The deprecation warning has been introduced in https://github.com/gradle/gradle/pull/18783 and fixed via https://github.com/google/protobuf-gradle-plugin/pull/530.