### PR TITLE
Backport pullRequest build feature in #19101

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
+++ b/.teamcity/src/main/kotlin/configurations/BaseGradleBuildType.kt
@@ -14,5 +14,8 @@ open class BaseGradleBuildType(model: CIBuildModel, val stage: Stage? = null, us
             param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
             param("env.GRADLE_INTERNAL_REPO_URL", "%gradle.internal.repository.url%")
         }
+        features {
+            enablePullRequestFeature()
+        }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -56,15 +56,12 @@ fun BuildFeatures.publishBuildStatusToGithub(model: CIBuildModel) {
     }
 }
 
-fun BuildFeatures.triggeredOnPullRequests() {
+fun BuildFeatures.enablePullRequestFeature() {
     pullRequests {
-        vcsRootExtId = "GradleMaster"
+        vcsRootExtId = "Gradle_Branches_GradlePersonalBranches"
         provider = github {
-            authType = token {
-                token = "%github.bot-gradle.token%"
-            }
-            filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
-            filterTargetBranch = allBranchesFilter
+            authType = vcsRoot()
+            filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
+++ b/.teamcity/src/main/kotlin/configurations/SanityCheck.kt
@@ -15,7 +15,6 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model
 
     features {
         publishBuildStatusToGithub(model)
-        triggeredOnPullRequests()
     }
 
     applyDefaults(


### PR DESCRIPTION
Without this change, branch with name like `pull/12345` is not
recognized by TeamCity.
