### PR TITLE
Default test suite behavior is no longer to use JUnit 4

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -50,7 +50,7 @@ The JVM Test Suite plugin adds the following task to the project:
 `test` — link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test]::
 _Depends on_: `testClasses` from the `java` plugin, and all tasks which produce the test runtime classpath
 +
-Runs the tests using JUnit by default but can be configured for other frameworks.
+Runs the tests using the framework configured for the default test suite.
 
 Additional instances of link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] tasks will be automatically created for each test suite added via the `testing` extension.
 
@@ -102,8 +102,8 @@ include::sample[dir="snippets/testing/test-suite-plugin/kotlin",files="build.gra
 ====
 
 <1> Configure all test suites for this project.
-<2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  By convention, the built-in `test` suite will use JUnit4.
-<3> Declare this test suite uses JUnit Jupiter.  The framework's dependencies are automatically included.  It is not necessary to explicitly name or configure the built-in `test` suite if JUnit4 is desired.
+<2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  You *must* specify a testing framework to use in order to run these tests (e.g. JUnit 4, JUnit Jupiter).
+<3> Declare this test suite uses JUnit Jupiter.  The framework's dependencies are automatically included.  It is always necessary to explicitly configure the built-in `test` suite even if JUnit4 is desired.
 <4> Define a new suite called `integrationTest`.
 <5> Add a dependency on the production code of the project to the `integrationTest` suite targets.  By convention, only the built-in `test` suite will automatically have a dependency on the production code of the project.
 <6> Configure all targets of this suite.  By convention, test suite targets have no relationship to other `Test` tasks.  This example shows that the slower integration test suite targets should run after all targets of the `test` suite are complete.

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -102,7 +102,7 @@ include::sample[dir="snippets/testing/test-suite-plugin/kotlin",files="build.gra
 ====
 
 <1> Configure all test suites for this project.
-<2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  You *must* specify a testing framework to use in order to run these tests (e.g. JUnit 4, JUnit Jupiter).
+<2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  You *must* specify a testing framework to use in order to run these tests (e.g. JUnit 4, JUnit Jupiter).  This suite is the only suite that will automatically have access to the production source's `implementation` dependencies, all other suites must explicitly declare these.
 <3> Declare this test suite uses JUnit Jupiter.  The framework's dependencies are automatically included.  It is always necessary to explicitly configure the built-in `test` suite even if JUnit4 is desired.
 <4> Define a new suite called `integrationTest`.  Note that all suites other than the built-in `test` suite will by convention work as if `useJUnitJupiter()` was called.  You do *not* have to explicitly configure the testing framework on these additional suites, unless you wish to change to another framework.
 <5> Add a dependency on the production code of the project to the `integrationTest` suite targets.  By convention, only the built-in `test` suite will automatically have a dependency on the production code of the project.

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -104,7 +104,7 @@ include::sample[dir="snippets/testing/test-suite-plugin/kotlin",files="build.gra
 <1> Configure all test suites for this project.
 <2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  You *must* specify a testing framework to use in order to run these tests (e.g. JUnit 4, JUnit Jupiter).
 <3> Declare this test suite uses JUnit Jupiter.  The framework's dependencies are automatically included.  It is always necessary to explicitly configure the built-in `test` suite even if JUnit4 is desired.
-<4> Define a new suite called `integrationTest`.
+<4> Define a new suite called `integrationTest`.  Note that all suites other than the built-in `test` suite will by convention work as if `useJUnitJupiter()` was called.  You do *not* have to explicitly configure the testing framework on these additional suites, unless you wish to change to another framework.
 <5> Add a dependency on the production code of the project to the `integrationTest` suite targets.  By convention, only the built-in `test` suite will automatically have a dependency on the production code of the project.
 <6> Configure all targets of this suite.  By convention, test suite targets have no relationship to other `Test` tasks.  This example shows that the slower integration test suite targets should run after all targets of the `test` suite are complete.
 <7> Configure the `check` task to depend on all `integrationTest` targets.  By convention, test suite targets are not associated with the `check` task.

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -670,4 +670,43 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds("assertSameFrameworkInstance")
     }
+
+    def "the default test suite does NOT use JUnit 4 by default"() {
+        given: "a build which uses the default test suite and doesn't specify a testing framework"
+        file("build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        // Empty
+                    }
+                }
+            }
+        """
+
+        and: "containing a test which uses Junit 4"
+        file("src/test/java/org/test/MyTest.java") << """
+            package org.test;
+
+            import org.junit.Test;
+            import org.junit.Assert;
+
+            public class MyTest {
+                @Test
+                public void testSomething() {
+                    Assert.assertEquals(1, MyFixture.calculateSomething());
+                }
+            }
+        """
+
+        expect: "does NOT compile due to a missing dependency"
+        fails( "test")
+        failure.assertHasErrorOutput("Compilation failed; see the compiler error output for details.")
+        failure.assertHasErrorOutput("error: package org.junit does not exist")
+    }
 }


### PR DESCRIPTION
This is a duplicate of https://github.com/gradle/gradle/pull/19471, from a new branch built off of the release branch.

---
Issues Addressed:

This is incorrectly noted here: https://docs.gradle.org/current/userguide/jvm_test_suite_plugin.html#sec:jvm_test_suite_tasks

This adds a new integration test to demonstrates this behavior.  This is intentional, see: https://github.com/gradle/gradle/blob/74fb3be30d536b3ee83c97a8d3be0d13c7ad8c54/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java#L125

This PR also adjust docs to note this.