### PR TITLE
fix typo in build_environment doc

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -300,7 +300,7 @@ systemProp.https.proxyHost=www.somehost.org
 systemProp.https.proxyPort=8080
 systemProp.https.proxyUser=userid
 systemProp.https.proxyPassword=password
-systemProp.http.nonProxyHosts=*.nonproxyrepos.com|localhost
+systemProp.https.nonProxyHosts=*.nonproxyrepos.com|localhost
 ----
 
 You may need to set other properties to access other networks. Here are 2 references that may be helpful:


### PR DESCRIPTION
Hi.
I looked at the documentation for gradle proxy use the gradle.properties.
i saw that some text correction was needed, so I create pull request.

https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy