### PR TITLE
Fingerprint all data from a`ResolvedComponentResult` used as a task intput

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
@@ -79,7 +79,9 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
             apply plugin: 'java-library'
             repositories { maven { url "${mavenHttpRepo.uri}" } }
             dependencies {
-                implementation 'org.external:external-lib:1.0'
+                implementation('org.external:external-lib:1.0') {
+                    because(System.getProperty('selectionReason', 'original'))
+                }
                 implementation 'org.external:external-lib2:1.0'
                 implementation project('project-lib')
                 implementation files('lib/file-lib.jar')
@@ -533,6 +535,13 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
 
         then:
         skipped ":verify"
+        notExecuted ":project-lib:jar", ":composite-lib:jar"
+
+        when: "changing selection reason"
+        succeeds "verify", "-DselectionReason=changed"
+
+        then:
+        executedAndNotSkipped ":verify"
         notExecuted ":project-lib:jar", ":composite-lib:jar"
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyManagementResultsAsInputsIntegrationTest.groovy
@@ -543,6 +543,27 @@ class DependencyManagementResultsAsInputsIntegrationTest extends AbstractHttpDep
         then:
         executedAndNotSkipped ":verify"
         notExecuted ":project-lib:jar", ":composite-lib:jar"
+
+        when: "changing project library variant metadata"
+        succeeds "verify", "-DprojectLibAttrValue=new-value"
+
+        then:
+        executedAndNotSkipped ":verify"
+        notExecuted ":project-lib:jar", ":composite-lib:jar"
+
+        when: "changing included library variant metadata"
+        succeeds "verify", "-DcompositeLibAttrValue=new-value"
+
+        then:
+        executedAndNotSkipped ":verify"
+        notExecuted ":project-lib:jar", ":composite-lib:jar"
+
+        when: "changing external library variant metadata"
+        succeeds "verify", "-DexternalLibAttrValue=new-value"
+
+        then:
+        executedAndNotSkipped ":verify"
+        notExecuted ":project-lib:jar", ":composite-lib:jar"
     }
 
     private void withOriginalSourceIn(String basePath) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -97,10 +97,11 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         register(AttributeContainer.class, attributeContainerSerializer);
         register(ResolvedVariantResult.class, new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer));
         register(ComponentSelectionDescriptor.class, new ComponentSelectionDescriptorSerializer(componentSelectionDescriptorFactory));
-        register(ComponentSelectionReason.class, new ComponentSelectionReasonSerializer(componentSelectionDescriptorFactory));
+        ComponentSelectionReasonSerializer componentSelectionReasonSerializer = new ComponentSelectionReasonSerializer(componentSelectionDescriptorFactory);
+        register(ComponentSelectionReason.class, componentSelectionReasonSerializer);
         ComponentSelectorSerializer componentSelectorSerializer = new ComponentSelectorSerializer(attributeContainerSerializer);
         register(ComponentSelector.class, componentSelectorSerializer);
-        register(ResolvedComponentResult.class, new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer));
+        register(ResolvedComponentResult.class, new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer, componentSelectionReasonSerializer));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -95,13 +95,14 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         register(ModuleComponentFileArtifactIdentifier.class, new ModuleComponentFileArtifactIdentifierSerializer());
         register(DefaultModuleComponentIdentifier.class, Cast.uncheckedCast(componentIdentifierSerializer));
         register(AttributeContainer.class, attributeContainerSerializer);
-        register(ResolvedVariantResult.class, new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer));
+        ResolvedVariantResultSerializer resolvedVariantResultSerializer = new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer);
+        register(ResolvedVariantResult.class, resolvedVariantResultSerializer);
         register(ComponentSelectionDescriptor.class, new ComponentSelectionDescriptorSerializer(componentSelectionDescriptorFactory));
         ComponentSelectionReasonSerializer componentSelectionReasonSerializer = new ComponentSelectionReasonSerializer(componentSelectionDescriptorFactory);
         register(ComponentSelectionReason.class, componentSelectionReasonSerializer);
         ComponentSelectorSerializer componentSelectorSerializer = new ComponentSelectorSerializer(attributeContainerSerializer);
         register(ComponentSelector.class, componentSelectorSerializer);
