### PR TITLE
Adjust ContinuousBuildChangeReportingIntegrationTest

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -26,7 +26,6 @@ import org.gradle.test.fixtures.file.TestFile
 import static org.gradle.internal.filewatch.DefaultFileSystemChangeWaiterFactory.QUIET_PERIOD_SYSPROP
 import static org.gradle.internal.filewatch.DefaultFileWatcherEventListener.SHOW_INDIVIDUAL_CHANGES_LIMIT
 
-// Developer is able to easily determine the file(s) that triggered a rebuild
 class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIntegrationTest {
     TestFile inputDir
     private static int changesLimit = SHOW_INDIVIDUAL_CHANGES_LIMIT
@@ -37,6 +36,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         buildFile << """
             task theTask {
               inputs.dir "inputDir"
+              outputs.files "build/outputs"
               doLast {}
             }
         """
@@ -60,7 +60,10 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
 
     def "should report the absolute file path of the created files when the number of files added to the input directory is at the limit"() {
         given:
-        def inputFiles = (1..changesLimit).collect { inputDir.file("input${it}.txt") }
+        // We need to put these files in subdirectories, since on Linux we'd stop watching a directory as soon as we
+        // received file changes for all the files inside.
+        def inputSubdirectories = (1..changesLimit).collect { inputDir.createDir("subdir${it}")}
+        def inputFiles = inputSubdirectories.collect { inputDir.file("input.txt") }
         when:
         succeeds("theTask")
         inputFiles.each { it.text = 'New input file' }
@@ -73,7 +76,10 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
 
     def "should report the absolute file path of the created files up to the limit and 'and some more changes' when the number of files added to the input directory is over the limit"() {
         given:
-        def inputFiles = (1..9).collect { inputDir.file("input${it}.txt") }
+        // We need to put these files in subdirectories, since on Linux we'd stop watching a directory as soon as we
+        // received file changes for all the files inside.
+        def inputSubdirectories = (1..9).collect { inputDir.createDir("subdir${it}")}
+        def inputFiles = inputSubdirectories.collect { it.file("input.txt") }
         when:
         succeeds("theTask")
         inputFiles.each { it.text = 'New input file' }


### PR DESCRIPTION
for new infrastructure. This means two changes:
- Create subdirectories for creating files, so we receive more than one file event with the new infrastructure
- Add an output file to the base task.