### PR TITLE
Update sourceSetOutput example to use Provider

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -58,13 +58,13 @@ import java.util.Map;
  * }
  *
  * def generateResourcesTask = tasks.register("generate-resources", GenerateResourcesTask) {
- *   resourcesDir.set(file("$buildDir/generated-resources/main"))
+ *   resourcesDir.set(layout.buildDirectory.dir("generated-resources/main"))
  * }
  *
+ * // Include all outputs of the `generate-resources` task as outputs of the main sourceSet.
  * sourceSets {
  *   main {
- *     // Register the generated 'resourcesDir' as an output of the main source set, retaining the task dependency.
- *     output.dir(generateResourcesTask.flatMap {it.resourcesDir} )
+ *     output.dir(generateResourcesTask)
  *   }
  * }
  *
@@ -80,7 +80,7 @@ import java.util.Map;
  * }
  * </pre>
  *
- * Find more information in {@link #dir(java.util.Map, Object)} and {@link #getDirs()}
+ * Find more information in {@link #dir(Object)} and {@link #getDirs()}
  */
 public interface SourceSetOutput extends FileCollection {
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -54,33 +54,30 @@ import java.util.Map;
  *
  * <pre class='autoTested'>
  * plugins {
- *     id 'java'
+ *   id 'java'
  * }
  *
- * def generatedResources = "$buildDir/generated-resources/main"
+ * def generateResourcesTask = tasks.register("generate-resources", GenerateResourcesTask) {
+ *   resourcesDir.set(file("$buildDir/generated-resources/main"))
+ * }
  *
  * sourceSets {
  *   main {
- *     //let's register an output folder on the main SourceSet:
- *     output.dir(generatedResources, builtBy: 'generateMyResources')
- *     //it is now a part of the 'main' classpath and will be a part of the jar
+ *     // Register the generated 'resourcesDir' as an output of the main source set, retaining the task dependency.
+ *     output.dir(generateResourcesTask.flatMap {it.resourcesDir} )
  *   }
  * }
  *
- * //a task that generates the resources:
- * task generateMyResources {
- *   outputs.dir generatedResources
- *   doLast {
- *     def generated = new File(generatedResources, "myGeneratedResource.properties")
+ * abstract class GenerateResourcesTask extends DefaultTask {
+ *   {@literal @}OutputDirectory
+ *   abstract DirectoryProperty getResourcesDir()
+ *
+ *   {@literal @}TaskAction
+ *   def generateResources() {
+ *     def generated = resourcesDir.file("myGeneratedResource.properties").get().asFile
  *     generated.text = "message=Stay happy!"
  *   }
  * }
- *
- * //Java plugin task 'classes' and 'testClasses' will automatically depend on relevant tasks registered with 'builtBy'
- *
- * //Eclipse/IDEA plugins will automatically depend on 'generateMyResources'
- * //because the output dir was registered with 'builtBy' information
- * apply plugin: 'idea'; apply plugin: 'eclipse'
  * </pre>
  *
  * Find more information in {@link #dir(java.util.Map, Object)} and {@link #getDirs()}


### PR DESCRIPTION
The "example how to work with generated resources" was using an old 'builtBy'
parameter to wire task dependencies. This change updates the example to use
a `DirectoryProperty` output and `task.flatMap` to do the wiring.
