### PR TITLE
Spike: alternate "re-resolving" behavior for ArtifactView

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactView.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.HasConfigurableAttributes;
@@ -85,5 +86,15 @@ public interface ArtifactView extends HasAttributes {
          */
         ViewConfiguration lenient(boolean lenient);
 
+        /**
+         * When invoked, this view will disregard existing attributes of its parent configuration and re-resolve the artifacts
+         * using only the attributes in the view's attribute container.
+         *
+         * <p>This behavior cannot be unset on a particular view once this method is invoked.
+         *
+         * @since 7.5
+         */
+        @Incubating
+        ViewConfiguration withVariantReselection();
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
@@ -1,0 +1,487 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.derived
+
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+import spock.lang.IgnoreIf
+
+@IgnoreIf({ GradleContextualExecuter.configCache }) // ResolvedArtifactResult as task input
+class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    MavenHttpModule direct
+    MavenHttpModule transitive
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                maven { url '$mavenHttpRepo.uri' }
+            }
+
+            dependencies {
+                implementation 'test:direct:1.0'
+            }
+
+            abstract class Resolve extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getArtifacts()
+
+                @InputFiles
+                abstract ConfigurableFileCollection getArtifactCollection()
+
+                @Internal
+                abstract SetProperty<ResolvedArtifactResult> getResolvedArtifacts()
+
+                @Internal
+                List<String> expectedFiles = []
+
+                @Internal
+                List<String> expectedVariants = []
+
+                @TaskAction
+                void assertThat() {
+                    assert artifacts.files*.name == expectedFiles
+                    assert artifactCollection.files*.name == expectedFiles
+                    assert resolvedArtifacts.get()*.variant.displayName == expectedVariants
+                }
+            }
+
+            task resolveSources(type: Resolve) {
+                def artifactView = configurations.runtimeClasspath.incoming.artifactView {
+                    lenient = true
+                    withVariantReselection()
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                }
+                artifacts.from(artifactView.files)
+                artifactCollection.from(artifactView.artifacts.artifactFiles)
+                resolvedArtifacts.set(artifactView.artifacts.resolvedArtifacts)
+            }
+
+            task resolveJavadoc(type: Resolve) {
+                def artifactView = configurations.runtimeClasspath.incoming.artifactView {
+                    lenient = true
+                    withVariantReselection()
+                    attributes {
+                        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.JAVADOC))
+                        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                }
+                artifacts.from(artifactView.files)
+                artifactCollection.from(artifactView.artifacts.artifactFiles)
+                resolvedArtifacts.set(artifactView.artifacts.resolvedArtifacts)
+            }
+        """
+        transitive = mavenHttpRepo.module("test", "transitive", "1.0")
+        direct = mavenHttpRepo.module("test", "direct", "1.0")
+        direct.dependsOn(transitive)
+    }
+
+    // region With Gradle Module Metadata
+    def "direct has GMM and no sources or javadoc jars"() {
+        transitive.withModuleMetadata()
+        transitive.publish()
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = []
+                expectedVariants = []
+            }
+            resolveJavadoc {
+                expectedFiles = []
+                expectedVariants = []
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.expectGet()
+        transitive.moduleMetadata.expectGet()
+
+        succeeds( 'resolveSources', 'resolveJavadoc')
+    }
+
+    def "direct has GMM and has sources jar"() {
+        transitive.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0.jar")
+        }
+        .variant("sources", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "sources",
+                "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0-sources.jar")
+        }
+        transitive.withModuleMetadata()
+        transitive.publish()
+
+        direct.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("direct-1.0.jar")
+        }
+        .variant("sources", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "sources",
+                "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("direct-1.0-sources.jar")
+        }
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
+                expectedVariants = ['test:direct:1.0 variant sources', 'test:transitive:1.0 variant sources']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.expectGet()
+        transitive.moduleMetadata.expectGet()
+        direct.artifact(classifier: "sources").expectGet()
+        transitive.artifact(classifier: "sources").expectGet()
+
+        succeeds( "resolveSources")
+    }
+
+    def "direct has GMM and has javadoc jar"() {
+        transitive.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0.jar")
+        }
+            .variant("javadoc", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "javadoc",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("transitive-1.0-javadoc.jar")
+            }
+        transitive.withModuleMetadata()
+        transitive.publish()
+
+        direct.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("direct-1.0.jar")
+        }
+            .variant("javadoc", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "javadoc",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("direct-1.0-javadoc.jar")
+            }
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            resolveJavadoc {
+                expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
+                expectedVariants = ['test:direct:1.0 variant javadoc', 'test:transitive:1.0 variant javadoc']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.expectGet()
+        transitive.moduleMetadata.expectGet()
+        direct.artifact(classifier: "javadoc").expectGet()
+        transitive.artifact(classifier: "javadoc").expectGet()
+
+        succeeds( "resolveJavadoc")
+    }
+
+    def "direct has GMM and has both sources and javadoc jars"() {
+        transitive.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0.jar")
+        }
+            .variant("sources", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "sources",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("transitive-1.0-sources.jar")
+            }
+            .variant("javadoc", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "javadoc",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("transitive-1.0-javadoc.jar")
+            }
+        transitive.withModuleMetadata()
+        transitive.publish()
+
+        direct.adhocVariants().variant("jar", [
+            "org.gradle.category": "library",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("direct-1.0.jar")
+        }
+            .variant("sources", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "sources",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("direct-1.0-sources.jar")
+            }
+            .variant("javadoc", [
+                "org.gradle.category": "documentation",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.docstype": "javadoc",
+                "org.gradle.usage": "java-runtime"
+            ]) {
+                artifact("direct-1.0-javadoc.jar")
+            }
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            resolveJavadoc {
+                expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
+                expectedVariants = ['test:direct:1.0 variant javadoc', 'test:transitive:1.0 variant javadoc']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.expectGet()
+        transitive.moduleMetadata.expectGet()
+        direct.artifact(classifier: 'javadoc').expectGet()
+        transitive.artifact(classifier: 'javadoc').expectGet()
+
+        succeeds( 'resolveJavadoc')
+
+        and:
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
+                expectedVariants = ['test:direct:1.0 variant sources', 'test:transitive:1.0 variant sources']
+            }
+        """
+
+        // POMs and GMM are already cached; querying for sources should do minimal additional work to fetch sources jars
+        direct.artifact(classifier: 'sources').expectGet()
+        transitive.artifact(classifier: 'sources').expectGet()
+
+        succeeds( 'resolveSources')
+    }
+
+    def "direct has GMM and no sources jar and transitive has GMM and has sources jar"() {
+        transitive.adhocVariants().variant("jar", [
+                "org.gradle.category": "library",
+                "org.gradle.dependency.bundling": "external",
+                "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0.jar")
+        }.variant("sources", [
+            "org.gradle.category": "documentation",
+            "org.gradle.dependency.bundling": "external",
+            "org.gradle.docstype": "sources",
+            "org.gradle.usage": "java-runtime"
+        ]) {
+            artifact("transitive-1.0-sources.jar")
+        }
+        transitive.withModuleMetadata()
+        transitive.publish()
+
+        direct.withModuleMetadata()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['transitive-1.0-sources.jar']
+                expectedVariants = ['test:transitive:1.0 variant sources']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        direct.moduleMetadata.expectGet()
+        transitive.pom.expectGet()
+        transitive.moduleMetadata.expectGet()
+        transitive.artifact(classifier: "sources").expectGet()
+
+        succeeds( "resolveSources")
+    }
+    // endregion
+
+    // region Without Gradle Module Metadata
+    def "direct has no GMM and no sources or javadoc jars"() {
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = []
+                expectedVariants = []
+            }
+            resolveJavadoc {
+                expectedFiles = []
+                expectedVariants = []
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        transitive.pom.expectGet()
+        direct.artifact(classifier: "sources").expectGetMissing()
+        transitive.artifact(classifier: "sources").expectGetMissing()
+        direct.artifact(classifier: "javadoc").expectGetMissing()
+        transitive.artifact(classifier: "javadoc").expectGetMissing()
+
+        succeeds( 'resolveSources', 'resolveJavadoc')
+    }
+
+    def "direct has no GMM and has sources jar"() {
+        direct.withSourceAndJavadoc()
+        transitive.withSourceAndJavadoc()
+
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
+                expectedVariants = ['test:direct:1.0 configuration sources', 'test:transitive:1.0 configuration sources']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        transitive.pom.expectGet()
+        direct.artifact(classifier: "sources").expectGet()
+        transitive.artifact(classifier: "sources").expectGet()
+
+        succeeds("resolveSources")
+    }
+
+    def "direct has no GMM and has javadoc jar"() {
+        direct.withSourceAndJavadoc()
+        transitive.withSourceAndJavadoc()
+
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            resolveJavadoc {
+                expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
+                expectedVariants = ['test:direct:1.0 configuration javadoc', 'test:transitive:1.0 configuration javadoc']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        transitive.pom.expectGet()
+        direct.artifact(classifier: "javadoc").expectGet()
+        transitive.artifact(classifier: "javadoc").expectGet()
+
+        succeeds("resolveJavadoc")
+    }
+
+    def "direct has no GMM and has both sources and javadoc jars"() {
+        direct.withSourceAndJavadoc()
+        transitive.withSourceAndJavadoc()
+
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['direct-1.0-sources.jar', 'transitive-1.0-sources.jar']
+                expectedVariants = ['test:direct:1.0 configuration sources', 'test:transitive:1.0 configuration sources']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        transitive.pom.expectGet()
+        direct.artifact(classifier: "sources").expectGet()
+        transitive.artifact(classifier: "sources").expectGet()
+
+        succeeds("resolveSources")
+
+        and:
+        buildFile << """
+            resolveJavadoc {
+                expectedFiles = ['direct-1.0-javadoc.jar', 'transitive-1.0-javadoc.jar']
+                expectedVariants = ['test:direct:1.0 configuration javadoc', 'test:transitive:1.0 configuration javadoc']
+            }
+        """
+
+        // POMs and GMM are already cached; querying for javadoc should do minimal additional work to fetch javadoc jars
+        direct.artifact(classifier: 'javadoc').expectGet()
+        transitive.artifact(classifier: 'javadoc').expectGet()
+
+        succeeds( 'resolveJavadoc')
+    }
+
+    def "direct has no GMM and no sources jar and transitive has no GMM and has sources jar"() {
+        transitive.withSourceAndJavadoc()
+        transitive.publish()
+        direct.publish()
+
+        buildFile << """
+            resolveSources {
+                expectedFiles = ['transitive-1.0-sources.jar']
+                expectedVariants = ['test:transitive:1.0 configuration sources']
+            }
+        """
+        expect:
+        direct.pom.expectGet()
+        transitive.pom.expectGet()
+        direct.artifact(classifier: "sources").expectGetMissing()
+        transitive.artifact(classifier: "sources").expectGet()
+
+        succeeds( "resolveSources")
+    }
+    // endregion
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
@@ -1,0 +1,305 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.derived
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.test.fixtures.file.TestFile
+
+class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        multiProjectBuild('root', ['producer', 'direct', 'transitive', 'consumer']) {
+            buildFile << '''
+
+            '''
+
+            defineVariants(file('producer'))
+
+            file('consumer/build.gradle') << '''
+                configurations {
+                    producerArtifacts {
+                        canBeConsumed = false
+                        canBeResolved = true
+
+                        attributes {
+                            attribute(Attribute.of('shared', String), 'shared-value')
+                            attribute(Attribute.of('unique', String), 'jar-value')
+                        }
+                    }
+                }
+
+                dependencies {
+                    producerArtifacts project(':producer')
+                }
+
+                abstract class Resolve extends DefaultTask {
+                    @InputFiles
+                    abstract ConfigurableFileCollection getArtifacts()
+
+                    @Internal
+                    List<String> expectations = []
+
+                    @TaskAction
+                    void assertThat() {
+                        logger.lifecycle 'Found files: {}', artifacts.files*.name
+                        assert artifacts.files*.name == expectations
+                    }
+                }
+
+                tasks.register('resolve', Resolve) {
+                    artifacts.from(configurations.producerArtifacts)
+                }
+
+                tasks.register('resolveJavadoc', Resolve) {
+                    artifacts.from(configurations.producerArtifacts.incoming.artifactView {
+                        withVariantReselection()
+                        attributes {
+                            attribute(Attribute.of('shared', String), 'shared-value')
+                            attribute(Attribute.of('unique', String), 'javadoc-value')
+                        }
+                    }.files)
+                }
+
+                tasks.register('resolveOther', Resolve) {
+                    artifacts.from(configurations.producerArtifacts.incoming.artifactView {
+                        withVariantReselection()
+                        attributes {
+                            attribute(Attribute.of('other', String), 'foobar')
+                        }
+                    }.files)
+                }
+            '''
+        }
+    }
+
+    void defineVariants(TestFile projectDir) {
+        projectDir.file(projectDir.name + "-jar.txt").text = "jar file"
+        projectDir.file(projectDir.name + "-javadoc.txt").text = "javadoc file"
+        projectDir.file(projectDir.name + "-producer/other.txt").text = "other file"
+
+        projectDir.file('build.gradle') << '''
+            configurations {
+                jarElements {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Attribute.of('shared', String), 'shared-value')
+                        attribute(Attribute.of('unique', String), 'jar-value')
+                    }
+
+                    outgoing {
+                        artifact(layout.projectDirectory.file(project.name + '-jar.txt'))
+                    }
+                }
+                javadocElements {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Attribute.of('shared', String), 'shared-value')
+                        attribute(Attribute.of('unique', String), 'javadoc-value')
+                    }
+
+                    outgoing {
+                        artifact(layout.projectDirectory.file(project.name + '-javadoc.txt'))
+                    }
+                }
+                otherElements {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Attribute.of('other', String), 'foobar')
+                    }
+
+                    outgoing {
+                        artifact(layout.projectDirectory.file(project.name + '-other.txt'))
+                    }
+                }
+            }
+        '''
+    }
+
+    @ToBeFixedForConfigurationCache(because = 'invokes outgoingVariants task')
+    def 'producer has expected outgoingVariants'() {
+        when:
+        succeeds(':producer:outgoingVariants')
+
+        then:
+        outputContains '''
+--------------------------------------------------
+Variant jarElements
+--------------------------------------------------
+Capabilities
+    - org.test:producer:1.0 (default capability)
+Attributes
+    - shared = shared-value
+    - unique = jar-value
+
+Artifacts
+    - producer-jar.txt
+
+--------------------------------------------------
+Variant javadocElements
+--------------------------------------------------
+Capabilities
+    - org.test:producer:1.0 (default capability)
+Attributes
+    - shared = shared-value
+    - unique = javadoc-value
+
+Artifacts
+    - producer-javadoc.txt
+
+--------------------------------------------------
+Variant otherElements
+--------------------------------------------------
+Capabilities
+    - org.test:producer:1.0 (default capability)
+Attributes
+    - other = foobar
+
+Artifacts
+    - producer-other.txt
+'''
+    }
+
+    def 'consumer resolves jar variant of producer'() {
+        file('consumer/build.gradle') << '''
+            resolve {
+                expectations = [ 'producer-jar.txt' ]
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolve')
+    }
+
+    def 'consumer resolves javadoc variant of producer'() {
+        file('consumer/build.gradle') << '''
+            resolveJavadoc {
+                expectations = [ 'producer-javadoc.txt' ]
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolveJavadoc')
+    }
+
+    def 'consumer resolves other variant of producer'() {
+        file('consumer/build.gradle') << '''
+            resolveOther {
+                expectations = [ 'producer-other.txt' ]
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolveOther')
+    }
+
+    def 'consumer resolves jar variant of producer with dependencies'() {
+        defineVariants(file('transitive'))
+
+        defineVariants(file('direct'))
+        file('direct/build.gradle') << '''
+            dependencies {
+                jarElements project(":transitive")
+            }
+        '''
+
+        file('producer/build.gradle') << '''
+            dependencies {
+                jarElements project(":direct")
+            }
+        '''
+        file('consumer/build.gradle') << '''
+            resolve {
+                expectations = ['producer-jar.txt', 'direct-jar.txt', 'transitive-jar.txt']
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolve')
+    }
+
+    def 'consumer resolves javadoc variant of producer with dependencies on jarElements'() {
+        defineVariants(file('transitive'))
+
+        defineVariants(file('direct'))
+        file('direct/build.gradle') << '''
+            dependencies {
+                jarElements project(":transitive")
+            }
+        '''
+
+        file('producer/build.gradle') << '''
+            dependencies {
+                jarElements project(":direct")
+            }
+        '''
+        file('consumer/build.gradle') << '''
+            resolveJavadoc {
+                expectations = ['producer-javadoc.txt', 'direct-javadoc.txt', 'transitive-javadoc.txt']
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolveJavadoc')
+    }
+
+    def 'consumer resolves other variant of producer with dependencies on jarElements'() {
+        defineVariants(file('transitive'))
+
+        defineVariants(file('direct'))
+        file('direct/build.gradle') << '''
+            dependencies {
+                jarElements project(":transitive")
+            }
+        '''
+
+        file('producer/build.gradle') << '''
+            dependencies {
+                jarElements project(":direct")
+            }
+        '''
+        file('consumer/build.gradle') << '''
+            resolveOther {
+                expectations = ['producer-other.txt', 'direct-other.txt', 'transitive-other.txt']
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolveOther')
+    }
+
+    def 'consumer resolves other variant of producer with dependencies on otherElements'() {
+        defineVariants(file('transitive'))
+
+        defineVariants(file('direct'))
+        file('direct/build.gradle') << '''
+            dependencies {
+                otherElements project(":transitive")
+            }
+        '''
+
+        file('producer/build.gradle') << '''
+            dependencies {
+                otherElements project(":direct")
+            }
+        '''
+        file('consumer/build.gradle') << '''
+            resolveOther {
+                expectations = ['producer-other.txt']
+            }
+        '''
+        expect:
+        succeeds(':consumer:resolveOther')
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -18,8 +18,11 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.LibraryElements;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -98,6 +101,26 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(componentType, objectInstantiator));
             concatCache.put(entry, result);
         }
+        return result;
+    }
+
+    @Override
+    public ImmutableAttributes sourcesVariant(ImmutableAttributes original) {
+        ImmutableAttributes result = original;
+        result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.DOCUMENTATION, objectInstantiator));
+        result = concat(result, Bundling.BUNDLING_ATTRIBUTE, objectInstantiator.named(Bundling.class, Bundling.EXTERNAL));
+        result = concat(result, DocsType.DOCS_TYPE_ATTRIBUTE, objectInstantiator.named(DocsType.class, DocsType.SOURCES));
+        result = concat(result, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(Usage.JAVA_RUNTIME, objectInstantiator));
+        return result;
+    }
+
+    @Override
+    public ImmutableAttributes javadocVariant(ImmutableAttributes original) {
+        ImmutableAttributes result = original;
+        result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.DOCUMENTATION, objectInstantiator));
+        result = concat(result, Bundling.BUNDLING_ATTRIBUTE, objectInstantiator.named(Bundling.class, Bundling.EXTERNAL));
+        result = concat(result, DocsType.DOCS_TYPE_ATTRIBUTE, objectInstantiator.named(DocsType.class, DocsType.JAVADOC));
+        result = concat(result, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(Usage.JAVA_RUNTIME, objectInstantiator));
         return result;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
