### PR TITLE
Don't tag CACHE_MISS for commit distribution build

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -17,6 +17,7 @@
 package gradlebuild.basics
 
 import gradlebuild.basics.BuildParams.BUILD_BRANCH
+import gradlebuild.basics.BuildParams.BUILD_COMMIT_DISTRIBUTION
 import gradlebuild.basics.BuildParams.BUILD_COMMIT_ID
 import gradlebuild.basics.BuildParams.BUILD_CONFIGURATION_ID
 import gradlebuild.basics.BuildParams.BUILD_FINAL_RELEASE
@@ -59,6 +60,7 @@ import org.gradle.api.provider.Provider
 object BuildParams {
     const val BUILD_BRANCH = "BUILD_BRANCH"
     const val BUILD_COMMIT_ID = "BUILD_COMMIT_ID"
+    const val BUILD_COMMIT_DISTRIBUTION = "buildCommitDistribution"
     const val BUILD_CONFIGURATION_ID = "BUILD_TYPE_ID"
     const val BUILD_FINAL_RELEASE = "finalRelease"
     const val BUILD_ID = "BUILD_ID"
@@ -144,6 +146,10 @@ val Project.buildCommitId: Provider<String>
         .orElse(gradleProperty(BUILD_PROMOTION_COMMIT_ID))
         .orElse(environmentVariable(BUILD_VCS_NUMBER))
         .orElse(currentGitCommit())
+
+
+val Project.isBuildCommitDistribution: Boolean
+    get() = gradleProperty(BUILD_COMMIT_DISTRIBUTION).map { it.toBoolean() }.orElse(false).get()
 
 
 val Project.buildConfigurationId: Provider<String>

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -87,13 +87,14 @@ abstract class BuildCommitDistribution @Inject internal constructor(
     private
     fun getBuildCommands(): Array<String> {
         val buildCommands = mutableListOf(
-            "./gradlew" + (if (OperatingSystem.current().isWindows()) ".bat" else ""),
+            "./gradlew" + (if (OperatingSystem.current().isWindows) ".bat" else ""),
             "--no-configuration-cache",
             "clean",
             ":distributions-full:install",
             "-Pgradle_installPath=" + commitDistributionHome.get().asFile.absolutePath,
             ":tooling-api:installToolingApiShadedJar",
-            "-PtoolingApiShadedJarInstallPath=" + commitDistributionToolingApiJar.get().asFile.absolutePath
+            "-PtoolingApiShadedJarInstallPath=" + commitDistributionToolingApiJar.get().asFile.absolutePath,
+            "-PbuildCommitDistribution=true"
         )
 
         if (project.gradle.startParameter.isBuildCacheEnabled) {

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -24,6 +24,7 @@ import gradlebuild.basics.buildConfigurationId
 import gradlebuild.basics.buildId
 import gradlebuild.basics.buildServerUrl
 import gradlebuild.basics.environmentVariable
+import gradlebuild.basics.isBuildCommitDistribution
 import gradlebuild.basics.kotlindsl.execAndGetStdout
 import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
@@ -40,7 +41,6 @@ import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType
-import org.gradle.kotlin.dsl.*
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.launcher.exec.RunBuildBuildOperationType
 import java.net.InetAddress
@@ -113,7 +113,7 @@ fun isAsciidoctorCacheMiss() = isMonitoredAsciidoctorTask() && !isExpectedAsciid
 fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this is ClasspathManifest) && !this.isKotlinJsIrLink()
 
 // https://youtrack.jetbrains.com/issue/KT-49915
-fun Task.isKotlinJsIrLink() = this.javaClass.name.startsWith("KotlinJsIrLink")
+fun Task.isKotlinJsIrLink() = this.javaClass.simpleName.startsWith("KotlinJsIrLink")
 
 fun isMonitoredAsciidoctorTask() = false // No asciidoctor tasks are cacheable for now
 
@@ -136,12 +136,13 @@ fun isExpectedCompileCacheMiss() =
 // 2. Gradleception which re-builds Gradle with a new Gradle version
 // 3. buildScanPerformance test, which doesn't depend on compileAll
 // 4. buildScanPerformance test, which doesn't depend on compileAll
+// 5. BuildCommitDistribution may build a commit which is not built before
     isInBuild(
         "Check_CompileAllBuild",
         "Component_GradlePlugin_Performance_PerformanceLatestMaster",
         "Component_GradlePlugin_Performance_PerformanceLatestReleased",
         "Check_Gradleception"
-    )
+    ) || isBuildCommitDistribution
 
 fun isInBuild(vararg buildTypeIds: String) = buildConfigurationId.orNull?.let { currentBuildTypeId ->
     buildTypeIds.any { currentBuildTypeId.endsWith(it) }


### PR DESCRIPTION
Sometimes it may build a commit which is not built before,
in this case, the cache miss is expected and we don't tag `CACHE_MISS`.
