### PR TITLE
Store complete sub-snapshots of filtered walk in VFS

### DIFF
--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -38,6 +38,7 @@ import org.gradle.internal.file.impl.DefaultFileMetadata;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.snapshot.DirectorySnapshot;
+import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocationSnapshotVisitor;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
@@ -70,7 +71,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT;
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
 /**
  * Packages build cache entries to a POSIX TAR file.
@@ -276,7 +277,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
     private TarArchiveEntry unpackDirectoryTree(TarArchiveInputStream input, TarArchiveEntry rootEntry, Map<String, FileSystemLocationSnapshot> snapshots, AtomicLong entries, File treeRoot, String treeName) throws IOException {
         RelativePathParser parser = new RelativePathParser(rootEntry.getName());
 
-        MerkleDirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
+        DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
         builder.enterDirectory(DIRECT, stringInterner.intern(treeRoot.getAbsolutePath()), stringInterner.intern(treeRoot.getName()), INCLUDE_EMPTY_DIRS);
 
         TarArchiveEntry entry;

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilder.java
@@ -22,6 +22,7 @@ import org.gradle.internal.file.FileMetadata;
 import org.gradle.internal.file.FileMetadata.AccessType;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
@@ -33,7 +34,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
 public class FileSystemSnapshotBuilder {
 
@@ -93,7 +94,7 @@ public class FileSystemSnapshotBuilder {
         if (rootDirectoryBuilder == null) {
             return FileSystemSnapshot.EMPTY;
         }
-        MerkleDirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.sortingRequired();
+        DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.sortingRequired();
         rootDirectoryBuilder.accept(rootPath, rootName, builder);
         return Preconditions.checkNotNull(builder.getResult());
     }
@@ -141,7 +142,7 @@ public class FileSystemSnapshotBuilder {
             return subDir;
         }
 
-        public void accept(String directoryPath, String directoryName, MerkleDirectorySnapshotBuilder builder) {
+        public void accept(String directoryPath, String directoryName, DirectorySnapshotBuilder builder) {
             builder.enterDirectory(determineAccessTypeForLocation(directoryPath), directoryPath, directoryName, INCLUDE_EMPTY_DIRS);
             for (Map.Entry<String, DirectoryBuilder> entry : subDirs.entrySet()) {
                 String subDirName = entry.getKey();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
@@ -227,8 +227,8 @@ public class OutputSnapshotUtil {
 
         @Override
         public void leaveDirectory(DirectorySnapshot directorySnapshot, boolean isRoot) {
-            boolean includedDir = merkleBuilder.leaveDirectory();
-            if (!includedDir) {
+            boolean excludedDir = merkleBuilder.leaveDirectory() == null;
+            if (excludedDir) {
                 currentRootFiltered = true;
                 hasBeenFiltered = true;
             }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
@@ -23,12 +23,13 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot;
 import org.gradle.internal.snapshot.DirectorySnapshot;
+import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
+import org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy;
 import org.gradle.internal.snapshot.FileSystemLeafSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocationSnapshotVisitor;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
-import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy;
 import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
@@ -41,8 +42,8 @@ import java.util.function.BiPredicate;
 
 import static com.google.common.collect.ImmutableSortedMap.copyOfSorted;
 import static com.google.common.collect.Maps.transformEntries;
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.EXCLUDE_EMPTY_DIRS;
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.EXCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 import static org.gradle.internal.snapshot.SnapshotUtil.index;
 
 public class OutputSnapshotUtil {
@@ -168,7 +169,7 @@ public class OutputSnapshotUtil {
         private final ImmutableList.Builder<FileSystemSnapshot> newRootsBuilder = ImmutableList.builder();
 
         private boolean hasBeenFiltered;
-        private MerkleDirectorySnapshotBuilder merkleBuilder;
+        private DirectorySnapshotBuilder directorySnapshotBuilder;
         private boolean currentRootFiltered;
         private DirectorySnapshot currentRoot;
 
@@ -182,7 +183,7 @@ public class OutputSnapshotUtil {
             EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy = isOutputDir
                 ? INCLUDE_EMPTY_DIRS
                 : EXCLUDE_EMPTY_DIRS;
-            merkleBuilder.enterDirectory(directorySnapshot, emptyDirectoryHandlingStrategy);
+            directorySnapshotBuilder.enterDirectory(directorySnapshot, emptyDirectoryHandlingStrategy);
         }
 
         @Override
@@ -190,8 +191,8 @@ public class OutputSnapshotUtil {
             snapshot.accept(new FileSystemLocationSnapshotVisitor() {
                 @Override
                 public void visitDirectory(DirectorySnapshot directorySnapshot) {
-                    if (merkleBuilder == null) {
-                        merkleBuilder = MerkleDirectorySnapshotBuilder.noSortingRequired();
+                    if (directorySnapshotBuilder == null) {
+                        directorySnapshotBuilder = MerkleDirectorySnapshotBuilder.noSortingRequired();
                         currentRoot = directorySnapshot;
                         currentRootFiltered = false;
                     }
@@ -216,28 +217,28 @@ public class OutputSnapshotUtil {
                 currentRootFiltered = true;
                 return;
             }
-            if (merkleBuilder == null) {
+            if (directorySnapshotBuilder == null) {
                 newRootsBuilder.add(snapshot);
             } else {
                 if (snapshot instanceof FileSystemLeafSnapshot) {
-                    merkleBuilder.visitLeafElement((FileSystemLeafSnapshot) snapshot);
+                    directorySnapshotBuilder.visitLeafElement((FileSystemLeafSnapshot) snapshot);
                 }
             }
         }
 
         @Override
         public void leaveDirectory(DirectorySnapshot directorySnapshot, boolean isRoot) {
-            boolean excludedDir = merkleBuilder.leaveDirectory() == null;
+            boolean excludedDir = directorySnapshotBuilder.leaveDirectory() == null;
             if (excludedDir) {
                 currentRootFiltered = true;
                 hasBeenFiltered = true;
             }
             if (isRoot) {
-                FileSystemLocationSnapshot result = merkleBuilder.getResult();
+                FileSystemLocationSnapshot result = directorySnapshotBuilder.getResult();
                 if (result != null) {
                     newRootsBuilder.add(currentRootFiltered ? result : currentRoot);
                 }
-                merkleBuilder = null;
+                directorySnapshotBuilder = null;
                 currentRoot = null;
             }
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -32,7 +32,7 @@ import org.gradle.internal.snapshot.RegularFileSnapshot
 
 import java.time.Duration
 
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS
 
 class CaptureStateAfterExecutionStepTest extends StepSpec<BeforeExecutionContext> {
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -445,7 +445,7 @@ abstract class AbstractFileWatcherUpdaterTest extends Specification {
     }
 
     DirectorySnapshot snapshotDirectory(File directory) {
-        directorySnapshotter.snapshot(directory.absolutePath, null, new AtomicBoolean(false)) as DirectorySnapshot
+        directorySnapshotter.snapshot(directory.absolutePath, null, new AtomicBoolean(false)) {} as DirectorySnapshot
     }
 
     void addSnapshot(FileSystemLocationSnapshot snapshot) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
@@ -20,6 +20,15 @@ import org.gradle.internal.file.FileMetadata;
 
 import javax.annotation.Nullable;
 
+/**
+ * A builder for {@link DirectorySnapshot}.
+ *
+ * In order to build a directory snapshot, you need to call the methods for entering/leaving a directory
+ * and for visiting leaf elements.
+ * The visit methods need to be called in depth-first order.
+ * When leaving a directory, the builder will create a {@link DirectorySnapshot} for the directory,
+ * calculating the combined hash of the entries.
+ */
 public interface DirectorySnapshotBuilder {
 
     void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy);
