### PR TITLE
Allow Gradle Enterprise to read the keys file

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Workarounds.kt
@@ -52,8 +52,10 @@ object Workarounds {
         }
 
     private
-    fun isBuildScanPlugin(from: String): Boolean =
-        from.startsWith("com.gradle.scan.plugin.internal.")
+    fun isBuildScanPlugin(from: String): Boolean = from.run {
+        startsWith("com.gradle.scan.plugin.internal.")
+            || startsWith("com.gradle.enterprise.agent.")
+    }
 
     // TODO(https://github.com/gradle/gradle-org-conventions-plugin/issues/18) Remove the workaround when our conventions plugin is compatible.
     private


### PR DESCRIPTION
Without it being considered a configuration cache input.

Fixes #19470