### PR TITLE
Fix method name typo in swift tests

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
@@ -393,11 +393,11 @@ class SwiftIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInt
         return result
     }
 
-    def swiftsourceinfoFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
+    def swiftmoduleFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
         return intermediateFileFor(sourceFile, intermediateFilesDir, "~partial.swiftmodule")
     }
 
-    def swiftmoduleFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
+    def swiftsourceinfoFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
         return intermediateFileFor(sourceFile, intermediateFilesDir, "~partial.swiftsourceinfo")
     }
 


### PR DESCRIPTION
The name was apparently wrong if you take a look at the method body.

This caused the build failing with Swift 4. This also reveals a problem that TD agent docker image lacks swift 4: https://github.com/gradle/gradle-build-test-distribution-agent/blob/master/Dockerfile#L141 so if the test happens to be scheduled on local executor (which has swift 4/5 installed), the build will fail. 
