### PR TITLE
Do not register BuildOperationAncestryTracker with scoped listeners

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiBuildEventListenerFactory.java
@@ -57,7 +57,6 @@ public class ToolingApiBuildEventListenerFactory implements BuildEventListenerFa
         ProgressEventConsumer progressEventConsumer = new ProgressEventConsumer(consumer, ancestryTracker);
 
         List<Object> listeners = new ArrayList<>();
-        listeners.add(ancestryTracker);
 
         if (subscriptions.isRequested(OperationType.TEST) && subscriptions.isRequested(OperationType.TEST_OUTPUT)) {
             listeners.add(new ClientForwardingTestOutputOperationListener(progressEventConsumer, idFactory));


### PR DESCRIPTION
Prior to BuildOperationAncestryTracker being converted to the global
service a new instance of it was created for each new build in the
ToolingApiBuildEventListenerFactory, and this instance was unregistered
alongside other scoped listeners at the end of the build. After the
change the tracker was registered once very early in a daemon lifecycle
but the scoped registration stayed.

This behavior is problematic in some cases. Consider several builds that
share a daemon:
  1. Daemon is initialized and register the tracker globally in the
     BuildEventServices.registerGlobalServices
  2. A build starts and uses tooling API (e. g. because of kotlin dsl),
     registering the tracker one more time through the scoping
     DefaultBuildEventsListenerRegistry.
  3. The build ends and the scoping registry unregisters the tracker.
     All registrations are removed.
  4. Another build starts in the same daemon, doesn't use tooling API.
     The tracker is never re-registered and becomes useless.

This CL removes the scoped registration. It isn't necessary because the
tracker is already registered at this point and shouldn't be
unregistered after the build ends.