@@ -36,4 +36,6 @@ public interface MavenImmutableAttributesFactory extends ImmutableAttributesFact
 
     ImmutableAttributes libraryWithUsage(ImmutableAttributes original, String usage);
     ImmutableAttributes platformWithUsage(ImmutableAttributes original, String usage, boolean enforced);
+    ImmutableAttributes sourcesVariant(ImmutableAttributes original);
+    ImmutableAttributes javadocVariant(ImmutableAttributes original);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -254,6 +254,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
         private CapabilitiesMetadata capabilities;
         private ImmutableAttributes attributes;
         private ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
+        private boolean requiresMavenArtifactDiscovery = DefaultConfigurationMetadata.super.requiresMavenArtifactDiscovery();
 
         Builder withName(String name) {
             this.name = name;
@@ -262,6 +263,8 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
 
         public Builder withArtifacts(ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts) {
             this.artifacts = artifacts;
+            // when explicitly specifying artifacts, disable maven repo "probing"
+            this.requiresMavenArtifactDiscovery = false;
             return this;
         }
 
@@ -305,7 +308,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                     lazyConfigDependencies(),
                     dependencyFilter,
                     capabilities == null ? DefaultConfigurationMetadata.this.getRawCapabilities() : capabilities,
-                    DefaultConfigurationMetadata.super.requiresMavenArtifactDiscovery(),
+                    requiresMavenArtifactDiscovery,
                     isExternalVariant()
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -60,12 +60,42 @@ public class JavaEcosystemVariantDerivationStrategy extends AbstractStatelessDer
                     // component we cannot mix precise usages with more generic ones)
                 libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
                 libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
+                libraryWithSourcesVariant(runtimeConfiguration, attributes, attributesFactory, metadata),
+                libraryWithJavadocVariant(runtimeConfiguration, attributes, attributesFactory, metadata),
                 platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false, shadowedPlatformCapability),
                 platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false, shadowedPlatformCapability),
                 platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true, shadowedEnforcedPlatformCapability),
                 platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true, shadowedEnforcedPlatformCapability));
         }
         return null;
