### PR TITLE
New sample: Sharing task outputs across projects

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -543,6 +543,13 @@ samples {
             description = "Developing a Gradle plugin in a build without publishing."
             category = "Build organization"
         }
+
+        crossProjectOutputSharing {
+            sampleDirectory = samplesRoot.dir("build-organization/cross-project-output-sharing")
+            displayName = "Sharing task outputs across projects in a multi-project build"
+            description = "Sharing a file made by a task in one Gradle project, with a task in another Gradle project."
+            category = "Build organization"
+        }
     }
 }
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -25,7 +25,6 @@ include::sample[dir="kotlin",files="consumer/build.gradle.kts[]"]
 See also:
 
 - <<../userguide/cross_project_publications.adoc#cross_project_publications, Sharing outputs between projects>>
-- https://github.com/robmoore-i/gradle-share-outputs-betwee-projects/tree/groovy[A minimal example Gradle project demonstrating this feature, provided from the community]
 
 == Anti-patterns:
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -1,0 +1,41 @@
+You want to share a file made by a task in one project with a task in another project.
+For example, one task makes a file, and the other task reads the file and uses some information inside it.
+This is one way you can share information across project boundaries. (Another way is to use extension objects.)
+
+== Example
+
+.Settings
+====
+include::sample[dir="groovy",files="settings.gradle[]"]
+include::sample[dir="kotlin",files="settings.gradle.kts[]"]
+====
+
+.Producer's build
+====
+include::sample[dir="groovy",files="producer/build.gradle[]"]
+include::sample[dir="kotlin",files="producer/build.gradle.kts[]"]
+====
+
+.Consumer's build
+====
+include::sample[dir="groovy",files="consumer/build.gradle[]"]
+include::sample[dir="kotlin",files="consumer/build.gradle.kts[]"]
+====
+
+See also:
+
+- <<../userguide/cross_project_publications.adoc#cross_project_publications, Sharing outputs between projects>>
+- https://github.com/robmoore-i/gradle-share-outputs-betwee-projects/tree/groovy[A minimal example Gradle project demonstrating this feature, provided from the community]
+
+== Anti-patterns:
+
+[WARNING]
+.Don't reference other project tasks directly
+====
+A frequent anti-pattern to declare cross-project dependencies is:
+[source,groovy]
+---- dependencies {
+// this is unsafe!
+implementation project(":other").tasks.someOtherJar } ---- This publication model is _unsafe_ and can lead to non-reproducible and hard to parallelize builds.
+(WHY?)
+====

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -32,10 +32,14 @@ See also:
 [WARNING]
 .Don't reference other project tasks directly
 ====
-A frequent anti-pattern to declare cross-project dependencies is:
+A frequent anti-pattern to declare cross-project dependencies is below. This publication model is unsafe and can lead to non-reproducible
+and hard to parallelize builds. By declaring a dependency in this way, the task ordering between consumers and producers is not known to Gradle
+at the time when it is deciding the order of tasks for a given build. This means that potentially, consumers of  this file "someOtherJar" can
+execute before the producer task that creates the jar! This would lead to builds that are either totally broken, or worse, broken is a way
+that is subtle, flaky, and difficult to debug.
 [source,groovy]
----- dependencies {
-// this is unsafe!
-implementation project(":other").tasks.someOtherJar } ---- This publication model is _unsafe_ and can lead to non-reproducible and hard to parallelize builds.
-(WHY?)
+dependencies {
+  // This publication model can make your build flaky and broken!
+  implementation project(":other").tasks.someOtherJar
+}
 ====

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -2,6 +2,13 @@ You want to share a file made by a task in one project with a task in another pr
 For example, one task makes a file, and the other task reads the file and uses some information inside it.
 This is one way you can share information across project boundaries. (Another way is to use extension objects.)
 
