### PR TITLE
Remove keys.fedoraproject.org from DefaultKeyServers

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultKeyServers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultKeyServers.java
@@ -25,7 +25,6 @@ import java.util.List;
 public abstract class DefaultKeyServers {
     private final static List<URI> DEFAULT_KEYSERVERS = ImmutableList.of(
         uri("hkp://ha.pool.sks-keyservers.net"),
-        uri("https://keys.fedoraproject.org"),
         uri("https://keyserver.ubuntu.com"),
         uri("https://keys.openpgp.org")
     );


### PR DESCRIPTION
Service was shutdown.

Fixes #19605
