### PR TITLE
Improve SmokeContinuousIntegrationTest

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -61,7 +61,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         inputFile.text = "second"
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputFile.text == "second"
     }
 
@@ -114,13 +114,13 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye World")
 
         when:
         mainSource.text = mainSource.text.replace("World", "Friend")
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye Friend")
     }
 
@@ -175,7 +175,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         pluginSource.text = pluginSource.text.replace("Hello", "Goodbye")
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye World")
 
         cleanup:
@@ -249,21 +249,21 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye First")
         outputContains("Goodbye Second")
 
         when:
         mainSourceSub1.text = mainSourceSub1.text.replace("First", '1st')
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye 1st")
         outputContains("Goodbye Second")
 
         when:
         mainSourceSub2.text = mainSourceSub2.text.replace("Second", '2nd')
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("Goodbye 1st")
         outputContains("Goodbye 2nd")
     }

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeContinuousBuildIntegrationTest.groovy
@@ -61,7 +61,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         inputFile.text = "second"
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputFile.text == "second"
     }
 
@@ -114,13 +114,13 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye World")
 
         when:
         mainSource.text = mainSource.text.replace("World", "Friend")
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye Friend")
     }
 
@@ -175,7 +175,7 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         pluginSource.text = pluginSource.text.replace("Hello", "Goodbye")
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye World")
 
         cleanup:
@@ -249,21 +249,21 @@ class CompositeContinuousBuildIntegrationTest extends AbstractContinuousIntegrat
         when:
         librarySource.text = librarySource.text.replace("Hello", "Goodbye")
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye First")
         outputContains("Goodbye Second")
 
         when:
         mainSourceSub1.text = mainSourceSub1.text.replace("First", '1st')
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye 1st")
         outputContains("Goodbye Second")
 
         when:
         mainSourceSub2.text = mainSourceSub2.text.replace("Second", '2nd')
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("Goodbye 1st")
         outputContains("Goodbye 2nd")
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
@@ -41,7 +41,7 @@ class BuildOperationNotificationContinuousBuildIntegrationTest extends AbstractC
         file("src/main/java/Thing.java").text = "class Thing {\n\n}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         def run2 = notifications.op(RunBuildBuildOperationType.Details)
 
         and:

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
@@ -41,7 +41,7 @@ class BuildOperationNotificationContinuousBuildIntegrationTest extends AbstractC
         file("src/main/java/Thing.java").text = "class Thing {\n\n}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         def run2 = notifications.op(RunBuildBuildOperationType.Details)
 
         and:

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ContinuousScopeIdsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ContinuousScopeIdsIntegrationTest.groovy
@@ -87,14 +87,14 @@ class ContinuousScopeIdsIntegrationTest extends AbstractContinuousIntegrationTes
         update(i1, "2")
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         afterBuild()
 
         when:
         update(i2, "2")
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         afterBuild()
 
         and:

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ContinuousScopeIdsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scopeids/ContinuousScopeIdsIntegrationTest.groovy
@@ -87,14 +87,14 @@ class ContinuousScopeIdsIntegrationTest extends AbstractContinuousIntegrationTes
         update(i1, "2")
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         afterBuild()
 
         when:
         update(i2, "2")
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         afterBuild()
 
         and:

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
@@ -61,7 +61,7 @@ class ContinuousBuildFileWatchingIntegrationTest extends AbstractContinuousInteg
         sourceFile.text = "class Thing { public void doStuff() {} }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         vfsLogs.getRetainedFilesSinceLastBuild() >= numberOfFilesInVfs - 1
         vfsLogs.getRetainedFilesInCurrentBuild() >= numberOfFilesInVfs
         executedAndNotSkipped(":compileJava")

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ContinuousBuildFileWatchingIntegrationTest.groovy
@@ -61,7 +61,7 @@ class ContinuousBuildFileWatchingIntegrationTest extends AbstractContinuousInteg
         sourceFile.text = "class Thing { public void doStuff() {} }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         vfsLogs.getRetainedFilesSinceLastBuild() >= numberOfFilesInVfs - 1
         vfsLogs.getRetainedFilesInCurrentBuild() >= numberOfFilesInVfs
         executedAndNotSkipped(":compileJava")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -103,7 +103,7 @@ abstract class AbstractContinuousIntegrationTest extends AbstractIntegrationSpec
         result
     }
 
