### PR TITLE
Documentation: Add 'Gradle Snippets' section

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradle-snippets/sharing_task_outputs_between_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle-snippets/sharing_task_outputs_between_projects.adoc
@@ -1,0 +1,49 @@
+[[sharing_task_outputs_between_projects]]
+= Sharing outputs between projects
+
+You want to share a file made by a task in one project with a task in another project.
+For example one task makes a file, and the other task uses the file.
+
+== Example
+
+.Settings
+====
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy",files="settings.gradle[]"]
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin",files="settings.gradle.kts[]"]
+====
+
+.Producer's build
+====
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy",files="producer/build.gradle[]"]
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin",files="producer/build.gradle.kts[]"]
+====
+
+.Consumer's build
+====
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy",files="consumer/build.gradle[]"]
+include::sample[dir="snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin",files="consumer/build.gradle.kts[]"]
+====
+
+See also:
+
+- <<cross_project_publications.adoc#cross_project_publications, Sharing outputs between projects>>
+- https://github.com/robmoore-i/gradle-share-outputs-between-projects/tree/groovy[A minimal example Gradle project demonstrating this feature, provided from the community]
+
+== Anti-patterns:
+
+[WARNING]
+.Don't reference other project tasks directly
+====
+A frequent anti-pattern to declare cross-project dependencies is:
+
+[source,groovy]
+----
+dependencies {
+   // this is unsafe!
+   implementation project(":other").tasks.someOtherJar
+}
+----
+
+This publication model is _unsafe_ and can lead to non-reproducible and hard to parallelize builds.
+(WHY?)
+====

--- a/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
@@ -12,9 +12,9 @@ Coming soon
 
 - I want to read and write files.
 - I want to run an arbitrary command on the shell.
-- I want to add a "Hello World" Gradle conventions plugin.
+- I want to add the simplest possible Gradle conventions plugin to my build.
 - I want to create a custom test task which has a separate directory for its sources (i.e. using a different `SourceSet`).
 - I want to replace an `allprojects` or `subprojects` block, with a convention plugin.
 - I want to build my JVM application JAR so that it can be run without specifying the classpath at runtime i.e. this should work: `java -jar mything.jar`.
-- I want to write the most basic possible test for my build logic, using testKit.
+- I want to write the most basic possible test for my build logic, using Gradle TestKit.
 - I want to make sure that a certain vulnerable version of a dependency is never on the classpath for my Java project.

--- a/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
@@ -1,0 +1,20 @@
+[[gradle_snippets_overview]]
+= Gradle snippets overview
+
+Sometimes when you arrive at documentation, you are wanting a solution to a specific problem that you're presently facing, perhaps a problem you think should be routine and perhaps even trivial. This section
+of the documentation is here to provide idiomatic solutions to common problems faced by Gradle build authors.
+
+If what you were looking for isn't here yet, please send an email about what you were looking for to snippet-suggestions@gradle.org so we can (a) help you (b) write documentation that would have helped you solve your problem without having to email us. You could also https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md[contribute a pull request to the Gradle build tool repository on GitHub].
+
+- <<sharing_task_outputs_between_projects.adoc#sharing_task_outputs_between_projects,I want to share a file produced by a task in one project, with a task in another project.>>
+
+Coming soon
+
+- I want to read and write files.
+- I want to run an arbitrary command on the shell.
+- I want to add a hello-world Gradle conventions plugin.
+- I want to create a custom test task which has a separate directory for its sources (i.e. using a different `SourceSet`).
+- I want to replace an `allprojects` or `subprojects` block, with a convention plugin.
+- I want to build my JVM application JAR so that it can be run without specifying the classpath at runtime i.e. this should work: `java -jar mything.jar`.
+- I want to write the most basic possible test for my build logic, using testKit.
+- I want to make sure that a certain vulnerable version of a dependency is not on the classpath for my Java project.

--- a/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle-snippets/snippets_overview.adoc
@@ -6,15 +6,15 @@ of the documentation is here to provide idiomatic solutions to common problems f
 
 If what you were looking for isn't here yet, please send an email about what you were looking for to snippet-suggestions@gradle.org so we can (a) help you (b) write documentation that would have helped you solve your problem without having to email us. You could also https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md[contribute a pull request to the Gradle build tool repository on GitHub].
 
-- <<sharing_task_outputs_between_projects.adoc#sharing_task_outputs_between_projects,I want to share a file produced by a task in one project, with a task in another project.>>
+- <<sharing_task_outputs_between_projects.adoc#sharing_task_outputs_between_projects,I want to share a file produced by a task in one subproject, with a task in another subproject.>>
 
 Coming soon
 
 - I want to read and write files.
 - I want to run an arbitrary command on the shell.
-- I want to add a hello-world Gradle conventions plugin.
+- I want to add a "Hello World" Gradle conventions plugin.
 - I want to create a custom test task which has a separate directory for its sources (i.e. using a different `SourceSet`).
 - I want to replace an `allprojects` or `subprojects` block, with a convention plugin.
 - I want to build my JVM application JAR so that it can be run without specifying the classpath at runtime i.e. this should work: `java -jar mything.jar`.
 - I want to write the most basic possible test for my build logic, using testKit.
