### PR TITLE
Remove wrong `@` from doNotTrackState in documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -1133,7 +1133,7 @@ Gradle automatically handles up-to-date checks for output files and directories,
 Perhaps it’s an update to a web service or a database table.
 Or sometimes you have a task which should always run.
 
-That’s where the `doNoTrackState()` method on `Task` comes in.
+That’s where the `doNotTrackState()` method on `Task` comes in.
 One can use this to disable up-to-date checks completely for a task, like so:
 
 .Ignoring up-to-date checks
@@ -1162,7 +1162,7 @@ If you are writing your own task that always should run, then you can also use t
 Sometimes you want to integrate an external tool like Git or Npm, both of which do their own up-to-date checking.
 In that case it doesn't make much sense for Gradle to also do up-to-date checks.
 You can disable Gradle's up-to-date checks by using the `@link:{javadocPath}/org/gradle/api/tasks/UntrackedTask.html[UntrackedTask]` annotation on the task wrapping the tool.
-Alternatively, you can use the runtime API method `@link:{groovyDslDoc}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()]`.
+Alternatively, you can use the runtime API method `link:{groovyDslDoc}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()]`.
 
 For example, let's say you want to implement a task which clones a Git repository.
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -157,9 +157,9 @@ Providing this flag in the compiler options will disable this behaviour and allo
 For up-to-date checks Gradle relies on tracking the state of the inputs and the outputs of a task.
 Gradle used to ignore unreadable files in the input or outputs to support certain use-cases, although it cannot track their state.
 Declaring input or output directories on tasks which contain unreadable content has been deprecated and these use-cases are now supported by declaring the task to be untracked.
-Use the @link:{javadocPath}/org/gradle/api/tasks/UntrackedTask.html[UntrackedTask] annotation or the @link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()] method to declare a task as untracked.
+Use the @link:{javadocPath}/org/gradle/api/tasks/UntrackedTask.html[UntrackedTask] annotation or the link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()] method to declare a task as untracked.
 
-When you are using a `@link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy]` task for copying single files into a directory which contains unreadable files, use the method link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()].
+When you are using a `link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy]` task for copying single files into a directory which contains unreadable files, use the method link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()].
 
 [[changes_7.2]]
 == Upgrading from 7.1 and earlier


### PR DESCRIPTION
I suppose these were typos/copy and paste errors.