-    protected ExecutionResult successfulBuildTriggered() {
+    protected ExecutionResult buildTriggeredAndSucceeded() {
         if (!gradle.isRunning()) {
             throw new UnexpectedBuildFailure("Gradle has exited")
         }
@@ -131,7 +131,7 @@ ${result.error}
         return extractFailure()
     }
 
-    ExecutionFailure failingBuildTriggered() {
+    ExecutionFailure buildTriggeredAndFailed() {
         if (!gradle.isRunning()) {
             throw new UnexpectedBuildFailure("Gradle has exited")
         }

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -77,7 +77,7 @@ abstract class AbstractCompilerContinuousIntegrationTest extends AbstractContinu
         inputFile.text = changedSourceContent
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         and:
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -77,7 +77,7 @@ abstract class AbstractCompilerContinuousIntegrationTest extends AbstractContinu
         inputFile.text = changedSourceContent
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         and:
         def compilerDaemonSets = compilerDaemonIdentityFile.readLines()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -54,7 +54,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         subDir.file("B").text = "B"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":zip")
         outputFile.exists()
         outputFile.unzipTo(unpackDir)
@@ -64,7 +64,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         sourceDir.file("newdir").createDir()
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":zip")
     }
 
@@ -107,7 +107,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         packDir."$packType"(sourceFile, readonly)
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":unpack")
         outputDir.file("A").text == "original"
         outputDir.file("B").text == "new-file"
@@ -152,7 +152,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         packDir."$packType"(sourceFile)
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":unpack")
         outputDir.file("A").text == "original-changed"
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ArchivesContinuousIntegrationTest.groovy
@@ -54,7 +54,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         subDir.file("B").text = "B"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":zip")
         outputFile.exists()
         outputFile.unzipTo(unpackDir)
@@ -64,7 +64,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         sourceDir.file("newdir").createDir()
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":zip")
     }
 
@@ -107,7 +107,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         packDir."$packType"(sourceFile, readonly)
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":unpack")
         outputDir.file("A").text == "original"
         outputDir.file("B").text == "new-file"
@@ -152,7 +152,7 @@ class ArchivesContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         packDir."$packType"(sourceFile)
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":unpack")
         outputDir.file("A").text == "original-changed"
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
@@ -60,7 +60,7 @@ class BuildSessionServiceReuseContinuousIntegrationTest extends AbstractContinuo
         triggerFile << "change"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         and:
         def ids = idFile.readLines()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
@@ -60,7 +60,7 @@ class BuildSessionServiceReuseContinuousIntegrationTest extends AbstractContinuo
         triggerFile << "change"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         and:
         def ids = idFile.readLines()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -54,7 +54,7 @@ class BuildSrcContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         """
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains "value: changed"
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSrcContinuousIntegrationTest.groovy
@@ -54,7 +54,7 @@ class BuildSrcContinuousIntegrationTest extends AbstractContinuousIntegrationTes
         """
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains "value: changed"
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/CancellationContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/CancellationContinuousIntegrationTest.groovy
@@ -86,7 +86,7 @@ class CancellationContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("src/main/java/Thing.java") << "class Thing {}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
     }
 
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/CancellationContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/CancellationContinuousIntegrationTest.groovy
@@ -86,7 +86,7 @@ class CancellationContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("src/main/java/Thing.java") << "class Thing {}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
     }
 
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -219,7 +219,7 @@ jar.dependsOn postCompile
 
         then:
         if (shouldTrigger) {
-            fails()
+            failingBuildTriggered()
         } else {
             noBuildTriggered()
         }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ChangesDuringBuildContinuousIntegrationTest.groovy
@@ -219,7 +219,7 @@ jar.dependsOn postCompile
 
         then:
         if (shouldTrigger) {
-            failingBuildTriggered()
+            buildTriggeredAndFailed()
         } else {
             noBuildTriggered()
         }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildCancellationIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildCancellationIntegrationTest.groovy
@@ -93,7 +93,7 @@ class ContinuousBuildCancellationIntegrationTest extends AbstractContinuousInteg
         when:
         for (int i = 0; i < 3; i++) {
             testfile << '// changed'
-            succeeds()
+            successfulBuildTriggered()
         }
         and:
         sendEOT()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildCancellationIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildCancellationIntegrationTest.groovy
@@ -93,7 +93,7 @@ class ContinuousBuildCancellationIntegrationTest extends AbstractContinuousInteg
         when:
         for (int i = 0; i < 3; i++) {
             testfile << '// changed'
-            successfulBuildTriggered()
+            buildTriggeredAndSucceeded()
         }
         and:
         sendEOT()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -20,8 +20,8 @@ import groovy.transform.TupleConstructor
 import org.gradle.integtests.fixtures.AbstractContinuousIntegrationTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.Flaky
+import org.gradle.test.fixtures.file.TestFile
 
 import static org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory.QUIET_PERIOD_SYSPROP
 import static org.gradle.internal.filewatch.DefaultFileWatcherEventListener.SHOW_INDIVIDUAL_CHANGES_LIMIT
@@ -53,7 +53,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFile.text = 'New input file'
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges([new ChangeEntry('new file', inputFile)])
     }
