### PR TITLE
Add some details to the console summary when project isolation is enabled

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultNestedBuildTest.groovy
@@ -81,7 +81,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "runs action and finishes build when model is not required by root build"() {
         given:
-        services.add(new BuildModelParameters(false, false, false, false, false, false))
+        services.add(new BuildModelParameters(false, false, false, false, false, false, false))
         def build = build()
 
         when:
@@ -101,7 +101,7 @@ class DefaultNestedBuildTest extends Specification {
 
     def "runs action but does not finish build when model is required by root build"() {
         given:
-        services.add(new BuildModelParameters(false, false, false, true, false, false))
+        services.add(new BuildModelParameters(false, false, false, true, false, false, false))
         def build = build()
 
         when:

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -98,6 +98,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c", ":d")
         }
     }
 
@@ -173,6 +174,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":")
             projectConfigured(":b") // has not been consumed by project dependency previously, but is now
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
 
         when:
@@ -207,6 +209,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
     }
 
@@ -260,8 +263,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model2[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle") << """
@@ -285,6 +287,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":")
             projectConfigured(":b") // has not been consumed by project dependency previously, but is now
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
 
         when:
@@ -319,6 +322,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
     }
 
@@ -395,6 +399,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
 
         when:
@@ -429,6 +434,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
     }
 
@@ -506,6 +512,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a", ":b", ":c")
+            modelsReused(":")
         }
 
         when:
@@ -540,6 +547,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a", ":b")
+            modelsReused(":", ":c")
         }
     }
 
@@ -630,6 +638,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
             projectConfigured(":")
             projectConfigured(":d")
             modelsCreated(":a", ":b", ":c")
+            modelsReused(":", ":d")
         }
     }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest.groovy
@@ -93,7 +93,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[3].message == "project :d classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -167,11 +167,10 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
-            // TODO - should skip this
             projectConfigured(":b") // has not been consumed by project dependency previously, but is now
             modelsCreated(":a")
         }
