### PR TITLE
Use neutral square icon for configuration cache inputs in the report

### DIFF
--- a/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/ConfigurationCacheReportPage.kt
@@ -40,6 +40,8 @@ sealed class ProblemNode {
 
     data class Warning(val label: ProblemNode, val docLink: ProblemNode?) : ProblemNode()
 
+    data class Info(val label: ProblemNode, val docLink: ProblemNode?) : ProblemNode()
+
     data class Task(val path: String, val type: String) : ProblemNode()
 
     data class Bean(val type: String) : ProblemNode()
@@ -271,7 +273,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun viewTree(
         subTrees: Sequence<Tree.Focus<ProblemNode>>,
         treeIntent: (ProblemTreeIntent) -> Intent,
-        suffixForWarning: (ProblemNode.Warning, Tree.Focus<ProblemNode>) -> View<Intent> = { _, _ -> empty }
+        suffixForInfo: (ProblemNode.Info, Tree.Focus<ProblemNode>) -> View<Intent> = { _, _ -> empty }
     ): View<Intent> = div(
         ol(
             viewSubTrees(subTrees) { focus ->
@@ -291,8 +293,17 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
                             focus,
                             labelNode.label,
                             labelNode.docLink,
-                            prefix = warningIcon,
-                            suffix = suffixForWarning(labelNode, focus)
+                            prefix = warningIcon
+                        )
+                    }
+                    is ProblemNode.Info -> {
+                        treeLabel(
+                            treeIntent,
+                            focus,
+                            labelNode.label,
+                            labelNode.docLink,
+                            prefix = squareIcon,
+                            suffix = suffixForInfo(labelNode, focus)
                         )
                     }
                     is ProblemNode.Exception -> {
@@ -369,7 +380,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     fun treeButtonFor(child: Tree.Focus<ProblemNode>, treeIntent: (ProblemTreeIntent) -> Intent): View<Intent> =
         when {
             child.tree.isNotEmpty() -> viewTreeButton(child, treeIntent)
-            else -> emptyTreeIcon
+            else -> squareIcon
         }
 
     private
@@ -404,7 +415,7 @@ object ConfigurationCacheReportPage : Component<ConfigurationCacheReportPage.Mod
     )
 
     private
-    val emptyTreeIcon = span<Intent>(
+    val squareIcon = span<Intent>(
         attributes { className("tree-icon") },
         "■"
     )

--- a/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
+++ b/subprojects/configuration-cache-report/src/main/kotlin/Main.kt
@@ -183,7 +183,7 @@ fun inputNodes(inputs: List<ImportedProblem>): Sequence<MutableList<ProblemNode>
             val inputType = message.fragments.first().unsafeCast<PrettyText.Fragment.Text>().text.trim()
             val inputDescription = message.copy(fragments = message.fragments.drop(1))
             add(
-                ProblemNode.Warning(
+                ProblemNode.Info(
                     ProblemNode.Label(inputType),
                     docLinkFor(input.problem)
                 )


### PR DESCRIPTION
Instead of the warning icon.
<img width="434" alt="Screen Shot 2022-01-07 at 11 05 25" src="https://user-images.githubusercontent.com/51689/148583715-6486357b-53ce-40aa-aa40-f5d565876525.png">