@@ -66,7 +66,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'New input file' }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('new file', it) })
     }
@@ -79,7 +79,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'New input file' }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('new file', it) }, true)
     }
@@ -95,7 +95,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.delete() }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('deleted', it) }, expectMoreChanges)
 
@@ -114,7 +114,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'File modified' }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('modified', it) }, expectMoreChanges)
 
@@ -133,7 +133,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputDirectories.each { it.mkdir() }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputDirectories.collect { new ChangeEntry('new directory', it) }, expectMoreChanges)
 
@@ -152,7 +152,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputDirectories.each { it.delete() }
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges(inputDirectories.collect { new ChangeEntry('deleted', it) }, expectMoreChanges)
 
@@ -175,7 +175,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         newfile2.text = 'New Input file'
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges([new ChangeEntry("new file", newfile1), new ChangeEntry("modified", inputFiles[2]), new ChangeEntry("deleted", inputFiles[7]), new ChangeEntry("new file", newfile2)], true)
     }
@@ -216,7 +216,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFile.text = 'New input file'
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         sendEOT()
         assertReportsChanges([new ChangeEntry('new file', inputFile)])
     }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -53,7 +53,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFile.text = 'New input file'
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges([new ChangeEntry('new file', inputFile)])
     }
@@ -66,7 +66,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'New input file' }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('new file', it) })
     }
@@ -79,7 +79,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'New input file' }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('new file', it) }, true)
     }
@@ -95,7 +95,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.delete() }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('deleted', it) }, expectMoreChanges)
 
@@ -114,7 +114,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFiles.each { it.text = 'File modified' }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputFiles.collect { new ChangeEntry('modified', it) }, expectMoreChanges)
 
@@ -133,7 +133,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputDirectories.each { it.mkdir() }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputDirectories.collect { new ChangeEntry('new directory', it) }, expectMoreChanges)
 
@@ -152,7 +152,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputDirectories.each { it.delete() }
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges(inputDirectories.collect { new ChangeEntry('deleted', it) }, expectMoreChanges)
 
@@ -175,7 +175,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         newfile2.text = 'New Input file'
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges([new ChangeEntry("new file", newfile1), new ChangeEntry("modified", inputFiles[2]), new ChangeEntry("deleted", inputFiles[7]), new ChangeEntry("new file", newfile2)], true)
     }
@@ -216,7 +216,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         inputFile.text = 'New input file'
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         sendEOT()
         assertReportsChanges([new ChangeEntry('new file', inputFile)])
     }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildGateIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildGateIntegrationTest.groovy
@@ -78,21 +78,21 @@ class ContinuousBuildGateIntegrationTest extends AbstractContinuousIntegrationTe
             class SimpleTask extends DefaultTask {
                 @InputFile
                 File inputFile = project.file("input.txt")
-                
+
                 @OutputFile
                 File outputFile = new File(project.buildDir, "output.txt")
-                
+
                 @TaskAction
                 void generate() {
                     outputFile.text = inputFile.text
-                } 
+                }
             }
-            
+
             def pendingChangesManager = gradle.services.get(${PendingChangesManager.canonicalName})
             pendingChangesManager.addListener new ${SingleFirePendingChangesListener.canonicalName}({
                 ${server.callFromBuild("pending")}
             } as ${PendingChangesListener.canonicalName})
