### PR TITLE
Deprecate several APIs that are not supported by configuration caching

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,6 +1,14 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.publish.ivy.tasks.PublishToIvyRepository",
+            "member": "Method org.gradle.api.publish.ivy.tasks.PublishToIvyRepository.getDuplicatePublicationTracker()",
+            "acceptation": "Type of service inject getter changed",
+            "changes": [
+                "Method return type has changed"
+            ]
+        },
+        {
             "type": "org.gradle.api.initialization.Settings",
             "member": "Method org.gradle.api.initialization.Settings.include(java.lang.String[])",
             "acceptation": "Adding new Settings#include(Iterable)",

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -237,6 +237,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
     }
 
     private class ListenerCleanup extends BuildAdapter {
+        @SuppressWarnings("deprecation")
         @Override
         public void buildFinished(BuildResult result) {
             // TODO - maybe make the registry a build scoped service

--- a/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
+++ b/subprojects/build-profile/src/main/java/org/gradle/profile/ProfileEventAdapter.java
@@ -74,6 +74,7 @@ public class ProfileEventAdapter implements InternalBuildListener, ProjectEvalua
         buildProfile.setProjectsEvaluated(clock.getCurrentTime());
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(BuildResult result) {
         buildProfile.setSuccessful(result.getFailure() == null);

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheProblemsListenerManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheProblemsListenerManagerAction.kt
@@ -19,7 +19,6 @@ package org.gradle.configurationcache
 import org.gradle.configurationcache.initialization.ConfigurationCacheBuildEnablement
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction
 
 
@@ -30,13 +29,13 @@ class ConfigurationCacheProblemsListenerManagerAction(
     val buildEnablement: ConfigurationCacheBuildEnablement,
 
     private
-    val serviceRegistry: ServiceRegistry
+    val problemsListener: ConfigurationCacheProblemsListener
 
 ) : BuildScopeListenerManagerAction {
 
     override fun execute(manager: ListenerManager) {
         if (buildEnablement.isProblemListenerEnabledForCurrentBuild) {
-            manager.addListener(serviceRegistry[ConfigurationCacheProblemsListener::class.java])
+            manager.addListener(problemsListener)
         }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildModelControllerServices.kt
@@ -73,6 +73,7 @@ class DefaultBuildModelControllerServices(
             registration.add(BuildDefinition::class.java, buildDefinition)
             registration.add(BuildState::class.java, owner)
             registration.addProvider(ServicesProvider(buildDefinition, parentBuild, services))
+            registration.add(DeprecatedFeaturesListenerManagerAction::class.java)
             if (buildModelParameters.isConfigurationCache) {
                 registration.add(ConfigurationCacheBuildEnablement::class.java)
                 registration.add(ConfigurationCacheProblemsListenerManagerAction::class.java)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListenerManagerAction.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DeprecatedFeaturesListenerManagerAction.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.internal.BuildScopeListenerRegistrationListener
+import org.gradle.api.internal.FeaturePreviews
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.tasks.execution.TaskExecutionAccessListener
+import org.gradle.internal.deprecation.DeprecationLogger
+import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction
+
+
+internal
+class DeprecatedFeaturesListenerManagerAction(
+    private val featurePreviews: FeaturePreviews
+) : BuildScopeListenerManagerAction {
+    override fun execute(manager: ListenerManager) {
+        manager.addListener(DeprecatedFeaturesListener(featurePreviews))
+    }
+
+    private
+    class DeprecatedFeaturesListener(
+        private val featurePreviews: FeaturePreviews
+    ) : BuildScopeListenerRegistrationListener, TaskExecutionAccessListener {
+        override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
+            if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)) {
+                DeprecationLogger.deprecateAction("Listener registration using $invocationDescription()")
+                    .willBecomeAnErrorInGradle8()
+                    .withUpgradeGuideSection(7, "task_execution_events")
+                    .nagUser()
+            }
+        }
+
+        override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
+            if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)) {
+                DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
+                    .willBecomeAnErrorInGradle8()
+                    .withUpgradeGuideSection(7, "task_project")
+                    .nagUser()
+            }
+        }
+
+        override fun onTaskDependenciesAccess(invocationDescription: String, task: TaskInternal) {
+            if (featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE)) {
+                DeprecationLogger.deprecateAction("Invocation of $invocationDescription at execution time")
+                    .willBecomeAnErrorInGradle8()
+                    .withUpgradeGuideSection(7, "task_dependencies")
+                    .nagUser()
+            }
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
@@ -17,7 +17,6 @@
 package org.gradle.configurationcache.initialization
 
 import org.gradle.api.InvalidUserCodeException
-import org.gradle.api.ProjectEvaluationListener
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.GradleInternal
@@ -33,7 +32,6 @@ import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.problems.StructuredMessage
 import org.gradle.configurationcache.problems.location
-import org.gradle.internal.InternalListener
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.service.scopes.ServiceScope
 
@@ -89,8 +87,9 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
             ?: PropertyTrace.Task(GeneratedSubclasses.unpackType(task), task.identityPath.path)
 
     override fun onBuildScopeListenerRegistration(listener: Any, invocationDescription: String, invocationSource: Any) {
-        if (listener is InternalListener || listener is ProjectEvaluationListener || isBuildSrcBuild(invocationSource))
+        if (isBuildSrcBuild(invocationSource)) {
             return
+        }
         problems.onProblem(
             listenerRegistrationProblem(
                 userCodeApplicationContext.location(null),

--- a/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildAdapter.java
@@ -40,6 +40,7 @@ public class BuildAdapter implements BuildListener {
     public void projectsEvaluated(Gradle gradle) {
     }
 
+    @Deprecated
     @Override
     public void buildFinished(BuildResult result) {
     }

--- a/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/BuildListener.java
@@ -64,6 +64,8 @@ public interface BuildListener {
      * <p>Called when the build is completed. All selected tasks have been executed.</p>
      *
      * @param result The result of the build. Never null.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void buildFinished(BuildResult result);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -200,6 +200,8 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     /**
      * <p>Returns the {@link Project} which this task belongs to.</p>
      *
+     * <p>Calling this method from a task action is not supported when configuration caching is enabled.</p>
+     *
      * @return The project this task belongs to. Never returns null.
      */
     @Internal
@@ -223,6 +225,8 @@ public interface Task extends Comparable<Task>, ExtensionAware {
 
     /**
      * <p>Returns a {@link TaskDependency} which contains all the tasks that this task depends on.</p>
+     *
+     * <p>Calling this method from a task action is not supported when configuration caching is enabled.</p>
      *
      * @return The dependencies of this task. Never returns null.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskActionListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskActionListener.java
@@ -21,8 +21,11 @@ import org.gradle.internal.service.scopes.Scopes;
 
 /**
  * <p>A {@code TaskActionListener} is notified of the actions that a task performs.</p>
+ *
+ * @deprecated This type is not supported when configuration caching is enabled.
  */
 @EventScope(Scopes.Build.class)
+@Deprecated
 public interface TaskActionListener {
     /**
      * This method is called immediately before the task starts performing its actions.

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
@@ -53,14 +53,18 @@ public interface TaskExecutionGraph {
      * <p>Adds a listener to this graph, to be notified as tasks are executed.</p>
      *
      * @param listener The listener to add. Does nothing if this listener has already been added.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void addTaskExecutionListener(TaskExecutionListener listener);
 
     /**
      * <p>Remove a listener from this graph.</p>
      *
      * @param listener The listener to remove. Does nothing if this listener was never added to this graph.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void removeTaskExecutionListener(TaskExecutionListener listener);
 
     /**
@@ -86,7 +90,9 @@ public interface TaskExecutionGraph {
      * parameter.</p>
      *
      * @param closure The closure to execute when a task is about to be executed.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void beforeTask(Closure closure);
 
     /**
@@ -94,9 +100,11 @@ public interface TaskExecutionGraph {
      * parameter.</p>
      *
      * @param action The action to execute when a task is about to be executed.
+     * @deprecated This method is not supported when configuration caching is enabled.
      *
      * @since 3.1
      */
+    @Deprecated
     void beforeTask(Action<Task> action);
 
     /**
@@ -105,7 +113,9 @@ public interface TaskExecutionGraph {
      * optional.</p>
      *
      * @param closure The closure to execute when a task has been executed
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void afterTask(Closure closure);
 
     /**
@@ -113,9 +123,11 @@ public interface TaskExecutionGraph {
      * first parameter.</p>
      *
      * @param action The action to execute when a task has been executed
+     * @deprecated This method is not supported when configuration caching is enabled.
      *
      * @since 3.1
      */
+    @Deprecated
     void afterTask(Action<Task> action);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionListener.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionListener.java
@@ -25,8 +25,11 @@ import org.gradle.internal.service.scopes.Scopes;
  * <p>A {@code TaskExecutionListener} is notified of the execution of the tasks in a build.</p>
  *
  * <p>You can add a {@code TaskExecutionListener} to a build using {@link org.gradle.api.execution.TaskExecutionGraph#addTaskExecutionListener}
+ *
+ * @deprecated This type is not supported when configuration caching is enabled.
  */
 @EventScope(Scopes.Build.class)
+@Deprecated
 public interface TaskExecutionListener {
     /**
      * This method is called immediately before a task is executed.

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/Gradle.java
@@ -269,7 +269,9 @@ public interface Gradle extends PluginAware {
      * A {@link BuildResult} instance is passed to the closure as a parameter.
      *
      * @param closure The closure to execute.
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void buildFinished(Closure closure);
 
     /**
@@ -279,7 +281,9 @@ public interface Gradle extends PluginAware {
      *
      * @param action The action to execute.
      * @since 3.4
+     * @deprecated This method is not supported when configuration caching is enabled.
      */
+    @Deprecated
     void buildFinished(Action<? super BuildResult> action);
 
     /**
@@ -298,12 +302,18 @@ public interface Gradle extends PluginAware {
      * <li>{@link org.gradle.BuildListener}
      * <li>{@link org.gradle.api.execution.TaskExecutionGraphListener}
      * <li>{@link org.gradle.api.ProjectEvaluationListener}
+     * <li>{@link org.gradle.api.logging.StandardOutputListener}
+     * <li>{@link org.gradle.api.artifacts.DependencyResolutionListener}
+     * </ul>
+     *
+     * <p>The following listener types can be used, but are not supported when configuration caching is enabled.
+     * Their usage is deprecated and adding a listener of these types become an error in a future Gradle version:</p>
+     *
+     * <ul>
      * <li>{@link org.gradle.api.execution.TaskExecutionListener}
      * <li>{@link org.gradle.api.execution.TaskActionListener}
-     * <li>{@link org.gradle.api.logging.StandardOutputListener}
      * <li>{@link org.gradle.api.tasks.testing.TestListener}
      * <li>{@link org.gradle.api.tasks.testing.TestOutputListener}
-     * <li>{@link org.gradle.api.artifacts.DependencyResolutionListener}
      * </ul>
      *
      * @param listener The listener to add. Does nothing if this listener has already been added.

--- a/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildAdapter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/InternalBuildAdapter.java
@@ -17,6 +17,12 @@
 package org.gradle.internal;
 
 import org.gradle.BuildAdapter;
+import org.gradle.BuildResult;
 
 public class InternalBuildAdapter extends BuildAdapter implements InternalBuildListener {
+    @SuppressWarnings("deprecation")
+    @Override
+    public void buildFinished(BuildResult result) {
+        super.buildFinished(result);
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/events/BuildExecutionEventsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/events/BuildExecutionEventsIntegrationTest.groovy
@@ -16,12 +16,68 @@
 
 package org.gradle.api.events
 
+import org.gradle.api.execution.TaskActionListener
+import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 class BuildExecutionEventsIntegrationTest extends AbstractIntegrationSpec {
+    @UnsupportedWithConfigurationCache(because = "tests listener behaviour")
+    def "nags when #type is registered via #path and feature preview is enabled"() {
+        settingsFile """
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+        """
+        buildFile """
+            def taskExecutionListener = new TaskExecutionListener() {
+                void beforeExecute(Task task) { }
+                void afterExecute(Task task, TaskState state) { }
+            }
+            def taskActionListener = new TaskActionListener() {
+                void beforeActions(Task task) { }
+                void afterActions(Task task) { }
+            }
+            $path($listener)
+            task broken
+        """
 
-    @UnsupportedWithConfigurationCache
+        when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using ${registrationPoint}() has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        run("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        type                  | listener                | path                                        | registrationPoint
+        TaskExecutionListener | "taskExecutionListener" | "gradle.addListener"                        | "Gradle.addListener"
+        TaskExecutionListener | "taskExecutionListener" | "gradle.taskGraph.addTaskExecutionListener" | "TaskExecutionGraph.addTaskExecutionListener"
+        TaskActionListener    | "taskActionListener"    | "gradle.addListener"                        | "Gradle.addListener"
+    }
+
+    @UnsupportedWithConfigurationCache(because = "tests listener behaviour")
+    def "nags when task execution hook #path is used and feature preview is enabled"() {
+        settingsFile """
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+        """
+        buildFile """
+            $path { }
+            task broken
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using ${registrationPoint}() has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        run("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        path                          | registrationPoint
+        "gradle.taskGraph.beforeTask" | "TaskExecutionGraph.beforeTask"
+        "gradle.taskGraph.afterTask"  | "TaskExecutionGraph.afterTask"
+    }
+
+    @UnsupportedWithConfigurationCache(because = "tests listener behaviour")
     def "events passed to any task execution listener are synchronised"() {
         settingsFile << "include 'a', 'b', 'c'"
         buildFile """

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.execution;
 
-import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecuterResult;
@@ -33,14 +32,15 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CallableBuildOperation;
 
+@SuppressWarnings("deprecation")
 public class EventFiringTaskExecuter implements TaskExecuter {
 
     private final BuildOperationExecutor buildOperationExecutor;
-    private final TaskExecutionListener taskExecutionListener;
+    private final org.gradle.api.execution.TaskExecutionListener taskExecutionListener;
     private final TaskListenerInternal taskListener;
     private final TaskExecuter delegate;
 
-    public EventFiringTaskExecuter(BuildOperationExecutor buildOperationExecutor, TaskExecutionListener taskExecutionListener, TaskListenerInternal taskListener, TaskExecuter delegate) {
+    public EventFiringTaskExecuter(BuildOperationExecutor buildOperationExecutor, org.gradle.api.execution.TaskExecutionListener taskExecutionListener, TaskListenerInternal taskListener, TaskExecuter delegate) {
         this.buildOperationExecutor = buildOperationExecutor;
         this.taskExecutionListener = taskExecutionListener;
         this.taskListener = taskListener;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.tasks.execution;
 
-import org.gradle.api.execution.TaskActionListener;
 import org.gradle.api.execution.internal.TaskInputsListeners;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.file.FileCollectionFactory;
@@ -46,6 +45,7 @@ import java.util.Optional;
 /**
  * A {@link TaskExecuter} which executes the actions of a task.
  */
+@SuppressWarnings("deprecation")
 public class ExecuteActionsTaskExecuter implements TaskExecuter {
     public enum BuildCacheState {
         ENABLED, DISABLED
@@ -61,7 +61,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     private final ExecutionHistoryStore executionHistoryStore;
     private final BuildOperationExecutor buildOperationExecutor;
     private final AsyncWorkTracker asyncWorkTracker;
-    private final TaskActionListener actionListener;
+    private final org.gradle.api.execution.TaskActionListener actionListener;
     private final TaskCacheabilityResolver taskCacheabilityResolver;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final ExecutionEngine executionEngine;
@@ -79,7 +79,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
         ExecutionHistoryStore executionHistoryStore,
         BuildOperationExecutor buildOperationExecutor,
         AsyncWorkTracker asyncWorkTracker,
-        TaskActionListener actionListener,
+        org.gradle.api.execution.TaskActionListener actionListener,
         TaskCacheabilityResolver taskCacheabilityResolver,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
         ExecutionEngine executionEngine,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -19,8 +19,6 @@ package org.gradle.api.internal.tasks.execution;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
-import org.gradle.api.execution.TaskActionListener;
-import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.execution.internal.TaskInputsListeners;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GeneratedSubclasses;
@@ -98,6 +96,7 @@ import java.util.stream.Collectors;
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RELEASE_AND_REACQUIRE_PROJECT_LOCKS;
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RELEASE_PROJECT_LOCKS;
 
+@SuppressWarnings("deprecation")
 public class TaskExecution implements UnitOfWork {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecution.class);
     private static final SnapshotTaskInputsBuildOperationType.Details SNAPSHOT_TASK_INPUTS_DETAILS = new SnapshotTaskInputsBuildOperationType.Details() {
@@ -107,7 +106,7 @@ public class TaskExecution implements UnitOfWork {
     private final TaskExecutionContext context;
     private final boolean emitLegacySnapshottingOperations;
 
-    private final TaskActionListener actionListener;
+    private final org.gradle.api.execution.TaskActionListener actionListener;
     private final AsyncWorkTracker asyncWorkTracker;
     private final BuildOperationExecutor buildOperationExecutor;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
@@ -125,7 +124,7 @@ public class TaskExecution implements UnitOfWork {
         TaskExecutionContext context,
         boolean emitLegacySnapshottingOperations,
 
-        TaskActionListener actionListener,
+        org.gradle.api.execution.TaskActionListener actionListener,
         AsyncWorkTracker asyncWorkTracker,
         BuildOperationExecutor buildOperationExecutor,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
@@ -200,7 +199,7 @@ public class TaskExecution implements UnitOfWork {
     }
 
     private void executeActions(TaskInternal task, @Nullable InputChangesInternal inputChanges) {
-        boolean hasTaskListener = listenerManager.hasListeners(TaskActionListener.class) || listenerManager.hasListeners(TaskExecutionListener.class);
+        boolean hasTaskListener = listenerManager.hasListeners(org.gradle.api.execution.TaskActionListener.class) || listenerManager.hasListeners(org.gradle.api.execution.TaskExecutionListener.class);
         Iterator<InputChangesAwareTaskAction> actions = new ArrayList<>(task.getTaskActions()).iterator();
         while (actions.hasNext()) {
             InputChangesAwareTaskAction action = actions.next();

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -254,6 +254,7 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
             this.provider = provider;
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public void buildFinished(BuildResult result) {
             provider.maybeStop();

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -17,8 +17,6 @@
 package org.gradle.execution;
 
 import org.gradle.StartParameter;
-import org.gradle.api.execution.TaskActionListener;
-import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.execution.internal.TaskInputsListeners;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.TaskExecutionModeResolver;
@@ -69,14 +67,15 @@ import org.gradle.normalization.internal.InputNormalizationHandlerInternal;
 
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class ProjectExecutionServices extends DefaultServiceRegistry {
 
     public ProjectExecutionServices(ProjectInternal project) {
         super("Configured project services for '" + project.getPath() + "'", project.getServices());
     }
 
-    TaskActionListener createTaskActionListener(ListenerManager listenerManager) {
-        return listenerManager.getBroadcaster(TaskActionListener.class);
+    org.gradle.api.execution.TaskActionListener createTaskActionListener(ListenerManager listenerManager) {
+        return listenerManager.getBroadcaster(org.gradle.api.execution.TaskActionListener.class);
     }
 
     TaskCacheabilityResolver createTaskCacheabilityResolver(RelativeFilePathResolver relativeFilePathResolver) {
@@ -106,10 +105,10 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         OutputChangeListener outputChangeListener,
         OutputFilesRepository outputFilesRepository,
         ReservedFileSystemLocationRegistry reservedFileSystemLocationRegistry,
-        TaskActionListener actionListener,
+        org.gradle.api.execution.TaskActionListener actionListener,
         TaskCacheabilityResolver taskCacheabilityResolver,
         TaskExecutionGraphInternal taskExecutionGraph,
-        TaskExecutionListener taskExecutionListener,
+        org.gradle.api.execution.TaskExecutionListener taskExecutionListener,
         TaskExecutionModeResolver repository,
         TaskInputsListeners taskInputsListeners,
         TaskListenerInternal taskListenerInternal,

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -25,7 +25,6 @@ import org.gradle.api.Task;
 import org.gradle.api.execution.TaskExecutionAdapter;
 import org.gradle.api.execution.TaskExecutionGraph;
 import org.gradle.api.execution.TaskExecutionGraphListener;
-import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
@@ -58,6 +57,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+@SuppressWarnings("deprecation")
 @NonNullApi
 public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTaskExecutionGraph.class);
@@ -66,7 +66,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     private final List<NodeExecutor> nodeExecutors;
     private final GradleInternal gradleInternal;
     private final ListenerBroadcast<TaskExecutionGraphListener> graphListeners;
-    private final ListenerBroadcast<TaskExecutionListener> taskListeners;
+    private final ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> taskListeners;
     private final BuildScopeListenerRegistrationListener buildScopeListenerRegistrationListener;
     private final ProjectStateRegistry projectStateRegistry;
     private final ServiceRegistry globalServices;
@@ -83,7 +83,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         ListenerBuildOperationDecorator listenerBuildOperationDecorator,
         GradleInternal gradleInternal,
         ListenerBroadcast<TaskExecutionGraphListener> graphListeners,
-        ListenerBroadcast<TaskExecutionListener> taskListeners,
+        ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> taskListeners,
         BuildScopeListenerRegistrationListener buildScopeListenerRegistrationListener,
         ProjectStateRegistry projectStateRegistry,
         ServiceRegistry globalServices
@@ -192,13 +192,13 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     @Override
-    public void addTaskExecutionListener(TaskExecutionListener listener) {
+    public void addTaskExecutionListener(org.gradle.api.execution.TaskExecutionListener listener) {
         notifyListenerRegistration("TaskExecutionGraph.addTaskExecutionListener", listener);
         taskListeners.add(listener);
     }
 
     @Override
-    public void removeTaskExecutionListener(TaskExecutionListener listener) {
+    public void removeTaskExecutionListener(org.gradle.api.execution.TaskExecutionListener listener) {
         taskListeners.remove(listener);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -38,6 +38,7 @@ import org.gradle.execution.plan.NodeExecutor;
 import org.gradle.execution.plan.PlanExecutor;
 import org.gradle.execution.plan.TaskNode;
 import org.gradle.internal.Cast;
+import org.gradle.internal.InternalListener;
 import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -237,6 +238,9 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     private void notifyListenerRegistration(String registrationPoint, Object listener) {
+        if (listener instanceof InternalListener) {
+            return;
+        }
         buildScopeListenerRegistrationListener.onBuildScopeListenerRegistration(
             listener,
             registrationPoint,

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+@SuppressWarnings("deprecation")
 public class DefaultBuildLifecycleController implements BuildLifecycleController {
     private enum State implements StateTransitionController.State {
         // Configuring the build, can access build model

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -100,6 +100,7 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(BuildResult result) {
         this.action = result.getAction();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.api.execution.TaskExecutionGraphListener;
-import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
@@ -97,6 +96,7 @@ import java.util.List;
 /**
  * Contains the services for a given {@link GradleInternal} instance.
  */
+@SuppressWarnings("deprecation")
 public class GradleScopeServices extends DefaultServiceRegistry {
 
     private final CompositeStoppable registries = new CompositeStoppable();
@@ -150,11 +150,11 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new WorkNodeExecutor();
     }
 
-    ListenerBroadcast<TaskExecutionListener> createTaskExecutionListenerBroadcast(ListenerManager listenerManager) {
-        return listenerManager.createAnonymousBroadcaster(TaskExecutionListener.class);
+    ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> createTaskExecutionListenerBroadcast(ListenerManager listenerManager) {
+        return listenerManager.createAnonymousBroadcaster(org.gradle.api.execution.TaskExecutionListener.class);
     }
 
-    TaskExecutionListener createTaskExecutionListener(ListenerBroadcast<TaskExecutionListener> broadcast) {
+    org.gradle.api.execution.TaskExecutionListener createTaskExecutionListener(ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> broadcast) {
         return broadcast.getSource();
     }
 
@@ -172,7 +172,7 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         BuildOperationExecutor buildOperationExecutor,
         ListenerBuildOperationDecorator listenerBuildOperationDecorator,
         GradleInternal gradleInternal,
-        ListenerBroadcast<TaskExecutionListener> taskListeners,
+        ListenerBroadcast<org.gradle.api.execution.TaskExecutionListener> taskListeners,
         ListenerBroadcast<TaskExecutionGraphListener> graphListeners,
         ListenerManager listenerManager,
         ProjectStateRegistry projectStateRegistry,

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -380,6 +380,9 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
     }
 
     private void notifyListenerRegistration(String registrationPoint, Object listener) {
+        if (listener instanceof InternalListener || listener instanceof ProjectEvaluationListener) {
+            return;
+        }
         getListenerManager().getBroadcaster(BuildScopeListenerRegistrationListener.class)
             .onBuildScopeListenerRegistration(listener, registrationPoint, this);
     }

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -49,6 +49,7 @@ import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.initialization.ClassLoaderScopeRegistry;
 import org.gradle.internal.Cast;
 import org.gradle.internal.InternalBuildAdapter;
+import org.gradle.internal.InternalListener;
 import org.gradle.internal.MutableActionSet;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.PublicBuildPath;
@@ -354,12 +355,14 @@ public abstract class DefaultGradle extends AbstractPluginAware implements Gradl
         buildListenerBroadcast.add("projectsEvaluated", getListenerBuildOperationDecorator().decorate("Gradle.projectsEvaluated", action));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(Closure closure) {
         notifyListenerRegistration("Gradle.buildFinished", closure);
         buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("buildFinished", closure));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(Action<? super BuildResult> action) {
         notifyListenerRegistration("Gradle.buildFinished", action);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -63,6 +63,7 @@ public class DependencyManagementGradleUserHomeScopeServices {
     ) {
         DefaultArtifactCaches artifactCachesProvider = new DefaultArtifactCaches(globalScopedCache, cacheRepository, parameters, documentationRegistry);
         listenerManager.addListener(new BuildAdapter() {
+            @SuppressWarnings("deprecation")
             @Override
             public void buildFinished(BuildResult result) {
                 artifactCachesProvider.getWritableCacheLockingManager().useCache(() -> {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/HelpTasksPlugin.java
@@ -159,8 +159,9 @@ public class HelpTasksPlugin implements Plugin<Project> {
             task.setDescription("Displays the insight into a specific dependency in " + projectName + ".");
             task.setGroup(HELP_GROUP);
             task.setImpliesSubProjects(true);
+            ComponentRegistry componentRegistry = ((ProjectInternal) task.getProject()).getServices().get(ComponentRegistry.class);
             new DslObject(task).getConventionMapping().map("configuration", () -> {
-                BuildableJavaComponent javaProject = ((ProjectInternal) task.getProject()).getServices().get(ComponentRegistry.class).getMainComponent();
+                BuildableJavaComponent javaProject = componentRegistry.getMainComponent();
                 return javaProject == null ? null : javaProject.getCompileDependencies();
             });
         }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -115,23 +115,62 @@ link:{javadocPath}/org/gradle/api/reporting/ConfigurableReport.html#setDestinati
 
 Use link:{javadocPath}/org/gradle/api/reporting/Report.html#getOutputLocation--[`Report#getOutputLocation().set(...)`] instead.
 
-==== Listeners
+[[task_execution_events]]
+==== Task execution listeners and events
 
-TBD - TaskExecutionListener
-TBD - TaskActionListener
-TBD - Registering TaskExecutionListener, TaskActionListener, TestListener, TestOutputListener via Gradle.addListener()
-TBD - Gradle.buildFinished()
-TBD - BuildListener.buildFinished()
-TBD - TaskExecutionGraph.addTaskExecutionListener(), removeTaskExecutionListener()
-TBD - TaskExecutionGraph.beforeTask(), afterTask()
+TODO - links
 
-==== Calling Task#getProject() from a task action
+Gradle configuration caching does not support listeners and events that have direct access to `Task` and `Project` instances,
+to allow Gradle to execute tasks in parallel and to store the minimal amount of data in the configuration cache.
+In order to move towards a consistent API, regardless of whether configuration caching is enabled or not, the following APIs
+are deprecated and will be removed or be made an error in Gradle 8.0:
 
-TBD - Calling Task.getProject() at execution time is now deprecated, but it can still be used during configuration time. It is recommended to avoid using it during configuration time
+- TaskExecutionListener
+- TaskActionListener
+- TaskExecutionGraph.addTaskExecutionListener()
+- TaskExecutionGraph.removeTaskExecutionListener()
+- TaskExecutionGraph.beforeTask()
+- TaskExecutionGraph.afterTask()
+- Registering TaskExecutionListener, TaskActionListener, TestListener, TestOutputListener via Gradle.addListener()
 
-==== Calling Task#getDependencies() from a task action
+See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
+configuration cache.
 
-TBD -
+[[build_finished_events]]
+==== Build finished events
+
+TODO - links
+
+As for task listeners, build finished listeners are not supported by Gradle configuration caching. And so, the following
+API are deprecated and will be removed in Gradle 8.0:
+
+- Gradle.buildFinished()
+- BuildListener.buildFinished()
+
+See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
+configuration cache.
+
+[[task_project]]
+==== Calling `Task#getProject()`` from a task action
+
+TODO - links
+
+Calling Task.getProject() from a task action at execution time is now deprecated and will be made an error in Gradle 8.0.
+This method can still be used during configuration time, but it is recommended to avoid doing this.
+
+See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
+configuration cache.
+
+[[task_dependencies]]
+==== Calling `Task#getTaskDependencies()`` from a task action
+
+TODO - links
+
+Calling Task.getTaskDependencies() from a task action at execution time is now deprecated and will be made an error in Gradle 8.0.
+This method can still be used during configuration time, but it is recommended to avoid doing this.
+
+See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
+configuration cache.
 
 [[changes_7.3]]
 == Upgrading from 7.2 and earlier

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -115,6 +115,24 @@ link:{javadocPath}/org/gradle/api/reporting/ConfigurableReport.html#setDestinati
 
 Use link:{javadocPath}/org/gradle/api/reporting/Report.html#getOutputLocation--[`Report#getOutputLocation().set(...)`] instead.
 
+==== Listeners
+
+TBD - TaskExecutionListener
+TBD - TaskActionListener
+TBD - Registering TaskExecutionListener, TaskActionListener, TestListener, TestOutputListener via Gradle.addListener()
+TBD - Gradle.buildFinished()
+TBD - BuildListener.buildFinished()
+TBD - TaskExecutionGraph.addTaskExecutionListener(), removeTaskExecutionListener()
+TBD - TaskExecutionGraph.beforeTask(), afterTask()
+
+==== Calling Task#getProject() from a task action
+
+TBD - Calling Task.getProject() at execution time is now deprecated, but it can still be used during configuration time. It is recommended to avoid using it during configuration time
+
+==== Calling Task#getDependencies() from a task action
+
+TBD -
+
 [[changes_7.3]]
 == Upgrading from 7.2 and earlier
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskActionIntegrationTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+
+class TaskActionIntegrationTest extends AbstractIntegrationSpec {
+    @UnsupportedWithConfigurationCache(because = "tests unsupported behaviour")
+    def "nags when task action uses #expression and feature preview is enabled"() {
+        settingsFile """
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+        """
+        buildFile """
+            task broken {
+                doLast {
+                    $expression
+                }
+            }
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Invocation of ${invocation} at execution time has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#${docSection}")
+        run("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        expression         | invocation              | docSection
+        "project"          | "Task.project"          | "task_project"
+        "taskDependencies" | "Task.taskDependencies" | "task_dependencies"
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/IvyServices.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/IvyServices.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.publish.ivy.internal.publisher.ContextualizingIvyPublisher;
 import org.gradle.api.publish.ivy.internal.publisher.DependencyResolverIvyPublisher;
+import org.gradle.api.publish.ivy.internal.publisher.IvyDuplicatePublicationTracker;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublisher;
 import org.gradle.api.publish.ivy.internal.publisher.ValidatingIvyPublisher;
 import org.gradle.internal.resource.local.FileResourceRepository;
@@ -35,6 +36,11 @@ public class IvyServices extends AbstractPluginServiceRegistry {
     @Override
     public void registerBuildServices(ServiceRegistration registration) {
         registration.addProvider(new BuildServices());
+    }
+
+    @Override
+    public void registerProjectServices(ServiceRegistration registration) {
+        registration.add(IvyDuplicatePublicationTracker.class);
     }
 
     private static class BuildServices {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDuplicatePublicationTracker.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDuplicatePublicationTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.publish.maven.internal.publisher;
+package org.gradle.api.publish.ivy.internal.publisher;
 
 import org.gradle.api.Project;
-import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.publish.internal.validation.DuplicatePublicationTracker;
 import org.gradle.internal.service.scopes.Scopes;
@@ -27,22 +26,16 @@ import javax.annotation.Nullable;
 import java.net.URI;
 
 @ServiceScope(Scopes.Project.class)
-public class MavenDuplicatePublicationTracker {
+public class IvyDuplicatePublicationTracker {
     private final Project project;
     private final DuplicatePublicationTracker duplicatePublicationTracker;
-    private final LocalMavenRepositoryLocator mavenRepositoryLocator;
 
-    public MavenDuplicatePublicationTracker(Project project, DuplicatePublicationTracker duplicatePublicationTracker, LocalMavenRepositoryLocator mavenRepositoryLocator) {
+    public IvyDuplicatePublicationTracker(Project project, DuplicatePublicationTracker duplicatePublicationTracker) {
         this.project = project;
         this.duplicatePublicationTracker = duplicatePublicationTracker;
-        this.mavenRepositoryLocator = mavenRepositoryLocator;
     }
 
-    public void checkCanPublish(PublicationInternal publication, @Nullable URI repositoryLocation, String repositoryName) {
+    public void checkCanPublish(PublicationInternal<?> publication, @Nullable URI repositoryLocation, String repositoryName) {
         duplicatePublicationTracker.checkCanPublish(project, publication, repositoryLocation, repositoryName);
-    }
-
-    public void checkCanPublishToMavenLocal(PublicationInternal publication) {
-        checkCanPublish(publication, mavenRepositoryLocator.getLocalMavenRepository().toURI(), "mavenLocal");
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/PublishToIvyRepository.java
@@ -23,9 +23,9 @@ import org.gradle.api.credentials.Credentials;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.internal.PublishOperation;
-import org.gradle.api.publish.internal.validation.DuplicatePublicationTracker;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
+import org.gradle.api.publish.ivy.internal.publisher.IvyDuplicatePublicationTracker;
 import org.gradle.api.publish.ivy.internal.publisher.IvyNormalizedPublication;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublisher;
 import org.gradle.api.tasks.Internal;
@@ -144,7 +144,7 @@ public class PublishToIvyRepository extends DefaultTask {
         if (repository == null) {
             throw new InvalidUserDataException("The 'repository' property is required");
         }
-        getDuplicatePublicationTracker().checkCanPublish(getProject(), publicationInternal, repository.getUrl(), repository.getName());
+        getDuplicatePublicationTracker().checkCanPublish(publicationInternal, repository.getUrl(), repository.getName());
 
         doPublish(publicationInternal, repository);
     }
@@ -166,7 +166,7 @@ public class PublishToIvyRepository extends DefaultTask {
     }
 
     @Inject
-    protected DuplicatePublicationTracker getDuplicatePublicationTracker() {
+    protected IvyDuplicatePublicationTracker getDuplicatePublicationTracker() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/GradleDelegate.kt
@@ -110,9 +110,11 @@ abstract class GradleDelegate : Gradle {
     override fun projectsEvaluated(action: Action<in Gradle>) =
         delegate.projectsEvaluated(action)
 
+    @Suppress("DEPRECATION")
     override fun buildFinished(closure: Closure<Any>) =
         delegate.buildFinished(closure)
 
+    @Suppress("DEPRECATION")
     override fun buildFinished(action: Action<in BuildResult>) =
         delegate.buildFinished(action)
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/MavenPublishServices.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/MavenPublishServices.java
@@ -21,7 +21,6 @@ import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
-import org.gradle.api.publish.internal.validation.DuplicatePublicationTracker;
 import org.gradle.api.publish.maven.internal.dependencies.MavenVersionRangeMapper;
 import org.gradle.api.publish.maven.internal.dependencies.VersionRangeMapper;
 import org.gradle.api.publish.maven.internal.publisher.MavenDuplicatePublicationTracker;
@@ -38,11 +37,16 @@ public class MavenPublishServices extends AbstractPluginServiceRegistry {
         registration.addProvider(new ComponentRegistrationAction());
     }
 
+    @Override
+    public void registerProjectServices(ServiceRegistration registration) {
+        registration.add(MavenDuplicatePublicationTracker.class);
+    }
+
     private static class ComponentRegistrationAction {
         public void configure(ServiceRegistration registration, ComponentTypeRegistry componentTypeRegistry) {
             // TODO There should be a more explicit way to execute an action against existing services
             componentTypeRegistry.maybeRegisterComponentType(MavenModule.class)
-                    .registerArtifactType(MavenPomArtifact.class, ArtifactType.MAVEN_POM);
+                .registerArtifactType(MavenPomArtifact.class, ArtifactType.MAVEN_POM);
         }
 
         public VersionRangeMapper createVersionRangeMapper(VersionSelectorScheme versionSelectorScheme) {
@@ -51,10 +55,6 @@ public class MavenPublishServices extends AbstractPluginServiceRegistry {
 
         public MavenPublishers createMavenPublishers(BuildCommencedTimeProvider timeProvider, RepositoryTransportFactory repositoryTransportFactory, LocalMavenRepositoryLocator mavenRepositoryLocator) {
             return new MavenPublishers(timeProvider, repositoryTransportFactory, mavenRepositoryLocator);
-        }
-
-        public MavenDuplicatePublicationTracker createDuplicatePublicationTracker(DuplicatePublicationTracker duplicatePublicationTracker, LocalMavenRepositoryLocator mavenRepositoryLocator) {
-            return new MavenDuplicatePublicationTracker(duplicatePublicationTracker, mavenRepositoryLocator);
         }
     }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenLocal.java
@@ -41,7 +41,7 @@ public class PublishToMavenLocal extends AbstractPublishToMaven {
             throw new InvalidUserDataException("The 'publication' property is required");
         }
 
-        getDuplicatePublicationTracker().checkCanPublishToMavenLocal(getProject(), publicationInternal);
+        getDuplicatePublicationTracker().checkCanPublishToMavenLocal(publicationInternal);
         return publicationInternal.asNormalisedPublication();
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/PublishToMavenRepository.java
@@ -96,7 +96,7 @@ public class PublishToMavenRepository extends AbstractPublishToMaven {
             throw new InvalidUserDataException("The 'repository' property is required");
         }
 
-        getDuplicatePublicationTracker().checkCanPublish(getProject(), publicationInternal, repository.getUrl(), repository.getName());
+        getDuplicatePublicationTracker().checkCanPublish(publicationInternal, repository.getUrl(), repository.getName());
         MavenNormalizedPublication normalizedPublication = publicationInternal.asNormalisedPublication();
         return new PublishSpec(
                 RepositorySpec.of(repository),

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEventsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEventsIntegrationTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestOutputListener
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+
+class TestEventsIntegrationTest extends AbstractIntegrationSpec {
+    @UnsupportedWithConfigurationCache(because = "tests listener behaviour")
+    def "nags when #type is registered via gradle.addListener() and feature preview is enabled"() {
+        settingsFile """
+            enableFeaturePreview 'STABLE_CONFIGURATION_CACHE'
+        """
+        buildFile """
+            def testListener = new TestListener() {
+                void beforeSuite(TestDescriptor suite) {}
+                void afterSuite(TestDescriptor suite, TestResult result) {}
+                void beforeTest(TestDescriptor testDescriptor) {}
+                void afterTest(TestDescriptor testDescriptor, TestResult result) {}
+            }
+            def testOutputListener = new TestOutputListener() {
+                void onOutput(TestDescriptor testDescriptor, TestOutputEvent outputEvent) {}
+            }
+            gradle.addListener($listener)
+            task broken
+        """
+
+        when:
+        executer.expectDocumentedDeprecationWarning("Listener registration using Gradle.addListener() has been deprecated. This will fail with an error in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#task_execution_events")
+        run("broken")
+
+        then:
+        noExceptionThrown()
+
+        where:
+        type               | listener
+        TestListener       | "testListener"
+        TestOutputListener | "testOutputListener"
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
