### PR TITLE
Only display the build scan hint when the Gradle Enterprise plugin is not applied

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -34,6 +34,8 @@ import org.gradle.internal.logging.text.BufferingStyledTextOutput;
 import org.gradle.internal.logging.text.LinePrefixingStyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutput;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.service.ServiceLookupException;
+import org.gradle.internal.service.UnknownServiceException;
 import org.gradle.util.internal.GUtil;
 
 import java.util.Collections;
@@ -318,7 +320,14 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
     private static boolean isGradleEnterprisePluginApplied(BuildResult result) {
         GradleInternal gradle = (GradleInternal) result.getGradle();
-        return gradle != null && gradle.getServices().get(GradleEnterprisePluginManager.class).isPresent();
+        if (gradle != null) {
+            try {
+                return gradle.getServices().get(GradleEnterprisePluginManager.class).isPresent();
+            } catch (UnknownServiceException | ServiceLookupException e) {
+                // If we can't determine if the Gradle Enterprise Plugin is applied, then just behave as if it isn't
+            }
+        }
+        return false;
     }
 
     private static class FailureDetails {

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -39,7 +39,7 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
     private final Logger logger;
     private final BuildExceptionReporter exceptionReporter;
     private final BuildResultLogger resultLogger;
-    private String action;
+    private BuildResult buildResult;
 
     public BuildLogger(
         Logger logger,
@@ -103,15 +103,15 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
     @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(BuildResult result) {
-        this.action = result.getAction();
+        this.buildResult = result;
     }
 
     public void logResult(Throwable buildFailure) {
-        if (action == null) {
+        if (buildResult == null) {
             // This logger has been replaced (for example using `Gradle.useLogger()`), so don't log anything
             return;
         }
-        BuildResult buildResult = new BuildResult(action, null, buildFailure);
+        BuildResult buildResult = new BuildResult(this.buildResult.getAction(), this.buildResult.getGradle(), buildFailure);
         exceptionReporter.buildFinished(buildResult);
         resultLogger.buildFinished(buildResult);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLogger.java
@@ -24,10 +24,12 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.execution.WorkValidationWarningReporter;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.internal.InternalBuildListener;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.logging.format.TersePrettyDurationFormatter;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
 import org.gradle.internal.time.Clock;
@@ -39,19 +41,20 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
     private final Logger logger;
     private final BuildExceptionReporter exceptionReporter;
     private final BuildResultLogger resultLogger;
-    private BuildResult buildResult;
+    private String action;
 
     public BuildLogger(
         Logger logger,
         StyledTextOutputFactory textOutputFactory,
-        StartParameter startParameter,
+        LoggingConfiguration loggingConfiguration,
         BuildRequestMetaData requestMetaData,
         BuildStartedTime buildStartedTime,
         Clock clock,
-        WorkValidationWarningReporter workValidationWarningReporter
+        WorkValidationWarningReporter workValidationWarningReporter,
+        GradleEnterprisePluginManager gradleEnterprisePluginManager
     ) {
         this.logger = logger;
-        exceptionReporter = new BuildExceptionReporter(textOutputFactory, startParameter, requestMetaData.getClient());
+        exceptionReporter = new BuildExceptionReporter(textOutputFactory, loggingConfiguration, requestMetaData.getClient(), gradleEnterprisePluginManager);
         resultLogger = new BuildResultLogger(textOutputFactory, buildStartedTime, clock, new TersePrettyDurationFormatter(), workValidationWarningReporter);
     }
 
@@ -103,15 +106,15 @@ public class BuildLogger implements InternalBuildListener, TaskExecutionGraphLis
     @SuppressWarnings("deprecation")
     @Override
     public void buildFinished(BuildResult result) {
-        this.buildResult = result;
+        this.action = result.getAction();
     }
 
     public void logResult(Throwable buildFailure) {
-        if (buildResult == null) {
+        if (action == null) {
             // This logger has been replaced (for example using `Gradle.useLogger()`), so don't log anything
             return;
         }
-        BuildResult buildResult = new BuildResult(this.buildResult.getAction(), this.buildResult.getGradle(), buildFailure);
+        BuildResult buildResult = new BuildResult(action, null, buildFailure);
         exceptionReporter.buildFinished(buildResult);
         resultLogger.buildFinished(buildResult);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLoggerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildLoggerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildevents;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.configuration.LoggingConfiguration;
+import org.gradle.execution.WorkValidationWarningReporter;
+import org.gradle.initialization.BuildRequestMetaData;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
+import org.gradle.internal.logging.text.StyledTextOutputFactory;
+import org.gradle.internal.time.Clock;
+
+public class BuildLoggerFactory {
+    private final StyledTextOutputFactory styledTextOutputFactory;
+    private final WorkValidationWarningReporter workValidationWarningReporter;
+    private final Clock clock;
+    private final GradleEnterprisePluginManager gradleEnterprisePluginManager;
+
+    public BuildLoggerFactory(StyledTextOutputFactory styledTextOutputFactory, WorkValidationWarningReporter workValidationWarningReporter, Clock clock, GradleEnterprisePluginManager gradleEnterprisePluginManager) {
+        this.styledTextOutputFactory = styledTextOutputFactory;
+        this.workValidationWarningReporter = workValidationWarningReporter;
+        this.clock = clock;
+        this.gradleEnterprisePluginManager = gradleEnterprisePluginManager;
+    }
+
+    public BuildLogger create(Logger logger, LoggingConfiguration loggingConfiguration, BuildStartedTime buildStartedTime, BuildRequestMetaData buildRequestMetaData) {
+        return new BuildLogger(logger, styledTextOutputFactory, loggingConfiguration, buildRequestMetaData, buildStartedTime, clock, workValidationWarningReporter, gradleEnterprisePluginManager);
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/buildevents/BuildExceptionReporterTest.groovy
@@ -20,20 +20,19 @@ import org.gradle.BuildResult
 import org.gradle.StartParameter
 import org.gradle.api.GradleException
 import org.gradle.api.internal.GradleInternal
-import org.gradle.api.internal.SettingsInternal
-import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.LoggingConfiguration
 import org.gradle.api.logging.configuration.ShowStacktrace
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.initialization.BuildClientMetaData
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.exceptions.FailureResolutionAware
 import org.gradle.internal.exceptions.LocationAwareException
 import org.gradle.internal.logging.DefaultLoggingConfiguration
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.logging.text.TestStyledTextOutput
-import org.gradle.plugin.management.internal.autoapply.AutoAppliedGradleEnterprisePlugin
+import org.gradle.internal.service.ServiceRegistry
 import spock.lang.Specification
 
 class BuildExceptionReporterTest extends Specification {
@@ -83,9 +82,9 @@ class BuildExceptionReporterTest extends Specification {
                 isBuildScan() >> true
                 isNoBuildScan() >> false
             }
-            getSettings() >> Mock(SettingsInternal) {
-                getPluginManager() >> Mock(PluginManagerInternal) {
-                    hasPlugin(AutoAppliedGradleEnterprisePlugin.ID.getId()) >> true
+            getServices() >> Mock(ServiceRegistry) {
+                get(GradleEnterprisePluginManager.class) >> Mock(GradleEnterprisePluginManager) {
+                    isPresent() >> true
                 }
             }
         }
@@ -115,9 +114,9 @@ class BuildExceptionReporterTest extends Specification {
                 isBuildScan() >> false
                 isNoBuildScan() >> true
             }
-            getSettings() >> Mock(SettingsInternal) {
-                getPluginManager() >> Mock(PluginManagerInternal) {
-                    hasPlugin(AutoAppliedGradleEnterprisePlugin.ID.getId()) >> true
+            getServices() >> Mock(ServiceRegistry) {
+                get(GradleEnterprisePluginManager.class) >> Mock(GradleEnterprisePluginManager) {
+                    isPresent() >> true
                 }
             }
         }

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanBuildFailureHintIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/core/BuildScanBuildFailureHintIntegrationTest.groovy
@@ -77,26 +77,19 @@ class BuildScanBuildFailureHintIntegrationTest extends AbstractIntegrationSpec {
         ["-$LogLevelOption.QUIET_SHORT_OPTION"]             | 'quiet'
     }
 
-    def "always renders hint for failing build if plugin was applied in plugins DSL and not requested for generation"() {
+    def "never renders hint for failing build if plugin was applied via command line argument and not requested for generation"() {
         given:
         buildFile << failingBuildFile()
 
         when:
-        fails(tasks as String[])
+        fails(DUMMY_TASK_AND_BUILD_SCAN as String[])
 
         then:
-        if (tasks == DUMMY_TASK_AND_BUILD_SCAN) {
-            fixture.appliedOnce(output)
-        }
-        failure.assertHasResolution(BUILD_SCAN_ERROR_MESSAGE_HINT)
-
-        where:
-        tasks                     | buildScanPublished
-        DUMMY_TASK_ONLY           | false
-        DUMMY_TASK_AND_BUILD_SCAN | true
+        fixture.appliedOnce(output)
+        failure.assertNotOutput(BUILD_SCAN_ERROR_MESSAGE_HINT)
     }
 
-    def "always renders hint for failing build if plugin was applied in buildscript and not requested for generation"() {
+    def "never renders hint for failing build if plugin was applied in plugins DSL and not requested for generation"() {
         given:
         settingsFile << fixture.plugins()
         buildFile << failingBuildFile()
@@ -106,12 +99,10 @@ class BuildScanBuildFailureHintIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         fixture.appliedOnce(output)
-        failure.assertHasResolution(BUILD_SCAN_ERROR_MESSAGE_HINT)
+        failure.assertNotOutput(BUILD_SCAN_ERROR_MESSAGE_HINT)
 
         where:
-        tasks                     | buildScanPublished
-        DUMMY_TASK_ONLY           | false
-        DUMMY_TASK_AND_BUILD_SCAN | true
+        tasks << [ DUMMY_TASK_ONLY, DUMMY_TASK_AND_BUILD_SCAN ]
     }
 
     static String failingBuildFile() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/BuildOutcomeReportingBuildActionRunner.java
@@ -19,9 +19,9 @@ package org.gradle.launcher.exec;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.tasks.execution.statistics.TaskExecutionStatisticsEventAdapter;
 import org.gradle.api.logging.Logging;
-import org.gradle.execution.WorkValidationWarningReporter;
 import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.internal.buildevents.BuildLogger;
+import org.gradle.internal.buildevents.BuildLoggerFactory;
 import org.gradle.internal.buildevents.BuildStartedTime;
 import org.gradle.internal.buildevents.TaskExecutionStatisticsReporter;
 import org.gradle.internal.buildtree.BuildActionRunner;
@@ -29,31 +29,27 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleController;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.invocation.BuildAction;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.internal.time.Clock;
 
 public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner {
     private final ListenerManager listenerManager;
     private final BuildActionRunner delegate;
     private final BuildStartedTime buildStartedTime;
     private final BuildRequestMetaData buildRequestMetaData;
-    private final Clock clock;
     private final StyledTextOutputFactory styledTextOutputFactory;
-    private final WorkValidationWarningReporter workValidationWarningReporter;
+    private final BuildLoggerFactory buildLoggerFactory;
 
     public BuildOutcomeReportingBuildActionRunner(StyledTextOutputFactory styledTextOutputFactory,
-                                                  WorkValidationWarningReporter workValidationWarningReporter,
                                                   ListenerManager listenerManager,
                                                   BuildActionRunner delegate,
                                                   BuildStartedTime buildStartedTime,
                                                   BuildRequestMetaData buildRequestMetaData,
-                                                  Clock clock) {
+                                                  BuildLoggerFactory buildLoggerFactory) {
         this.styledTextOutputFactory = styledTextOutputFactory;
-        this.workValidationWarningReporter = workValidationWarningReporter;
         this.listenerManager = listenerManager;
         this.delegate = delegate;
         this.buildStartedTime = buildStartedTime;
         this.buildRequestMetaData = buildRequestMetaData;
-        this.clock = clock;
+        this.buildLoggerFactory = buildLoggerFactory;
     }
 
     @Override
@@ -62,7 +58,7 @@ public class BuildOutcomeReportingBuildActionRunner implements BuildActionRunner
         TaskExecutionStatisticsEventAdapter taskStatisticsCollector = new TaskExecutionStatisticsEventAdapter();
         listenerManager.addListener(taskStatisticsCollector);
 
-        BuildLogger buildLogger = new BuildLogger(Logging.getLogger(BuildLogger.class), styledTextOutputFactory, startParameter, buildRequestMetaData, buildStartedTime, clock, workValidationWarningReporter);
+        BuildLogger buildLogger = buildLoggerFactory.create(Logging.getLogger(BuildLogger.class), startParameter, buildStartedTime, buildRequestMetaData);
         // Register as a 'logger' to support this being replaced by build logic.
         buildController.beforeBuild(gradle -> gradle.useLogger(buildLogger));
 


### PR DESCRIPTION
Fixes #18956

This changes the error message at the end of a build to only suggest using `--scan` when the Gradle Enterprise plugin has not been applied.

One implication of this is that the `use --scan` suggestion will no longer be printed in scenarios where the GE plugin is applied, but for some reason build scan publishing is disabled.  This is not a situation we could handle without either 1) making Gradle build tool know more about the internals of the GE plugin or 2) allowing the GE plugin to somehow modify the suggestions when there is a failed build.  This seems like an unlikely case given the vast majority of our users configure `publishAlways()`.