+    }
+
+    /**
+     * Synthesizes a "sources" variant since maven metadata cannot represent it
+     *
+     * @return synthetic metadata for the sources-classifier jar
+     */
+    private static DefaultConfigurationMetadata libraryWithSourcesVariant(DefaultConfigurationMetadata runtimeConfiguration, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, ModuleComponentResolveMetadata metadata) {
+        return runtimeConfiguration.mutate()
+            .withName("sources")
+            .withAttributes(attributesFactory.sourcesVariant(originAttributes))
+            .withArtifacts(ImmutableList.of(metadata.artifact("source", "jar", "sources")))
+            .withoutConstraints()
+            .build();
+    }
+
+    /**
+     * Synthesizes a "javadoc" variant since maven metadata cannot represent it
+     *
+     * @return synthetic metadata for the javadoc-classifier jar
+     */
+    private static DefaultConfigurationMetadata libraryWithJavadocVariant(DefaultConfigurationMetadata runtimeConfiguration, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, ModuleComponentResolveMetadata metadata) {
+        return runtimeConfiguration.mutate()
+            .withName("javadoc")
+            .withAttributes(attributesFactory.javadocVariant(originAttributes))
+            .withArtifacts(ImmutableList.of(metadata.artifact("javadoc", "jar", "javadoc")))
+            .withoutConstraints()
+            .build();
     }
 
     private ImmutableCapabilities buildShadowPlatformCapability(ModuleComponentIdentifier componentId, boolean enforced) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -136,23 +136,29 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         assertHasOnlyStatusAttribute(compileConf.attributes)
         assertHasOnlyStatusAttribute(runtimeConf.attributes)
 
