### PR TITLE
Add Shared Build Services to docs navigation, also rename Advance Techniques to Other Developing Gradle Topics

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -183,7 +183,7 @@
                     <li><a href="../userguide/authoring_maintainable_build_scripts.html">Following Best Practices</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-tasks" aria-expanded="false" aria-controls="advanced-techniques">Developing Gradle Tasks</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-tasks" aria-expanded="false" aria-controls="developing-gradle-tasks">Developing Gradle Tasks</a>
                 <ul id="developing-tasks">
                     <li><a href="../userguide/more_about_tasks.html">Authoring Tasks</a></li>
                     <li><a href="../userguide/custom_tasks.html">Writing Gradle Task Types</a></li>
@@ -192,7 +192,7 @@
                     <li><a href="../userguide/worker_api.html">Developing Parallel Tasks</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#publishing" aria-expanded="false" aria-controls="developing-plugins">Developing Gradle Plugins</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-gradle-plugins" aria-expanded="false" aria-controls="developing-plugins">Developing Gradle Plugins</a>
                 <ul id="developing-plugins">
                     <li><a href="../userguide/custom_plugins.html">Starting Plugin Development</a></li>
                     <li><a href="../userguide/designing_gradle_plugins.html">Designing Plugins</a></li>
@@ -201,9 +201,10 @@
                     <li><a href="../userguide/publishing_gradle_plugins.html">Publishing Plugins</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#advanced-techniques" aria-expanded="false" aria-controls="advanced-techniques">Advanced Techniques</a>
-                <ul id="advanced-techniques">
-                    <li><a href="../userguide/custom_gradle_types.html">Writing Custom Gradle Types</a></li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#other-developing-gradle-topics" aria-expanded="false" aria-controls="other-developing-gradle-topics">Other Developing Gradle Topics</a>
+                <ul id="other-developing-gradle-topics">
+                    <li><a href="../userguide/custom_gradle_types.html">Writing Custom Gradle Types and Service Injection</a></li>
+                    <li><a href="../userguide/build_services.html">Shared Build Services</a></li>
                     <li><a href="../userguide/test_kit.html">Testing a Build with TestKit</a></li>
                     <li><a href="../userguide/ant.html">Using Ant from Gradle</a></li>
                 </ul>

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -183,7 +183,7 @@
                     <li><a href="../userguide/authoring_maintainable_build_scripts.html">Following Best Practices</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-tasks" aria-expanded="false" aria-controls="developing-gradle-tasks">Developing Gradle Tasks</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-tasks" aria-expanded="false" aria-controls="developing-tasks">Developing Gradle Tasks</a>
                 <ul id="developing-tasks">
                     <li><a href="../userguide/more_about_tasks.html">Authoring Tasks</a></li>
                     <li><a href="../userguide/custom_tasks.html">Writing Gradle Task Types</a></li>
@@ -192,7 +192,7 @@
                     <li><a href="../userguide/worker_api.html">Developing Parallel Tasks</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-gradle-plugins" aria-expanded="false" aria-controls="developing-plugins">Developing Gradle Plugins</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#developing-plugins" aria-expanded="false" aria-controls="developing-plugins">Developing Gradle Plugins</a>
                 <ul id="developing-plugins">
                     <li><a href="../userguide/custom_plugins.html">Starting Plugin Development</a></li>
                     <li><a href="../userguide/designing_gradle_plugins.html">Designing Plugins</a></li>
@@ -201,8 +201,8 @@
                     <li><a href="../userguide/publishing_gradle_plugins.html">Publishing Plugins</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#other-developing-gradle-topics" aria-expanded="false" aria-controls="other-developing-gradle-topics">Other Developing Gradle Topics</a>
-                <ul id="other-developing-gradle-topics">
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#other-developing-topics" aria-expanded="false" aria-controls="other-developing-topics">Other Developing Gradle Topics</a>
+                <ul id="other-developing-topics">
                     <li><a href="../userguide/custom_gradle_types.html">Writing Custom Gradle Types and Service Injection</a></li>
                     <li><a href="../userguide/build_services.html">Shared Build Services</a></li>
                     <li><a href="../userguide/test_kit.html">Testing a Build with TestKit</a></li>


### PR DESCRIPTION
I noticed I can't find Shared Build Services without a search. So maybe it makes sense to add it to the navigation.

I also renamed:
- `Advanced Techniques` to `Other Developing Gradle Topics`: It's not perfect, but advanced techniques sound scary to me: If I were using Gradle the first time, I would not check this, since I would not feel "advanced enough". Also, I wanted to have it somehow related to `Developing Gradle Tasks` and `Developing Gradle Plugins`. 
- `Writing Custom Gradle Types` to `Writing Custom Gradle Types and Service Injection` since I think service injection is an important topic and hard to discover otherwise

WDYT?

Before:
<img width="260" alt="Screenshot 2021-12-24 at 12 25 10" src="https://user-images.githubusercontent.com/3939893/147349243-57445e81-68d5-43fe-b36d-48182081a142.png">

After:
<img width="256" alt="Screenshot 2021-12-24 at 12 55 41" src="https://user-images.githubusercontent.com/3939893/147350729-8e4b2e07-59df-40b7-b883-57c07a8389a2.png">


