### PR TITLE
Update Gradle Enterprise plugin to 3.8

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 dependencies {
     constraints {
         // Gradle Plugins
-        api("com.gradle:gradle-enterprise-gradle-plugin:3.7.2")
+        api("com.gradle:gradle-enterprise-gradle-plugin:3.8")
         api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.2-rc-2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.19.1")
         api("com.gradle.publish:plugin-publish-plugin:0.18.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.7.2")
+    id("com.gradle.enterprise").version("3.8")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.5")
     id("gradlebuild.base.allprojects")
     id("com.gradle.enterprise.test-distribution").version("2.2.2-rc-2") // Sync with `build-logic/build-platform/build.gradle.kts`

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.7.2";
+    public static final String VERSION = "3.8";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -65,7 +65,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.6.4",
         "3.7",
         "3.7.1",
-        "3.7.2"
+        "3.7.2",
+        "3.8"
     ]
 
     private static final VersionNumber FIRST_VERSION_SUPPORTING_CONFIGURATION_CACHE = VersionNumber.parse("3.4")


### PR DESCRIPTION
We should merge this **after** ge.gradle.org is updated to Gradle Enterprise 2021.4.