### PR TITLE
Force the build timestamp to include the time if testing samples/snippets in docs

### DIFF
--- a/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -152,4 +152,3 @@ fun isRunningInstallTask() =
 fun isRunningDocsTestTask() =
     setOf(":docs:docsTest", "docs:docsTest")
         .any(gradle.startParameter.taskNames::contains)
-

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -122,6 +122,9 @@ fun Project.buildTimestamp(): Provider<String> =
             runningInstallTask.set(
                 provider { isRunningInstallTask() }
             )
+            runningDocsTestTask.set(
+                provider { isRunningDocsTestTask() }
+            )
         }
     }
 
@@ -146,4 +149,7 @@ fun isRunningInstallTask() =
         .flatMap { listOf(":distributions-full:$it", "distributions-full:$it", it) }
         .any(gradle.startParameter.taskNames::contains)
 
+fun isRunningDocsTestTask() =
+    setOf(":docs:docsTest", "docs:docsTest")
+        .any(gradle.startParameter.taskNames::contains)
 

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampValueSource.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampValueSource.kt
@@ -39,6 +39,7 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
         val runningOnCi: Property<Boolean>
 
         val runningInstallTask: Property<Boolean>
+        val runningDocsTestTask: Property<Boolean>
     }
 
     override fun obtain(): String? = parameters.run {
@@ -57,7 +58,7 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
             buildTimestampFromProperty != null -> {
                 timestampFormat.parse(buildTimestampFromProperty)
             }
-            runningInstallTask.get() || runningOnCi.get() -> {
+            runningInstallTask.get() || runningDocsTestTask.get() || runningOnCi.get() -> {
                 Date()
             }
             else -> {
@@ -77,6 +78,7 @@ abstract class BuildTimestampValueSource : ValueSource<String, BuildTimestampVal
                 buildTimestampFromBuildReceipt.isPresent -> "from build receipt"
                 buildTimestampFromGradleProperty.isPresent -> "from buildTimestamp property"
                 runningInstallTask.get() -> "from current time because installing"
+                runningDocsTestTask.get() -> "from current time because testing docs"
                 runningOnCi.get() -> "from current time because CI"
                 else -> "from current date"
             }


### PR DESCRIPTION
Is this what you had in mind here, @wolfs?  Now the `buildTime` includes a time when running `docsTest`.  Is there anything else needed to ensure this allows will get the kotlin samples access to same-day API changes?