### PR TITLE
Fix discovering of new Testng 7.x methods

### DIFF
--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -7,6 +7,15 @@ description = "A set of generic services and utilities."
 
 gradlebuildJava.usedInWorkers()
 
+/**
+ * Use Java 8 compatibility for Unit tests, so we can test Java 8 features as well
+ */
+tasks.named<JavaCompile>("compileTestJava") {
+    options.release.set(null)
+    sourceCompatibility = "8"
+    targetCompatibility = "8"
+}
+
 moduleIdentity.createBuildReceipt()
 
 dependencies {

--- a/subprojects/base-services/build.gradle.kts
+++ b/subprojects/base-services/build.gradle.kts
@@ -11,9 +11,7 @@ gradlebuildJava.usedInWorkers()
  * Use Java 8 compatibility for Unit tests, so we can test Java 8 features as well
  */
 tasks.named<JavaCompile>("compileTestJava") {
-    options.release.set(null)
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
+    options.release.set(8)
 }
 
 moduleIdentity.createBuildReceipt()

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaMethod.java
@@ -78,11 +78,15 @@ public class JavaMethod<T, R> {
         Method method = findMethodFrom(target.getMethods(), name, allowStatic, paramTypes);
         if (method == null) {
             // Else search declared methods recursively
-            return findDeclaredMethod(target, name, allowStatic, paramTypes);
+            method = findDeclaredMethod(target, name, allowStatic, paramTypes);
         }
-        return method;
+        if (method != null) {
+            return method;
+        }
+        throw new NoSuchMethodException(String.format("Could not find method %s(%s) on %s.", name, StringUtils.join(paramTypes, ", "), target.getSimpleName()));
     }
 
+    @Nullable
     private static Method findDeclaredMethod(Class<?> origTarget, String name, boolean allowStatic, Class<?>[] paramTypes) {
         Class<?> target = origTarget;
         while (target != null) {
@@ -92,7 +96,7 @@ public class JavaMethod<T, R> {
             }
             target = target.getSuperclass();
         }
-        throw new NoSuchMethodException(String.format("Could not find method %s(%s) on %s.", name, StringUtils.join(paramTypes, ", "), origTarget.getSimpleName()));
+        return null;
     }
 
     @Nullable

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTest.groovy
@@ -82,4 +82,8 @@ class JavaMethodTest extends Specification {
         e.message == /Could not find method unknown() on JavaMethodTestSubjectSubclass./
     }
 
+    def "default methods are discovered"() {
+        expect:
+        JavaMethod.of(JavaMethodTestSubjectSubclass, String, "defaultMethod").invoke(new JavaMethodTestSubjectSubclass()) == "parent-interface"
+    }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTestSubject.java
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTestSubject.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.reflect;
 
 @SuppressWarnings("UnusedDeclaration")
-public class JavaMethodTestSubject {
+public class JavaMethodTestSubject implements JavaMethodTestSubjectInterface {
     private static String myStaticProperty;
 
     final IllegalStateException failure = new IllegalStateException();

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTestSubjectInterface.java
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaMethodTestSubjectInterface.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect;
+
+interface JavaMethodTestSubjectInterface {
+
+    default String defaultMethod() {
+        return "parent-interface";
+    }
+
+}


### PR DESCRIPTION
If an interface has a default method we might not find it by just checking the declared methods.
So now we first check all public methods and if method is not found we check declared methods
recursively.

Fixes #18566, since some of 7.x. TestNG interfaces have default methods that we previously did not find.

