### PR TITLE
Fix IndexOutOfBoundsException when invalidating

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/VfsRelativePath.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/VfsRelativePath.java
@@ -57,7 +57,7 @@ public class VfsRelativePath {
     }
 
     private static String normalizeRoot(String absolutePath) {
-        if (absolutePath.equals("/")) {
+        if (absolutePath.isEmpty() || absolutePath.equals("/")) {
             return absolutePath;
         }
         return isFileSeparator(absolutePath.charAt(absolutePath.length() - 1))

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/VfsRelativePathTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/VfsRelativePathTest.groovy
@@ -36,6 +36,7 @@ class VfsRelativePathTest extends Specification {
         '/a'                   | 'a'
         '/a/b/c'               | 'a/b/c'
         '/a/b/c/'              | 'a/b/c'
+        ''                     | ''
     }
 
     def "'#relativePath' fromChild '#child' is '#result'"() {


### PR DESCRIPTION
Under some circumstances, it is possible that we invalidate the root of the VFS, denoted by the empty absolute path. This happens for example when we the path comes from the root of a FileHierarchySet.

This PR fixes a StringIndexOutOfBoundsException which happens in that case.