### PR TITLE
Fix map property validation with the configuration cache enabled

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.provider
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Issue
 
 class MapPropertyIntegrationTest extends AbstractIntegrationSpec {
@@ -611,7 +610,6 @@ task thing {
         succeeds('verify')
     }
 
-    @ToBeFixedForConfigurationCache
     @Issue('https://github.com/gradle/gradle/issues/11036')
     def "fails with precise error message when property is a map literal with null values"() {
         given:

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -468,7 +468,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (fixed) {
                 Map<K, V> entries = new LinkedHashMap<>();
                 for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
-                    entries.putAll(value.getFixedValue());
+                    entryCollector.addAll(value.getFixedValue().entrySet(), entries);
                 }
                 ExecutionTimeValue<Map<K, V>> value = ExecutionTimeValue.fixedValue(ImmutableMap.copyOf(entries));
                 if (changingContent) {


### PR DESCRIPTION
By reusing the existing validation logic.

This is a follow up to https://github.com/gradle/gradle/pull/18415
