### PR TITLE
Correctly resolve platform dependencies from aggregator project

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -188,6 +188,28 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
     }
 
+    def 'aggregated report infers dependency versions from platform'() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+        """
+        file("transitive/build.gradle") << """
+            dependencies {
+                implementation 'org.apache.commons:commons-io:1.3.2'
+                implementation(platform('org.springframework.boot:spring-boot-dependencies:2.5.8'))
+                runtimeOnly 'org.codehaus.janino:janino'
+            }
+        """
+
+        when:
+        succeeds(":application:testCodeCoverageReport")
+
+        then:
+        def report = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
+        report.assertDoesNotContainClass("org.codehaus.janino.Parser")
+    }
+
     def 'multiple test suites create multiple aggregation tasks'() {
         given:
         file("transitive/build.gradle") << """
@@ -322,6 +344,54 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         report.assertHasClassCoverage("application.Adder")
         report.assertHasClassCoverage("direct.Multiplier")
         report.assertHasClassCoverage("transitive.Powerize")
+    }
+
+    def "can aggregate jacoco reports from root project with platform"() {
+        given:
+        file("transitive/build.gradle") << """
+            dependencies {
+                implementation 'org.apache.commons:commons-io:1.3.2'
+                implementation(platform('org.springframework.boot:spring-boot-dependencies:2.5.8'))
+                runtimeOnly 'org.codehaus.janino:janino'
+            }
+        """
+
+        buildFile << """
+            apply plugin: 'jvm-ecosystem'
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+
+            dependencies {
+                jacocoAggregation project(":application")
+                jacocoAggregation project(":direct")
+            }
+
+            reporting {
+                reports {
+                    testCodeCoverageReport(JacocoCoverageReport) {
+                        testType = TestSuiteType.UNIT_TEST
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds(":testCodeCoverageReport")
+
+        then:
+        file("transitive/build/jacoco/test.exec").assertExists()
+        file("direct/build/jacoco/test.exec").assertExists()
+        file("application/build/jacoco/test.exec").assertExists()
+
+        file("build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("application.Adder")
+        report.assertHasClassCoverage("direct.Multiplier")
+        report.assertHasClassCoverage("transitive.Powerize")
+
+        // verify that external dependencies are filtered
+        report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
+        report.assertDoesNotContainClass("org.codehaus.janino.Parser")
     }
 
     def 'can apply custom attributes to refine coverage results'() {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -53,6 +53,7 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply("org.gradle.reporting-base");
+        project.getPluginManager().apply("jvm-ecosystem");
         project.getPluginManager().apply("jacoco");
 
         Configuration jacocoAggregation = project.getConfigurations().create(JACOCO_AGGREGATION_CONFIGURATION_NAME);


### PR DESCRIPTION
An aggregator project without the `java` plugin applied fails to incorporate dependency constraints read from a BOM when resolving dependencies.

This fix applies the `jvm-ecosystem` plugin when applying `jacoco-report-aggregation`. This is a no-op if the project doing the aggregation already has the `java` plugin applied.