-            
+
             task work(type: SimpleTask)
         """
 
@@ -124,7 +124,7 @@ class ContinuousBuildGateIntegrationTest extends AbstractContinuousIntegrationTe
         server.expect(server.get("command").send("stop"))
         then:
         // waits for build to start and finish
-        succeeds()
+        successfulBuildTriggered()
         // Change has been incorporated
         outputFile.text == "changed"
     }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildGateIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildGateIntegrationTest.groovy
@@ -124,7 +124,7 @@ class ContinuousBuildGateIntegrationTest extends AbstractContinuousIntegrationTe
         server.expect(server.get("command").send("stop"))
         then:
         // waits for build to start and finish
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         // Change has been incorporated
         outputFile.text == "changed"
     }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ContinuousWorkerDaemonServiceIntegrationTest extends AbstractContinuousInt
         triggerNewBuild()
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         and:
         outputContains("Runnable executed...")

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousWorkerDaemonServiceIntegrationTest.groovy
@@ -47,7 +47,7 @@ class ContinuousWorkerDaemonServiceIntegrationTest extends AbstractContinuousInt
         triggerNewBuild()
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         and:
         outputContains("Runnable executed...")

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/DeploymentContinuousBuildIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/DeploymentContinuousBuildIntegrationTest.groovy
@@ -56,7 +56,7 @@ class DeploymentContinuousBuildIntegrationTest extends AbstractContinuousIntegra
         def lastBuildTime = single(buildTimes)
         waitBeforeModification fixture.triggerFile
         fixture.triggerFile << "\n#a change"
-        succeeds()
+        successfulBuildTriggered()
 
         then:
         fixture.assertDeploymentIsRunning(key)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/DeploymentContinuousBuildIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/DeploymentContinuousBuildIntegrationTest.groovy
@@ -56,7 +56,7 @@ class DeploymentContinuousBuildIntegrationTest extends AbstractContinuousIntegra
         def lastBuildTime = single(buildTimes)
         waitBeforeModification fixture.triggerFile
         fixture.triggerFile << "\n#a change"
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         then:
         fixture.assertDeploymentIsRunning(key)

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
@@ -56,7 +56,7 @@ class GradleBuildContinuousIntegrationTest extends AbstractContinuousIntegration
         when:
         file("gradle-build/inputs/input.txt").text = "second"
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputFile.text == "second"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/GradleBuildContinuousIntegrationTest.groovy
@@ -56,7 +56,7 @@ class GradleBuildContinuousIntegrationTest extends AbstractContinuousIntegration
         when:
         file("gradle-build/inputs/input.txt").text = "second"
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputFile.text == "second"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
@@ -52,14 +52,14 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream { int change = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":upstream:compileJava", ":downstream:compileJava"
 
         when:
         downstreamSource.text = "class Downstream extends Upstream { int change = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":downstream:compileJava"
         skipped ":upstream:compileJava"
 
@@ -67,7 +67,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream {"
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
 
         when:
         downstreamSource.text = "class Downstream extends Upstream { int change = 11; }"
@@ -80,7 +80,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream {}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":upstream:compileJava", ":downstream:compileJava"
     }
 
@@ -117,7 +117,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("A").text = "A"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":a", ":upstream:a", ":downstream:a")
 
         expect:
@@ -129,7 +129,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("B").text = "B"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":downstream:a")
     }
 
@@ -155,21 +155,21 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         downstreamSource.text = "class Downstream extends Upstream { int change = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         skipped extraCompileTasks
 
         when:
         upstreamSource.text = "class Upstream { int change = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped extraCompileTasks
 
         when:
         file("${anExtraProjectName}/src/main/java/Thing.java").text = "class Thing extends Upstream{ int change = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":$anExtraProjectName:compileJava"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/MultiProjectContinuousIntegrationTest.groovy
@@ -52,14 +52,14 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream { int change = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":upstream:compileJava", ":downstream:compileJava"
 
         when:
         downstreamSource.text = "class Downstream extends Upstream { int change = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":downstream:compileJava"
         skipped ":upstream:compileJava"
 
@@ -67,7 +67,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream {"
 
         then:
-        fails()
+        failingBuildTriggered()
 
         when:
         downstreamSource.text = "class Downstream extends Upstream { int change = 11; }"
@@ -80,7 +80,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         upstreamSource.text = "class Upstream {}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":upstream:compileJava", ":downstream:compileJava"
     }
 
@@ -117,7 +117,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("A").text = "A"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":a", ":upstream:a", ":downstream:a")
 
         expect:
@@ -129,7 +129,7 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         file("B").text = "B"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":downstream:a")
     }
 
@@ -155,21 +155,21 @@ class MultiProjectContinuousIntegrationTest extends AbstractContinuousIntegratio
         downstreamSource.text = "class Downstream extends Upstream { int change = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         skipped extraCompileTasks
 
         when:
         upstreamSource.text = "class Upstream { int change = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped extraCompileTasks
 
         when:
         file("${anExtraProjectName}/src/main/java/Thing.java").text = "class Thing extends Upstream{ int change = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":$anExtraProjectName:compileJava"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
@@ -60,7 +60,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
 
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":compileJava")
         executed(":build")
     }
@@ -90,7 +90,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile << "*/"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
     }
 
     def "can run tests"() {
@@ -107,7 +107,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "class Thing { static public int FLAG = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":compileJava", ":compileTestJava", ":test")
         skipped(":processResources")
 
@@ -115,7 +115,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         testFile.text = "class TestThing extends Thing { static public int FLAG = 1; }"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":compileTestJava", ":test")
         skipped(":processResources", ":compileJava")
 
@@ -123,7 +123,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         resourceFile << "# another change"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":processResources", ":test")
         skipped(":compileJava", ":compileTestJava")
     }
@@ -140,14 +140,14 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         testSourceFile << " broken "
 
         then:
-        fails()
+        failingBuildTriggered()
         failureDescriptionStartsWith("Execution failed for task ':compileTestJava'.")
 
         when:
         sourceFile << " broken "
 
         then:
-        fails()
+        failingBuildTriggered()
         failureDescriptionStartsWith("Execution failed for task ':compileJava'.")
 
         when:
@@ -160,7 +160,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "class Thing {}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
     }
 
     // Just exercises the dependency management layers to shake out any weirdness
@@ -184,7 +184,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "import org.apache.log4j.LogManager; class Thing {}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -209,21 +209,21 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         jarWithClasses(somelib, Thing: 'class Thing { public void foo () {} }')
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":compileJava"
 
         when:
         jarWithClasses(somelib, Thing: 'class Thing { public void bar() {} }')
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":compileJava"
 
         when:
         somelib.delete()
 
         then:
-        fails()
+        failingBuildTriggered()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -248,7 +248,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         anotherJar.delete()
 
         then:
-        fails()
+        failingBuildTriggered()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -262,7 +262,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         file("src/main/java/Thing.java") << "class Thing {}"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped ":compileJava"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
@@ -60,7 +60,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
 
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":compileJava")
         executed(":build")
     }
@@ -90,7 +90,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile << "*/"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
     }
 
     def "can run tests"() {
@@ -107,7 +107,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "class Thing { static public int FLAG = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":compileJava", ":compileTestJava", ":test")
         skipped(":processResources")
 
@@ -115,7 +115,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         testFile.text = "class TestThing extends Thing { static public int FLAG = 1; }"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":compileTestJava", ":test")
         skipped(":processResources", ":compileJava")
 
@@ -123,7 +123,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         resourceFile << "# another change"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":processResources", ":test")
         skipped(":compileJava", ":compileTestJava")
     }
@@ -140,14 +140,14 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         testSourceFile << " broken "
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         failureDescriptionStartsWith("Execution failed for task ':compileTestJava'.")
 
         when:
         sourceFile << " broken "
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         failureDescriptionStartsWith("Execution failed for task ':compileJava'.")
 
         when:
@@ -160,7 +160,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "class Thing {}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
     }
 
     // Just exercises the dependency management layers to shake out any weirdness
@@ -184,7 +184,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         sourceFile.text = "import org.apache.log4j.LogManager; class Thing {}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -209,21 +209,21 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         jarWithClasses(somelib, Thing: 'class Thing { public void foo () {} }')
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":compileJava"
 
         when:
         jarWithClasses(somelib, Thing: 'class Thing { public void bar() {} }')
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":compileJava"
 
         when:
         somelib.delete()
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -248,7 +248,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         anotherJar.delete()
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         executedAndNotSkipped ":compileJava"
     }
 
@@ -262,7 +262,7 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         file("src/main/java/Thing.java") << "class Thing {}"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped ":compileJava"
     }
 }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -100,7 +100,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task echo {
+            task build {
               inputs.files "marker"
               outputs.files "build/marker"
               doLast {
@@ -110,7 +110,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("echo")
+        succeeds("build")
         output.contains "value: original"
 
         when:
@@ -131,7 +131,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task echo {
+            task build {
               inputs.files "marker"
               outputs.files "build/marker"
               doLast {
@@ -142,7 +142,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
         then:
         executer.withArgument("-q")
-        succeeds("echo")
+        succeeds("build")
         output.contains "value: original"
 
         when:
@@ -285,7 +285,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task echo {
+            task build {
               inputs.files file("marker")
               outputs.files "build/marker"
               doLast {
@@ -300,7 +300,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("echo")
+        succeeds("build")
         output.contains "value: original"
         output.contains "reuse: false"
 
@@ -318,7 +318,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "considered to be long lived process"() {
         when:
         buildFile << """
