### PR TITLE
Fix `ConfigurationCacheFixture` when running with the parallel executor

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/strict/StrictVersionsInPlatformCentricDevelopmentIntegrationTest.groovy
@@ -313,7 +313,7 @@ class StrictVersionsInPlatformCentricDevelopmentIntegrationTest extends Abstract
         }
         then:
         def platformVariant = platformType == MODULE ? 'runtime' : 'apiElements'
-        (platformType == ENFORCED_PLATFORM && failureOrNull == null) || failure.assertHasCause(
+        (platformType == ENFORCED_PLATFORM && !failed) || failure.assertHasCause(
             """Cannot find a version of 'org:foo' that satisfies the version constraints:
    Dependency path ':test:unspecified' --> 'org:bar:2.0' (runtime) --> 'org:foo:3.1'
    Constraint path ':test:unspecified' --> 'org:platform:1.1' (${platformVariant}) --> 'org:foo:{strictly 3.1.1; reject 3.1 & 3.2}'

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -46,7 +46,6 @@ import org.intellij.lang.annotations.Language
 import org.junit.Rule
 import spock.lang.Specification
 
-import javax.annotation.Nullable
 import java.nio.file.Files
 
 import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.DEFAULT_TIMEOUT_SECONDS
@@ -390,11 +389,6 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         return currentResult
     }
 
-    @Nullable
-    ExecutionResult getResultOrNull() {
-        return currentResult
-    }
-
     void setResult(ExecutionResult result) {
         currentFailure = null
         currentResult = result
@@ -407,9 +401,8 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         return currentFailure
     }
 
-    @Nullable
-    ExecutionFailure getFailureOrNull() {
-        return currentFailure
+    boolean isFailed() {
+        return currentFailure != null
     }
 
     void setFailure(ExecutionFailure failure) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -211,8 +211,7 @@ class ConfigurationCacheFixture {
     }
 
     private void assertHasProblems(HasProblems problemDetails) {
-        boolean isFailure = spec.result instanceof ExecutionFailure
-        if (isFailure) {
+        if (spec.failed) {
             problems.assertFailureHasProblems(spec.failure) {
                 applyProblemsTo(problemDetails, delegate)
             }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/AbstractLanguageInterOpIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.KotlinDslTestUtil
-import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.test.fixtures.file.TestFile
 
 import java.nio.file.Files
@@ -50,7 +49,7 @@ class AbstractLanguageInterOpIntegrationTest extends AbstractIntegrationSpec {
 
     def cleanup() {
         // Let's copy the Kotlin compiler logs in case of failure
-        if (resultOrNull instanceof ExecutionFailure) {
+        if (failed) {
             def pattern = "kotlin-daemon.${new Date().format("yyyy-MM-dd")}.*.log"
             def kotlinCompilerLogFiles = new FileNameFinder().getFileNames(System.getenv("TMPDIR"), pattern)
             def target = buildContext.gradleUserHomeDir.createDir("kotlin-compiler-daemon").toPath()


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
