### PR TITLE
Delete distribution zip file after installing from the wrapper

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -7,6 +7,7 @@ We would like to thank the following community members for their contributions t
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 -->
+[altrisi](https://github.com/altrisi)
 
 ## Upgrade instructions
 

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/Install.java
@@ -104,6 +104,7 @@ public class Install {
                 if (installCheck.isVerified()) {
                     setExecutablePermissions(installCheck.gradleHome);
                     markerFile.createNewFile();
+                    localZipFile.delete();
                     return installCheck.gradleHome;
                 }
                 // Distribution couldn't be installed.

--- a/subprojects/wrapper-shared/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
+++ b/subprojects/wrapper-shared/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
@@ -81,7 +81,6 @@ class InstallTest extends Specification {
         homeDir == gradleHomeDir
         gradleHomeDir.assertIsDir()
         gradleHomeDir.file("bin/gradle").assertIsFile()
-        zipDestination.assertIsFile()
 
         and:
         1 * download.download(configuration.distribution, _) >> { createTestZip(it[1]) }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("91a239400bb638f36a1795d8fdf7939d532cdc7d794d1119b7261aac158b1e60")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("b95314dbc8c92954d14d1b8e8c14eab50e7a599468fbb2e9fae81ec1f4fafc0a")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
Fixes #19480, fixes #3605.

### Context
Each gradle distribution zip uses around (recently over) 100MB (110MB for 7.3). If you update the gradle installation in projects regularly via the wrapper, this can fill up your drive with lots of unnecessary data, given the extracted files are next to it and the zip isn't ever used again for anything.

This PR also removes the line in the tests that checks for the zip to be present, given it's not actually needed to reuse the distribution (only the ok file is). You can see an image of gradle launching without the zip [here](https://user-images.githubusercontent.com/17107132/148225765-c38f9112-88ba-49f6-b7be-041c9b076713.png).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

Tests also ran in an action runner in https://github.com/altrisi/gradle/actions/runs/1658407331.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes

Signed-off-by: altrisi <altrisi.trillosierra@gmail.com>