-            task echo {
+            task build {
               doLast {
                 println "isLongLivingProcess: " + services.get($GradleBuildEnvironment.name).isLongLivingProcess()
               }
@@ -326,7 +326,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("echo")
+        succeeds("build")
         output.contains "isLongLivingProcess: true"
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -55,7 +55,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         waitBeforeModification(markerFile)
         markerFile.text = "created"
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "exists: true"
     }
 
@@ -82,7 +82,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         waitBeforeModification(markerFile)
         markerFile.text = "changed"
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "value: changed"
 
         where:
@@ -118,7 +118,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "value: changed"
     }
 
@@ -148,7 +148,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         includedFile.text = "changed"
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("includedFiles: 1")
 
         when:
@@ -159,13 +159,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         sources.file("sub/some/otherIncluded.txt").createFile()
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("includedFiles: 2")
 
         when:
         sources.file("sub/other/included.txt").createFile()
         then:
-        succeeds()
+        successfulBuildTriggered()
         outputContains("includedFiles: 3")
     }
 
@@ -197,7 +197,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "value: changed"
     }
 
@@ -233,7 +233,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.delete()
 
         then:
-        fails()
+        failingBuildTriggered()
         failure.assertHasCause "java.lang.Exception: file does not exist"
 
         when:
@@ -241,7 +241,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile << "changed"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "value: changed"
     }
 
