### PR TITLE
Watch watchable hierarchies on Linux

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -106,8 +106,11 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
     protected abstract WatchableHierarchies.Invalidator createInvalidator();
 
     private void update(SnapshotHierarchy root) {
+        FileHierarchySet oldWatchedFiles = watchedFiles;
         watchedFiles = resolveWatchedFiles(watchableHierarchies, root);
-        updateWatchesOnChangedWatchedFiles(watchedFiles);
+        if (!watchedFiles.equals(oldWatchedFiles)) {
+            updateWatchesOnChangedWatchedFiles(oldWatchedFiles, watchedFiles);
+        }
 
         // Probe every hierarchy that is watched, even ones nested inside others
         ImmutableSet<File> oldProbedHierarchies = probedHierarchies;
@@ -139,7 +142,7 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
             });
     }
 
-    protected abstract void updateWatchesOnChangedWatchedFiles(FileHierarchySet watchedFiles);
+    protected abstract void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles);
 
     protected abstract void startWatchingProbeDirectory(File probeDirectory);
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -109,7 +109,7 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
         FileHierarchySet oldWatchedFiles = watchedFiles;
         watchedFiles = resolveWatchedFiles(watchableHierarchies, root);
         if (!watchedFiles.equals(oldWatchedFiles)) {
-            updateWatchesOnChangedWatchedFiles(oldWatchedFiles, watchedFiles);
+            updateWatchesOnChangedWatchedFiles(watchedFiles);
         }
 
         // Probe every hierarchy that is watched, even ones nested inside others
@@ -142,7 +142,7 @@ public abstract class AbstractFileWatcherUpdater implements FileWatcherUpdater {
             });
     }
 
-    protected abstract void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles);
+    protected abstract void updateWatchesOnChangedWatchedFiles(FileHierarchySet newWatchedFiles);
 
     protected abstract void startWatchingProbeDirectory(File probeDirectory);
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -97,7 +97,7 @@ public class HierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdater {
     }
 
     @Override
-    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles) {
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet newWatchedFiles) {
         ImmutableSet<File> oldWatchedHierarchies = watchedHierarchies;
         ImmutableSet.Builder<File> watchedHierarchiesBuilder = ImmutableSet.builder();
         newWatchedFiles.visitRoots(absolutePath -> watchedHierarchiesBuilder.add(new File(absolutePath)));

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -97,36 +97,34 @@ public class HierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdater {
     }
 
     @Override
-    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet newWatchedFiles) {
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles) {
         ImmutableSet<File> oldWatchedHierarchies = watchedHierarchies;
         ImmutableSet.Builder<File> watchedHierarchiesBuilder = ImmutableSet.builder();
         newWatchedFiles.visitRoots(absolutePath -> watchedHierarchiesBuilder.add(new File(absolutePath)));
         watchedHierarchies = watchedHierarchiesBuilder.build();
 
-        if (!oldWatchedHierarchies.equals(watchedHierarchies)) {
-            if (watchedHierarchies.isEmpty()) {
-                LOGGER.info("Not watching anything anymore");
-            }
-
-            List<File> hierarchiesToStopWatching = oldWatchedHierarchies.stream()
-                .filter(oldWatchedHierarchy -> !watchedHierarchies.contains(oldWatchedHierarchy))
-                .collect(ImmutableList.toImmutableList());
-            if (!hierarchiesToStopWatching.isEmpty()) {
-                if (!fileWatcher.stopWatching(hierarchiesToStopWatching)) {
-                    LOGGER.debug("Couldn't stop watching directories: {}", hierarchiesToStopWatching);
-                }
-            }
-
-            List<File> hierarchiesToStartWatching = watchedHierarchies.stream()
-                .filter(newWatchedHierarchy -> !oldWatchedHierarchies.contains(newWatchedHierarchy))
-                .collect(ImmutableList.toImmutableList());
-            if (!hierarchiesToStartWatching.isEmpty()) {
-                hierarchiesToStartWatching.forEach(locationToWatchValidator::validateLocationToWatch);
-                fileWatcher.startWatching(hierarchiesToStartWatching);
-            }
-
-            LOGGER.info("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
+        if (watchedHierarchies.isEmpty()) {
+            LOGGER.info("Not watching anything anymore");
         }
+
+        List<File> hierarchiesToStopWatching = oldWatchedHierarchies.stream()
+            .filter(oldWatchedHierarchy -> !watchedHierarchies.contains(oldWatchedHierarchy))
+            .collect(ImmutableList.toImmutableList());
+        if (!hierarchiesToStopWatching.isEmpty()) {
+            if (!fileWatcher.stopWatching(hierarchiesToStopWatching)) {
+                LOGGER.debug("Couldn't stop watching directories: {}", hierarchiesToStopWatching);
+            }
+        }
+
+        List<File> hierarchiesToStartWatching = watchedHierarchies.stream()
+            .filter(newWatchedHierarchy -> !oldWatchedHierarchies.contains(newWatchedHierarchy))
+            .collect(ImmutableList.toImmutableList());
+        if (!hierarchiesToStartWatching.isEmpty()) {
+            hierarchiesToStartWatching.forEach(locationToWatchValidator::validateLocationToWatch);
+            fileWatcher.startWatching(hierarchiesToStartWatching);
+        }
+
+        LOGGER.info("Watching {} directory hierarchies to track changes", watchedHierarchies.size());
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -171,16 +171,20 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     private static void decrement(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(value == null ? -1 : value - 1));
+        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(nullToZero(value) - 1));
     }
 
     private static void increment(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(value == null ? 1 : value + 1));
+        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(nullToZero(value) + 1));
     }
 
     @Nullable
     private static Integer zeroToNull(int value) {
         return value == 0 ? null : value;
+    }
+
+    private static int nullToZero(@Nullable Integer value) {
+        return value == null ? 0 : value;
     }
 
     private class SubdirectoriesToWatchVisitor extends RootTrackingFileSystemSnapshotHierarchyVisitor {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -35,6 +35,7 @@ import org.gradle.internal.watch.registry.FileWatcherProbeRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.HashMap;
@@ -49,6 +50,7 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     private final FileWatcher fileWatcher;
     private final Multiset<String> watchedDirectories = HashMultiset.create();
     private final Map<String, String> watchedDirectoryForSnapshot = new HashMap<>();
+    private final Set<String> watchedWatchableHierarchies = new HashSet<>();
 
     public NonHierarchicalFileWatcherUpdater(
         FileWatcher fileWatcher,
@@ -95,8 +97,19 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     @Override
-    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet watchedFiles) {
-        // The changes already happened in `handleVirtualFileSystemContentsChanged`.
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles) {
+        // Most of the changes already happened in `handleVirtualFileSystemContentsChanged`.
+        // Here we only need to update watches for the roots of the hierarchies.
+        Map<String, Integer> changedWatchDirectories = new HashMap<>();
+        watchedWatchableHierarchies.forEach(absolutePath -> decrement(absolutePath, changedWatchDirectories));
+        watchedWatchableHierarchies.clear();
+        newWatchedFiles.visitRoots(absolutePath -> {
+            watchedWatchableHierarchies.add(absolutePath);
+            increment(absolutePath, changedWatchDirectories);
+        });
+        if (!changedWatchDirectories.isEmpty()) {
+            updateWatchedDirectories(changedWatchDirectories);
+        }
     }
 
     @Override
@@ -158,11 +171,16 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     private static void decrement(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> value == null ? -1 : value - 1);
+        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(value == null ? -1 : value - 1));
     }
 
     private static void increment(String path, Map<String, Integer> changedWatchedDirectories) {
-        changedWatchedDirectories.compute(path, (key, value) -> value == null ? 1 : value + 1);
+        changedWatchedDirectories.compute(path, (key, value) -> zeroToNull(value == null ? 1 : value + 1));
+    }
+
+    @Nullable
+    private static Integer zeroToNull(int value) {
+        return value == 0 ? null : value;
     }
 
     private class SubdirectoriesToWatchVisitor extends RootTrackingFileSystemSnapshotHierarchyVisitor {

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdater.java
@@ -97,7 +97,7 @@ public class NonHierarchicalFileWatcherUpdater extends AbstractFileWatcherUpdate
     }
 
     @Override