-        register(ResolvedComponentResult.class, new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer, componentSelectionReasonSerializer));
+        register(ResolvedComponentResult.class, new ResolvedComponentResultSerializer(moduleVersionIdentifierSerializer, componentIdentifierSerializer, componentSelectorSerializer, resolvedVariantResultSerializer, componentSelectionReasonSerializer));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult;
 import org.gradle.api.internal.artifacts.result.DefaultUnresolvedDependencyResult;
@@ -31,6 +32,7 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,17 +40,20 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
     private final Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer;
     private final Serializer<ComponentIdentifier> componentIdSerializer;
     private final Serializer<ComponentSelector> componentSelectorSerializer;
+    private final Serializer<ResolvedVariantResult> resolvedVariantResultSerializer;
     private final Serializer<ComponentSelectionReason> componentSelectionReasonSerializer;
 
     public ResolvedComponentResultSerializer(
         Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer,
         Serializer<ComponentIdentifier> componentIdSerializer,
         Serializer<ComponentSelector> componentSelectorSerializer,
+        Serializer<ResolvedVariantResult> resolvedVariantResultSerializer,
         Serializer<ComponentSelectionReason> componentSelectionReasonSerializer
     ) {
         this.moduleVersionIdSerializer = moduleVersionIdSerializer;
         this.componentIdSerializer = componentIdSerializer;
         this.componentSelectorSerializer = componentSelectorSerializer;
+        this.resolvedVariantResultSerializer = resolvedVariantResultSerializer;
         this.componentSelectionReasonSerializer = componentSelectionReasonSerializer;
     }
 
@@ -78,6 +83,11 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
         moduleVersionIdSerializer.write(encoder, component.getModuleVersion());
         componentIdSerializer.write(encoder, component.getId());
         componentSelectionReasonSerializer.write(encoder, component.getSelectionReason());
+        List<ResolvedVariantResult> variants = component.getVariants();
+        encoder.writeSmallInt(variants.size());
+        for (ResolvedVariantResult variant : variants) {
+            resolvedVariantResultSerializer.write(encoder, variant);
+        }
         Set<? extends DependencyResult> dependencies = component.getDependencies();
         encoder.writeSmallInt(dependencies.size());
         for (DependencyResult dependency : dependencies) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ResolvedComponentResultSerializer.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
@@ -37,15 +38,18 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
     private final Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer;
     private final Serializer<ComponentIdentifier> componentIdSerializer;
     private final Serializer<ComponentSelector> componentSelectorSerializer;
+    private final Serializer<ComponentSelectionReason> componentSelectionReasonSerializer;
 
     public ResolvedComponentResultSerializer(
         Serializer<ModuleVersionIdentifier> moduleVersionIdSerializer,
         Serializer<ComponentIdentifier> componentIdSerializer,
-        Serializer<ComponentSelector> componentSelectorSerializer
+        Serializer<ComponentSelector> componentSelectorSerializer,
+        Serializer<ComponentSelectionReason> componentSelectionReasonSerializer
     ) {
         this.moduleVersionIdSerializer = moduleVersionIdSerializer;
         this.componentIdSerializer = componentIdSerializer;
         this.componentSelectorSerializer = componentSelectorSerializer;
+        this.componentSelectionReasonSerializer = componentSelectionReasonSerializer;
     }
 
     @Override
@@ -73,6 +77,7 @@ public class ResolvedComponentResultSerializer implements Serializer<ResolvedCom
         encoder.writeSmallInt(id);
         moduleVersionIdSerializer.write(encoder, component.getModuleVersion());
         componentIdSerializer.write(encoder, component.getId());
+        componentSelectionReasonSerializer.write(encoder, component.getSelectionReason());
         Set<? extends DependencyResult> dependencies = component.getDependencies();
         encoder.writeSmallInt(dependencies.size());
         for (DependencyResult dependency : dependencies) {


### PR DESCRIPTION
Two pieces were missing:
* the selection reason
* the variants metadata

This PR adds snapshotting of the missing pieces, reusing existing serializers that are shared with the dependency resolution result caching.
