### PR TITLE
prevent excluding JUnit Platform tests with non-standard `TestSource`

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -191,7 +191,7 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
                 }
             }
 
-            return false;
+            return true;
         }
 
         private boolean matchesParentMethod(TestDescriptor descriptor, String methodName) {

--- a/subprojects/testing-jvm/build.gradle.kts
+++ b/subprojects/testing-jvm/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.commonsIo)
     implementation(libs.asm)
     implementation(libs.junit)
+    implementation(libs.archunitJunit5)
     implementation(libs.testng)
     implementation(libs.inject)
     implementation(libs.bsh)

--- a/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -26,6 +26,7 @@ class JUnitCoverage {
     final static String LATEST_JUPITER_VERSION = LATEST_JUNIT5_VERSION
     final static String LATEST_VINTAGE_VERSION = LATEST_JUNIT5_VERSION
     final static String LATEST_PLATFORM_VERSION = '1.7.1'
+    final static String LATEST_ARCHUNIT_VERSION = '0.22.0'
     final static String JUPITER = 'Jupiter:' + LATEST_JUPITER_VERSION
     final static String VINTAGE = 'Vintage:' + LATEST_VINTAGE_VERSION
     final static List<String> LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST]


### PR DESCRIPTION
At the moment the API of `filter { excludeTestsMatching '*somePattern' }` is tailored very closely to the JUnit Jupiter test model, i.e. classes and methods. The respective `JUnitPlatformTestClassProcessor.ClassMethodNameFilter` can only filter tests with a `TestDescriptor` that either has a `Class-` or a `MethodSource` attached. While `ClassMethodNameFilter.shouldRun(..)` would run any `TestDescriptor` that does not have any `TestSource` attached, it would exclude any `TestDescriptor` that has a non-standard `TestSource` attached.

This causes problems for `TestEngines` that attach non-standard `TestSources` to their `TestDescriptors`. Take for example the [`ArchUnitTestEngine`](https://github.com/TNG/ArchUnit/blob/main/archunit-junit/junit5/engine/src/main/java/com/tngtech/archunit/junit/ArchUnitTestEngine.java), which allows declaring tests as fields. In this case the respective `TestDescriptor` will have a custom `FieldSource` attached, instead of a `MethodSource`. As a consequence any exclude pattern specified via `excludeTestsMatching "*somePattern"` would cause all ArchUnit rules declared as fields to be skipped, even if the pattern would not match them in any way (compare https://github.com/TNG/ArchUnit/issues/743).

To fix this problem I have changed the behavior of `ClassMethodNameFilter.shouldRun(..)` to return `true` for any `TestDescriptor` which has a non-standard `TestSource`. This way the behavior is also consistent with `TestDescriptors` that have no `TestSource` at all. Note that this will likely feel somewhat surprising if the pattern would actually match the field name, but the Javadoc of `TestFilter` clearly states that the pattern only applies to classes or methods, so it follows the specification.

<!--- The issue this PR addresses -->
Fixes #19352

### Context

See #19352. On the one hand the adjusted exclude-behavior will be more consistent (why should `TestDescriptors` without a `TestSource` run, but `TestDescriptors` with a `TestSource` that can't be handled not?). But on the other hand the current implementation prevents users to use a JUnit `TestEngine` with non-standard `TestSources` together with `excludeTestsMatching`, because it will exclude all non-standard tests regardless the pattern.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
