### PR TITLE
Make `expectDocumentedDeprecationWarning` less error-prone

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
@@ -51,7 +51,7 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
             }""".stripIndent()
 
         expect:
-        executer.expectDocumentedDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
+        executer.expectDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
         succeeds("outgoingVariants")
     }
 
@@ -91,7 +91,7 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds("outgoingVariants")
-        executer.expectDocumentedDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
+        executer.expectDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
         outputContains("org.gradle:sample:1.0 (default capability)")
     }
 
@@ -136,7 +136,7 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         succeeds("outgoingVariants")
-        executer.expectDocumentedDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
+        executer.expectDeprecationWarning("Consumable configurations with identical capabilities within a project must have unique attributes, but configuration ':sample2' and configuration ':sample1' contain identical attribute sets.")
         outputContains("org.gradle:sample:1.0 (default capability)")
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1443,7 +1443,13 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
 
     @Override
     public GradleExecuter expectDocumentedDeprecationWarning(String warning) {
-        return expectDeprecationWarning(warning.replace("https://docs.gradle.org/current/", "https://docs.gradle.org/" + GradleVersion.current().getVersion() + "/"));
+        String pattern = "https://docs.gradle.org/current/";
+        String replacement = "https://docs.gradle.org/" + GradleVersion.current().getVersion() + "/";
+        String expectedWarning = warning.replace(pattern, replacement);
+        if (warning.equals(expectedWarning)) {
+            throw new IllegalArgumentException("Documented deprecation warning must reference '" + pattern + "'.");
+        }
+        return expectDeprecationWarning(expectedWarning);
     }
 
     @Override

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskIntegrationTest.groovy
@@ -311,7 +311,7 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             }
         """.stripIndent()
 
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
 
         expect:
         succeeds("test", "verifyTestOptions", "--warn")
@@ -348,7 +348,7 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             }
         """.stripIndent()
 
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
 
         when:
         succeeds("test", "verifyTestOptions", "--warn")
@@ -386,7 +386,7 @@ class TestTaskIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             }
         """.stripIndent()
 
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated.")
 
         expect:
         succeeds("test", "verifyTestOptions", "--warn")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -434,7 +434,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
             check.dependsOn testing.suites
         """
 
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
 
         expect:
         succeeds("check")
@@ -473,8 +473,8 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
-        executer.expectDocumentedDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
+        executer.expectDeprecationWarning("Accessing test options prior to setting test framework has been deprecated. This is scheduled to be removed in Gradle 8.0.")
 
         when:
         succeeds( "test")


### PR DESCRIPTION
By asserting the given warning references the right url.