-        variantsForGraphTraversal.size() == 6
+        variantsForGraphTraversal.size() == 8
         variantsForGraphTraversal[0].name == "compile"
         variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
         variantsForGraphTraversal[1].name == "runtime"
         variantsForGraphTraversal[1].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-        variantsForGraphTraversal[2].name == "platform-compile"
-        variantsForGraphTraversal[2].attributes.getAttribute(stringUsageAttribute) == "java-api"
-        variantsForGraphTraversal[2].attributes.getAttribute(componentTypeAttribute) == "platform"
-        variantsForGraphTraversal[3].name == "platform-runtime"
+        variantsForGraphTraversal[2].name == "sources"
+        variantsForGraphTraversal[2].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        variantsForGraphTraversal[2].attributes.getAttribute(componentTypeAttribute) == "documentation"
+        variantsForGraphTraversal[3].name == "javadoc"
         variantsForGraphTraversal[3].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-        variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "platform"
-        variantsForGraphTraversal[4].name == "enforced-platform-compile"
+        variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "documentation"
+        variantsForGraphTraversal[4].name == "platform-compile"
         variantsForGraphTraversal[4].attributes.getAttribute(stringUsageAttribute) == "java-api"
-        variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
-        variantsForGraphTraversal[5].name == "enforced-platform-runtime"
+        variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "platform"
+        variantsForGraphTraversal[5].name == "platform-runtime"
         variantsForGraphTraversal[5].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-        variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
