### PR TITLE
Fix dependency verification when first resolved configuration has dependency verification disabled

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
@@ -53,11 +53,11 @@ class AbstractDependencyVerificationIntegTest extends AbstractHttpDependencyReso
                 id 'java-library'
             }
 
-            repositories {
-                maven {
-                    url "${mavenHttpRepo.uri}"
-                }
-            }
+//            repositories {
+//                maven {
+//                    url "${mavenHttpRepo.uri}"
+//                }
+//            }
         """
         def projectName = "main"
         if (f != buildFile) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/AbstractDependencyVerificationIntegTest.groovy
@@ -53,11 +53,11 @@ class AbstractDependencyVerificationIntegTest extends AbstractHttpDependencyReso
                 id 'java-library'
             }
 
-//            repositories {
-//                maven {
-//                    url "${mavenHttpRepo.uri}"
-//                }
-//            }
+            repositories {
+                maven {
+                    url "${mavenHttpRepo.uri}"
+                }
+            }
         """
         def projectName = "main"
         if (f != buildFile) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -927,7 +927,6 @@ This can indicate that a dependency has been compromised. Please carefully verif
         terse << [true, false]
     }
 
-    @ToBeFixedForConfigurationCache
     def "fails validation when first configuration has verification disabled"() {
         createMetadataFile {
             addChecksum("org:foo:1.0", 'sha256', "invalid")
@@ -950,9 +949,11 @@ This can indicate that a dependency has been compromised. Please carefully verif
             }
 
             tasks.register("printConfigurations") {
+                FileCollection unverified = configurations.unverified
+                FileCollection classpath = configurations.compileClasspath
                 doLast {
-                    println configurations.unverified.files
-                    println configurations.compileClasspath.files
+                    println unverified.files
+                    println classpath.files
                 }
             }
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -184,7 +184,7 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
                 for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
                     ModuleComponentArtifactIdentifier moduleComponentArtifactIdentifier = (ModuleComponentArtifactIdentifier) artifact.getId();
                     if (!operation.wasAlreadyProcessed(moduleComponentArtifactIdentifier, repositoryId)) {
-                        resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
+//                        resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -179,10 +179,9 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
         @Override
         public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             delegate.resolveArtifacts(component, variant, result);
-            if (result.hasResult() && result.isSuccessful() && component.getId() instanceof ModuleComponentIdentifier) {
+            if (result.hasResult() && result.isSuccessful()) {
                 for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
-                    ModuleComponentArtifactIdentifier moduleComponentArtifactIdentifier = (ModuleComponentArtifactIdentifier) artifact.getId();
-                    if (!operation.wasAlreadyProcessed(moduleComponentArtifactIdentifier, getId())) {
+                    if (isExternalArtifactId(artifact.getId()) && !operation.wasAlreadyProcessed((ModuleComponentArtifactIdentifier) artifact.getId(), getId())) {
                         resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -180,11 +180,10 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
         public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             delegate.resolveArtifacts(component, variant, result);
             if (result.hasResult() && result.isSuccessful() && component.getId() instanceof ModuleComponentIdentifier) {
-                String repositoryId = getId();
                 for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
                     ModuleComponentArtifactIdentifier moduleComponentArtifactIdentifier = (ModuleComponentArtifactIdentifier) artifact.getId();
-                    if (!operation.wasAlreadyProcessed(moduleComponentArtifactIdentifier, repositoryId)) {
-//                        resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
+                    if (!operation.wasAlreadyProcessed(moduleComponentArtifactIdentifier, getId())) {
+                        resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -179,6 +179,13 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
         @Override
         public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             delegate.resolveArtifacts(component, variant, result);
+            if (component.getId() instanceof ModuleComponentIdentifier) {
+                if (result.hasResult() && result.isSuccessful()) {
+                    for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
+                        resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
+                    }
+                }
+            }
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -179,9 +179,11 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
         @Override
         public void resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata variant, BuildableComponentArtifactsResolveResult result) {
             delegate.resolveArtifacts(component, variant, result);
-            if (component.getId() instanceof ModuleComponentIdentifier) {
-                if (result.hasResult() && result.isSuccessful()) {
-                    for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
+            if (result.hasResult() && result.isSuccessful() && component.getId() instanceof ModuleComponentIdentifier) {
+                String repositoryId = getId();
+                for (ComponentArtifactMetadata artifact : variant.getArtifacts()) {
+                    ModuleComponentArtifactIdentifier moduleComponentArtifactIdentifier = (ModuleComponentArtifactIdentifier) artifact.getId();
+                    if (!operation.wasAlreadyProcessed(moduleComponentArtifactIdentifier, repositoryId)) {
                         resolveArtifact(artifact, component.getSources(), new DefaultBuildableArtifactResolveResult());
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ArtifactVerificationOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ArtifactVerificationOperation.java
@@ -22,6 +22,7 @@ import java.io.File;
 
 public interface ArtifactVerificationOperation {
     void onArtifact(ArtifactKind kind, ModuleComponentArtifactIdentifier artifact, File mainFile, Factory<File> signatureFile, String repositoryName, String repositoryId);
+    boolean wasAlreadyProcessed(ModuleComponentArtifactIdentifier artifact, String repositoryId);
 
     enum ArtifactKind {
         METADATA,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/ChecksumAndSignatureVerificationOverride.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.artifacts.verification.DependencyVerificationMode;
@@ -69,7 +70,7 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
     private final ChecksumService checksumService;
     private final SignatureVerificationService signatureVerificationService;
     private final DependencyVerificationMode verificationMode;
-    private final Set<VerificationQuery> verificationQueries = Sets.newConcurrentHashSet();
+    private final Set<String> verificationQueries = Sets.newConcurrentHashSet();
     private final Deque<VerificationEvent> verificationEvents = Queues.newArrayDeque();
     private final AtomicBoolean closed = new AtomicBoolean();
     private final AtomicBoolean hasFatalFailure = new AtomicBoolean();
@@ -107,12 +108,17 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
 
     @Override
     public void onArtifact(ArtifactKind kind, ModuleComponentArtifactIdentifier artifact, File mainFile, Factory<File> signatureFile, String repositoryName, String repositoryId) {
-        if (verificationQueries.add(new VerificationQuery(artifact, repositoryId))) {
+        if (verificationQueries.add(getVerificationQuery(artifact, repositoryId))) {
             VerificationEvent event = new VerificationEvent(kind, artifact, mainFile, signatureFile, repositoryName);
             synchronized (verificationEvents) {
                 verificationEvents.add(event);
             }
         }
+    }
+
+    @Override
+    public boolean wasAlreadyProcessed(ModuleComponentArtifactIdentifier artifact, String repositoryId) {
+        return verificationQueries.contains(getVerificationQuery(artifact, repositoryId));
     }
 
     private void verifyConcurrently() {
@@ -224,50 +230,9 @@ public class ChecksumAndSignatureVerificationOverride implements DependencyVerif
         signatureVerificationService.stop();
     }
 
-    private static class VerificationQuery {
-        private final ModuleComponentArtifactIdentifier artifact;
-        private final String repositoryId;
-        private final int hashCode;
-
-        public VerificationQuery(ModuleComponentArtifactIdentifier artifact, String repositoryId) {
-            this.artifact = artifact;
-            this.repositoryId = repositoryId;
-            this.hashCode = precomputeHashCode(artifact, repositoryId);
-        }
-
-        private int precomputeHashCode(ModuleComponentArtifactIdentifier artifact, String repositoryId) {
-            int hashCode = artifact.getComponentIdentifier().hashCode();
-            hashCode = 31 * hashCode + artifact.getFileName().hashCode();
-            hashCode = 31 * hashCode + repositoryId.hashCode();
-            return hashCode;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            VerificationQuery that = (VerificationQuery) o;
-            if (hashCode != that.hashCode) {
-                return false;
-            }
-            if (!artifact.getComponentIdentifier().equals(that.artifact.getComponentIdentifier())) {
-                return false;
-            }
-            if (!artifact.getFileName().equals(that.artifact.getFileName())) {
-                return false;
-            }
-            return repositoryId.equals(that.repositoryId);
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode;
-        }
+    private String getVerificationQuery(ModuleComponentArtifactIdentifier artifactIdentifier, String repositoryId) {
+        ModuleComponentIdentifier componentIdentifier = artifactIdentifier.getComponentIdentifier();
+        return componentIdentifier.getVersion() + ":" + componentIdentifier.getModule() + ":" + componentIdentifier.getGroup() + ":" + artifactIdentifier.getFileName() + ":" + repositoryId;
     }
 
     private static class VerificationEvent {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -437,6 +437,13 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         }
     }
 
+    @Override
+    public boolean wasAlreadyProcessed(ModuleComponentArtifactIdentifier artifact, String repositoryId) {
+        // Since writing to a file is done rarely and this is called only to avoid resolving
+        // artifacts again when already cached, there is not much penalty to not do any check here
+        return false;
+    }
+
     private void addPgp(ModuleComponentArtifactIdentifier id, ArtifactKind kind, File mainFile, Factory<File> signatureFile) {
         PgpEntry entry = new PgpEntry(id, kind, mainFile, signatureFile);
         synchronized (entriesToBeWritten) {


### PR DESCRIPTION
Previously if the dependency artifact was already resolved with an unverified configuration, then when resolving the second configuration `resolveArtifact` was not called. Since in `resolveArtifact` we register verification operation (and download signature file) verification was not done.

So now for `DependencyVerifyingModuleComponentRepository` when `resolveArtifacts` is called we also do a call to `resolveArtifact` in case it was not called before, so verification operation is registered.

Fixes [#3497](https://github.com/gradle/gradle-private/issues/3497)