+[NOTE]
+====
+This demonstrates the <<../userguide/cross_project_publications.adoc#simple-sharing-artifacts-between-projects, simple version>> of sharing information across project boundaries, by explicitly specifying which producer project's _consumable configuration_ to use for a locally available artifact.
+
+When the producer publishes an artifact to a repository, to retrieve that artifact you will need to use <<../userguide/cross_project_publications.adoc#variant-aware-sharing, the advanced version>> of variant aware dependency resolution.  This method will also work locally.
+====
+
 == Example
 
 .Settings

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/README.adoc
@@ -6,7 +6,8 @@ This is one way you can share information across project boundaries. (Another wa
 ====
 This demonstrates the <<../userguide/cross_project_publications.adoc#simple-sharing-artifacts-between-projects, simple version>> of sharing information across project boundaries, by explicitly specifying which producer project's _consumable configuration_ to use for a locally available artifact.
 
-When the producer publishes an artifact to a repository, to retrieve that artifact you will need to use <<../userguide/cross_project_publications.adoc#variant-aware-sharing, the advanced version>> of variant aware dependency resolution.  This method will also work locally.
+When the producer publishes an artifact to a repository, to retrieve that artifact you will need to use <<../userguide/cross_project_publications.adoc#variant-aware-sharing, the advanced version>> of variant aware dependency resolution.
+This method will also work locally.
 ====
 
 == Example
@@ -38,11 +39,11 @@ See also:
 [WARNING]
 .Don't reference other project tasks directly
 ====
-A frequent anti-pattern to declare cross-project dependencies is below. This publication model is unsafe and can lead to non-reproducible
-and hard to parallelize builds. By declaring a dependency in this way, the task ordering between consumers and producers is not known to Gradle
-at the time when it is deciding the order of tasks for a given build. This means that potentially, consumers of  this file "someOtherJar" can
-execute before the producer task that creates the jar! This would lead to builds that are either totally broken, or worse, broken is a way
-that is subtle, flaky, and difficult to debug.
+A frequent anti-pattern to declare cross-project dependencies is below.
+This publication model is unsafe and can lead to non-reproducible and hard to parallelize builds.
+By declaring a dependency in this way, the task ordering between consumers and producers is not known to Gradle at the time when it is deciding the order of tasks for a given build.
+This means that potentially, consumers of the file "someOtherJar" can execute before the producer task that creates the jar!
+This would lead to builds that are either totally broken, or worse, broken is a way that is subtle, flaky, and difficult to debug.
 [source,groovy]
 dependencies {
   // This publication model can make your build flaky and broken!

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
@@ -13,6 +13,6 @@ tasks.register("showFile") {
     FileCollection sharedFiles = configurations.getByName("sharedConfiguration")
     inputs.files(sharedFiles)
     doFirst {
-        logger.lifecycle("File is at {}", sharedFiles.singleFile.absolutePath)
+        logger.lifecycle("Shared file contains the text: '{}'", sharedFiles.singleFile.text)
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
@@ -10,9 +10,9 @@ dependencies {
 }
 
 tasks.register("showFile") {
-    def sharedConfiguration = configurations.getByName("sharedConfiguration")
-    it.inputs.files(sharedConfiguration)
-    it.doFirst {
-        logger.lifecycle("File is at {}", sharedConfiguration.singleFile.absolutePath)
+    FileCollection sharedFiles = configurations.getByName("sharedConfiguration")
+    inputs.files(sharedFiles)
+    doFirst {
+        logger.lifecycle("File is at {}", sharedFiles.singleFile.absolutePath)
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/consumer/build.gradle
@@ -1,0 +1,18 @@
+configurations {
+    sharedConfiguration {
+        canBeConsumed = false
+        canBeResolved = true
+    }
+}
+
+dependencies {
+    sharedConfiguration(project("path": ":producer", "configuration": "sharedConfiguration"))
+}
+
+tasks.register("showFile") {
+    def sharedConfiguration = configurations.getByName("sharedConfiguration")
+    it.inputs.files(sharedConfiguration)
+    it.doFirst {
+        logger.lifecycle("File is at {}", sharedConfiguration.singleFile.absolutePath)
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
@@ -1,8 +1,9 @@
-def outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
-def makeFile = tasks.register("makeFile", DefaultTask) {
-    it.outputs.file(outputFile)
-    it.doFirst {
-        outputFile.get().asFile << "This file is shared across Gradle subprojects."
+def sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
+
+def makeFile = tasks.register("makeFile") {
+    outputs.file(sharedFile)
+    doFirst {
+        sharedFile.get().asFile << "This file is shared across Gradle subprojects."
     }
 }
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
@@ -1,6 +1,5 @@
-def sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
-
 def makeFile = tasks.register("makeFile") {
+    def sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
     outputs.file(sharedFile)
     doFirst {
         sharedFile.get().asFile << "This file is shared across Gradle subprojects."

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
@@ -1,10 +1,8 @@
-import java.nio.file.Files
-
 def outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
 def makeFile = tasks.register("makeFile", DefaultTask) {
     it.outputs.file(outputFile)
     it.doFirst {
-        Files.writeString(outputFile.get().asFile.toPath(), "This file is shared across Gradle subprojects.")
+        outputFile.get().asFile << "This file is shared across Gradle subprojects."
     }
 }
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
@@ -1,0 +1,20 @@
+import java.nio.file.Files
+
+def outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+def makeFile = tasks.register("makeFile", DefaultTask) {
+    it.outputs.file(outputFile)
+    it.doFirst {
+        Files.writeString(outputFile.get().asFile.toPath(), "This file is shared across Gradle subprojects.")
+    }
+}
+
+configurations {
+    sharedConfiguration {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+artifacts {
+    sharedConfiguration(makeFile)
+}

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/producer/build.gradle
@@ -1,5 +1,5 @@
 def makeFile = tasks.register("makeFile") {
-    def sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
+    def sharedFile = layout.buildDirectory.file("some-subdir/shared-file.txt")
     outputs.file(sharedFile)
     doFirst {
         sharedFile.get().asFile << "This file is shared across Gradle subprojects."

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/groovy/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = "sharing-outputs"
+include("producer")
+include("consumer")

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -11,6 +11,6 @@ tasks.register("showFile") {
     val sharedFiles: FileCollection = sharedConfiguration
     inputs.files(sharedFiles)
     doFirst {
-        logger.lifecycle("File is at {}", sharedFiles.singleFile.absolutePath)
+        logger.lifecycle("Shared file contains the text: '{}'", sharedFiles.singleFile.readText())
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -1,0 +1,15 @@
+val sharedConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+dependencies {
+    add(sharedConfiguration.name, project(mapOf("path" to ":producer", "configuration" to "sharedConfiguration")))
+}
+
+tasks.register("showFile") {
+    inputs.files(sharedConfiguration)
+    doFirst {
+        logger.lifecycle(sharedConfiguration.singleFile.absolutePath)
+    }
+}

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -8,9 +8,9 @@ dependencies {
 }
 
 tasks.register("showFile") {
-    inputs.files(sharedConfiguration)
-
+    val sharedFiles: FileCollection = sharedConfiguration
+    inputs.files(sharedFiles)
     doFirst {
-        logger.lifecycle("File is at {}", sharedConfiguration.singleFile.absolutePath)
+        logger.lifecycle("File is at {}", sharedFiles.singleFile.absolutePath)
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -7,13 +7,10 @@ dependencies {
     sharedConfiguration(project(path = ":producer", configuration = "sharedConfiguration"))
 }
 
-val sharedFile: File = sharedConfiguration.singleFile
-
 tasks.register("showFile") {
-    inputs.file(sharedFile)
+    inputs.files(sharedConfiguration)
 
-    val sharedFileAbsolutePath = sharedFile.absolutePath
     doFirst {
-        logger.lifecycle(sharedFileAbsolutePath)
+        logger.lifecycle("File is at {}", sharedConfiguration.singleFile.absolutePath)
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -4,7 +4,7 @@ val sharedConfiguration: Configuration by configurations.creating {
 }
 
 dependencies {
-    add(sharedConfiguration.name, project(mapOf("path" to ":producer", "configuration" to "sharedConfiguration")))
+    sharedConfiguration(project(path = ":producer", configuration = "sharedConfiguration"))
 }
 
 tasks.register("showFile") {

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/consumer/build.gradle.kts
@@ -7,9 +7,13 @@ dependencies {
     sharedConfiguration(project(path = ":producer", configuration = "sharedConfiguration"))
 }
 
+val sharedFile: File = sharedConfiguration.singleFile
+
 tasks.register("showFile") {
-    inputs.files(sharedConfiguration)
+    inputs.file(sharedFile)
+
+    val sharedFileAbsolutePath = sharedFile.absolutePath
     doFirst {
-        logger.lifecycle(sharedConfiguration.singleFile.absolutePath)
+        logger.lifecycle(sharedFileAbsolutePath)
     }
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -1,6 +1,5 @@
-val sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
-
 val makeFile = tasks.register("makeFile") {
+    val sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
     outputs.file(sharedFile)
     doFirst {
         sharedFile.get().asFile.writeText("This file is shared across Gradle subprojects.")
@@ -13,5 +12,5 @@ val sharedConfiguration by configurations.creating {
 }
 
 artifacts {
-    add(sharedConfiguration.name, sharedFile)
+    add(sharedConfiguration.name, makeFile)
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -1,0 +1,17 @@
+val outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+val makeFile = tasks.register("makeFile") {
+    outputs.file(outputFile)
+    doFirst {
+        outputFile.get().asFile
+            .writeText("This file is shared across Gradle subprojects.")
+    }
+}
+
+val sharedConfiguration: Configuration by configurations.creating {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+}
+
+artifacts {
+    add(sharedConfiguration.name, makeFile)
+}

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -1,9 +1,11 @@
-val outputFile = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+val sharedFile: Provider<RegularFile> = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+
 val makeFile = tasks.register("makeFile") {
-    outputs.file(outputFile)
+    outputs.file(sharedFile)
+
+    val fileToWrite = sharedFile.get().asFile
     doFirst {
-        outputFile.get().asFile
-            .writeText("This file is shared across Gradle subprojects.")
+        fileToWrite.writeText("This file is shared across Gradle subprojects.")
     }
 }
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -2,7 +2,6 @@ val sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt
 
 val makeFile = tasks.register("makeFile") {
     outputs.file(sharedFile)
-
     doFirst {
         sharedFile.get().asFile.writeText("This file is shared across Gradle subprojects.")
     }
@@ -14,5 +13,5 @@ val sharedConfiguration by configurations.creating {
 }
 
 artifacts {
-    add(sharedConfiguration.name, makeFile)
+    add(sharedConfiguration.name, sharedFile)
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -3,9 +3,8 @@ val sharedFile: Provider<RegularFile> = project.layout.buildDirectory.dir("some-
 val makeFile = tasks.register("makeFile") {
     outputs.file(sharedFile)
 
-    val fileToWrite = sharedFile.get().asFile
     doFirst {
-        fileToWrite.writeText("This file is shared across Gradle subprojects.")
+        sharedFile.get().asFile.writeText("This file is shared across Gradle subprojects.")
     }
 }
 

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -9,7 +9,7 @@ val makeFile = tasks.register("makeFile") {
     }
 }
 
-val sharedConfiguration: Configuration by configurations.creating {
+val sharedConfiguration by configurations.creating {
     isCanBeConsumed = true
     isCanBeResolved = false
 }

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -1,4 +1,4 @@
-val sharedFile: Provider<RegularFile> = project.layout.buildDirectory.dir("some-subdir").map { it.file("shared-file.txt") }
+val sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
 
 val makeFile = tasks.register("makeFile") {
     outputs.file(sharedFile)

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/producer/build.gradle.kts
@@ -1,5 +1,5 @@
 val makeFile = tasks.register("makeFile") {
-    val sharedFile = project.layout.buildDirectory.file("some-subdir/shared-file.txt")
+    val sharedFile = layout.buildDirectory.file("some-subdir/shared-file.txt")
     outputs.file(sharedFile)
     doFirst {
         sharedFile.get().asFile.writeText("This file is shared across Gradle subprojects.")

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/kotlin/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "sharing-outputs"
+include("producer")
+include("consumer")

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.out
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.out
@@ -1,0 +1,4 @@
+> Task :producer:makeFile
+
+> Task :consumer:showFile
+Shared file contains the text: 'This file is shared across Gradle subprojects.'

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
@@ -1,0 +1,4 @@
+commands: [{
+    executable: gradle
+    args: check
+}]

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
@@ -1,4 +1,4 @@
 commands: [{
     executable: gradle
-    args: check
+    args: showFile
 }]

--- a/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
+++ b/subprojects/docs/src/samples/build-organization/cross-project-output-sharing/tests/check.sample.conf
@@ -1,4 +1,6 @@
 commands: [{
     executable: gradle
     args: showFile
+    expected-output-file: check.out
+    allow-additional-output: true
 }]


### PR DESCRIPTION
This sample answers a user who is pondering this question:

"I want to make a file over here, and then use it over there. How do I do that?"