### PR TITLE
Add additional tests for file change detection from timestamp

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -283,34 +283,16 @@ public abstract class CreateEmptyDirectory extends DefaultTask {
             }
         """
         def inputFile = file("input/input.txt")
-        inputFile.text = "[1] Hello World!"
-        def previousInputFileLength = inputFile.length()
+        inputFile.text = "[0] Hello World!"
+        def originalInputFileLength = inputFile.length()
 
-        when:
-        run "printFile"
-        then:
-        executedAndNotSkipped(":printFile")
-
-        when:
-        inputFile.text = "[2] Hello World!"
-        run "printFile"
-        then:
-        executedAndNotSkipped(":printFile")
-        previousInputFileLength == inputFile.length()
-
-        when:
-        inputFile.text = "[3] Hello World!"
-        run "printFile"
-        then:
-        executedAndNotSkipped(":printFile")
-        previousInputFileLength == inputFile.length()
-
-        when:
-        inputFile.text = "[4] Hello World!"
-        run "printFile"
-        then:
-        executedAndNotSkipped(":printFile")
-        previousInputFileLength == inputFile.length()
+        expect:
+        [1, 2, 3, 4].each {
+            inputFile.text = "[$it] Hello World!"
+            run "printFile"
+            executedAndNotSkipped(":printFile")
+            assert originalInputFileLength == inputFile.length()
+        }
 
         where:
         inputAnnotation   | inputType             | inputPath         | inputToPrint

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/UpToDateIntegTest.groovy
@@ -287,10 +287,12 @@ public abstract class CreateEmptyDirectory extends DefaultTask {
         def originalInputFileLength = inputFile.length()
 
         expect:
-        [1, 2, 3, 4].each {
-            inputFile.text = "[$it] Hello World!"
+        (1..4).each {
+            def givenText = "[$it] Hello World!"
+            inputFile.text = givenText
             run "printFile"
             executedAndNotSkipped(":printFile")
+            outputContains(givenText)
             assert originalInputFileLength == inputFile.length()
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/BuildSessionScopeFileTimeStampInspectorTest.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.changedetection.state
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Rule
+import spock.lang.Specification
+
+import java.nio.file.Files
+
+class BuildSessionScopeFileTimeStampInspectorTest extends Specification {
+
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
+    File workDir
+    BuildSessionScopeFileTimeStampInspector timestampInspector
+
+    def setup() {
+        workDir = tmpDir.testDirectory
+        timestampInspector = new BuildSessionScopeFileTimeStampInspector(workDir)
+    }
+
+    def "last build timestamp is 0 on the first build"() {
+        when:
+        timestampInspector.afterStart()
+
+        then:
+        timestampInspector.lastBuildTimestamp == 0
+    }
+
+    def "updates last build timestamp before complete"() {
+        when:
+        timestampInspector.afterStart()
+        def afterStartTimestamp = timestampInspector.lastBuildTimestamp
+        timestampInspector.beforeComplete()
+        def beforeCompleteTimestamp = timestampInspector.lastBuildTimestamp
+
+        then:
+        afterStartTimestamp == 0
+        beforeCompleteTimestamp > 0
+    }
+
+    def "last build timestamp is equal to minimum of timestamps of the marker file"() {
+        given:
+        timestampInspector.afterStart()
+        timestampInspector.beforeComplete()
+        def markerFile = new File(workDir, "last-build.bin")
+        // File.lastModified() and Files.getLastModifiedTime() uses different resolution on some JDKs < 11
+        def markerFileTimestamp = Math.min(markerFile.lastModified(), Files.getLastModifiedTime(markerFile.toPath()).toMillis())
+
+        when:
+        def lastBuildTimestamp = timestampInspector.lastBuildTimestamp
+
+        then:
+        lastBuildTimestamp > 0
+        lastBuildTimestamp == markerFileTimestamp
+    }
+
+    def "timestamp cannot be used to detect file changes if it's equal to the last build timestamp"() {
+        given:
+        timestampInspector.afterStart()
+        timestampInspector.beforeComplete()
+        def lastBuildTimestamp = timestampInspector.lastBuildTimestamp
+
+        when:
+        def canBeUsedToDetectFileChange = timestampInspector.timestampCanBeUsedToDetectFileChange("test-file.java", lastBuildTimestamp)
+
+        then:
+        lastBuildTimestamp > 0
+        !canBeUsedToDetectFileChange
+    }
+
+    def "timestamp can be used to detect file changes if it's not equal to the last build timestamp"() {
+        given:
+        timestampInspector.afterStart()
+        timestampInspector.beforeComplete()
+        def lastBuildTimestamp = timestampInspector.lastBuildTimestamp
+
+        when:
+        def canBeUsedToDetectFileChange = timestampInspector.timestampCanBeUsedToDetectFileChange("test-file.java", lastBuildTimestamp + 1)
+
+        then:
+        lastBuildTimestamp > 0
+        canBeUsedToDetectFileChange
+    }
+}

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
@@ -49,53 +49,6 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         executedAndNotSkipped ":compileJava", ":classes", ":run"
     }
 
-    @Issue("https://github.com/gradle/gradle/issues/19353")
-    def "source file changes are recognized when file length does not change"() {
-        buildFile << """
-            apply plugin: "application"
-
-            application.mainClass = "Main"
-        """
-
-        def mainSourceFileRelativePath = "src/main/java/Main.java"
-        def mainSourceFile = file(mainSourceFileRelativePath)
-        mainSourceFile.text = sourceFileWithGreeting("Hello World!1")
-        def previousSourceFileLength = mainSourceFile.length()
-
-        when:
-        runWithWatchingEnabled("run")
-        then:
-        outputContains "Hello World!1"
-        executedAndNotSkipped ":compileJava", ":classes", ":run"
-
-        when:
-        mainSourceFile.text = sourceFileWithGreeting("Hello World!2")
-        waitForChangesToBePickedUp()
-        runWithWatchingEnabled "run"
-        then:
-        previousSourceFileLength == mainSourceFile.length()
-        outputContains "Hello World!2"
-        executedAndNotSkipped ":compileJava", ":classes", ":run"
-
-        when:
-        mainSourceFile.text = sourceFileWithGreeting("Hello World!3")
-        waitForChangesToBePickedUp()
-        runWithWatchingEnabled "run"
-        then:
-        previousSourceFileLength == mainSourceFile.length()
-        outputContains "Hello World!3"
-        executedAndNotSkipped ":compileJava", ":classes", ":run"
-
-        when:
-        mainSourceFile.text = sourceFileWithGreeting("Hello World!4")
-        waitForChangesToBePickedUp()
-        runWithWatchingEnabled "run"
-        then:
-        previousSourceFileLength == mainSourceFile.length()
-        outputContains "Hello World!4"
-        executedAndNotSkipped ":compileJava", ":classes", ":run"
-    }
-
     def "buildSrc changes are recognized"() {
         def taskSourceFile = file("buildSrc/src/main/java/PrinterTask.java")
         taskSourceFile.text = taskWithGreeting("Hello from original task!")

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesBetweenBuildsFileSystemWatchingIntegrationTest.groovy
@@ -49,6 +49,53 @@ class ChangesBetweenBuildsFileSystemWatchingIntegrationTest extends AbstractFile
         executedAndNotSkipped ":compileJava", ":classes", ":run"
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/19353")
+    def "source file changes are recognized when file length does not change"() {
+        buildFile << """
+            apply plugin: "application"
+
+            application.mainClass = "Main"
+        """
+
+        def mainSourceFileRelativePath = "src/main/java/Main.java"
+        def mainSourceFile = file(mainSourceFileRelativePath)
+        mainSourceFile.text = sourceFileWithGreeting("Hello World!1")
+        def previousSourceFileLength = mainSourceFile.length()
+
+        when:
+        runWithWatchingEnabled("run")
+        then:
+        outputContains "Hello World!1"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+
+        when:
+        mainSourceFile.text = sourceFileWithGreeting("Hello World!2")
+        waitForChangesToBePickedUp()
+        runWithWatchingEnabled "run"
+        then:
+        previousSourceFileLength == mainSourceFile.length()
+        outputContains "Hello World!2"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+
+        when:
+        mainSourceFile.text = sourceFileWithGreeting("Hello World!3")
+        waitForChangesToBePickedUp()
+        runWithWatchingEnabled "run"
+        then:
+        previousSourceFileLength == mainSourceFile.length()
+        outputContains "Hello World!3"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+
+        when:
+        mainSourceFile.text = sourceFileWithGreeting("Hello World!4")
+        waitForChangesToBePickedUp()
+        runWithWatchingEnabled "run"
+        then:
+        previousSourceFileLength == mainSourceFile.length()
+        outputContains "Hello World!4"
+        executedAndNotSkipped ":compileJava", ":classes", ":run"
+    }
+
     def "buildSrc changes are recognized"() {
         def taskSourceFile = file("buildSrc/src/main/java/PrinterTask.java")
         taskSourceFile.text = taskWithGreeting("Hello from original task!")


### PR DESCRIPTION
This adds tests for `BuildSessionScopeFileTimeStampInspector` and also adds an integration test for the issue https://github.com/gradle/gradle/issues/19353. I checked it without a fix and on Oracle JDK8u301 test fails.

`ChangesBetweenBuildsFileSystemWatchingIntegrationTest` might not be the right class, since this is actually not a VFS issue. Probably should be moved to the core where FileTimeStampInspector is. WDYT?

