### PR TITLE
Upgrade to Gradle Profiler 0.17-alpha11

### DIFF
--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
         api(libs.googleHttpClient)      { version { strictly(googleApiVersion); because("our GCS version requires 1.25.0") }}
         api(libs.googleHttpClientJackson2) { version { strictly(googleApiVersion); because("our GCS version requires 1.25.0") }}
         api(libs.googleOauthClient)     { version { strictly(googleApiVersion); because("our GCS version requires 1.25.0") }}
-        api(libs.gradleProfiler)        { version { strictly("0.17.0-alpha10") }}
+        api(libs.gradleProfiler)        { version { strictly("0.17.0-alpha11") }}
         api(libs.groovy)                { version { strictly(libs.groovyVersion) }}
         api(libs.groovyAnt)             { version { strictly(libs.groovyVersion) }}
         api(libs.groovyAstbuilder)      { version { strictly(libs.groovyVersion) }}


### PR DESCRIPTION
So we can try out the new flame graph diffs.