@@ -272,7 +272,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile << "original"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executed(":a")
 
         and:
@@ -356,7 +356,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         output.contains "value: changed"
         output.contains "reuse: true"
 
@@ -446,7 +446,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         bFlag.text = "b executed"
         then:
-        fails()
+        failingBuildTriggered()
         failureDescriptionContains("Could not determine the dependencies of task ':b'.")
     }
 
@@ -477,13 +477,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         file("source/test.txt") << "foo"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         when:
         file("ancillary/test.txt") << "-bar"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
     }
 
     @Ignore("This goes into a continuous loop since .gradle files change")
@@ -518,7 +518,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.text = "A"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":a")
 
         when: "file is changed"
@@ -526,7 +526,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.text = "B"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":a")
 
         when:
@@ -534,7 +534,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.delete()
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":a")
     }
 
@@ -589,7 +589,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         topLevelFile.text = "hello"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":inner", ":outer")
 
         when: "file is changed"
@@ -597,7 +597,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         nestedFile.text = "B"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":outer")
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -122,7 +122,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         output.contains "value: changed"
     }
 
-    def "detects changes in filtered file trees"() {
+    def "detects changes in filtered file tree inputs"() {
         def sources = file("sources").createDir()
         def excludedFile = sources.file("sub/some/excluded").createFile()
         def includedFile = sources.file("sub/some/included.txt").createFile()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -55,7 +55,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         waitBeforeModification(markerFile)
         markerFile.text = "created"
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "exists: true"
     }
 
@@ -82,7 +82,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         waitBeforeModification(markerFile)
         markerFile.text = "changed"
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "value: changed"
 
         where:
@@ -118,7 +118,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "value: changed"
     }
 
@@ -148,7 +148,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         includedFile.text = "changed"
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("includedFiles: 1")
 
         when:
@@ -159,13 +159,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         sources.file("sub/some/otherIncluded.txt").createFile()
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("includedFiles: 2")
 
         when:
         sources.file("sub/other/included.txt").createFile()
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         outputContains("includedFiles: 3")
     }
 
@@ -197,7 +197,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "value: changed"
     }
 
@@ -233,7 +233,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.delete()
 
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         failure.assertHasCause "java.lang.Exception: file does not exist"
 
         when:
@@ -241,7 +241,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile << "changed"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "value: changed"
     }
 
@@ -272,7 +272,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile << "original"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executed(":a")
 
         and:
@@ -356,7 +356,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "changed"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         output.contains "value: changed"
         output.contains "reuse: true"
 
@@ -446,7 +446,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         bFlag.text = "b executed"
         then:
-        failingBuildTriggered()
+        buildTriggeredAndFailed()
         failureDescriptionContains("Could not determine the dependencies of task ':b'.")
     }
 
@@ -477,13 +477,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         file("source/test.txt") << "foo"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         when:
         file("ancillary/test.txt") << "-bar"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
     }
 
     @Ignore("This goes into a continuous loop since .gradle files change")
@@ -518,7 +518,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.text = "A"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":a")
 
         when: "file is changed"
@@ -526,7 +526,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.text = "B"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":a")
 
         when:
@@ -534,7 +534,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         aFile.delete()
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":a")
     }
 
@@ -589,7 +589,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         topLevelFile.text = "hello"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":inner", ":outer")
 
         when: "file is changed"
