### PR TITLE
Update Log4j to 2.17.0

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ScriptDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ScriptDependencyResolveIntegrationTest.groovy
@@ -67,7 +67,7 @@ task check {
     @Issue("gradle/gradle#19328")
     def 'carries implicit constraint for log4j-core'() {
         given:
-        mavenRepo().module('org.apache.logging.log4j', 'log4j-core', '2.16.0').publish()
+        mavenRepo().module('org.apache.logging.log4j', 'log4j-core', '2.17.0').publish()
 
         and:
         settingsFile << """
@@ -92,7 +92,7 @@ task check {
 
         expect:
         succeeds 'buildEnvironment'
-        outputContains('org.apache.logging.log4j:log4j-core:{require 2.16.0; reject [2.0, 2.16)} -> 2.16.0 (c)')
+        outputContains('org.apache.logging.log4j:log4j-core:{require 2.17.0; reject [2.0, 2.17)} -> 2.17.0 (c)')
     }
 
     @Issue("gradle/gradle#19328")
@@ -132,6 +132,6 @@ task check {
 
         expect:
         succeeds 'buildEnvironment'
-        outputContains('org.apache.logging.log4j:log4j-core:{require 2.16.0; reject [2.0, 2.16)} -> 3.1.0 (c)')
+        outputContains('org.apache.logging.log4j:log4j-core:{require 2.17.0; reject [2.0, 2.17)} -> 3.1.0 (c)')
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/util/Log4jBannedVersion.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/util/Log4jBannedVersion.java
@@ -22,6 +22,6 @@ package org.gradle.internal.logging.util;
  */
 public class Log4jBannedVersion {
     public static final String LOG4J2_CORE_COORDINATES = "org.apache.logging.log4j:log4j-core";
-    public static final String LOG4J2_CORE_VULNERABLE_VERSION_RANGE = "[2.0, 2.16)";
-    public static final String LOG4J2_CORE_REQUIRED_VERSION = "2.16.0";
+    public static final String LOG4J2_CORE_VULNERABLE_VERSION_RANGE = "[2.0, 2.17)";
+    public static final String LOG4J2_CORE_REQUIRED_VERSION = "2.17.0";
 }

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -262,7 +262,7 @@ task someTask
 
     @ToBeFixedForConfigurationCache(because = ":dependencies")
     @Issue("gradle/gradle#19328")
-    def 'show that log4j-core, if present, is 2_16_0 at the minimum'() {
+    def 'show that log4j-core, if present, is 2_17_0 at the minimum'() {
         given:
         file('build.gradle') << """
             apply plugin: 'scala'
@@ -273,7 +273,7 @@ task someTask
         def versionPattern = ~/.*-> 2\.(\d+).*/
         expect:
         succeeds('dependencies', '--configuration', 'zinc')
-        def log4jOutput = result.getOutputLineThatContains("log4j-core:{require 2.16.0; reject [2.0, 2.16)}")
+        def log4jOutput = result.getOutputLineThatContains("log4j-core:{require 2.17.0; reject [2.0, 2.17)}")
         def matcher = log4jOutput =~ versionPattern
         matcher.find()
         Integer.valueOf(matcher.group(1)) >= 16


### PR DESCRIPTION
This is required following discovery of https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105