### PR TITLE
Update TD plugin to released version 2.2.2

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     constraints {
         // Gradle Plugins
         api("com.gradle:gradle-enterprise-gradle-plugin:3.8")
-        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.2-rc-2") // Sync with `settings.gradle.kts`
+        api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.19.1")
         api("com.gradle.publish:plugin-publish-plugin:0.18.0")
         api("gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext:1.0.1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("com.gradle.enterprise").version("3.8")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.5")
     id("gradlebuild.base.allprojects")
-    id("com.gradle.enterprise.test-distribution").version("2.2.2-rc-2") // Sync with `build-logic/build-platform/build.gradle.kts`
+    id("com.gradle.enterprise.test-distribution").version("2.2.2") // Sync with `build-logic/build-platform/build.gradle.kts`
     id("gradlebuild.internal.testfiltering")
     id("com.gradle.internal.test-selection").version("0.6.5-rc-1")
     id("gradlebuild.internal.cc-experiment")


### PR DESCRIPTION
The `ge.gradle.org` instance has been upgraded to 2021.4, so merging should be safe.

Following the precedent of assigning to RC milestone.