### PR TITLE
Stabilize version catalogs

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -63,6 +63,22 @@
             "changes": [
                 "METHOD_ADDED_TO_PUBLIC_CLASS"
             ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.dsl.DependencyHandler",
+            "member": "Method org.gradle.api.artifacts.dsl.DependencyHandler.addProviderConvertible(java.lang.String,org.gradle.api.provider.ProviderConvertible,org.gradle.api.Action)",
+            "acceptation": "Stabilizing version catalogs",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.dsl.DependencyHandler",
+            "member": "Method org.gradle.api.artifacts.dsl.DependencyHandler.addProviderConvertible(java.lang.String,org.gradle.api.provider.ProviderConvertible)",
+            "acceptation": "Stabilizing version catalogs",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependencyBundle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependencyBundle.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
-
 import java.util.List;
 
 /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependencyBundle.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ExternalModuleDependencyBundle.java
@@ -24,6 +24,5 @@ import java.util.List;
  *
  * @since 6.8
  */
-@Incubating
 public interface ExternalModuleDependencyBundle extends List<MinimalExternalModuleDependency> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MinimalExternalModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MinimalExternalModuleDependency.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -23,7 +22,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 6.8
  */
-@Incubating
 @HasInternalProtocol
 public interface MinimalExternalModuleDependency {
     ModuleIdentifier getModule();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.provider.Provider;
@@ -32,7 +31,6 @@ import java.util.Optional;
  *
  * @since 7.0
  */
-@Incubating
 @NonNullApi
 public interface VersionCatalog extends Named {
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
@@ -26,7 +26,6 @@ import java.util.Set;
  *
  * @since 7.0
  */
-@Incubating
 public interface VersionCatalogsExtension extends Iterable<VersionCatalog> {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalogsExtension.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.artifacts;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 
 import java.util.Optional;

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
@@ -300,7 +299,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 6.8
      */
-    @Incubating
     <T, U extends ExternalModuleDependency> void addProvider(String configurationName, Provider<T> dependencyNotation, Action<? super U> configuration);
 
     /**
@@ -311,7 +309,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 7.0
      */
-    @Incubating
     <T> void addProvider(String configurationName, Provider<T> dependencyNotation);
 
     /**
@@ -323,7 +320,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 7.4
      */
-    @Incubating
     <T, U extends ExternalModuleDependency> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation, Action<? super U> configuration);
 
     /**
@@ -334,7 +330,6 @@ public interface DependencyHandler extends ExtensionAware {
      *
      * @since 7.4
      */
-    @Incubating
     <T> void addProviderConvertible(String configurationName, ProviderConvertible<T> dependencyNotation);
 
     /**
@@ -623,7 +618,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the configured variant
      * @since 6.8
      */
-    @Incubating
     Provider<MinimalExternalModuleDependency> variantOf(Provider<MinimalExternalModuleDependency> dependencyProvider, Action<? super ExternalModuleDependencyVariantSpec> variantSpec);
 
     /**
@@ -635,7 +629,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the configured variant
      * @since 7.3
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> variantOf(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible,
                                                                 Action<? super ExternalModuleDependencyVariantSpec> variantSpec) {
         return variantOf(dependencyProviderConvertible.asProvider(), variantSpec);
@@ -647,7 +640,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the platform variant of the component
      * @since 6.8
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> platform(Provider<MinimalExternalModuleDependency> dependencyProvider) {
         return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::platform);
     }
@@ -658,7 +650,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the platform variant of the component
      * @since 7.3
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> platform(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
         return platform(dependencyProviderConvertible.asProvider());
     }
@@ -669,7 +660,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the enforced-platform variant of the component
      * @since 7.3
      */
-    @Incubating
     Provider<MinimalExternalModuleDependency> enforcedPlatform(Provider<MinimalExternalModuleDependency> dependencyProvider);
 
     /**
@@ -678,7 +668,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the enforced-platform variant of the component
      * @since 7.3
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> enforcedPlatform(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
         return enforcedPlatform(dependencyProviderConvertible.asProvider());
     }
@@ -689,7 +678,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the test fixtures of the component
      * @since 6.8
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> testFixtures(Provider<MinimalExternalModuleDependency> dependencyProvider) {
         return variantOf(dependencyProvider, ExternalModuleDependencyVariantSpec::testFixtures);
     }
@@ -700,7 +688,6 @@ public interface DependencyHandler extends ExtensionAware {
      * @return a new dependency provider targeting the test fixtures of the component
      * @since 7.3
      */
-    @Incubating
     default Provider<MinimalExternalModuleDependency> testFixtures(ProviderConvertible<MinimalExternalModuleDependency> dependencyProviderConvertible) {
         return testFixtures(dependencyProviderConvertible.asProvider());
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api.artifacts.dsl;
 
-import org.gradle.api.Incubating;
-
 /**
  * The specification of a dependency variant. Some dependencies can be fined tuned
  * to select a particular variant. For example, one might want to select the test

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ExternalModuleDependencyVariantSpec.java
@@ -24,7 +24,6 @@ import org.gradle.api.Incubating;
  *
  * @since 6.8
  */
-@Incubating
 public interface ExternalModuleDependencyVariantSpec {
     /**
      * Configures the dependency to select the "platform" variant.

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.attributes;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 
 /**
@@ -116,6 +115,5 @@ public interface Usage extends Named {
      *
      * @since 7.0
      */
-    @Incubating
     String VERSION_CATALOG = "version-catalog";
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/dsl/VersionCatalogBuilder.java
@@ -30,7 +30,6 @@ import java.util.List;
  *
  * @since 7.0
  */
-@Incubating
 @HasInternalProtocol
 public interface VersionCatalogBuilder extends Named {
 
@@ -174,7 +173,6 @@ public interface VersionCatalogBuilder extends Named {
      *
      * @since 7.0
      */
-    @Incubating
     interface LibraryAliasBuilder {
         /**
          * Configures the version for this alias
@@ -207,7 +205,6 @@ public interface VersionCatalogBuilder extends Named {
      *
      * @since 7.2
      */
-    @Incubating
     interface PluginAliasBuilder {
         /**
          * Configures the version for this alias

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
@@ -24,6 +24,5 @@ import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
  *
  * @since 7.0
  */
-@Incubating
 public interface MutableVersionCatalogContainer extends NamedDomainObjectContainer<VersionCatalogBuilder> {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/initialization/resolve/MutableVersionCatalogContainer.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.initialization.resolve;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.provider;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.NonExtensible;
 import org.gradle.internal.HasInternalProtocol;
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderConvertible.java
@@ -26,7 +26,6 @@ import org.gradle.internal.HasInternalProtocol;
  * @param <T> Type of value represented by provider
  * @since 7.3
  */
-@Incubating
 @HasInternalProtocol
 @NonExtensible
 public interface ProviderConvertible<T> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -32,7 +32,7 @@ public class FeaturePreviews {
         GROOVY_COMPILATION_AVOIDANCE(true),
         ONE_LOCKFILE_PER_PROJECT(false),
         VERSION_ORDERING_V2(false),
-        VERSION_CATALOGS(true),
+        VERSION_CATALOGS(false),
         TYPESAFE_PROJECT_ACCESSORS(true),
         STABLE_CONFIGURATION_CACHE(true);
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/AbstractVersionCatalogIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/AbstractVersionCatalogIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.resolve.catalog
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
 abstract class AbstractVersionCatalogIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -31,7 +30,6 @@ abstract class AbstractVersionCatalogIntegrationTest extends AbstractHttpDepende
         settingsFile << """
             rootProject.name = 'test'
         """
-        FeaturePreviewsFixture.enableVersionCatalog(settingsFile)
         settingsFile << """
             dependencyResolutionManagement {
                 repositories {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/KotlinDslVersionCatalogExtensionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.catalog
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.test.fixtures.file.LeaksFileHandles
@@ -35,7 +34,6 @@ class KotlinDslVersionCatalogExtensionIntegrationTest extends AbstractHttpDepend
         settingsKotlinFile << """
             rootProject.name = "test"
         """
-        FeaturePreviewsFixture.enableVersionCatalog(settingsKotlinFile)
         settingsKotlinFile << """
             dependencyResolutionManagement {
                 repositories {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -257,8 +257,7 @@ class DependencyManagementBuildScopeServices {
                                                                                     DependencyMetaDataProvider dependencyMetaDataProvider,
                                                                                     ObjectFactory objects,
                                                                                     ProviderFactory providers,
-                                                                                    CollectionCallbackActionDecorator collectionCallbackActionDecorator,
-                                                                                    FeaturePreviews featurePreviews) {
+                                                                                    CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         return instantiator.newInstance(DefaultDependencyResolutionManagement.class,
             context,
             dependencyManagementServices,
@@ -267,8 +266,7 @@ class DependencyManagementBuildScopeServices {
             dependencyMetaDataProvider,
             objects,
             providers,
-            collectionCallbackActionDecorator,
-            featurePreviews
+            collectionCallbackActionDecorator
         );
     }
 
@@ -590,7 +588,6 @@ class DependencyManagementBuildScopeServices {
                                                                 ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
                                                                 InstantiatorFactory instantiatorFactory,
                                                                 ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
-                                                                FeaturePreviews featurePreviews,
                                                                 CalculatedValueContainerFactory calculatedValueContainerFactory) {
         return new DefaultArtifactDependencyResolver(
             buildOperationExecutor,
@@ -607,7 +604,6 @@ class DependencyManagementBuildScopeServices {
             componentMetadataSupplierRuleExecutor,
             instantiatorFactory,
             componentSelectionDescriptorFactory,
-            featurePreviews,
             calculatedValueContainerFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.artifacts.DependencySubstitution;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactDependencyResolver;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.GlobalDependencyResolutionRules;
@@ -93,7 +92,6 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
     private final ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor;
     private final Instantiator instantiator;
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;
-    private final FeaturePreviews featurePreviews;
     private final CalculatedValueContainerFactory calculatedValueContainerFactory;
 
     public DefaultArtifactDependencyResolver(BuildOperationExecutor buildOperationExecutor,
@@ -110,7 +108,6 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
                                              ComponentMetadataSupplierRuleExecutor componentMetadataSupplierRuleExecutor,
                                              InstantiatorFactory instantiatorFactory,
                                              ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
-                                             FeaturePreviews featurePreviews,
                                              CalculatedValueContainerFactory calculatedValueContainerFactory) {
         this.resolverFactories = resolverFactories;
         this.projectDependencyResolver = projectDependencyResolver;
@@ -126,7 +123,6 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         this.componentMetadataSupplierRuleExecutor = componentMetadataSupplierRuleExecutor;
         this.instantiator = instantiatorFactory.decorateScheme().instantiator();
         this.componentSelectionDescriptorFactory = componentSelectionDescriptorFactory;
-        this.featurePreviews = featurePreviews;
         this.calculatedValueContainerFactory = calculatedValueContainerFactory;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultDependencyResolutionManagement.java
@@ -34,7 +34,6 @@ import org.gradle.api.initialization.resolve.RepositoriesMode;
 import org.gradle.api.initialization.resolve.RulesMode;
 import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
@@ -81,15 +80,14 @@ public class DefaultDependencyResolutionManagement implements DependencyResoluti
                                                  DependencyMetaDataProvider dependencyMetaDataProvider,
                                                  ObjectFactory objects,
                                                  ProviderFactory providers,
-                                                 CollectionCallbackActionDecorator collectionCallbackActionDecorator,
-                                                 FeaturePreviews featurePreviews) {
+                                                 CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.context = context;
         this.repositoryMode = objects.property(RepositoriesMode.class).convention(RepositoriesMode.PREFER_PROJECT);
         this.rulesMode = objects.property(RulesMode.class).convention(RulesMode.PREFER_PROJECT);
         this.dependencyResolutionServices = Lazy.locking().of(() -> dependencyManagementServices.create(fileResolver, fileCollectionFactory, dependencyMetaDataProvider, makeUnknownProjectFinder(), RootScriptDomainObjectContext.INSTANCE));
         this.librariesExtensionName = objects.property(String.class).convention("libs");
         this.projectsExtensionName = objects.property(String.class).convention("projects");
-        this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, providers, dependencyResolutionServices, context, featurePreviews);
+        this.versionCatalogs = objects.newInstance(DefaultVersionCatalogBuilderContainer.class, collectionCallbackActionDecorator, objects, providers, dependencyResolutionServices, context);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
@@ -18,14 +18,11 @@ package org.gradle.internal.management;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import org.gradle.api.Action;
-import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.api.initialization.resolve.MutableVersionCatalogContainer;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
@@ -50,7 +47,6 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
     private final Interner<String> strings = Interners.newStrongInterner();
     private final Interner<ImmutableVersionConstraint> versions = Interners.newStrongInterner();
     private final Supplier<DependencyResolutionServices> dependencyResolutionServices;
-    private final FeaturePreviews featurePreviews;
 
     private final ObjectFactory objects;
     private final ProviderFactory providers;
@@ -62,14 +58,12 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
                                                  ObjectFactory objects,
                                                  ProviderFactory providers,
                                                  Supplier<DependencyResolutionServices> dependencyResolutionServices,
-                                                 UserCodeApplicationContext context,
-                                                 FeaturePreviews featurePreviews) {
+                                                 UserCodeApplicationContext context) {
         super(VersionCatalogBuilder.class, instantiator, callbackActionDecorator);
         this.objects = objects;
         this.providers = providers;
         this.context = context;
         this.dependencyResolutionServices = dependencyResolutionServices;
-        this.featurePreviews = featurePreviews;
     }
 
     private static void validateName(String name) {
@@ -80,10 +74,6 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
 
     @Override
     public VersionCatalogBuilder create(String name, Action<? super VersionCatalogBuilder> configureAction) throws InvalidUserDataException {
-        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.VERSION_CATALOGS)) {
-            throw new InvalidUserCodeException("Using dependency catalogs requires the activation of the matching feature preview.\n" +
-                "See the documentation at " + new DocumentationRegistry().getDocumentationFor("platforms", "sub:central-declaration-of-dependencies"));
-        }
         validateName(name);
         return super.create(name, model -> {
             UserCodeApplicationContext.Application current = context.current();

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -4,12 +4,6 @@
 [[sub:central-declaration-of-dependencies]]
 == Central declaration of dependencies
 
-[WARNING]
-====
-Central declaration of dependencies is an incubating feature.
-It requires the activation of the `VERSION_CATALOGS` <<feature_lifecycle#feature_preview,feature preview>>.
-====
-
 [[sub:version-catalog]]
 === Using a version catalog
 

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/groovy/consumer/settings.gradle
@@ -16,8 +16,6 @@
 
 rootProject.name = 'consumer'
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformCatalog/kotlin/consumer/settings.gradle.kts
@@ -16,8 +16,6 @@
 
 rootProject.name = "consumer"
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         maven {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/groovy/settings.gradle
@@ -15,8 +15,6 @@
  */
 rootProject.name = 'platform'
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     versionCatalogs {
         libs {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-javaPlatformUsage/kotlin/settings.gradle.kts
@@ -15,8 +15,6 @@
  */
 rootProject.name = "platform"
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -16,8 +16,6 @@
 
 rootProject.name = 'catalog'
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -16,8 +16,6 @@
 
 rootProject.name = "catalog"
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/buildSrc/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/buildSrc/settings.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 // tag::import_main_catalog[]
 dependencyResolutionManagement {
     versionCatalogs {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/groovy/settings.gradle
@@ -16,8 +16,6 @@
 
 rootProject.name = 'toml-catalog'
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/buildSrc/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/buildSrc/settings.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 // tag::import_main_catalog[]
 dependencyResolutionManagement {
     versionCatalogs {

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-toml/kotlin/settings.gradle.kts
@@ -16,8 +16,6 @@
 
 rootProject.name = "toml-catalog"
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -30,9 +30,4 @@ enableFeaturePreview('GROOVY_COMPILATION_AVOIDANCE')
 """
     }
 
-    static void enableVersionCatalog(File settings) {
-        settings << """
-            enableFeaturePreview("VERSION_CATALOGS")
-        """
-    }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/catalog/VersionCatalogResolveIntegrationTest.groovy
@@ -24,7 +24,6 @@ class VersionCatalogResolveIntegrationTest extends AbstractHttpDependencyResolut
     def setup() {
         settingsFile << """
             rootProject.name = 'test'
-            enableFeaturePreview('VERSION_CATALOGS')
         """
         buildFile << """
             plugins {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
@@ -16,7 +16,6 @@
 package org.gradle.api.plugins.catalog;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.initialization.dsl.VersionCatalogBuilder;
 import org.gradle.internal.HasInternalProtocol;
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/CatalogPluginExtension.java
@@ -25,7 +25,6 @@ import org.gradle.internal.HasInternalProtocol;
  *
  * @since 7.0
  */
-@Incubating
 @HasInternalProtocol
 public interface CatalogPluginExtension {
     /**

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/catalog/VersionCatalogPlugin.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.plugins.catalog;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -23,8 +22,6 @@ import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.catalog.internal.DefaultVersionCatalogPluginExtension;
 import org.gradle.api.plugins.catalog.internal.CatalogExtensionInternal;
@@ -40,10 +37,7 @@ import javax.inject.Inject;
  *
  * @since 7.0
  */
-@Incubating
 public class VersionCatalogPlugin implements Plugin<Project> {
-    private final static Logger LOGGER = Logging.getLogger(VersionCatalogPlugin.class);
-
     public static final String GENERATE_CATALOG_FILE_TASKNAME = "generateCatalogAsToml";
     public static final String GRADLE_PLATFORM_DEPENDENCIES = "versionCatalog";
     public static final String VERSION_CATALOG_ELEMENTS = "versionCatalogElements";

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
@@ -311,10 +311,6 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
         }
         """
 
-        settingsFile << """
-        enableFeaturePreview('VERSION_CATALOGS')
-        """.stripIndent(8)
-
         versionCatalog = file('gradle', 'libs.versions.toml') << """
         [versions]
         guava = "30.1.1-jre"
@@ -365,10 +361,6 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
             }
         }
         """
-
-        settingsFile << """
-        enableFeaturePreview('VERSION_CATALOGS')
-        """.stripIndent(8)
 
         versionCatalog = file('gradle', 'libs.versions.toml') << """
         [versions]
@@ -425,10 +417,6 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
             }
         }
         """
-
-        settingsFile << """
-        enableFeaturePreview('VERSION_CATALOGS')
-        """.stripIndent(8)
 
         versionCatalog = file('gradle', 'libs.versions.toml') << """
         [versions]
@@ -490,8 +478,6 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         settingsFile << """
-        enableFeaturePreview('VERSION_CATALOGS')
-
         dependencyResolutionManagement {
             versionCatalogs {
                 libs {


### PR DESCRIPTION
Removes the need to enable `VERSION_CATALOGS` feature preview and removes `@Incubating` from most types related to version catalogs.