### PR TITLE
Fix broken Kotlin DSL model builders cross version tests

### DIFF
--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/AbstractKotlinScriptModelCrossVersionTest.groovy
@@ -70,6 +70,9 @@ abstract class AbstractKotlinScriptModelCrossVersionTest extends ToolingApiSpeci
     def setup() {
         // Required for the lenient classpath mode
         toolingApi.requireDaemons()
+        // Only Kotlin settings scripts
+        settingsFile.delete()
+        file("settings.gradle.kts").touch()
     }
 
     private String defaultSettingsScript = ""

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r41/KotlinBuildScriptTemplateModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r41/KotlinBuildScriptTemplateModelCrossVersionSpec.groovy
@@ -27,9 +27,6 @@ class KotlinBuildScriptTemplateModelCrossVersionSpec extends AbstractKotlinScrip
 
     def "can load script template using classpath model"() {
 
-        given:
-        settingsFile << ""
-
         when:
         def model = loadToolingModel(KotlinBuildScriptTemplateModel)
 

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/KotlinBuildScriptModelCrossVersionSpec.groovy
@@ -22,7 +22,6 @@ import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVers
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.Flaky
 import org.hamcrest.Matcher
-import spock.lang.Ignore
 
 import static org.hamcrest.CoreMatchers.allOf
 import static org.hamcrest.CoreMatchers.equalTo
@@ -169,7 +168,6 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         )
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "can fetch buildscript classpath for sub-project script"() {
 
         expect:
@@ -455,7 +453,6 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         )
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "sourcePath includes buildscript classpath sources resolved against project"() {
 
         expect:
@@ -470,7 +467,6 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         )
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "sourcePath includes buildscript classpath sources resolved against project hierarchy"() {
 
         expect:
@@ -485,7 +481,6 @@ class KotlinBuildScriptModelCrossVersionSpec extends AbstractKotlinScriptModelCr
         )
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "sourcePath includes plugins classpath sources resolved against project"() {
 
         expect:

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r54/PrecompiledScriptPluginModelCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.kotlin.dsl.tooling.builders.AbstractKotlinScriptModelCrossVers
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.Flaky
-import spock.lang.Ignore
 
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.startsWith
@@ -69,7 +68,6 @@ class PrecompiledScriptPluginModelCrossVersionSpec extends AbstractKotlinScriptM
         )
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "given a multi-project build, the classpath of a precompiled script plugin is the compile classpath of its enclosing source-set"() {
 
         given:

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,10 +17,12 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
 

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -18,11 +18,9 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Ignore("https://github.com/gradle/gradle-private/issues/3500")
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
 

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -18,11 +18,9 @@ package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
-@Ignore("https://github.com/gradle/gradle-private/issues/3500")
 class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "can fetch model for a given set of scripts"() {

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslGivenScriptsModelCrossVersionSpec.groovy
@@ -17,10 +17,12 @@
 package org.gradle.kotlin.dsl.tooling.builders.r60
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @TargetGradleVersion(">=6.0")
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslGivenScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
     def "can fetch model for a given set of scripts"() {

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r60/KotlinDslScriptsModelCrossVersionSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.kotlin.dsl.tooling.models.KotlinBuildScriptModel
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslScriptModel
 import org.gradle.test.fixtures.Flaky
-import spock.lang.Ignore
 
 import java.lang.reflect.Proxy
 
@@ -30,7 +29,6 @@ import java.lang.reflect.Proxy
 @Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 class KotlinDslScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/3500")
     def "single request models equal multi requests models"() {
 
         given:

--- a/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
+++ b/subprojects/kotlin-dsl-tooling-builders/src/crossVersionTest/groovy/org/gradle/kotlin/dsl/tooling/builders/r68/KotlinDslDefaultScriptsModelCrossVersionSpec.groovy
@@ -17,9 +17,11 @@
 package org.gradle.kotlin.dsl.tooling.builders.r68
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
 @TargetGradleVersion(">=6.8")
+@Flaky(because = 'https://github.com/gradle/gradle-private/issues/3414')
 @LeaksFileHandles("Kotlin Compiler Daemon taking time to shut down")
 class KotlinDslDefaultScriptsModelCrossVersionSpec extends AbstractKotlinDslScriptsModelCrossVersionSpec {
 


### PR DESCRIPTION
Those tests were broken by https://github.com/gradle/gradle/commit/0139f007e35e344781bd60a055d637323554fca7 that added a `settings.gradle` file to all TAPI tests, interfering with the `settings.gradle.kts` used by the tests. This PR fixes this.

https://github.com/gradle/gradle-private/issues/3500