### PR TITLE
Remove sourceCompatibility and targetCompatibility from build-logic-commons

### DIFF
--- a/build-logic-commons/build-scan/build.gradle.kts
+++ b/build-logic-commons/build-scan/build.gradle.kts
@@ -20,11 +20,6 @@ plugins {
 
 description = "Provides a plugin that configures build scans in the Gradle build"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 group = "gradlebuild"
 
 dependencies {

--- a/build-logic-commons/code-quality-rules/build.gradle.kts
+++ b/build-logic-commons/code-quality-rules/build.gradle.kts
@@ -3,11 +3,6 @@ plugins {
 }
 description = "Provides a custom CodeNarc rule used by the Gradle build"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 group = "gradlebuild"
 
 dependencies {

--- a/build-logic-commons/code-quality/build.gradle.kts
+++ b/build-logic-commons/code-quality/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
 
 description = "Provides a plugin that configures code quality plugins in the Gradle build"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 group = "gradlebuild"
 
 dependencies {

--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
 
 description = "Provides plugins used to create a Gradle plugin with Groovy or Kotlin DSL within build-logic builds"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}
-
 dependencies {
     implementation(project(":code-quality"))
     implementation(project(":build-scan"))


### PR DESCRIPTION
We don't need them to be Java 8 compatible. According to the doc, the default value is current JVM version, which is Java 11.

> JavaVersion sourceCompatibility
> Java version compatibility to use when compiling Java source. Default value: version of the current JVM in use.