### PR TITLE
Pass init scripts to buildSrc

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -106,6 +106,7 @@ public class BuildStateFactory {
         buildSrcStartParameter.setProjectProperties(containingBuildParameters.getProjectProperties());
         buildSrcStartParameter.doNotSearchUpwards();
         buildSrcStartParameter.setProfile(containingBuildParameters.isProfile());
+        buildSrcStartParameter.setInitScripts(containingBuildParameters.getInitScripts());
         return buildSrcStartParameter;
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/InitScriptIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.initialization
 
-import groovy.test.NotYetImplemented
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -48,7 +47,6 @@ class InitScriptIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-    @NotYetImplemented
     @Issue(['GRADLE-1457', 'GRADLE-3197'])
     def 'init scripts passed on the command line are applied to buildSrc'() {
         given:

--- a/subprojects/logging/src/integTest/resources/org/gradle/internal/logging/LoggingIntegrationTest/logging/init.gradle
+++ b/subprojects/logging/src/integTest/resources/org/gradle/internal/logging/LoggingIntegrationTest/logging/init.gradle
@@ -1,4 +1,6 @@
-
+if (gradle.startParameter.currentDir.name == "buildSrc") {
+    return
+}
 println 'init QUIET out'
 logging.captureStandardOutput LogLevel.INFO
 println 'init INFO out'

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/ProjectConfigurationChildrenProgressCrossVersionSpec.groovy
@@ -190,7 +190,12 @@ class ProjectConfigurationChildrenProgressCrossVersionSpec extends AbstractProgr
         and:
         println events.describeOperationsTree()
 
-        events.operation(applyInitScript(initScript)).with { operation ->
+        def applyInitScriptOperations = events.operations(applyInitScript(initScript))
+        applyInitScriptOperations[0].parent.parent.descriptor.name == "Load build"
+        if (targetVersion >= GradleVersion.version("7.5")) {
+            applyInitScriptOperations[1].parent.parent.descriptor.name == "Load build (:buildSrc)"
+        }
+        applyInitScriptOperations.each { operation ->
             operation.child applyInitScriptPlugin(scriptPlugin1)
             operation.child applyInitScriptPlugin(scriptPlugin2)
         }


### PR DESCRIPTION
This brings it in line with other included builds and allows IntelliJ to register its custom
model builder for the buildSrc build. This is a prerequisite for them using the new editableBuilds
property instead of doing two separate Tooling API invocations.

Signed-off-by: Stefan Oehme <st.oehme@gmail.com>

Fixes #14563

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