-    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet oldWatchedFiles, FileHierarchySet newWatchedFiles) {
+    protected void updateWatchesOnChangedWatchedFiles(FileHierarchySet newWatchedFiles) {
         // Most of the changes already happened in `handleVirtualFileSystemContentsChanged`.
         // Here we only need to update watches for the roots of the hierarchies.
         Map<String, Integer> changedWatchDirectories = new HashMap<>();

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -46,6 +46,7 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         then:
         1 * watcher.startWatching({ equalIgnoringOrder(it, [probeRegistry.getProbeDirectory(file("first"))]) })
         1 * watcher.startWatching({ equalIgnoringOrder(it, [fileInWatchableHierarchies.parentFile]) })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [watchableHierarchies[0]]) })
         0 * _
 
         when:
@@ -101,15 +102,16 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         addSnapshot(snapshotRegularFile(watchableContent))
         then:
         vfsHasSnapshotsAt(watchableContent)
-        1 * watcher.startWatching({ it as List == [probeRegistry.getProbeDirectory(watchableHierarchy)] })
-        1 * watcher.startWatching({ it as List == [watchableContent.parentFile] })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [probeRegistry.getProbeDirectory(watchableHierarchy)]) })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [watchableContent.parentFile]) })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [watchableHierarchy]) })
         0 * _
 
         when:
         addSnapshot(snapshotRegularFile(unwatchableContent))
         then:
         vfsHasSnapshotsAt(unwatchableContent)
-        1 * watcher.startWatching({ it as List == [unwatchableContent.parentFile] })
+        1 * watcher.startWatching({ equalIgnoringOrder(it, [unwatchableContent.parentFile]) })
         0 * _
 
         when:
@@ -117,7 +119,7 @@ class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTe
         then:
         vfsHasSnapshotsAt(watchableContent)
         !vfsHasSnapshotsAt(unwatchableContent)
-        1 * watcher.stopWatching({ it as List == [unwatchableContent.parentFile] })
+        1 * watcher.stopWatching({ equalIgnoringOrder(it, [unwatchableContent.parentFile]) })
         0 * _
     }
 }


### PR DESCRIPTION
if they contain something worth watching. This allows us to capture events when the project root directory is moved to a different location.

Fixes #19250