@@ -187,8 +186,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model4[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle") << """
@@ -204,7 +202,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model5[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -281,11 +279,10 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
-            // TODO - should skip this
             projectConfigured(":b") // has not been consumed by project dependency previously, but is now
             modelsCreated(":a")
         }
@@ -301,8 +298,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model4[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle") << """
@@ -318,7 +314,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model5[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -379,8 +375,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model2[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle").replace('implementation(project(":b"))', "")
@@ -395,7 +390,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -413,8 +408,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model4[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("a/build.gradle") << """
@@ -430,7 +424,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model5[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -491,8 +485,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model2[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateLoaded {
-        }
+        fixture.assertStateLoaded()
 
         when:
         file("c/build.gradle") << """
@@ -508,7 +501,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("c/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -542,7 +535,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model5[2].message == "project :c classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("b/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -631,7 +624,7 @@ class IsolatedProjectToolingModelsWithDependencyResolutionIntegrationTest extend
         model3[3].message == "project :d classpath = 0"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -122,18 +122,7 @@ class IsolatedProjectsFixture {
      * and the appropriate console logging, reports and build operations are generated.
      */
     void assertStateRecreated(@DelegatesTo(StoreRecreatedDetails) Closure closure) {
-        def details = new StoreRecreatedDetails()
-        closure.delegate = details
-        closure()
-
-        assertHasRecreateReason(details)
-        spec.postBuildOutputContains("Configuration cache entry stored.")
-        assertHasWarningThatIncubatingFeatureUsed()
-
-        configurationCacheBuildOperations.assertStateStored()
-
-        assertProjectsConfigured(details)
-        assertModelsQueried(details)
+        doStateRecreated(closure, "stored")
     }
 
     /**
@@ -156,6 +145,31 @@ class IsolatedProjectsFixture {
         configurationCacheBuildOperations.assertStateStored()
 
         assertHasProblems(totalProblems, details.problems)
+
+        assertProjectsConfigured(details)
+        assertModelsQueried(details)
+    }
+
+    /**
+     * Asserts that the cache entry is updated with no problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateUpdated(@DelegatesTo(StoreRecreatedDetails) Closure closure) {
+        doStateRecreated(closure, "updated")
+    }
+
+    private void doStateRecreated(Closure closure, String action) {
+        def details = new StoreRecreatedDetails()
+        closure.delegate = details
+        closure()
+
+        assertHasRecreateReason(details)
+        spec.postBuildOutputContains("Configuration cache entry $action.")
+        assertHasWarningThatIncubatingFeatureUsed()
+
+        configurationCacheBuildOperations.assertStateStored()
 
         assertProjectsConfigured(details)
         assertModelsQueried(details)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -67,10 +67,10 @@ class IsolatedProjectsFixture {
         closure.delegate = details
         closure()
 
-        def totalProblems = details.problems.inject(0) { a, b -> a + b.count }
+        def totalProblems = details.totalProblems
 
         assertHasStoreReason(details)
-        assertHasStoreMessage(totalProblems)
+        spec.result.assertHasPostBuildOutput("Configuration cache entry stored with ${details.problemsString}.")
         assertHasWarningThatIncubatingFeatureUsed()
 
         configurationCacheBuildOperations.assertStateStored()
@@ -122,7 +122,11 @@ class IsolatedProjectsFixture {
      * and the appropriate console logging, reports and build operations are generated.
      */
     void assertStateRecreated(@DelegatesTo(StoreRecreatedDetails) Closure closure) {
-        doStateRecreated(closure, "stored")
+        def details = new StoreRecreatedDetails()
+        closure.delegate = details
+        closure()
+
+        doStateStored(details, "stored")
     }
 
     /**
@@ -136,18 +140,7 @@ class IsolatedProjectsFixture {
         closure.delegate = details
         closure()
 
-        def totalProblems = details.problems.inject(0) { a, b -> a + b.count }
-
-        assertHasRecreateReason(details)
-        assertHasStoreMessage(totalProblems)
-        assertHasWarningThatIncubatingFeatureUsed()
-
-        configurationCacheBuildOperations.assertStateStored()
-
-        assertHasProblems(totalProblems, details.problems)
-
-        assertProjectsConfigured(details)
-        assertModelsQueried(details)
+        doStoreWithProblems(details, details, "stored with $details.problemsString")
     }
 
     /**
@@ -156,17 +149,31 @@ class IsolatedProjectsFixture {
      * Also asserts that the expected set of projects is configured, the expected models are queried
      * and the appropriate console logging, reports and build operations are generated.
      */
-    void assertStateUpdated(@DelegatesTo(StoreRecreatedDetails) Closure closure) {
-        doStateRecreated(closure, "updated")
-    }
-
-    private void doStateRecreated(Closure closure, String action) {
-        def details = new StoreRecreatedDetails()
+    void assertStateUpdated(@DelegatesTo(StoreUpdateDetails) Closure closure) {
+        def details = new StoreUpdateDetails()
         closure.delegate = details
         closure()
 
+        doStateStored(details, "updated for ${details.updatedProjectsString}, ${details.reusedProjectsString} up-to-date")
+    }
+
+    /**
+     * Asserts that the cache entry is updated with the given problems.
+     *
+     * Also asserts that the expected set of projects is configured, the expected models are queried
+     * and the appropriate console logging, reports and build operations are generated.
+     */
+    void assertStateUpdatedWithProblems(@DelegatesTo(StoreUpdatedWithProblemsDetails) Closure closure) {
+        def details = new StoreUpdatedWithProblemsDetails()
+        closure.delegate = details
+        closure()
+
+        doStoreWithProblems(details, details, "updated for ${details.updatedProjectsString} with $details.problemsString, ${details.reusedProjectsString} up-to-date")
+    }
+
+    private void doStateStored(StoreInvalidationDetails details, String storeAction) {
         assertHasRecreateReason(details)
-        spec.postBuildOutputContains("Configuration cache entry $action.")
+        spec.postBuildOutputContains("Configuration cache entry $storeAction.")
         assertHasWarningThatIncubatingFeatureUsed()
 
         configurationCacheBuildOperations.assertStateStored()
@@ -175,7 +182,22 @@ class IsolatedProjectsFixture {
         assertModelsQueried(details)
     }
 
-    private void assertHasRecreateReason(StoreRecreatedDetails details) {
+    private void doStoreWithProblems(StoreInvalidationDetails details, HasProblems problems, String storeAction) {
+        def totalProblems = problems.totalProblems
+
+        assertHasRecreateReason(details)
+        spec.result.assertHasPostBuildOutput("Configuration cache entry $storeAction.")
+        assertHasWarningThatIncubatingFeatureUsed()
+
+        configurationCacheBuildOperations.assertStateStored()
+
+        assertHasProblems(totalProblems, problems.problems)
+
+        assertProjectsConfigured(details)
+        assertModelsQueried(details)
+    }
+
+    private void assertHasRecreateReason(StoreInvalidationDetails details) {
         // Inputs can be discovered in parallel, so required that any one of the changed inputs is reported
         def reasons = []
         details.changedFiles.each { file ->
@@ -231,14 +253,6 @@ class IsolatedProjectsFixture {
         }
     }
 
-    private void assertHasStoreMessage(int totalProblems) {
-        assert totalProblems > 0
-        if (totalProblems == 1) {
-            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with 1 problem.")
-        } else {
-            spec.result.assertHasPostBuildOutput("Configuration cache entry stored with ${totalProblems} problems.")
-        }
-    }
 
     private assertHasProblems(int totalProblems, List<ProblemDetails> problems) {
         spec.problems.assertResultHasProblems(spec.result) {
@@ -291,13 +305,13 @@ class IsolatedProjectsFixture {
         spec.outputDoesNotContain(AbstractOptInFeatureIntegrationTest.CONFIGURE_ON_DEMAND_MESSAGE)
     }
 
-    private String fullPath(BuildOperationRecord record) {
-        if (record.details.buildPath == ':') {
-            return record.details.projectPath
-        } else if (record.details.projectPath == ':') {
-            return record.details.buildPath
+    private String fullPath(BuildOperationRecord operationRecord) {
+        if (operationRecord.details.buildPath == ':') {
+            return operationRecord.details.projectPath
+        } else if (operationRecord.details.projectPath == ':') {
+            return operationRecord.details.buildPath
         } else {
-            return record.details.buildPath + record.details.projectPath
+            return operationRecord.details.buildPath + operationRecord.details.projectPath
         }
     }
 
@@ -351,17 +365,35 @@ class IsolatedProjectsFixture {
             runsTasks = false
             models.add(new ModelDetails(path, count))
         }
+
+        void modelsQueriedAndNotPresent(String... paths) {
+            for (path in paths) {
+                modelsCreated(path, 0)
+            }
+        }
     }
 
-    static class StoreWithProblemsDetails extends StoreDetails {
+    trait HasProblems {
         final List<ProblemDetails> problems = []
 
         void problem(String message, int count = 1) {
             problems.add(new ProblemDetails(message, count))
         }
+
+        int getTotalProblems() {
+            return problems.inject(0) { a, b -> a + b.count }
+        }
+
+        String getProblemsString() {
+            def count = totalProblems
+            return count == 1 ? "1 problem" : "$count problems"
+        }
     }
 
-    static class StoreRecreatedDetails extends StoreDetails {
+    static class StoreWithProblemsDetails extends StoreDetails implements HasProblems {
+    }
+
+    static class StoreInvalidationDetails extends StoreDetails {
         List<String> changedFiles = []
         boolean changedGradleProperty
         String changedSystemProperty
@@ -384,12 +416,38 @@ class IsolatedProjectsFixture {
         }
     }
 
-    static class StoreRecreatedWithProblemsDetails extends StoreRecreatedDetails {
-        final List<ProblemDetails> problems = []
+    static class StoreRecreatedDetails extends StoreInvalidationDetails {
+    }
 
-        void problem(String message, int count = 1) {
-            problems.add(new ProblemDetails(message, count))
+    static class StoreRecreatedWithProblemsDetails extends StoreRecreatedDetails implements HasProblems {
+    }
+
+    static class StoreUpdateDetails extends StoreInvalidationDetails {
+        Set<String> projectsReused = new HashSet<>()
+
+        void modelsReused(String... paths) {
+            projectsReused.addAll(paths.toList())
         }
+
+        String getUpdatedProjectsString() {
+            def updatedProjects = models.size()
+            return updatedProjects == 1 ? "1 project" : "$updatedProjects projects"
+        }
+
+        String getReusedProjectsString() {
+            def reusedProjects = projectsReused.size()
+            switch (reusedProjects) {
+                case 0:
+                    return "no projects"
+                case 1:
+                    return "1 project"
+                default:
+                    return "${reusedProjects} projects"
+            }
+        }
+    }
+
+    static class StoreUpdatedWithProblemsDetails extends StoreUpdateDetails implements HasProblems {
     }
 
     static class LoadDetails {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -84,7 +84,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model3[1].message == "It works from project :a"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
@@ -117,7 +117,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model5[1].message == "this is project a"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
@@ -261,7 +261,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model3[1].message == "It works from project :b"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             gradlePropertyChanged()
             buildModelQueries = 1 // TODO:configuration-cache ???
             projectConfigured(":buildSrc")
@@ -291,7 +291,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model5[1].message == "It works from project :b"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             systemPropertyChanged("a-input")
             projectConfigured(":buildSrc")
             projectsConfigured(":")
@@ -320,7 +320,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model7[1].message == "It works from project :b"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             systemPropertyChanged("b-input")
             projectConfigured(":buildSrc")
             projectsConfigured(":")
@@ -388,7 +388,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model3[1].message == "It works from project :a"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
@@ -462,7 +462,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model3.empty
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiBuildActionIntegrationTest.groovy
@@ -88,6 +88,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
+            modelsReused(":a", ":b")
         }
         outputContains("creating model for root project 'root'")
 
@@ -122,6 +123,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b")
         }
         outputContains("creating model for project ':a'")
     }
@@ -261,7 +263,8 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
         model3[1].message == "It works from project :b"
 
         and:
-        fixture.assertStateUpdated {
+        // TODO - should not invalidate all cached state
+        fixture.assertStateRecreated {
             gradlePropertyChanged()
             buildModelQueries = 1 // TODO:configuration-cache ???
             projectConfigured(":buildSrc")
@@ -296,6 +299,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             projectConfigured(":buildSrc")
             projectsConfigured(":")
             modelsCreated(":a")
+            modelsReused(":", ":b", ":c")
         }
 
         when:
@@ -325,6 +329,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             projectConfigured(":buildSrc")
             projectsConfigured(":")
             modelsCreated(":b")
+            modelsReused(":", ":a", ":c")
         }
     }
 
@@ -392,6 +397,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
+            modelsReused(":a", ":b")
         }
         outputContains("creating model for root project 'root'")
 
@@ -466,6 +472,7 @@ class IsolatedProjectsToolingApiBuildActionIntegrationTest extends AbstractIsola
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
+            modelsReused(":a", ":b")
         }
         outputContains("creating model for root project 'root'")
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
@@ -221,7 +221,7 @@ class IsolatedProjectsToolingApiCompositeBuildsIntegrationTest extends AbstractI
         model3[1].message == "It works from project :libs:a"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("libs/build.gradle")
             projectConfigured(":plugins")
             projectsConfigured(":libs:a", ":libs:b") // TODO - should not be configured, but this currently happens to calculate the dependency substitutions

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCompositeBuildsIntegrationTest.groovy
@@ -226,6 +226,7 @@ class IsolatedProjectsToolingApiCompositeBuildsIntegrationTest extends AbstractI
             projectConfigured(":plugins")
             projectsConfigured(":libs:a", ":libs:b") // TODO - should not be configured, but this currently happens to calculate the dependency substitutions
             modelsCreated(":libs")
+            modelsReused(":", ":plugins", ":libs:a", ":libs:b")
         }
     }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiCoupledProjectsIntegrationTest.groovy
@@ -94,11 +94,12 @@ class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractI
         model3[2].message == "It works from project :c"
 
         and:
-        fixture.assertStateRecreatedWithProblems {
+        fixture.assertStateUpdatedWithProblems {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
-            projectConfigured(":")
             modelsCreated(":a", ":b")
+            modelsQueriedAndNotPresent(":")
+            modelsReused(":c")
             problem("Build file 'build.gradle': Cannot access project ':a' from project ':'", 3)
             problem("Build file 'build.gradle': Cannot access project ':b' from project ':'")
         }
@@ -161,12 +162,11 @@ class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractI
         model3[0].message == "It works from project :b"
 
         and:
-        fixture.assertStateRecreatedWithProblems {
+        fixture.assertStateUpdatedWithProblems {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
-            projectsConfigured(":", ":a")
-            // TODO - should invalidate the model for root
-            modelsCreated()
+            modelsQueriedAndNotPresent(":", ":a")
+            modelsReused(":b")
             problem("Build file 'a/build.gradle': Cannot access project ':' from project ':a'", 2)
         }
     }
@@ -232,11 +232,12 @@ class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractI
         model3[1].message == "the message"
 
         and:
-        fixture.assertStateRecreatedWithProblems {
+        fixture.assertStateUpdatedWithProblems {
             fileChanged("b/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a", ":b")
+            modelsReused(":", ":c")
             problem("Build file 'b/build.gradle': Cannot access project ':a' from project ':b'")
         }
 
@@ -264,11 +265,12 @@ class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractI
         model5[1].message == "new message"
 
         and:
-        fixture.assertStateRecreatedWithProblems {
+        fixture.assertStateUpdatedWithProblems {
             fileChanged("a/build.gradle")
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a", ":b")
+            modelsReused(":", ":c")
             problem("Build file 'b/build.gradle': Cannot access project ':a' from project ':b'")
         }
     }
@@ -334,11 +336,12 @@ class IsolatedProjectsToolingApiCoupledProjectsIntegrationTest extends AbstractI
         model3[1].message == "the message"
 
         and:
-        fixture.assertStateRecreatedWithProblems {
+        fixture.assertStateUpdatedWithProblems {
             fileChanged("b/build.gradle")
             projectConfigured(":buildSrc")
-            projectsConfigured(":", ":a") // :a and :b are coupled
+            projectsConfigured(":", ":a") // :a and :b are coupled, so configure a but reuse its model
             modelsCreated(":b")
+            modelsReused(":", ":a", ":c")
             problem("Build file 'b/build.gradle': Cannot access project ':a' from project ':b'")
         }
     }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiIModelQueryIntegrationTest.groovy
@@ -75,7 +75,7 @@ class IsolatedProjectsToolingApiIModelQueryIntegrationTest extends AbstractIsola
         model3.message == "this is the root project"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -103,7 +103,7 @@ class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends Abs
         model3[2].message == "this is project b"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("a/build.gradle")
             fileChanged("b/build.gradle")
             projectConfigured(":buildSrc")

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -109,6 +109,7 @@ class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends Abs
             projectConfigured(":buildSrc")
             projectConfigured(":")
             modelsCreated(":a", ":b")
+            modelsReused(":")
         }
 
         when:

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -103,6 +103,7 @@ class IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest extends Abstrac
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")
+            modelsReused(":a", ":b")
         }
         outputContains("creating model for root project 'root'")
     }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest.groovy
@@ -99,7 +99,7 @@ class IsolatedProjectsToolingApiPhasedBuildActionIntegrationTest extends Abstrac
         model3[1].message == "It works from project :a"
 
         and:
-        fixture.assertStateRecreated {
+        fixture.assertStateUpdated {
             fileChanged("build.gradle")
             projectConfigured(":buildSrc")
             modelsCreated(":")

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -26,6 +26,11 @@ import org.gradle.util.Path
 @ServiceScope(Scopes.BuildTree::class)
 interface BuildTreeConfigurationCache {
     /**
+     * Determines whether the cache entry can be loaded or needs to be stored or updated.
+     */
+    fun initializeCacheEntry()
+
+    /**
      * Loads the scheduled tasks from cache, if available, or else runs the given function to schedule the tasks and then
      * writes the result to the cache.
      */

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAction.kt
@@ -19,5 +19,5 @@ package org.gradle.configurationcache
 
 internal
 enum class ConfigurationCacheAction {
-    LOAD, STORE
+    LOAD, STORE, UPDATE
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
@@ -42,6 +42,11 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
     val vintageFactory = VintageBuildTreeLifecycleControllerFactory(buildModelParameters, taskGraph, buildOperationExecutor, projectLeaseRegistry, stateTransitionControllerFactory)
 
     override fun createRootBuildController(targetBuild: BuildLifecycleController, workExecutor: BuildTreeWorkExecutor, finishExecutor: BuildTreeFinishExecutor): BuildTreeLifecycleController {
+        // Some temporary wiring: the cache implementation is still scoped to the root build rather than the build tree
+        cache.attachRootBuild(targetBuild.gradle.services.get())
+
+        cache.initializeCacheEntry()
+
         // Currently, apply the decoration only to the root build, as the cache implementation is still scoped to the root build (that is, it assumes it is only applied to the root build)
         return createController(true, targetBuild, workExecutor, finishExecutor)
     }
@@ -70,11 +75,6 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
             ConfigurationCacheAwareFinishExecutor(finishExecutor, cache)
         } else {
             finishExecutor
-        }
-
-        // Some temporary wiring: the cache implementation is still scoped to the root build rather than the build tree
-        if (applyCaching) {
-            cache.attachRootBuild(targetBuild.gradle.services.get())
         }
 
         return DefaultBuildTreeLifecycleController(targetBuild, taskGraph, workPreparer, workExecutor, modelCreator, finisher, stateTransitionControllerFactory)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -39,7 +39,6 @@ import org.gradle.configurationcache.serialization.withGradleIsolate
 import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.configurationcache.serialization.writeFile
 import org.gradle.internal.build.BuildStateRegistry
-import org.gradle.internal.build.RootBuildState
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
@@ -116,9 +115,7 @@ class ConfigurationCacheIO internal constructor(
     fun collectRootDirs(buildStateRegistry: BuildStateRegistry): MutableSet<File> {
         val rootDirs = mutableSetOf<File>()
         buildStateRegistry.visitBuilds { build ->
-            if (build !is RootBuildState) {
-                rootDirs.add(build.buildRootDir)
-            }
+            rootDirs.add(build.buildRootDir)
         }
         return rootDirs
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -84,18 +84,14 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    val canLoad by lazy { canLoad() }
-
-    private
-    var rootBuild: Host? = null
+    lateinit var cacheAction: ConfigurationCacheAction
 
     // Have one or more values been successfully written to the entry?
     private
     var hasSavedValues = false
 
     private
-    val host: Host
-        get() = rootBuild!!
+    lateinit var host: Host
 
     private
     val store by lazy { cacheRepository.forKey(cacheKey.string) }
@@ -114,15 +110,23 @@ class DefaultConfigurationCache internal constructor(
         get() = host.service()
 
     override val isLoaded: Boolean
-        get() = canLoad
+        get() = cacheAction == ConfigurationCacheAction.LOAD
+
+    override fun initializeCacheEntry() {
+        cacheAction = determineCacheAction()
+        problems.action(cacheAction) {
+            store.useForStore { layout ->
+                invalidateConfigurationCacheState(layout)
+            }
+        }
+    }
 
     override fun attachRootBuild(host: Host) {
-        require(rootBuild == null)
-        rootBuild = host
+        this.host = host
     }
 
     override fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, scheduler: (BuildTreeWorkGraph) -> Unit) {
-        if (canLoad) {
+        if (isLoaded) {
             loadWorkGraph(graph)
         } else {
             runWorkThatContributesToCacheEntry {
@@ -133,7 +137,7 @@ class DefaultConfigurationCache internal constructor(
     }
 
     override fun maybePrepareModel(action: () -> Unit) {
-        if (canLoad) {
+        if (isLoaded) {
             return
         }
         runWorkThatContributesToCacheEntry {
@@ -142,7 +146,7 @@ class DefaultConfigurationCache internal constructor(
     }
 
     override fun <T : Any> loadOrCreateModel(creator: () -> T): T {
-        if (canLoad) {
+        if (isLoaded) {
             return loadModel().uncheckedCast()
         }
         return runWorkThatContributesToCacheEntry {
@@ -174,10 +178,10 @@ class DefaultConfigurationCache internal constructor(
     }
 
     private
-    fun canLoad(): Boolean = when {
+    fun determineCacheAction(): ConfigurationCacheAction = when {
         startParameter.recreateCache -> {
             logBootstrapSummary("Recreating configuration cache")
-            false
+            ConfigurationCacheAction.STORE
         }
         startParameter.isRefreshDependencies -> {
             logBootstrapSummary(
@@ -185,7 +189,7 @@ class DefaultConfigurationCache internal constructor(
                 buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                 "--refresh-dependencies"
             )
-            false
+            ConfigurationCacheAction.STORE
         }
         startParameter.isWriteDependencyLocks -> {
             logBootstrapSummary(
@@ -193,7 +197,7 @@ class DefaultConfigurationCache internal constructor(
                 buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                 "--write-locks"
             )
-            false
+            ConfigurationCacheAction.STORE
         }
         startParameter.isUpdateDependencyLocks -> {
             logBootstrapSummary(
@@ -201,7 +205,7 @@ class DefaultConfigurationCache internal constructor(
                 buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                 "--update-locks"
             )
-            false
+            ConfigurationCacheAction.STORE
         }
         else -> {
             when (val checkedFingerprint = checkFingerprint()) {
@@ -211,7 +215,7 @@ class DefaultConfigurationCache internal constructor(
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                         buildActionModelRequirements.configurationCacheKeyDisplayName.displayName
                     )
-                    false
+                    ConfigurationCacheAction.STORE
                 }
                 is CheckedFingerprint.EntryInvalid -> {
                     logBootstrapSummary(
@@ -219,7 +223,7 @@ class DefaultConfigurationCache internal constructor(
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                         checkedFingerprint.reason
                     )
-                    false
+                    ConfigurationCacheAction.STORE
                 }
                 is CheckedFingerprint.ProjectsInvalid -> {
                     logBootstrapSummary(
@@ -227,11 +231,11 @@ class DefaultConfigurationCache internal constructor(
                         buildActionModelRequirements.actionDisplayName.capitalizedDisplayName,
                         checkedFingerprint.reason
                     )
-                    false
+                    ConfigurationCacheAction.UPDATE
                 }
                 is CheckedFingerprint.Valid -> {
                     logBootstrapSummary("Reusing configuration cache.")
-                    true
+                    ConfigurationCacheAction.LOAD
                 }
             }
         }
@@ -309,9 +313,6 @@ class DefaultConfigurationCache internal constructor(
 
         buildOperationExecutor.withStoreOperation {
             store.useForStore { layout ->
-                problems.storing {
-                    invalidateConfigurationCacheState(layout)
-                }
                 try {
                     action(layout.fileFor(stateType))
                 } catch (error: ConfigurationCacheError) {
@@ -345,7 +346,6 @@ class DefaultConfigurationCache internal constructor(
     private
     fun <T : Any> loadFromCache(stateType: StateType, action: (ConfigurationCacheStateFile) -> T): T {
         prepareConfigurationTimeBarrier()
-        problems.loading()
 
         // No need to record the `ClassLoaderScope` tree
         // when loading the task graph.

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -44,6 +44,7 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
         val allInitScripts: List<File>
         val startParameterProperties: Map<String, Any?>
         val buildStartTime: Long
+        val invalidateCoupledProjects: Boolean
         fun gradleProperty(propertyName: String): String?
         fun fingerprintOf(fileCollection: FileCollectionInternal): HashCode
         fun hashCodeOf(file: File): HashCode?
@@ -96,10 +97,12 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                     target.consumedBy(consumer)
                 }
                 is ProjectSpecificFingerprint.CoupledProjects -> {
-                    val referrer = projects.entryFor(input.referringProject)
-                    val target = projects.entryFor(input.targetProject)
-                    target.consumedBy(referrer)
-                    referrer.consumedBy(target)
+                    if (host.invalidateCoupledProjects) {
+                        val referrer = projects.entryFor(input.referringProject)
+                        val target = projects.entryFor(input.targetProject)
+                        target.consumedBy(referrer)
+                        referrer.consumedBy(target)
+                    }
                 }
                 else -> throw IllegalStateException("Unexpected configuration cache fingerprint: $input")
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -316,6 +316,9 @@ class ConfigurationCacheFingerprintController internal constructor(
         override val buildStartTime: Long
             get() = buildCommencedTimeProvider.currentTime
 
+        override val invalidateCoupledProjects: Boolean
+            get() = modelParameters.isInvalidateCoupledProjects
+
         override fun gradleProperty(propertyName: String): String? =
             gradleProperties.find(propertyName)?.uncheckedCast()
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/metadata/ProjectMetadataController.kt
@@ -58,6 +58,7 @@ class ProjectMetadataController(
     private val cacheIO: ConfigurationCacheIO,
     store: ConfigurationCacheStateStore
 ) : ProjectStateStore<Path, LocalComponentMetadata>(store, StateType.ProjectMetadata) {
+
     override fun projectPathForKey(key: Path) = key
 
     override fun write(encoder: Encoder, value: LocalComponentMetadata) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/IntermediateModelController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/IntermediateModelController.kt
@@ -39,7 +39,7 @@ internal
 class IntermediateModelController(
     private val host: DefaultConfigurationCache.Host,
     private val cacheIO: ConfigurationCacheIO,
-    val store: ConfigurationCacheStateStore,
+    store: ConfigurationCacheStateStore,
     private val cacheFingerprintController: ConfigurationCacheFingerprintController
 ) : ProjectStateStore<ModelKey, IntermediateModel>(store, StateType.IntermediateModels) {
     override fun projectPathForKey(key: ModelKey) = key.identityPath

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
@@ -104,9 +104,10 @@ abstract class ProjectStateStore<K, V>(
             try {
                 return valuesStore.read(addressOfCached)
             } catch (e: Exception) {
-                throw RuntimeException("Could not load $key", e)
+                throw RuntimeException("Could not load entry for $key", e)
             }
         }
+        // TODO - should protect from concurrent creation
         val value = creator()
         val address = valuesStore.write(value)
         currentValues[key] = address

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
@@ -82,7 +82,7 @@ abstract class ProjectStateStore<K, V>(
         }
     }
 
-    fun visitReusedProjects(consumer: Consumer<Path>) {
+    fun visitProjects(reusedProjects: Consumer<Path>, updatedProjects: Consumer<Path>) {
         val currentProjects = currentValues.keys.mapNotNull { projectPathForKey(it) }
         val previousProjects = HashSet<Path>()
         for (key in previousValues.keys) {
@@ -93,7 +93,9 @@ abstract class ProjectStateStore<K, V>(
         }
         for (path in currentProjects) {
             if (previousProjects.contains(path)) {
-                consumer.accept(path)
+                reusedProjects.accept(path)
+            } else {
+                updatedProjects.accept(path)
             }
         }
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/models/ProjectStateStore.kt
@@ -101,7 +101,11 @@ abstract class ProjectStateStore<K, V>(
     fun loadOrCreateValue(key: K, creator: () -> V): V {
         val addressOfCached = locateCachedValue(key)
         if (addressOfCached != null) {
-            return valuesStore.read(addressOfCached)
+            try {
+                return valuesStore.read(addressOfCached)
+            } catch (e: Exception) {
+                throw RuntimeException("Could not load $key", e)
+            }
         }
         val value = creator()
         val address = valuesStore.write(value)

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/BuildModelParameters.java
@@ -27,6 +27,7 @@ public class BuildModelParameters {
     private final boolean requiresBuildModel;
     private final boolean intermediateModelCache;
     private final boolean parallelToolingApiActions;
+    private final boolean invalidateCoupledProjects;
 
     public BuildModelParameters(
         boolean configureOnDemand,
@@ -34,7 +35,8 @@ public class BuildModelParameters {
         boolean isolatedProjects,
         boolean requiresBuildModel,
         boolean intermediateModelCache,
-        boolean parallelToolingApiActions
+        boolean parallelToolingApiActions,
+        boolean invalidateCoupledProjects
     ) {
         this.configureOnDemand = configureOnDemand;
         this.configurationCache = configurationCache;
@@ -42,12 +44,13 @@ public class BuildModelParameters {
         this.requiresBuildModel = requiresBuildModel;
         this.intermediateModelCache = intermediateModelCache;
         this.parallelToolingApiActions = parallelToolingApiActions;
+        this.invalidateCoupledProjects = invalidateCoupledProjects;
     }
 
     /**
      * Will the build model, that is the configured Gradle and Project objects, be required during the build execution?
      *
-     * <p>When the build model is not required, certain state can be discarded.
+     * <p>When the build model is not required, certain state can be discarded or not created.
      */
     public boolean isRequiresBuildModel() {
         return requiresBuildModel;
@@ -66,7 +69,8 @@ public class BuildModelParameters {
     }
 
     /**
-     * Should intermediate tooling models be cached?
+     * When {@link  #isIsolatedProjects()} is true, should intermediate tooling models be cached?
+     * This is currently true when fetching a tooling model, otherwise false.
      */
     public boolean isIntermediateModelCache() {
         return intermediateModelCache;
@@ -77,5 +81,13 @@ public class BuildModelParameters {
      */
     public boolean isParallelToolingApiActions() {
         return parallelToolingApiActions;
+    }
+
+    /**
+     * When {@link  #isIsolatedProjects()} is true, should project state be invalidated when a project it is coupled with changes?
+     * This parameter is only used for benchmarking purposes.
+     */
+    public boolean isInvalidateCoupledProjects() {
+        return invalidateCoupledProjects;
     }
 }

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -109,7 +109,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         then:
         skipped(":includedBuild:jar")
         // configuration cache registers all build directories at startup so the cache fingerprint can be checked
-        def expectedWatchableCount = GradleContextualExecuter.isConfigCache() ? 3 : 2
+        def expectedWatchableCount = GradleContextualExecuter.isConfigCache() ? 4 : 2
         assertWatchableHierarchies([ImmutableSet.of(consumer, includedBuild)] * expectedWatchableCount)
         when:
         includedBuild.file("src/main/java/NewClass.java")  << "public class NewClass {}"
@@ -150,7 +150,9 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         when:
         withWatchFs().run "buildInBuild", "--info"
         then:
-        assertWatchableHierarchies(expectedWatchableHierarchies)
+        // configuration cache registers all build directories at startup so the cache fingerprint can be checked
+        def expectedWatchableCount = GradleContextualExecuter.isConfigCache() ? 2 : 1
+        assertWatchableHierarchies([ImmutableSet.of(consumer)] * expectedWatchableCount + [ImmutableSet.of(consumer, buildInBuild)])
     }
 
     def "gracefully handle the root project directory not being available"() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheProblemsFixture.groovy
@@ -416,7 +416,7 @@ final class ConfigurationCacheProblemsFixture {
     }
 
     private static ProblemsSummary extractSummary(String text) {
-        def headerPattern = Pattern.compile("(\\d+) (problems were|problem was) found (storing|reusing) the configuration cache(, (\\d+) of which seem(s)? unique)?.*")
+        def headerPattern = Pattern.compile("(\\d+) (problems were|problem was) found (storing|reusing|updating) the configuration cache(, (\\d+) of which seem(s)? unique)?.*")
         def problemPattern = Pattern.compile("- (.*)")
         def docPattern = Pattern.compile(" {2}\\QSee https://docs.gradle.org\\E.*")
         def tooManyProblemsPattern = Pattern.compile("plus (\\d+) more problems. Please see the report for details.")


### PR DESCRIPTION
<!--- The issue this PR addresses -->

When reusing some cached project state, report the configuration cache entry as "updated" rather than "stored" and also include the number of reused and updated projects.

Also add an internal property that disables invalidation of coupled projects, to be used with benchmarking.

Move the decision whether to reuse, update or store the configuration cache entry so that it done as an explicit step early in the build tree lifecycle, rather than on demand. This allow the information to be used when registering services.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
