### PR TITLE
Mention reproducer repository in GitHub bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributor_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/contributor_bug_report.md
@@ -28,8 +28,11 @@ Please open Gradle Native-related issues at https://github.com/gradle/gradle-nat
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
 ### Steps to Reproduce 
-<!--- Provide a self-contained example project (as an attached archive or a Github project). -->
-<!--- In the rare cases where this is infeasible, we will also accept a detailed set of instructions. -->
+<!---
+Provide a self-contained example project as an attached archive or a Github project.
+You can use the following template with a Gradle GitHub action set up to showcase your problem: https://github.com/gradle/gradle-issue-reproducer
+In the rare cases where this is infeasible, we will also accept a detailed set of instructions.
+-->
 
 ### Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->


### PR DESCRIPTION
I've prepared a simple template repository with a Gradle GitHub action set up. Reporters can use this repository to sketch a reproducer project and exhibit a failure. This has several advantages:
- We can inspect Gradle's output without relying on copy-pasted text on the issue
- We don't need to run anything locally, which is a security concern
- We can observe the behavior on multiple OSs by default

TODOs:
- [x] The https://github.com/gradle/gradle-issue-reproducer repository needs to be public if this PR gets merged.
