### PR TITLE
Move WatchMode to org.gradle.internal.watch.registry

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/StartParameterInternal.java
@@ -21,7 +21,7 @@ import org.gradle.initialization.BuildLayoutParameters;
 import org.gradle.initialization.StartParameterBuildOptions.ConfigurationCacheProblemsOption;
 import org.gradle.internal.buildoption.BuildOption;
 import org.gradle.internal.buildtree.BuildModelParameters;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 
 import java.io.File;
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -32,7 +32,7 @@ import org.gradle.internal.buildoption.IntegerBuildOption;
 import org.gradle.internal.buildoption.ListBuildOption;
 import org.gradle.internal.buildoption.Origin;
 import org.gradle.internal.buildoption.StringBuildOption;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/EnableFileSystemWatchingIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.internal.watch
 
 import org.gradle.initialization.StartParameterBuildOptions
-import org.gradle.internal.watch.vfs.WatchMode
+import org.gradle.internal.watch.registry.WatchMode
 
 class EnableFileSystemWatchingIntegrationTest extends AbstractFileSystemWatchingIntegrationTest {
     private static final String ENABLED_MESSAGE = "Watching the file system is configured to be enabled"

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -19,7 +19,6 @@ package org.gradle.internal.watch.registry;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.WatchingNotSupportedException;
-import org.gradle.internal.watch.vfs.WatchMode;
 
 import javax.annotation.CheckReturnValue;
 import java.io.Closeable;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherUpdater.java
@@ -19,7 +19,6 @@ package org.gradle.internal.watch.registry;
 import org.gradle.internal.file.FileHierarchySet;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
-import org.gradle.internal.watch.vfs.WatchMode;
 
 import javax.annotation.CheckReturnValue;
 import java.io.File;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/WatchMode.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/WatchMode.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.internal.watch.vfs;
+package org.gradle.internal.watch.registry;
 
 import org.slf4j.Logger;
 import org.slf4j.helpers.NOPLogger;

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdater.java
@@ -25,7 +25,7 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -24,7 +24,7 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdater.java
@@ -24,7 +24,7 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry;
 import org.gradle.internal.watch.registry.FileWatcherUpdater;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/WatchableHierarchies.java
@@ -23,7 +23,7 @@ import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -20,6 +20,7 @@ import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.internal.vfs.VirtualFileSystem;
+import org.gradle.internal.watch.registry.WatchMode;
 
 import java.io.File;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -24,12 +24,12 @@ import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.internal.vfs.impl.AbstractVirtualFileSystem;
 import org.gradle.internal.vfs.impl.VfsRootReference;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.VfsLogging;
 import org.gradle.internal.watch.vfs.WatchLogging;
-import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -30,6 +30,7 @@ import org.gradle.internal.vfs.impl.VfsRootReference;
 import org.gradle.internal.watch.WatchingNotSupportedException;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex;
 import org.gradle.internal.watch.registry.impl.SnapshotCollectingDiffListener;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
@@ -38,7 +39,6 @@ import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperatio
 import org.gradle.internal.watch.vfs.FileSystemWatchingStatistics;
 import org.gradle.internal.watch.vfs.VfsLogging;
 import org.gradle.internal.watch.vfs.WatchLogging;
-import org.gradle.internal.watch.vfs.WatchMode;
 import org.gradle.internal.watch.vfs.WatchableFileSystemDetector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/AbstractFileWatcherUpdaterTest.groovy
@@ -33,7 +33,7 @@ import org.gradle.internal.vfs.impl.AbstractVirtualFileSystem
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.watch.registry.FileWatcherProbeRegistry
 import org.gradle.internal.watch.registry.FileWatcherUpdater
-import org.gradle.internal.watch.vfs.WatchMode
+import org.gradle.internal.watch.registry.WatchMode
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/HierarchicalFileWatcherUpdaterTest.groovy
@@ -20,7 +20,7 @@ import net.rubygrapefruit.platform.file.FileWatcher
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.snapshot.MissingFileSnapshot
 import org.gradle.internal.watch.registry.FileWatcherUpdater
-import org.gradle.internal.watch.vfs.WatchMode
+import org.gradle.internal.watch.registry.WatchMode
 
 import static org.gradle.internal.watch.registry.impl.HierarchicalFileWatcherUpdater.FileSystemLocationToWatchValidator.NO_VALIDATION
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/registry/impl/NonHierarchicalFileWatcherUpdaterTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.watch.registry.impl
 
 import net.rubygrapefruit.platform.file.FileWatcher
 import org.gradle.internal.watch.registry.FileWatcherUpdater
-import org.gradle.internal.watch.vfs.WatchMode
+import org.gradle.internal.watch.registry.WatchMode
 
 class NonHierarchicalFileWatcherUpdaterTest extends AbstractFileWatcherUpdaterTest {
 

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystemTest.groovy
@@ -21,9 +21,9 @@ import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.snapshot.SnapshotHierarchy
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.vfs.impl.VfsRootReference
+import org.gradle.internal.watch.registry.WatchMode
 import org.gradle.internal.watch.vfs.VfsLogging
 import org.gradle.internal.watch.vfs.WatchLogging
-import org.gradle.internal.watch.vfs.WatchMode
 import spock.lang.Specification
 
 class WatchingNotSupportedVirtualFileSystemTest extends Specification {

--- a/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
+++ b/subprojects/file-watching/src/test/groovy/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystemTest.groovy
@@ -24,10 +24,10 @@ import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 import org.gradle.internal.vfs.impl.VfsRootReference
 import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory
+import org.gradle.internal.watch.registry.WatchMode
 import org.gradle.internal.watch.registry.impl.DaemonDocumentationIndex
 import org.gradle.internal.watch.vfs.VfsLogging
 import org.gradle.internal.watch.vfs.WatchLogging
-import org.gradle.internal.watch.vfs.WatchMode
 import org.gradle.internal.watch.vfs.WatchableFileSystemDetector
 import spock.lang.Specification
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -28,10 +28,10 @@ import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.scopes.VirtualFileSystemServices;
 import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics;
 import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.VfsLogging;
 import org.gradle.internal.watch.vfs.WatchLogging;
-import org.gradle.internal.watch.vfs.WatchMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/action/BuildActionSerializer.java
@@ -36,7 +36,7 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.ListSerializer;
 import org.gradle.internal.serialize.Serializer;
 import org.gradle.internal.serialize.SetSerializer;
-import org.gradle.internal.watch.vfs.WatchMode;
+import org.gradle.internal.watch.registry.WatchMode;
 import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.protocol.events.InternalTestDescriptor;
 import org.gradle.tooling.internal.protocol.test.InternalDebugOptions;

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -26,10 +26,10 @@ import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.operations.BuildOperationRunner
 import org.gradle.internal.snapshot.impl.DirectorySnapshotterStatistics
 import org.gradle.internal.watch.options.FileSystemWatchingSettingsFinalizedProgressDetails
+import org.gradle.internal.watch.registry.WatchMode
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem
 import org.gradle.internal.watch.vfs.VfsLogging
 import org.gradle.internal.watch.vfs.WatchLogging
-import org.gradle.internal.watch.vfs.WatchMode
 import spock.lang.Specification
 
 class FileSystemWatchingBuildActionRunnerTest extends Specification {


### PR DESCRIPTION
The registry should not depend on the virtual file system,
and leaving WatchMode in `vfs` causes a cyclic dependency
when doing the continuous build changes.