### PR TITLE
Move bot-gradle token to BasePromotionBuildType

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -43,7 +43,8 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)
 
         params {
-            param("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%;%e.grdev.net.access.key%")
+            password("env.GRADLE_ENTERPRISE_ACCESS_KEY", "%ge.gradle.org.access.key%;%e.grdev.net.access.key%")
+            password("env.ORG_GRADLE_PROJECT_botGradleGitHubToken", "%github.bot-gradle.token%")
         }
 
         features {

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistribution.kt
@@ -49,10 +49,6 @@ abstract class PublishGradleDistribution(
             }
         }
 
-        params {
-            password("env.ORG_GRADLE_PROJECT_botGradleGitHubToken", "%github.bot-gradle.token%")
-        }
-
         dependencies {
             snapshot(RelativeId("Check_Stage_${this@PublishGradleDistribution.triggerName}_Trigger")) {
             }


### PR DESCRIPTION
so all promotion builds can create pre-tested commits.