### PR TITLE
Accept performance regression

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -33,7 +33,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         AndroidTestProject.useStableAgpVersion(runner)
         // AGP 4.1 requires 6.5+
         // forUseAtConfigurationTime API used in this scenario

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioMockupPerformanceTest.groovy
@@ -41,7 +41,7 @@ class RealLifeAndroidStudioMockupPerformanceTest extends AbstractCrossVersionPer
         runner.warmUpRuns = 40
         runner.runs = 40
         runner.minimumBaseVersion = "6.5"
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         runner.toolingApi("Android Studio Sync") {
             it.action(new GetModel())

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -37,7 +37,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumBaseVersion = "3.5"
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "clean assemble with remote http cache"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingNativePerformanceTest.groovy
@@ -30,7 +30,7 @@ class TaskOutputCachingNativePerformanceTest extends AbstractTaskOutputCachingPe
 
     def setup() {
         runner.minimumBaseVersion = "4.3"
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.args += ["-Dorg.gradle.caching.native=true"]
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingSwiftPerformanceTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class TaskOutputCachingSwiftPerformanceTest extends AbstractTaskOutputCachingPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = "4.5"
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "clean assemble with local cache (swift)"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ArchiveTreePerformanceTest.groovy
@@ -27,7 +27,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class ArchiveTreePerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     @RunFor(

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/DeprecationCreationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class DeprecationCreationPerformanceTest extends AbstractCrossVersionPerformance
         given:
         runner.tasksToRun = ['help']
         runner.minimumBaseVersion = '6.3'
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         when:
         def result = runner.run()
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -31,7 +31,7 @@ class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceT
 
     def setup() {
         runner.minimumBaseVersion = '5.6.4'
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "merge exclude rules"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/IdeIntegrationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
     def "eclipse"() {
         given:
         runner.tasksToRun = ['eclipse']
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()
@@ -46,7 +46,7 @@ class IdeIntegrationPerformanceTest extends AbstractCrossVersionPerformanceTest 
     def "idea"() {
         given:
         runner.tasksToRun = ['idea']
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -34,7 +34,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.minimumBaseVersion = '5.6.4'
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "resolve large dependency graph from file repo"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ParallelDownloadsPerformanceTest.groovy
@@ -49,7 +49,7 @@ class ParallelDownloadsPerformanceTest extends AbstractCrossVersionPerformanceTe
     }
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         // Example project requires TaskContainer.register
         runner.minimumBaseVersion = "5.6"
         runner.warmUpRuns = 5

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/RichConsolePerformanceTest.groovy
@@ -40,7 +40,7 @@ class RichConsolePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.tasksToRun = tasks.split(' ')
         runner.warmUpRuns = 5
         runner.runs = 8
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/TaskCreationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class TaskCreationPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def "create many tasks"() {
         given:
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.runs = 60
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/VerboseTestOutputPerformanceTest.groovy
@@ -32,7 +32,7 @@ class VerboseTestOutputPerformanceTest extends AbstractCrossVersionPerformanceTe
         given:
         runner.tasksToRun = ['cleanTest', 'test']
         runner.args = ['-q']
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaCleanAssemblePerformanceTest.groovy
@@ -35,7 +35,7 @@ class JavaCleanAssemblePerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.warmUpRuns = 2
         runner.runs = 6
         runner.tasksToRun = ["clean", "assemble"]
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.minimumBaseVersion = runner.testProject.contains("Composite") ? "4.0" : null
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationCachePerformanceTest.groovy
@@ -36,7 +36,7 @@ class JavaConfigurationCachePerformanceTest extends AbstractCrossVersionPerforma
 
     def setup() {
         stateDirectory = temporaryFolder.file(".gradle/configuration-cache")
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.minimumBaseVersion = "6.6"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -31,7 +31,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
     def "configure"() {
         given:
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaDependencyReportPerformanceTest.groovy
@@ -33,7 +33,7 @@ class JavaDependencyReportPerformanceTest extends AbstractCrossVersionPerformanc
         given:
         def subProject = (runner.testProject == LARGE_JAVA_MULTI_PROJECT.projectName) ? 'project363:' : ''
         runner.tasksToRun = ["${subProject}dependencyReport"]
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
 
         when:
         def result = runner.run()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "first use"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class JavaIDEModelPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.minimumBaseVersion = "2.11"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIncrementalExecutionPerformanceTest.groovy
@@ -41,7 +41,7 @@ class JavaIncrementalExecutionPerformanceTest extends AbstractIncrementalExecuti
     boolean isGroovyProject
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         testProject = JavaTestProject.findProjectFor(runner.testProject)
         isGroovyProject = testProject?.name()?.contains("GROOVY")
         if (isGroovyProject) {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaTasksPerformanceTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 
 class JavaTasksPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     @RunFor(

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildDependentsPerformanceTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class NativeBuildDependentsPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.minimumBaseVersion = "4.0"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeBuildPerformanceTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class NativeBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "up-to-date assemble (native)"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/NativeCleanBuildPerformanceTest.groovy
@@ -26,7 +26,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class NativeCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.1' // minimum version that contains new C++ plugins
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -32,7 +32,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
         runner.minimumBaseVersion = "4.0"
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftBuildPerformanceTest.groovy
@@ -31,7 +31,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class SwiftBuildPerformanceTest extends AbstractCrossVersionPerformanceTest {
     def setup() {
         runner.minimumBaseVersion = '4.6'
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "up-to-date assemble (swift)"() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/SwiftCleanBuildPerformanceTest.groovy
@@ -30,7 +30,7 @@ class SwiftCleanBuildPerformanceTest extends AbstractCrossVersionPerformanceTest
 
     def setup() {
         runner.minimumBaseVersion = '4.6'
-        runner.targetVersions = ["7.4-branch-moved_dirs-20211214170925+0000"]
+        runner.targetVersions = ["7.4-20211214223504+0000"]
     }
 
     def "clean assemble (swift)"() {


### PR DESCRIPTION
We now take about 20ms extra to check if the directories did move on
`largeJavaMultiProject`.

This is the rebase on a nightly from `master` after the merge of
https://github.com/gradle/gradle/pull/19278.