@@ -597,7 +597,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         nestedFile.text = "B"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":outer")
     }
 

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -94,17 +94,17 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     @ToBeFixedForConfigurationCache
     def "basic smoke test"() {
         given:
-        def markerFile = file("marker")
+        def markerFile = file("input/marker")
 
         when:
         markerFile.text = "original"
 
         buildFile << """
             task build {
-              inputs.files "marker"
+              inputs.files "input/marker"
               outputs.files "build/marker"
               doLast {
-                println "value: " + file("marker").text
+                println "value: " + file("input/marker").text
               }
             }
         """
@@ -125,17 +125,17 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     @ToBeFixedForConfigurationCache
     def "notifications work with quiet logging"() {
         given:
-        def markerFile = file("marker")
+        def markerFile = file("input/marker")
 
         when:
         markerFile.text = "original"
 
         buildFile << """
             task build {
-              inputs.files "marker"
+              inputs.files "input/marker"
               outputs.files "build/marker"
               doLast {
-                println "value: " + file("marker").text
+                println "value: " + file("input/marker").text
               }
             }
         """
@@ -156,13 +156,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
     def "can recover from build failure"() {
         given:
-        def markerFile = file("marker")
+        def markerFile = file("input/marker")
         file("inputFile").createFile()
 
         when:
         buildFile << """
             task build {
-              def f = file("marker")
+              def f = file("input/marker")
               inputs.files f
               inputs.files "inputFile"
               outputs.files "build/marker"
@@ -279,17 +279,17 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     @ToBeFixedForConfigurationCache
     def "reuses build script classes"() {
         given:
-        def markerFile = file("marker")
+        def markerFile = file("input/marker")
 
         when:
         markerFile.text = "original"
 
         buildFile << """
             task build {
-              inputs.files file("marker")
+              inputs.files file("input/marker")
               outputs.files "build/marker"
               doLast {
-                println "value: " + file("marker").text
+                println "value: " + file("input/marker").text
                 println "reuse: " + Reuse.initialized
                 Reuse.initialized = true
               }

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -36,7 +36,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         given:
         def markerFile = file("input/marker")
         buildFile << """
-            task build {
+            task myTask {
               def inputFile = file("input/marker")
               inputs.files inputFile
               outputs.files "build/marker"
@@ -47,7 +47,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         when:
-        succeeds("build")
+        succeeds("myTask")
         then:
         output.contains "exists: false"
 
@@ -63,7 +63,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         given:
         def markerFile = file("input/marker")
         buildFile << """
-            task build {
+            task myTask {
               def inputFile = file("input/marker")
               inputs.files inputFile
               doLast {
@@ -74,7 +74,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
         when:
         markerFile.text = "original"
-        succeeds("build")
+        succeeds("myTask")
         then:
         output.contains "value: original"
 
@@ -100,7 +100,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task build {
+            task myTask {
               inputs.files "input/marker"
               outputs.files "build/marker"
               doLast {
@@ -110,7 +110,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("build")
+        succeeds("myTask")
         output.contains "value: original"
 
         when:
@@ -128,7 +128,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         def includedFile = sources.file("sub/some/included.txt").createFile()
 
         buildFile << """
-            task build {
+            task myTask {
               def inputFileTree = fileTree("sources").include("**/*.txt")
               inputs.files(inputFileTree)
                 .ignoreEmptyDirectories()
@@ -141,7 +141,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         when:
-        succeeds("build")
+        succeeds("myTask")
         then:
         outputContains("includedFiles: 1")
 
@@ -178,7 +178,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task build {
+            task myTask {
               inputs.files "input/marker"
               outputs.files "build/marker"
               doLast {
@@ -189,7 +189,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
         then:
         executer.withArgument("-q")
-        succeeds("build")
+        succeeds("myTask")
         output.contains "value: original"
 
         when:
@@ -208,7 +208,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
         when:
         buildFile << """
-            task build {
+            task myTask {
               def f = file("input/marker")
               inputs.files f
               inputs.files "inputFile"
@@ -225,7 +225,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile << "original"
 
         then:
-        succeeds "build"
+        succeeds "myTask"
         output.contains "value: original"
 
         when:
@@ -332,7 +332,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         markerFile.text = "original"
 
         buildFile << """
-            task build {
+            task myTask {
               inputs.files file("input/marker")
               outputs.files "build/marker"
               doLast {
@@ -347,7 +347,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("build")
+        succeeds("myTask")
         output.contains "value: original"
         output.contains "reuse: false"
 
@@ -365,7 +365,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "considered to be long lived process"() {
         when:
         buildFile << """
-            task build {
+            task myTask {
               doLast {
                 println "isLongLivingProcess: " + services.get($GradleBuildEnvironment.name).isLongLivingProcess()
               }
@@ -373,7 +373,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("build")
+        succeeds("myTask")
         output.contains "isLongLivingProcess: true"
     }
 
@@ -454,7 +454,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         when:
         file("source").createDir()
         buildScript """
-            task build {
+            task myTask {
               inputs.files(fileTree("source"))
                 .skipWhenEmpty()
                 .ignoreEmptyDirectories()
@@ -465,7 +465,7 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
         """
 
         then:
-        succeeds("build")
+        succeeds("myTask")
 
         when:
         file("ancillary/test.txt") << "foo"

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/jdk7/SymlinkContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/jdk7/SymlinkContinuousIntegrationTest.groovy
@@ -50,13 +50,13 @@ class SymlinkContinuousIntegrationTest extends AbstractContinuousIntegrationTest
         when: "symlink is deleted"
         symlink.delete()
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":echo")
         output.contains("text: missing")
         when: "symlink is created"
         Files.createSymbolicLink(Paths.get(symlink.toURI()), Paths.get(sourceFile.toURI()))
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         executedAndNotSkipped(":echo")
         output.contains("text: original")
         when: "changes made to target of symlink"
@@ -94,7 +94,7 @@ class SymlinkContinuousIntegrationTest extends AbstractContinuousIntegrationTest
         then:
         // OSX uses a polling implementation, so changes to links are detectable
         if (OperatingSystem.current().isMacOsX()) {
-            successfulBuildTriggered()
+            buildTriggeredAndSucceeded()
         } else {
             // Other OS's do not produce filesystem events for deleted symlinks
             noBuildTriggered()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/jdk7/SymlinkContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/jdk7/SymlinkContinuousIntegrationTest.groovy
@@ -50,13 +50,13 @@ class SymlinkContinuousIntegrationTest extends AbstractContinuousIntegrationTest
         when: "symlink is deleted"
         symlink.delete()
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":echo")
         output.contains("text: missing")
         when: "symlink is created"
         Files.createSymbolicLink(Paths.get(symlink.toURI()), Paths.get(sourceFile.toURI()))
         then:
-        succeeds()
+        successfulBuildTriggered()
         executedAndNotSkipped(":echo")
         output.contains("text: original")
         when: "changes made to target of symlink"
@@ -94,7 +94,7 @@ class SymlinkContinuousIntegrationTest extends AbstractContinuousIntegrationTest
         then:
         // OSX uses a polling implementation, so changes to links are detectable
         if (OperatingSystem.current().isMacOsX()) {
-            succeeds()
+            successfulBuildTriggered()
         } else {
             // Other OS's do not produce filesystem events for deleted symlinks
             noBuildTriggered()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
@@ -83,7 +83,7 @@ class JavaApplicationDeploymentIntegrationTest extends AbstractContinuousIntegra
         when:
         file("ready").delete()
         messageSrc.text = messageSrc.text.replace("APP", "NEW")
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         then:
         assertApplicationReady()
         assertLogHasMessage("[NEW] > Hello, World!")
@@ -103,7 +103,7 @@ class JavaApplicationDeploymentIntegrationTest extends AbstractContinuousIntegra
 
         when:
         messageSrc.text = messageSrc.text.replace("APP", "NEW")
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
         then:
         assertLogDoesNotHasMessage("[NEW] > Hello, World!")
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/internal/deployment/JavaApplicationDeploymentIntegrationTest.groovy
@@ -83,7 +83,7 @@ class JavaApplicationDeploymentIntegrationTest extends AbstractContinuousIntegra
         when:
         file("ready").delete()
         messageSrc.text = messageSrc.text.replace("APP", "NEW")
-        succeeds()
+        successfulBuildTriggered()
         then:
         assertApplicationReady()
         assertLogHasMessage("[NEW] > Hello, World!")
@@ -103,7 +103,7 @@ class JavaApplicationDeploymentIntegrationTest extends AbstractContinuousIntegra
 
         when:
         messageSrc.text = messageSrc.text.replace("APP", "NEW")
-        succeeds()
+        successfulBuildTriggered()
         then:
         assertLogDoesNotHasMessage("[NEW] > Hello, World!")
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/external/PlayExternalContinuousBuildIntegrationTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/external/PlayExternalContinuousBuildIntegrationTest.groovy
@@ -41,19 +41,19 @@ class PlayExternalContinuousBuildIntegrationTest extends AbstractMultiVersionPla
         file("conf/routes") << "\n# changed"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         when:
         file("conf/routes") << "\n# changed again"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         when:
         file("conf/routes") << "\n# changed yet again"
 
         then:
-        succeeds()
+        successfulBuildTriggered()
     }
 
     def "build failure prior to launch does not prevent launch on subsequent build" () {
@@ -70,7 +70,7 @@ class PlayExternalContinuousBuildIntegrationTest extends AbstractMultiVersionPla
         file("app/controllers/Application.scala").text = original
 
         then:
-        succeeds()
+        successfulBuildTriggered()
 
         and:
         appIsRunningAndDeployed()

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/external/PlayExternalContinuousBuildIntegrationTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/play/integtest/external/PlayExternalContinuousBuildIntegrationTest.groovy
@@ -41,19 +41,19 @@ class PlayExternalContinuousBuildIntegrationTest extends AbstractMultiVersionPla
         file("conf/routes") << "\n# changed"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         when:
         file("conf/routes") << "\n# changed again"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         when:
         file("conf/routes") << "\n# changed yet again"
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
     }
 
     def "build failure prior to launch does not prevent launch on subsequent build" () {
@@ -70,7 +70,7 @@ class PlayExternalContinuousBuildIntegrationTest extends AbstractMultiVersionPla
         file("app/controllers/Application.scala").text = original
 
         then:
-        successfulBuildTriggered()
+        buildTriggeredAndSucceeded()
 
         and:
         appIsRunningAndDeployed()


### PR DESCRIPTION
In a preparation for continuous build using the new file system watching this is a rework of `SmokeContinuousIntegrationTest`. The main goal is that
- Most tests continue working with the new continuous build
- There are specific tests which show what doesn't work with the new continuous build.

The main difference is that tasks which we are supposed to be watching need to snapshot their inputs, and that we won't watch a project directory if it only contains missing files.