### PR TITLE
Use new VCS roots

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -88,7 +88,7 @@ fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, buildJvm: Jvm = BuildToolB
     }
 
     vcs {
-        root(AbsoluteId("Gradle_Branches_GradlePersonalBranches"))
+        root(AbsoluteId("GradleBuildTooBranches"))
         checkoutMode = CheckoutMode.ON_AGENT
         branchFilter = branchesFilterExcluding()
     }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -73,9 +73,11 @@ fun BuildFeatures.publishBuildStatusToGithub(model: CIBuildModel) {
 
 fun BuildFeatures.enablePullRequestFeature() {
     pullRequests {
-        vcsRootExtId = "Gradle_Branches_GradlePersonalBranches"
+        vcsRootExtId = "GradleBuildTooBranches"
         provider = github {
-            authType = vcsRoot()
+            authType = token {
+                token = "%github.bot-teamcity.token%"
+            }
             filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             filterTargetBranch = "+:refs/heads/${VersionedSettingsBranch.fromDslContext().branchName}"
         }
@@ -84,7 +86,7 @@ fun BuildFeatures.enablePullRequestFeature() {
 
 fun BuildFeatures.publishBuildStatusToGithub() {
     commitStatusPublisher {
-        vcsRootExtId = "Gradle_Branches_GradlePersonalBranches"
+        vcsRootExtId = "GradleBuildTooBranches"
         publisher = github {
             githubUrl = "https://api.github.com"
             authType = personalToken {


### PR DESCRIPTION
We somehow experience slow "Collecting Changes" time on VCS.
Let's try to use a new VCS root with identical settings as before.

After switching to the new VCS root, the time on experimental pipeline is crazingly fast:

<img width="1152" alt="Xnip2021-12-31_16-03-29" src="https://user-images.githubusercontent.com/12689835/147811307-9d66ae14-d8c9-4f4f-8942-95420247944c.png">


Also, this PR resolves this warning by using GitHub token:

![image](https://user-images.githubusercontent.com/12689835/147811231-15462baa-4ada-4b2a-856d-b2c56b8e9e16.png)
