### PR TITLE
Monitor cache misses in build-logic

### DIFF
--- a/build-logic-commons/build-scan/build.gradle.kts
+++ b/build-logic-commons/build-scan/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-dependencyResolutionManagement {
-    repositories {
-        gradlePluginPortal()
-    }
+plugins {
+    `kotlin-dsl`
 }
 
-include("code-quality")
-include("build-scan")
-include("code-quality-rules")
-include("gradle-plugin")
+description = "Provides a plugin that configures build scans in the Gradle build"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+group = "gradlebuild"
+
+dependencies {
+    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.8")
+}

--- a/build-logic-commons/build-scan/build.gradle.kts
+++ b/build-logic-commons/build-scan/build.gradle.kts
@@ -28,5 +28,5 @@ java {
 group = "gradlebuild"
 
 dependencies {
-    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.8")
+    compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.8")
 }

--- a/build-logic-commons/build-scan/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/build-scan/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.gradle.scan.plugin.BuildScanExtension
+import java.util.concurrent.atomic.AtomicBoolean
+
+val cacheMissTagged = AtomicBoolean(false)
+val buildScan = extensions.findByType<BuildScanExtension>()
+
+if (System.getenv("TEAMCITY_VERSION") != null) {
+    gradle.taskGraph.afterTask {
+        if (buildCacheEnabled() && isCacheMiss() && isNotTaggedYet()) {
+            buildScan?.tag("CACHE_MISS")
+        }
+    }
+}
+
+fun buildCacheEnabled() = gradle.startParameter.isBuildCacheEnabled
+
+fun isNotTaggedYet() = cacheMissTagged.compareAndSet(false, true)
+
+fun Task.isCacheMiss() = !state.skipped && state.failure == null && (isCompileCacheMiss() || isAsciidoctorCacheMiss())
+
+fun Task.isCompileCacheMiss() = isMonitoredCompileTask() && !isExpectedCompileCacheMiss()
+
+fun isAsciidoctorCacheMiss() = isMonitoredAsciidoctorTask() && !isExpectedAsciidoctorCacheMiss()
+
+fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this.isClasspathManifest()) && !this.isKotlinJsIrLink()
+
+fun Task.isClasspathManifest() = this.javaClass.simpleName.startsWith("ClasspathManifest")
+
+// https://youtrack.jetbrains.com/issue/KT-49915
+fun Task.isKotlinJsIrLink() = this.javaClass.simpleName.startsWith("KotlinJsIrLink")
+
+fun isMonitoredAsciidoctorTask() = false // No asciidoctor tasks are cacheable for now
+
+fun isExpectedAsciidoctorCacheMiss() =
+// Expected cache-miss for asciidoctor task:
+// 1. CompileAll is the seed build for docs:distDocs
+// 2. BuildDistributions is the seed build for other asciidoctor tasks
+// 3. buildScanPerformance test, which doesn't depend on compileAll
+// 4. buildScanPerformance test, which doesn't depend on compileAll
+    isInBuild(
+        "Check_CompileAllBuild",
+        "Check_BuildDistributions",
+        "Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Component_GradlePlugin_Performance_PerformanceLatestReleased"
+    )
+
+fun isExpectedCompileCacheMiss() =
+// Expected cache-miss:
+// 1. CompileAll is the seed build
+// 2. Gradleception which re-builds Gradle with a new Gradle version
+// 3. buildScanPerformance test, which doesn't depend on compileAll
+// 4. buildScanPerformance test, which doesn't depend on compileAll
+// 5. BuildCommitDistribution may build a commit which is not built before
+    isInBuild(
+        "Check_CompileAllBuild",
+        "Component_GradlePlugin_Performance_PerformanceLatestMaster",
+        "Component_GradlePlugin_Performance_PerformanceLatestReleased",
+        "Check_Gradleception"
+    ) || isBuildCommitDistribution
+
+val Project.isBuildCommitDistribution: Boolean
+    get() = providers.gradleProperty("buildCommitDistribution").map { it.toBoolean() }.orElse(false).get()
+
+
+fun isInBuild(vararg buildTypeIds: String) = providers.environmentVariable("BUILD_TYPE_ID").orNull?.let { currentBuildTypeId ->
+    buildTypeIds.any { currentBuildTypeId.endsWith(it) }
+} ?: false

--- a/build-logic-commons/build-scan/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/build-scan/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -18,12 +18,14 @@ import com.gradle.scan.plugin.BuildScanExtension
 import java.util.concurrent.atomic.AtomicBoolean
 
 val cacheMissTagged = AtomicBoolean(false)
-val buildScan = extensions.findByType<BuildScanExtension>()
+plugins.withId("com.gradle.build-scan") {
+    val buildScan = extensions.findByType<BuildScanExtension>()
 
-if (System.getenv("TEAMCITY_VERSION") != null) {
-    gradle.taskGraph.afterTask {
-        if (buildCacheEnabled() && isCacheMiss() && isNotTaggedYet()) {
-            buildScan?.tag("CACHE_MISS")
+    if (System.getenv("TEAMCITY_VERSION") != null) {
+        gradle.taskGraph.afterTask {
+            if (buildCacheEnabled() && isCacheMiss() && isNotTaggedYet()) {
+                buildScan?.tag("CACHE_MISS")
+            }
         }
     }
 }

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -11,6 +11,7 @@ java {
 
 dependencies {
     implementation(project(":code-quality"))
+    implementation(project(":build-scan"))
 
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.2.0")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.7.0")

--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.build-logic.kotlin-dsl-gradle-plugin.gradle.kts
@@ -36,6 +36,7 @@ java {
 dependencies {
     api(platform(project(":build-platform")))
     implementation("gradlebuild:code-quality")
+    implementation("gradlebuild:build-scan")
 
     testImplementation("org.junit.vintage:junit-vintage-engine")
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("gradlebuild.cache-miss-monitor")
+}
+
 description = "Provides plugins that are used by Gradle subprojects"
 
 tasks.register("check") {


### PR DESCRIPTION
This PR extracts `cache-miss-monitor` to `build-logic-commons` so that cache misses in `build-logic` can be monitored.