### PR TITLE
Ignore tests incompatible with `integForceRealizeTest` executer

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/DerivedVariantsResolutionIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.IgnoreIf
 
+import static org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataProcessor.FORCE_REALIZE
+
 @IgnoreIf({ GradleContextualExecuter.configCache }) // ResolvedArtifactResult as task input
 class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     MavenHttpModule direct
@@ -359,6 +361,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
     // endregion
 
     // region Without Gradle Module Metadata
+    @IgnoreIf({ FORCE_REALIZE })
     def "direct has no GMM and no sources or javadoc jars"() {
         transitive.publish()
         direct.publish()
@@ -384,6 +387,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         succeeds( 'resolveSources', 'resolveJavadoc')
     }
 
+    @IgnoreIf({ FORCE_REALIZE })
     def "direct has no GMM and has sources jar"() {
         direct.withSourceAndJavadoc()
         transitive.withSourceAndJavadoc()
@@ -406,6 +410,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         succeeds("resolveSources")
     }
 
+    @IgnoreIf({ FORCE_REALIZE })
     def "direct has no GMM and has javadoc jar"() {
         direct.withSourceAndJavadoc()
         transitive.withSourceAndJavadoc()
@@ -428,6 +433,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         succeeds("resolveJavadoc")
     }
 
+    @IgnoreIf({ FORCE_REALIZE })
     def "direct has no GMM and has both sources and javadoc jars"() {
         direct.withSourceAndJavadoc()
         transitive.withSourceAndJavadoc()
@@ -464,6 +470,7 @@ class DerivedVariantsResolutionIntegrationTest extends AbstractHttpDependencyRes
         succeeds( 'resolveJavadoc')
     }
 
+    @IgnoreIf({ FORCE_REALIZE })
     def "direct has no GMM and no sources jar and transitive has no GMM and has sources jar"() {
         transitive.withSourceAndJavadoc()
         transitive.publish()


### PR DESCRIPTION
Ignore tests incompatible with `integForceRealizeTest` executer

 - This executer is not part of the normal PR checks and only runs once a day