### PR TITLE
Minor fixes for configuration caching

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -70,6 +70,9 @@ class ConfigurationCacheProblems(
     var updatedProjects = 0
 
     private
+    var hasIncompatibleTypes = false
+
+    private
     lateinit var cacheAction: ConfigurationCacheAction
 
     private
@@ -99,6 +102,7 @@ class ConfigurationCacheProblems(
     }
 
     override fun forIncompatibleType(): ProblemsListener {
+        hasIncompatibleTypes = true
         return object : ProblemsListener {
             override fun onProblem(problem: PropertyProblem) {
                 onProblem(problem, ProblemSeverity.Warn)
@@ -130,7 +134,7 @@ class ConfigurationCacheProblems(
     override fun report(reportDir: File, validationFailures: Consumer<in Throwable>) {
         val summary = summarizer.get()
         val failDueToProblems = summary.failureCount > 0 && isFailOnProblems
-        val discardStateDueToProblems = summary.problemCount > 0 && isFailOnProblems
+        val discardStateDueToProblems = (summary.problemCount > 0 || hasIncompatibleTypes) && isFailOnProblems
         val hasTooManyProblems = summary.problemCount > startParameter.maxProblems
         val discardState = discardStateDueToProblems || hasTooManyProblems
         if (cacheAction != LOAD && discardState) {
@@ -195,6 +199,7 @@ class ConfigurationCacheProblems(
         override fun beforeComplete() {
             val problemCount = summarizer.get().problemCount
             val hasProblems = problemCount > 0
+            val discardStateDueToProblems = (problemCount > 0 || hasIncompatibleTypes) && isFailOnProblems
             val hasTooManyProblems = problemCount > startParameter.maxProblems
             val problemCountString = problemCount.counter("problem")
             val reusedProjectsString = reusedProjects.counter("project")
@@ -202,7 +207,8 @@ class ConfigurationCacheProblems(
             when {
                 isFailingBuildDueToSerializationError && !hasProblems -> log("Configuration cache entry discarded.")
                 isFailingBuildDueToSerializationError -> log("Configuration cache entry discarded with {}.", problemCountString)
-                cacheAction == STORE && isFailOnProblems && hasProblems -> log("Configuration cache entry discarded with {}.", problemCountString)
+                cacheAction == STORE && discardStateDueToProblems && !hasProblems -> log("Configuration cache entry discarded.")
+                cacheAction == STORE && discardStateDueToProblems -> log("Configuration cache entry discarded with {}.", problemCountString)
                 cacheAction == STORE && hasTooManyProblems -> log("Configuration cache entry discarded with too many problems ({}).", problemCountString)
                 cacheAction == STORE && !hasProblems -> log("Configuration cache entry stored.")
                 cacheAction == STORE -> log("Configuration cache entry stored with {}.", problemCountString)

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -163,6 +163,14 @@ Previously, in order for Gradle to correctly treat external values such as envir
 
 Gradle 7.4 simplifies adoption of the configuration cache by deprecating `Provider.forUseAtConfigurationTime()` and allowing external values to be read using standard Java and Gradle APIs. Please check the [corresponding section of the upgrade guide](userguide/upgrading_version_7.html#for_use_at_configuration_time_deprecation) for details.
 
+#### Opt incompatible tasks out of configuration caching
+
+It is now possible to declare that a particular task is not compatible with the configuration cache. Gradle will disable the configuration cache
+whenever an incompatible task is scheduled to run. This makes it possible to enable the configuration cache for a build without having to first 
+migrate all tasks to be compatible.
+
+Please check the [user manual](userguide/configuration_cache.html#config_cache:task_out_out) for more details.
+
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE
 ==========================================================

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -118,59 +118,53 @@ Use link:{javadocPath}/org/gradle/api/reporting/Report.html#getOutputLocation--[
 [[task_execution_events]]
 ==== Task execution listeners and events
 
-TODO - links
+The Gradle configuration cache does not support listeners and events that have direct access to `Task` and `Project` instances,
+which allows Gradle to execute tasks in parallel and to store the minimal amount of data in the configuration cache.
+In order to move towards an API that is consistent whether the configuration cache is enabled or not,
+the following APIs are deprecated and will be removed or be made an error in Gradle 8.0:
 
-Gradle configuration caching does not support listeners and events that have direct access to `Task` and `Project` instances,
-to allow Gradle to execute tasks in parallel and to store the minimal amount of data in the configuration cache.
-In order to move towards a consistent API, regardless of whether configuration caching is enabled or not, the following APIs
-are deprecated and will be removed or be made an error in Gradle 8.0:
+- Interface link:{javadocPath}/org/gradle/api/execution/TaskExecutionListener.html[TaskExecutionListener]
+- Interface link:{javadocPath}/org/gradle/api/execution/TaskActionListener.html[TaskActionListener]
+- Method link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html#addTaskExecutionListener-org.gradle.api.execution.TaskExecutionListener-[TaskExecutionGraph.addTaskExecutionListener()]
+- Method link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html#removeTaskExecutionListener-org.gradle.api.execution.TaskExecutionListener-[TaskExecutionGraph.removeTaskExecutionListener()]
+- Method link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html#beforeTask-org.gradle.api.Action-[TaskExecutionGraph.beforeTask()]
+- Method link:{javadocPath}/org/gradle/api/execution/TaskExecutionGraph.html#afterTask-org.gradle.api.Action-[TaskExecutionGraph.afterTask()]
+- Registering TaskExecutionListener, TaskActionListener, TestListener, TestOutputListener via link:{javadocPath}/org/gradle/api/invocation/Gradle.html#addListener-java.lang.Object-[Gradle.addListener()]
 
-- TaskExecutionListener
-- TaskActionListener
-- TaskExecutionGraph.addTaskExecutionListener()
-- TaskExecutionGraph.removeTaskExecutionListener()
-- TaskExecutionGraph.beforeTask()
-- TaskExecutionGraph.afterTask()
-- Registering TaskExecutionListener, TaskActionListener, TestListener, TestOutputListener via Gradle.addListener()
-
-See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
-configuration cache.
+See the <<configuration_cache#config_cache:requirements:build_listeners,configuration cache chapter>> for details on how to migrate
+these usages to APIs that are supported by the configuration cache.
 
 [[build_finished_events]]
 ==== Build finished events
 
-TODO - links
+Build finished listeners are not supported by the Gradle configuration cache. And so, the following API are deprecated and will be
+removed in Gradle 8.0:
 
-As for task listeners, build finished listeners are not supported by Gradle configuration caching. And so, the following
-API are deprecated and will be removed in Gradle 8.0:
+- Method link:{javadocPath}/org/gradle/api/invocation/Gradle.html#buildFinished-org.gradle.api.Action-[Gradle.buildFinished()]
+- Method link:{javadocPath}/org/gradle/BuildListener.html#buildFinished-org.gradle.BuildResult-[BuildListener.buildFinished()]
 
-- Gradle.buildFinished()
-- BuildListener.buildFinished()
-
-See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
-configuration cache.
+See the <<configuration_cache#config_cache:requirements:build_listeners,configuration cache chapter>> for details on how to migrate
+these usages to APIs that are supported by the configuration cache.
 
 [[task_project]]
-==== Calling `Task#getProject()`` from a task action
+==== Calling `Task#getProject()` from a task action
 
-TODO - links
+Calling link:{javadocPath}/org/gradle/api/Task.html#getProject--[Task.getProject()] from a task action at execution time is
+now deprecated and will be made an error in Gradle 8.0.
+This method can be used during configuration time, but it is recommended to avoid doing this.
 
-Calling Task.getProject() from a task action at execution time is now deprecated and will be made an error in Gradle 8.0.
-This method can still be used during configuration time, but it is recommended to avoid doing this.
-
-See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
-configuration cache.
+See the <<configuration_cache#config_cache:requirements:use_project_during_execution,configuration cache chapter>> for details on
+how to migrate these usages to APIs that are supported by the configuration cache.
 
 [[task_dependencies]]
-==== Calling `Task#getTaskDependencies()`` from a task action
+==== Calling `Task#getTaskDependencies()` from a task action
 
-TODO - links
+Calling link:{javadocPath}/org/gradle/api/Task.html#getTaskDependencies--[Task.getTaskDependencies()] from a task action at
+execution time is now deprecated and will be made an error in Gradle 8.0.
+This method can be used during configuration time, but it is recommended to avoid doing this.
 
-Calling Task.getTaskDependencies() from a task action at execution time is now deprecated and will be made an error in Gradle 8.0.
-This method can still be used during configuration time, but it is recommended to avoid doing this.
-
-See the configuration cache user guide chapter for details on how to migrate these usages to APIs that are supported by the
-configuration cache.
+See the <<configuration_cache#config_cache:requirements:use_project_during_execution,configuration cache chapter>> for details on
+how to migrate these usages to APIs that are supported by the configuration cache.
 
 [[changes_7.3]]
 == Upgrading from 7.2 and earlier

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -26,7 +26,7 @@ In other words, the configuration cache saves the output of the configuration ph
 
 [IMPORTANT]
 ====
-This feature is currently *_experimental_* and not enabled by default.
+This feature is currently *_incubating_* and not enabled by default.
 
 Not all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> are supported.
 Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.
@@ -447,7 +447,7 @@ include::sample[dir="snippets/configurationCache/problemsFixedReuse/kotlin",file
 ====
 <1> We wired the system property provider directly, without reading it at configuration time.
 
-With this simple change in place we can run the task any number of time, change the system property value, and reuse the configuration cache:
+With this simple change in place we can run the task any number of times, change the system property value, and reuse the configuration cache:
 
 ----
 ❯ gradle --configuration-cache someTask -DsomeDestination=dest
@@ -461,6 +461,16 @@ Configuration cache entry reused.
 We're now done with fixing the problems with this simple task.
 
 Keep reading to learn how to adopt the configuration cache for your build or your plugins.
+
+[[config_cache:task_out_out]]
+=== Declare a task incompatible with the configuration cache
+
+It is possible to declare that a particular task is not compatible with the configuration cache. When a task that is incompatible is scheduled to
+run, Gradle will disable the configuration cache, if it is enabled.  You can use this to help with migration, by temporarily opting out certain tasks
+that are difficult to change to work with the configuration cache. We recommend that you use this only with tasks that are infrequently used.
+
+To declare a task is incompatible with the configuration, use the
+link:{javadocPath}/org/gradle/api/Task.html#notCompatibleWithConfigurationCache-java.lang.String-[Task.notCompatibleWithConfigurationCache()] method.
 
 [[config_cache:adoption]]
 == Adoption steps

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -390,7 +390,11 @@ class ConfigurationCacheFixture {
     static class StateDiscardedWithProblemsDetails implements HasBuildActions, HasProblems {
         @Override
         String getStoreAction() {
-            return "discarded with ${problemsString}"
+            if (totalProblems == 0) {
+                return "discarded"
+            } else {
+                return "discarded with ${problemsString}"
+            }
         }
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

- Do not store the cache entry when incompatible tasks are present in the task graph, regardless of whether any problems are generated.
- Some minimal documentation for Task.notCompatibleWithConfigurationCache(). A later PR will improve this.
- Fleshed out migration guide for APIs that are deprecated because they are not compatible with configuration cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
