### PR TITLE
Include display name of Describable ValueSources in the configuration cache report

### DIFF
--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampFromBuildReceiptValueSource.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/provider/BuildTimestampFromBuildReceiptValueSource.kt
@@ -17,13 +17,14 @@
 package gradlebuild.identity.provider
 
 import gradlebuild.identity.tasks.BuildReceipt
+import org.gradle.api.Describable
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Optional
 
 
-abstract class BuildTimestampFromBuildReceiptValueSource : ValueSource<String, BuildTimestampFromBuildReceiptValueSource.Parameters> {
+abstract class BuildTimestampFromBuildReceiptValueSource : ValueSource<String, BuildTimestampFromBuildReceiptValueSource.Parameters>, Describable {
 
     interface Parameters : ValueSourceParameters {
 
@@ -41,8 +42,17 @@ abstract class BuildTimestampFromBuildReceiptValueSource : ValueSource<String, B
             }
     }
 
+    override fun getDisplayName(): String =
+        "the build timestamp extracted from the build receipt".let {
+            when {
+                parameters.ignoreIncomingBuildReceipt.get() -> "$it (ignored)"
+                else -> it
+            }
+        }
+
     private
-    fun Parameters.buildReceiptString(): String? =
-        if (ignoreIncomingBuildReceipt.get()) null
-        else buildReceiptFileContents.orNull
+    fun Parameters.buildReceiptString(): String? = when {
+        ignoreIncomingBuildReceipt.get() -> null
+        else -> buildReceiptFileContents.orNull
+    }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -215,7 +215,8 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun <T : Any, P : ValueSourceParameters> valueObtained(
-        obtainedValue: ValueSourceProviderFactory.Listener.ObtainedValue<T, P>
+        obtainedValue: ValueSourceProviderFactory.Listener.ObtainedValue<T, P>,
+        source: org.gradle.api.provider.ValueSource<T, P>
     ) {
         when (val parameters = obtainedValue.valueSourceParameters) {
             is FileContentValueSource.Parameters -> {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
@@ -57,7 +57,8 @@ public interface ValueSourceProviderFactory {
     interface Listener {
 
         <T, P extends ValueSourceParameters> void valueObtained(
-            ObtainedValue<T, P> obtainedValue
+            ObtainedValue<T, P> obtainedValue,
+            ValueSource<T, P> source
         );
 
         interface ObtainedValue<T, P extends ValueSourceParameters> {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -68,7 +68,8 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
             it.parameters.value.set('42')
         }
         def obtainedValueCount = 0
-        valueSourceProviderFactory.addListener {
+        valueSourceProviderFactory.addListener { value, source ->
+            assert source instanceof EchoValueSource
             obtainedValueCount += 1
         }
 
@@ -91,7 +92,10 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
             it.parameters.value.set("42")
         }
         List<ObtainedValue<?, ValueSourceParameters>> obtainedValues = []
-        valueSourceProviderFactory.addListener { obtainedValues.add(it) }
+        valueSourceProviderFactory.addListener { value, source ->
+            assert source instanceof  EchoValueSource
+            obtainedValues.add(value)
+        }
 
         when: "value is obtained for the 1st time"
         provider.get()

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultValueSourceProviderFactoryTest.groovy
@@ -93,7 +93,7 @@ class DefaultValueSourceProviderFactoryTest extends ValueSourceBasedSpec {
         }
         List<ObtainedValue<?, ValueSourceParameters>> obtainedValues = []
         valueSourceProviderFactory.addListener { value, source ->
-            assert source instanceof  EchoValueSource
+            assert source instanceof EchoValueSource
             obtainedValues.add(value)
         }
 


### PR DESCRIPTION
For a more comprehensible report:
<img width="712" alt="Screen Shot 2022-01-07 at 15 36 26" src="https://user-images.githubusercontent.com/51689/148595322-e2bbe398-b764-49f4-956f-eab0cc47ee1a.png">