+        variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "platform"
+        variantsForGraphTraversal[6].name == "enforced-platform-compile"
+        variantsForGraphTraversal[6].attributes.getAttribute(stringUsageAttribute) == "java-api"
+        variantsForGraphTraversal[6].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
+        variantsForGraphTraversal[7].name == "enforced-platform-runtime"
+        variantsForGraphTraversal[7].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        variantsForGraphTraversal[7].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
 
         where:
         packaging << ["pom", "jar", "maven-plugin", "war", "aar"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -165,7 +165,7 @@ class VariantFilesMetadataRulesTest extends Specification {
 
         where:
         metadataType | metadata                       | initialVariantCount
-        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "maven"      | mavenComponentMetadata('dep')  | 8 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }
@@ -186,7 +186,7 @@ class VariantFilesMetadataRulesTest extends Specification {
 
         where:
         metadataType | metadata                       | initialVariantCount
-        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "maven"      | mavenComponentMetadata('dep')  | 8 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }
@@ -258,7 +258,7 @@ class VariantFilesMetadataRulesTest extends Specification {
 
         where:
         metadataType | metadata                       | initialVariantCount
-        "maven"      | mavenComponentMetadata('dep')  | 6 // default derivation strategy for maven
+        "maven"      | mavenComponentMetadata('dep')  | 8 // default derivation strategy for maven
         "ivy"        | ivyComponentMetadata('dep')    | 0 // there is no derivation strategy for ivy
         "gradle"     | gradleComponentMetadata('dep') | 1 // 'runtime' added in test setup
     }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
@@ -45,6 +45,13 @@ Execution failed for task ':failRuntimeClasspathResolve'.
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Doesn't say anything about its elements (required them packaged as a jar)
                   - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')
+          - Variant 'javadoc' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a component, and its dependencies declared externally:
+              - Incompatible because this component declares documentation and the consumer needed a library
+              - Other compatible attributes:
+                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
+                  - Doesn't say anything about its target Java version (required compatibility with Java 11)
+                  - Doesn't say anything about its elements (required them packaged as a jar)
+                  - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')
           - Variant 'natives-linux-arm32-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar:
               - Incompatible because this component declares a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'linux' and the consumer needed a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'
               - Other compatible attributes:
@@ -85,3 +92,10 @@ Execution failed for task ':failRuntimeClasspathResolve'.
                   - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
+          - Variant 'sources' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a component, and its dependencies declared externally:
+              - Incompatible because this component declares documentation and the consumer needed a library
+              - Other compatible attributes:
+                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
+                  - Doesn't say anything about its target Java version (required compatibility with Java 11)
+                  - Doesn't say anything about its elements (required them packaged as a jar)
+                  - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')

--- a/subprojects/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
+++ b/subprojects/docs/src/snippets/java/fixtures/tests/dependencyInsight.out
@@ -6,6 +6,8 @@ com.google.code.gson:gson:2.8.5 FAILED
           - Unable to find a variant of com.google.code.gson:gson:2.8.5 providing the requested capability com.google.code.gson:gson-test-fixtures:
                - Variant compile provides com.google.code.gson:gson:2.8.5
                - Variant runtime provides com.google.code.gson:gson:2.8.5
+               - Variant sources provides com.google.code.gson:gson:2.8.5
+               - Variant javadoc provides com.google.code.gson:gson:2.8.5
                - Variant platform-compile provides com.google.code.gson:gson-derived-platform:2.8.5
                - Variant platform-runtime provides com.google.code.gson:gson-derived-platform:2.8.5
                - Variant enforced-platform-compile provides com.google.code.gson:gson-derived-enforced-platform:2.8.5


### PR DESCRIPTION
Using new API `ArtifactView.ViewConfiguration#withVariantReselection()`, consumers can instruct an artifact view to disregard the parent attributes inherited from the base configuration, while preserving a flattened list of the original graph for re-resolution. Allows, for example, attribute-based selection of sources jars using the dependency resolution engine (and inherent parallel downloads). For maven metadata, also synthesizes a "sources" variant (based on the runtimeClasspath) exposing the sources jar artifact.

Tests for project dependencies: `MultiProjectVariantResolutionIntegrationTest`

Tests for external dependencies (with and without GMM): `DerivedVariantsResolutionIntegrationTest`