@@ -33,6 +42,13 @@ public interface DirectorySnapshotBuilder {
     @Nullable
     FileSystemLocationSnapshot leaveDirectory();
 
+    /**
+     * Returns the snapshot for the root directory.
+     *
+     * May return null if
+     * - nothing was visited, or
+     * - only empty directories have been visited with {@link EmptyDirectoryHandlingStrategy#EXCLUDE_EMPTY_DIRS}.
+     */
     @Nullable
     FileSystemLocationSnapshot getResult();
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+import org.gradle.internal.file.FileMetadata;
+
+import javax.annotation.Nullable;
+
+public interface DirectorySnapshotBuilder {
+
+    void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy);
+
+    void enterDirectory(FileMetadata.AccessType accessType, String absolutePath, String name, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy);
+
+    void visitLeafElement(FileSystemLeafSnapshot snapshot);
+
+    void visitDirectory(DirectorySnapshot directorySnapshot);
+
+    @Nullable
+    FileSystemLocationSnapshot leaveDirectory();
+
+    @Nullable
+    FileSystemLocationSnapshot getResult();
+
+    enum EmptyDirectoryHandlingStrategy {
+        INCLUDE_EMPTY_DIRS,
+        EXCLUDE_EMPTY_DIRS
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshotBuilder.java
@@ -31,14 +31,30 @@ import javax.annotation.Nullable;
  */
 public interface DirectorySnapshotBuilder {
 
-    void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy);
+    /**
+     * Convenience method for {@link #enterDirectory(FileMetadata.AccessType, String, String, EmptyDirectoryHandlingStrategy)}
+     * when you already have a {@link DirectorySnapshot}.
+     */
+    default void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
+        enterDirectory(directorySnapshot.getAccessType(), directorySnapshot.getAbsolutePath(), directorySnapshot.getName(), emptyDirectoryHandlingStrategy);
+    }
 
+    /**
+     * Method to call before visiting all the entries of a directory.
+     */
     void enterDirectory(FileMetadata.AccessType accessType, String absolutePath, String name, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy);
 
     void visitLeafElement(FileSystemLeafSnapshot snapshot);
 
     void visitDirectory(DirectorySnapshot directorySnapshot);
 
+    /**
+     * Method to call after having visited all the entries of a directory.
+     *
+     * May return {@code null} when the directory is empty and {@link EmptyDirectoryHandlingStrategy#EXCLUDE_EMPTY_DIRS}
+     * has been used when calling {@link #enterDirectory(FileMetadata.AccessType, String, String, EmptyDirectoryHandlingStrategy)}.
+     * This means that the directory will not be part of the built snapshot.
+     */
     @Nullable
     FileSystemLocationSnapshot leaveDirectory();
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -44,7 +44,7 @@ public class MerkleDirectorySnapshotBuilder {
         return new MerkleDirectorySnapshotBuilder(false);
     }
 
-    private MerkleDirectorySnapshotBuilder(boolean sortingRequired) {
+    protected MerkleDirectorySnapshotBuilder(boolean sortingRequired) {
         this.sortingRequired = sortingRequired;
     }
 
@@ -64,13 +64,13 @@ public class MerkleDirectorySnapshotBuilder {
         collectEntry(directorySnapshot);
     }
 
-    public boolean leaveDirectory() {
+    @Nullable
+    public FileSystemLocationSnapshot leaveDirectory() {
         FileSystemLocationSnapshot snapshot = directoryStack.removeLast().fold();
-        if (snapshot == null) {
-            return false;
+        if (snapshot != null) {
+            collectEntry(snapshot);
         }
-        collectEntry(snapshot);
-        return true;
+        return snapshot;
     }
 
     private void collectEntry(FileSystemLocationSnapshot snapshot) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -29,6 +29,14 @@ import java.util.List;
 
 import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.EXCLUDE_EMPTY_DIRS;
 
+/**
+ * A builder for {@link DirectorySnapshot} instances.
+ *
+ * This implementation combines the hashes of the children of a directory into a single hash for the directory.
+ * For the hash to be reproducible, the children must be sorted in a consistent order.
+ * The implementation uses {@link FileSystemLocationSnapshot#BY_NAME} ordering.
+ * If you already provide the children in sorted order, use {@link #noSortingRequired()} to avoid the overhead of sorting again.
+ */
 public class MerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder {
     private static final HashCode DIR_SIGNATURE = Hashing.signature("DIR");
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/MerkleDirectorySnapshotBuilder.java
@@ -57,11 +57,6 @@ public class MerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder 
     }
 
     @Override
-    public void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
-        enterDirectory(directorySnapshot.getAccessType(), directorySnapshot.getAbsolutePath(), directorySnapshot.getName(), emptyDirectoryHandlingStrategy);
-    }
-
-    @Override
     public void enterDirectory(AccessType accessType, String absolutePath, String name, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
         directoryStack.addLast(new Directory(accessType, absolutePath, name, emptyDirectoryHandlingStrategy));
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -34,8 +34,6 @@ import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.gradle.internal.snapshot.RelativePathTracker;
 import org.gradle.internal.snapshot.SnapshottingFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -60,7 +58,6 @@ import java.util.function.Predicate;
 import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
 public class DirectorySnapshotter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DirectorySnapshotter.class);
     private static final EnumSet<FileVisitOption> DONT_FOLLOW_SYMLINKS = EnumSet.noneOf(FileVisitOption.class);
     private static final SymbolicLinkMapping EMPTY_SYMBOLIC_LINK_MAPPING = new SymbolicLinkMapping() {
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -391,11 +391,11 @@ public class DirectorySnapshotter {
         }
 
         private boolean shouldVisitDirectory(Path dir, String internedName) {
-            return pathTracker.isRoot() || shouldVisit(dir, internedName, true, pathTracker.getSegments());
+            return pathTracker.isRoot() || shouldVisit(dir, internedName, true);
         }
 
         private boolean shouldVisitFile(Path file, String internedName) {
-            return shouldVisit(file, internedName, false, pathTracker.getSegments());
+            return shouldVisit(file, internedName, false);
         }
 
         private BasicFileAttributes readAttributesOfSymlinkTarget(Path symlink, BasicFileAttributes symlinkAttributes) {
@@ -433,7 +433,7 @@ public class DirectorySnapshotter {
                 // This way, we include each file only once.
                 if (isNotFileSystemLoopException(exc)) {
                     boolean isDirectory = Files.isDirectory(file);
-                    if (shouldVisit(file, internedFileName, isDirectory, pathTracker.getSegments())) {
+                    if (shouldVisit(file, internedFileName, isDirectory)) {
                         throw new UncheckedIOException(exc);
                     }
                 }
@@ -456,7 +456,7 @@ public class DirectorySnapshotter {
          * based on the directory/file excludes or the provided filtering predicate.
          * Excludes won't mark this walk as `filtered`, only if the `predicate` rejects any entry.
          **/
-        private boolean shouldVisit(Path path, String internedName, boolean isDirectory, Iterable<String> relativePath) {
+        private boolean shouldVisit(Path path, String internedName, boolean isDirectory) {
             if (isDirectory) {
                 if (defaultExcludes.excludeDir(internedName)) {
                     return false;
@@ -468,7 +468,7 @@ public class DirectorySnapshotter {
             if (predicate == null) {
                 return true;
             }
-            boolean allowed = predicate.test(path, internedName, isDirectory, symbolicLinkMapping.getRemappedSegments(relativePath));
+            boolean allowed = predicate.test(path, internedName, isDirectory, symbolicLinkMapping.getRemappedSegments(pathTracker.getSegments()));
             if (!allowed) {
                 builder.markCurrentLevelAsFiltered();
                 hasBeenFiltered.set(true);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -60,6 +60,9 @@ import java.util.function.Predicate;
 
 import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
+/**
+ * For creating {@link DirectorySnapshot}s of directories.
+ */
 public class DirectorySnapshotter {
     private static final EnumSet<FileVisitOption> DONT_FOLLOW_SYMLINKS = EnumSet.noneOf(FileVisitOption.class);
     private static final SymbolicLinkMapping EMPTY_SYMBOLIC_LINK_MAPPING = new SymbolicLinkMapping() {
@@ -92,6 +95,23 @@ public class DirectorySnapshotter {
         this.collector = collector;
     }
 
+    /**
+     * Snapshots a directory.
+     *
+     * Follows symlinks and includes them in the returned snapshot.
+     * Snapshots of followed symlinks are marked with {@link AccessType#VIA_SYMLINK}.
+     *
+     * @param absolutePath The absolute path of the directory to snapshot.
+     * @param predicate A predicate that determines which files to include in the snapshot.
+     *                  {@code null} means to include everything.
+     * @param hasBeenFiltered Whether the returned snapshot is a filtered snapshot of the directory.
+     * @param unfilteredSnapshotConsumer If the returned snapshot is filtered by the predicate, i.e. it doesn't have all the contents of the directory,
+     *                                   then this consumer will receive all the unfiltered snapshots within the snapshot directory.
+     *                                   For example, if an element of a directory is filtered out, the consumer will receive all the non-filtered out
+     *                                   file snapshots and all the non-filtered directory snapshots in the directory.
+     *
+     * @return The (possible filtered) snapshot of the directory.
+     */
     public FileSystemLocationSnapshot snapshot(String absolutePath, @Nullable SnapshottingFilter.DirectoryWalkerPredicate predicate, final AtomicBoolean hasBeenFiltered, Consumer<FileSystemLocationSnapshot> unfilteredSnapshotConsumer) {
         try {
             Path rootPath = Paths.get(absolutePath);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
 /**
  * For creating {@link DirectorySnapshot}s of directories.

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilter.java
@@ -19,6 +19,7 @@ package org.gradle.internal.snapshot.impl;
 import com.google.common.collect.ImmutableList;
 import org.gradle.internal.RelativePathSupplier;
 import org.gradle.internal.snapshot.DirectorySnapshot;
+import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.FileSystemLeafSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocationSnapshotTransformer;
@@ -33,7 +34,7 @@ import org.gradle.internal.snapshot.SnapshottingFilter;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
+import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS;
 
 public class FileSystemSnapshotFilter {
 
@@ -41,7 +42,7 @@ public class FileSystemSnapshotFilter {
     }
 
     public static FileSystemSnapshot filterSnapshot(SnapshottingFilter.FileSystemSnapshotPredicate predicate, FileSystemSnapshot unfiltered) {
-        MerkleDirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
+        DirectorySnapshotBuilder builder = MerkleDirectorySnapshotBuilder.noSortingRequired();
         AtomicBoolean hasBeenFiltered = new AtomicBoolean(false);
         unfiltered.accept(new RelativePathTracker(), new FilteringVisitor(predicate, builder, hasBeenFiltered));
         if (builder.getResult() == null) {
@@ -52,10 +53,10 @@ public class FileSystemSnapshotFilter {
 
     private static class FilteringVisitor implements RelativePathTrackingFileSystemSnapshotHierarchyVisitor {
         private final SnapshottingFilter.FileSystemSnapshotPredicate predicate;
-        private final MerkleDirectorySnapshotBuilder builder;
+        private final DirectorySnapshotBuilder builder;
         private final AtomicBoolean hasBeenFiltered;
 
-        public FilteringVisitor(SnapshottingFilter.FileSystemSnapshotPredicate predicate, MerkleDirectorySnapshotBuilder builder, AtomicBoolean hasBeenFiltered) {
+        public FilteringVisitor(SnapshottingFilter.FileSystemSnapshotPredicate predicate, DirectorySnapshotBuilder builder, AtomicBoolean hasBeenFiltered) {
             this.predicate = predicate;
             this.builder = builder;
             this.hasBeenFiltered = hasBeenFiltered;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
@@ -21,8 +21,8 @@ import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.DirectorySnapshotBuilder;
 import org.gradle.internal.snapshot.FileSystemLeafSnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
-import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
+import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 
 import javax.annotation.Nullable;
@@ -82,16 +82,10 @@ public class FilteredTrackingMerkleDirectorySnapshotBuilder implements Directory
         boolean leftLevelUnfiltered = isCurrentLevelUnfiltered.removeLast();
         isCurrentLevelUnfiltered.addLast(isCurrentLevelUnfiltered.removeLast() && leftLevelUnfiltered);
         if (!leftLevelUnfiltered && directorySnapshot != null) {
-            directorySnapshot.accept(new FileSystemSnapshotHierarchyVisitor() {
-                private boolean isRoot = true;
+            directorySnapshot.accept(new RootTrackingFileSystemSnapshotHierarchyVisitor() {
 
                 @Override
-                public void enterDirectory(DirectorySnapshot directorySnapshot) {
-                    isRoot = false;
-                }
-
-                @Override
-                public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
+                public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
                     if (isRoot) {
                         return SnapshotVisitResult.CONTINUE;
                     } else {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
@@ -30,6 +30,15 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Consumer;
 
+/**
+ * A {@link DirectorySnapshotBuilder} that tracks whether a directory has been filtered.
+ *
+ * You can mark a directory as filtered by {@link #markCurrentLevelAsFiltered()}.
+ * When you do that, all the parent levels are marked as filtered as well.
+ * On {@link #leaveDirectory()}, the {@code unfilteredSnapshotConsumer} will receive the direct child snapshots
+ * of the left directory if it was marked as filtered, or nothing if it wasn't.
+ * This builder delegates to {@link MerkleDirectorySnapshotBuilder} for the actual building of the snapshot.
+ */
 public class FilteredTrackingMerkleDirectorySnapshotBuilder implements DirectorySnapshotBuilder {
     private final Deque<Boolean> isCurrentLevelUnfiltered = new ArrayDeque<>();
     private final Consumer<FileSystemLocationSnapshot> unfilteredSnapshotConsumer;

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/FilteredTrackingMerkleDirectorySnapshotBuilder.java
@@ -56,11 +56,6 @@ public class FilteredTrackingMerkleDirectorySnapshotBuilder implements Directory
     }
 
     @Override
-    public void enterDirectory(DirectorySnapshot directorySnapshot, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
-        delegate.enterDirectory(directorySnapshot, emptyDirectoryHandlingStrategy);
-    }
-
-    @Override
     public void enterDirectory(FileMetadata.AccessType accessType, String absolutePath, String name, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
         isCurrentLevelUnfiltered.addLast(true);
         delegate.enterDirectory(accessType, absolutePath, name, emptyDirectoryHandlingStrategy);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/IncompleteTrackingMerkleDirectorySnapshotBuilder.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/IncompleteTrackingMerkleDirectorySnapshotBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+import org.gradle.internal.file.FileMetadata;
+import org.gradle.internal.snapshot.DirectorySnapshot;
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
+import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
+import org.gradle.internal.snapshot.MerkleDirectorySnapshotBuilder;
+import org.gradle.internal.snapshot.SnapshotVisitResult;
+
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Consumer;
+
+public class IncompleteTrackingMerkleDirectorySnapshotBuilder extends MerkleDirectorySnapshotBuilder {
+    private final Deque<Boolean> isCurrentLevelComplete = new ArrayDeque<>();
+
+    public static IncompleteTrackingMerkleDirectorySnapshotBuilder sortingRequired() {
+        return new IncompleteTrackingMerkleDirectorySnapshotBuilder(true);
+    }
+
+    private IncompleteTrackingMerkleDirectorySnapshotBuilder(boolean sortingRequired) {
+        super(sortingRequired);
+        // The root starts out as complete.
+        isCurrentLevelComplete.addLast(true);
+    }
+
+    @Override
+    public void enterDirectory(FileMetadata.AccessType accessType, String absolutePath, String name, EmptyDirectoryHandlingStrategy emptyDirectoryHandlingStrategy) {
+        isCurrentLevelComplete.addLast(true);
+        super.enterDirectory(accessType, absolutePath, name, emptyDirectoryHandlingStrategy);
+    }
+
+    public void markCurrentLevelAsIncomplete() {
+        isCurrentLevelComplete.removeLast();
+        isCurrentLevelComplete.addLast(false);
+    }
+
+    public boolean isCurrentLevelComplete() {
+        return isCurrentLevelComplete.getLast();
+    }
+
+    @Override
+    public FileSystemLocationSnapshot leaveDirectory() {
+        return leaveDirectory(snapshot -> {});
+    }
+
+    @Nullable
+    public FileSystemLocationSnapshot leaveDirectory(Consumer<FileSystemLocationSnapshot> incompleteSnapshotConsumer) {
+        FileSystemLocationSnapshot directorySnapshot = super.leaveDirectory();
+        boolean leftLevelComplete = isCurrentLevelComplete.removeLast();
+        isCurrentLevelComplete.addLast(isCurrentLevelComplete.removeLast() && leftLevelComplete);
+        if (!leftLevelComplete && directorySnapshot != null) {
+            directorySnapshot.accept(new FileSystemSnapshotHierarchyVisitor() {
+                private boolean isRoot = true;
+
+                @Override
+                public void enterDirectory(DirectorySnapshot directorySnapshot) {
+                    isRoot = false;
+                }
+
+                @Override
+                public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
+                    if (isRoot) {
+                        return SnapshotVisitResult.CONTINUE;
+                    } else {
+                        incompleteSnapshotConsumer.accept(snapshot);
+                    }
+
+                    return SnapshotVisitResult.SKIP_SUBTREE;
+                }
+            });
+        }
+        return directorySnapshot;
+    }
+}

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/DefaultFileSystemAccess.java
@@ -157,7 +157,11 @@ public class DefaultFileSystemAccess implements FileSystemAccess {
                 return missingFileSnapshot;
             case Directory:
                 AtomicBoolean hasBeenFiltered = new AtomicBoolean(false);
-                FileSystemLocationSnapshot directorySnapshot = directorySnapshotter.snapshot(location, filter.isEmpty() ? null : filter.getAsDirectoryWalkerPredicate(), hasBeenFiltered);
+                FileSystemLocationSnapshot directorySnapshot = directorySnapshotter.snapshot(
+                    location,
+                    filter.isEmpty() ? null : filter.getAsDirectoryWalkerPredicate(),
+                    hasBeenFiltered,
+                    snapshot -> virtualFileSystem.store(snapshot.getAbsolutePath(), snapshot));
                 if (!hasBeenFiltered.get()) {
                     virtualFileSystem.store(directorySnapshot.getAbsolutePath(), directorySnapshot);
                 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -26,13 +26,16 @@ import org.gradle.api.internal.file.collections.DirectoryFileTree
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.fingerprint.impl.PatternSetSnapshottingFilter
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.SnapshotVisitorUtil
 import org.gradle.internal.snapshot.SnapshottingFilter
 
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Consumer
 
 class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerTest<DirectorySnapshotter> {
+    Consumer<FileSystemLocationSnapshot> completeSnapshotConsumer = Stub()
 
     def "directory snapshotter returns the same details as directory walker"() {
         given:
@@ -58,7 +61,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
         }
 
         when:
-        directorySnapshotter().snapshot(rootDir.absolutePath, directoryWalkerPredicate(patternSet), new AtomicBoolean())
+        directorySnapshotter().snapshot(rootDir.absolutePath, directoryWalkerPredicate(patternSet), new AtomicBoolean(), completeSnapshotConsumer)
         then:
         1 * patternSet.getAsSpec() >> assertingSpec
 
@@ -87,7 +90,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
 
     @Override
     protected List<String> walkDirForPaths(DirectorySnapshotter walker, File rootDir, PatternSet patternSet) {
-        def snapshot = walker.snapshot(rootDir.absolutePath, directoryWalkerPredicate(patternSet), new AtomicBoolean())
+        def snapshot = walker.snapshot(rootDir.absolutePath, directoryWalkerPredicate(patternSet), new AtomicBoolean(), completeSnapshotConsumer)
         return SnapshotVisitorUtil.getAbsolutePaths(snapshot)
     }
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterStatisticsTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterStatisticsTest.groovy
@@ -169,6 +169,6 @@ class DirectorySnapshotterStatisticsTest extends Specification {
     }
 
     private snapshot(File root) {
-        directorySnapshotter.snapshot(root.absolutePath, null, new AtomicBoolean())
+        directorySnapshotter.snapshot(root.absolutePath, null, new AtomicBoolean()) {}
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -741,7 +741,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
     }
 
     private FileSystemLocationSnapshot snapshotDir(File dir) {
-        directorySnapshotter.snapshot(dir.absolutePath, null, new AtomicBoolean(false))
+        directorySnapshotter.snapshot(dir.absolutePath, null, new AtomicBoolean(false)) {}
     }
 
     private static FileSystemLocationSnapshot snapshotFile(File file) {


### PR DESCRIPTION
so we are watching for changes there as well. We need this for continuous build, so a continuous build is also triggered when there is only a filtered snapshot for a location.

We do this instead of https://github.com/gradle/gradle/issues/14410, since it is less complicated, and the performance improvements from storing partial directory information in the VFS are not evident.

As a follow up change, we could re-use the virtual file system contents when snapshotting a directory, though this would be a pure performance improvement. See https://github.com/gradle/gradle/issues/14409.