-- I want to make sure that a certain vulnerable version of a dependency is not on the classpath for my Java project.
+- I want to make sure that a certain vulnerable version of a dependency is never on the classpath for my Java project.

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -318,6 +318,12 @@
             <li><a href="../userguide/travis-ci.html">Travis CI</a></li>
         </ul>
 
+        <h3 id="gradle-snippets">Gradle Snippets</h3>
+        <ul>
+            <li><a href="../userguide/snippets_overview.html">Gradle Snippets Overview</a></li>
+            <li><a href="../userguide/sharing_task_outputs_between_projects.html">Sharing task outputs between projects</a></li>
+        </ul>
+
         <h3 id="reference">Reference</h3>
         <ul>
             <li><a href="../userguide/plugin_reference.html">Core Plugins</a></li>

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/consumer/build.gradle
@@ -1,0 +1,18 @@
+configurations {
+    sharedConfiguration {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
+dependencies {
+    sharedConfiguration(project("path": ":producer", "configuration": "sharedConfiguration"))
+}
+
+tasks.register("showFile") {
+    def sharedConfiguration = configurations.getByName("sharedConfiguration")
+    it.inputs.files(sharedConfiguration)
+    it.doFirst {
+        logger.lifecycle("File is at {}", sharedConfiguration.singleFile.absolutePath)
+    }
+}

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/producer/build.gradle
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/producer/build.gradle
@@ -1,0 +1,20 @@
+import java.nio.file.Files
+
+def outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+def makeFile = tasks.register("makeFile", DefaultTask) {
+    it.outputs.file(outputFile)
+    it.doFirst {
+        Files.writeString(outputFile.get().asFile.toPath(), "This file is shared across Gradle subprojects.")
+    }
+}
+
+configurations {
+    sharedConfiguration {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+    sharedConfiguration(makeFile)
+}

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/groovy/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = "sharing-outputs"
+include("producer")
+include("consumer")

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/consumer/build.gradle.kts
@@ -1,0 +1,15 @@
+val sharedConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    add(sharedConfiguration.name, project(mapOf("path" to ":producer", "configuration" to "sharedConfiguration")))
+}
+
+tasks.register("showFile") {
+    inputs.files(sharedConfiguration)
+    doFirst {
+        logger.lifecycle(sharedConfiguration.singleFile.absolutePath)
+    }
+}

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/producer/build.gradle.kts
@@ -1,0 +1,17 @@
+val outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+val makeFile = tasks.register("makeFile") {
+    outputs.file(outputFile)
+    doFirst {
+        outputFile.get().asFile
+            .writeText("This file is shared across Gradle subprojects.")
+    }
+}
+
+val sharedConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+artifacts {
+    add(sharedConfiguration.name, makeFile)
+}

--- a/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/gradle-snippets/sharing-task-outputs-between-projects/kotlin/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "sharing-outputs"
+include("producer")
+include("consumer")


### PR DESCRIPTION
### Context

#### What's the problem with the docs right now?

Solutions to some common problems for Gradle build authors sometimes have quite disappointing discoverability.

For example, Googling "gradle write file" should probably result in an easy ride to the answer. It's actually not. You get to [Working with Files](https://docs.gradle.org/current/userguide/working_with_files.html), and it doesn't really contain that information at a glance.

Another example is running shell commands. "gradle run shell commands" -- actually if you try typing this out in Google, don't hit enter right away. Satisfy yourself that a lot of people want an answer to this question: Look at the variety of auto-complete options you get from Google (or whatever other search engine you're using).

#### Can't we just update the existing docs pages?

We _could_ provide answers to these questions all over the place. For example we can (and I think should) update Working with Files to include reading & writing files. We could make an off-hand mention of running shell commands somewhere else, or perhaps add a bit more explanation to the [Exec documentation](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Exec.html).

This is a fragmented way of doing things though, and leaves users without a single place to find the answers to the most common questions that we can anticipate. It is great that we have docs that go deeply into a topic, for example, [variant aware sharing of artefacts between projects](https://docs.gradle.org/current/userguide/cross_project_publications.html#sec:variant-aware-sharing). These more focused pieces of writing aren't the right place for quick-fire "just tell me the answer right now" queries that users very often have.

#### Summary

By having users find their answers by copy-pasting from Stack Overflow, Baeldung, and random blog posts, we lose the opportunity to get them to land on docs.gradle.org, where they will be given not just the code snippet they're looking for, but in particular, the latest idiomatic solution. On the official documentation, they can also get an explanation of _why_ that's the idiomatic solution, and maybe a short description of other possible solutions, or variations of them, in both Groovy and Kotlin, and warnings about anti-patterns, and why they are anti-patterns. etc. etc.

In short, I think we can do a lot more to make all Gradle users, skilled Gradle users.

Let me know your thoughts.

If you like the idea, I would be thrilled, and would also create snippets for the additional common problems I identified, and also gather more from the wider community of non-expert Gradle users I know (and also skeptical Maven users 👀). Of course, I am myself very far from the world's best Gradle build tool user, and would always appreciate your comments on what I write.

Rob

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes