### PR TITLE
Enforce naming pattern for version catalogs

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/CatalogPluginsKotlinDSLIntegrationTest.groovy
@@ -52,7 +52,7 @@ dependencyResolutionManagement {
         create("libs") {
             plugin("$alias", "com.acme.greeter").version("1.5")
         }
-        create("other") {
+        create("otherLibs") {
             plugin("$alias", "com.acme.greeter").version("1.5")
         }
     }
@@ -60,7 +60,7 @@ dependencyResolutionManagement {
         buildFile.renameTo(file('fixture.gradle'))
         buildKotlinFile << """
             plugins {
-                alias(other.plugins.${alias.replace('-', '.')})
+                alias(otherLibs.plugins.${alias.replace('-', '.')})
             }
 
             apply(from="fixture.gradle")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -566,14 +566,14 @@ my-lib = {group = "org.gradle.test", name="lib", version.require="1.0"}
         def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.0").publish()
         settingsFile << """
             dependencyResolutionManagement {
-                defaultLibrariesExtensionName = 'libraries'
+                defaultLibrariesExtensionName = 'myLibs'
             }
         """
         buildFile << """
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libraries.my.lib
+                implementation myLibs.my.lib
             }
         """
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -541,7 +541,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
-                    libraries {
+                    myLibs {
                         library("myLib", "org.gradle.test", "lib").version {
                             require "1.0"
                         }
@@ -554,7 +554,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libraries.myLib
+                implementation myLibs.myLib
             }
         """
 
@@ -577,12 +577,12 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
-                    libraries {
+                    myLibs {
                         library("myLib", "org.gradle.test", "lib").version {
                             require "1.0"
                         }
                     }
-                    other {
+                    otherLibs {
                         library("great", "org.gradle.test", "lib2").version {
                             require "1.1"
                         }
@@ -596,8 +596,8 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libraries.myLib
-                implementation other.great
+                implementation myLibs.myLib
+                implementation otherLibs.great
             }
         """
 
@@ -625,12 +625,12 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         settingsFile << """
             dependencyResolutionManagement {
                 versionCatalogs {
-                    libraries {
+                    myLibs {
                         library("myLib", "org.gradle.test", "lib").version {
                             require "1.0"
                         }
                     }
-                    other {
+                    otherLibs {
                         library("myLib", "org.gradle.test", "lib").version {
                             require "1.0"
                         }
@@ -643,8 +643,8 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             apply plugin: 'java-library'
 
             dependencies {
-                implementation libraries.myLib
-                implementation other.myLib
+                implementation myLibs.myLib
+                implementation otherLibs.myLib
             }
         """
 
@@ -661,6 +661,44 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                 module('org.gradle.test:lib:1.0')
             }
         }
+    }
+
+    def "nags when not using a library name ending with 'Libs'"() {
+        settingsFile << """
+            dependencyResolutionManagement {
+                versionCatalogs {
+                    notLibsEnding {
+                        library("myLib", "org.gradle.test", "lib").version {
+                            require "1.0"
+                        }
+                    }
+                }
+            }
+        """
+        def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.0").publish()
+        buildFile << """
+            apply plugin: 'java-library'
+
+            dependencies {
+                implementation notLibsEnding.myLib
+            }
+        """
+
+        when:
+        lib.pom.expectGet()
+        lib.artifact.expectGet()
+
+        then:
+        run ':checkDeps'
+
+        then:
+        executer.expectDeprecationWarning("The name of version catalogs must end with 'Libs' to reduce chances of extension conflicts.")
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org.gradle.test:lib:1.0')
+            }
+        }
+
     }
 
     def "extension can be used in any subproject"() {
@@ -1433,7 +1471,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
                         plugin("plug", "org.test2").version("1.0")
                         bundle("all", ["lib", "lib2"])
                     }
-                    other {
+                    otherLibs {
                         version("ver", "1.1")
                         library("lib", "org", "test2").versionRef("ver")
                     }
@@ -1446,7 +1484,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
             tasks.register("verifyCatalogs") {
                 doLast {
                     def libs = catalogs.named("libs")
-                    def other = catalogs.find("other").get()
+                    def other = catalogs.find("otherLibs").get()
                     assert !catalogs.find("missing").present
                     def lib = libs.findLibrary('lib')
                     assert lib.present

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
@@ -35,6 +35,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 
 import javax.inject.Inject;
@@ -75,6 +76,13 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
     private static void validateName(String name) {
         if (!VALID_EXTENSION_PATTERN.matcher(name).matches()) {
             throw new InvalidUserDataException("Invalid model name '" + name + "': it must match the following regular expression: " + VALID_EXTENSION_NAME);
+        }
+
+        if (!name.equals("libs") && !name.endsWith("Libs")) {
+            DeprecationLogger.deprecateBehaviour("The name of version catalogs must end with 'Libs' to reduce chances of extension conflicts.")
+                .willBecomeAnErrorInGradle8()
+                .withUserManual("platforms", "sec:multiple")
+                .nagUser();
         }
     }
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -185,6 +185,25 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",fil
 include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="build.gradle.kts[tags=use_plugin]"]
 ====
 
+[[sec:multiple]]
+==== Using multiple catalogs
+
+Aside from the conventional `libs` catalog, you can declare any number of catalogs through the `Settings` API.
+This allows you to separate dependency declarations in multiple sources in a way that makes sense for your projects.
+
+.Using a custom catalog
+====
+include::sample[dir="snippets/dependencyManagement/catalogs-settings/groovy",files="settings.gradle[tags=extra_catalog]"]
+include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",files="settings.gradle.kts[tags=extra_catalog]"]
+====
+
+[NOTE]
+====
+Each catalog will generate an extension applied to all projects for accessing its content.
+As such it makes sense to reduce the chance of collisions by picking a name that reduces the potential conflicts.
+Gradle will emit a deprecation warning if a catalog does not have a name that ends with `Libs`.
+====
+
 [[sub:conventional-dependencies-toml]]
 === The libs.versions.toml file
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -86,3 +86,15 @@ dependencyResolutionManagement {
     }
 }
 // end::catalog_with_plugin[]
+
+// tag::extra_catalog[]
+dependencyResolutionManagement {
+    versionCatalogs {
+        testLibs {
+            def junit5 = version('junit5', '5.7.1')
+            library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').version(junit5)
+            library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').version(junit5)
+        }
+    }
+}
+// end::extra_catalog[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -110,3 +110,15 @@ if (providers.systemProperty("create4").getOrNull() != null) {
         }
     }
 }
+
+// tag::extra_catalog[]
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("testLibs") {
+            val junit5 = version("junit5", "5.7.1")
+            library("junit-api", "org.junit.jupiter", "junit-jupiter-api").version(junit5)
+            library("junit-engine", "org.junit.jupiter", "junit-jupiter-engine").version(junit5)
+        }
+    }
+}
+// end::extra_catalog[]

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/build.gradle
@@ -16,9 +16,9 @@
 
 plugins {
     id 'java-library'
-    alias(deps.plugins.jmh)
+    alias(projectLibs.plugins.jmh)
 }
 
 dependencies {
-    api deps.bundles.groovy
+    api projectLibs.bundles.groovy
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
 
 // tag::change_default_extension_name[]
 dependencyResolutionManagement {
-    defaultLibrariesExtensionName.set('deps')
+    defaultLibrariesExtensionName.set('projectLibs')
 }
 // end::change_default_extension_name[]
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/build.gradle.kts
@@ -16,9 +16,9 @@
 
 plugins {
     `java-library`
-    alias(deps.plugins.jmh)
+    alias(projectLibs.plugins.jmh)
 }
 
 dependencies {
-    api(deps.bundles.groovy)
+    api(projectLibs.bundles.groovy)
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
@@ -26,7 +26,7 @@ dependencyResolutionManagement {
 
 // tag::change_default_extension_name[]
 dependencyResolutionManagement {
-    defaultLibrariesExtensionName.set("deps")
+    defaultLibrariesExtensionName.set("projectLibs")
 }
 // end::change_default_extension_name[]
 


### PR DESCRIPTION
In order to reduce extension collisions, enforce that a catalog nmae
must end with 'Libs'