### PR TITLE
Move org.jetbrains.teamcity:server-api to test scope

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -148,6 +148,7 @@
             <groupId>org.jetbrains.teamcity</groupId>
             <artifactId>server-api</artifactId>
             <version>${teamcity.dsl.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.teamcity</groupId>


### PR DESCRIPTION
`teamcity-configs:generate` does not work when this dependency is present,
while the tests don't work if the dependency is not present. Moving `server-api`
to the test scope seems to make both work.