### PR TITLE
Review types excluded from annotation analysis

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionAware.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/ExtensionAware.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.plugins;
 
+import org.gradle.api.tasks.Internal;
+
 /**
  * Objects that can be extended at runtime with other objects.
  *
@@ -84,6 +86,7 @@ public interface ExtensionAware {
     /**
      * The container of extensions.
      */
+    @Internal
     ExtensionContainer getExtensions();
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -25,11 +25,8 @@ import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.DefaultDomainObjectCollection;
-import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DefaultNamedDomainObjectCollection;
-import org.gradle.api.internal.DefaultNamedDomainObjectList;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
-import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
@@ -155,11 +152,8 @@ public class ExecutionGlobalServices {
                 // Inputs can extend these classes,
                 // so we want to ignore get methods declared in these classes
                 DefaultDomainObjectCollection.class,
-                DefaultDomainObjectSet.class,
                 DefaultNamedDomainObjectCollection.class,
-                DefaultNamedDomainObjectList.class,
                 DefaultNamedDomainObjectSet.class,
-                DefaultPolymorphicDomainObjectContainer.class,
                 // Used in gradle-base so it can't have annotations anyway
                 Describable.class
             ),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -52,6 +52,7 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.internal.tasks.properties.annotations.TypeAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.UntrackedTaskTypeAnnotationHandler;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -154,6 +155,8 @@ public class ExecutionGlobalServices {
                 DefaultDomainObjectCollection.class,
                 DefaultNamedDomainObjectCollection.class,
                 DefaultNamedDomainObjectSet.class,
+                // Task extends this interface
+                ExtensionAware.class,
                 // Used in gradle-base so it can't have annotations anyway
                 Describable.class
             ),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -156,19 +156,33 @@ public class ExecutionGlobalServices {
                 "kotlin"
             ),
             ImmutableSet.of(
-                ClosureBackedAction.class,
-                ConfigureUtil.WrappedConfigureAction.class,
+//                // model-core
+//                ClosureBackedAction.class,
+//                // model-core
+//                ConfigureUtil.WrappedConfigureAction.class,
+                // Used in gradle-base
                 Describable.class,
-                DefaultDomainObjectCollection.class,
-                DefaultDomainObjectSet.class,
-                DefaultNamedDomainObjectCollection.class,
-                DefaultNamedDomainObjectList.class,
-                DefaultNamedDomainObjectSet.class,
-                DefaultPolymorphicDomainObjectContainer.class,
-                DynamicObjectAware.class,
-                ExtensionAware.class,
-                deprecatedHasConvention,
-                IConventionAware.class,
+//                // core
+//                DefaultDomainObjectCollection.class,
+//                // core
+//                DefaultDomainObjectSet.class,
+//                // core
+//                DefaultNamedDomainObjectCollection.class,
+//                // core
+//                DefaultNamedDomainObjectList.class,
+//                // core
+//                DefaultNamedDomainObjectSet.class,
+//                // core
+//                DefaultPolymorphicDomainObjectContainer.class,
+//                // model-core
+//                DynamicObjectAware.class,
+//                // core-api
+//                ExtensionAware.class,
+//                // model-core
+//                deprecatedHasConvention,
+//                // model-core
+//                IConventionAware.class,
+                // core
                 ScriptOrigin.class
             ),
             ImmutableSet.of(

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -88,6 +88,7 @@ import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
 import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore;
 import org.gradle.internal.scripts.ScriptOrigin;
+import org.gradle.util.internal.ConfigureUtil;
 import org.gradle.work.DisableCachingByDefault;
 import org.gradle.work.Incremental;
 import org.gradle.work.NormalizeLineEndings;
@@ -149,6 +150,8 @@ public class ExecutionGlobalServices {
                 "kotlin"
             ),
             ImmutableSet.of(
+                // Getter called when there is a nested bean with action in a Task
+                ConfigureUtil.WrappedConfigureAction.class,
                 // Inputs can extend these classes,
                 // so we want to ignore get methods declared in these classes
                 DefaultDomainObjectCollection.class,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -24,6 +24,12 @@ import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.DefaultDomainObjectCollection;
+import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.DefaultNamedDomainObjectCollection;
+import org.gradle.api.internal.DefaultNamedDomainObjectList;
+import org.gradle.api.internal.DefaultNamedDomainObjectSet;
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
@@ -126,8 +132,6 @@ public class ExecutionGlobalServices {
     }
 
     TypeAnnotationMetadataStore createAnnotationMetadataStore(CrossBuildInMemoryCacheFactory cacheFactory, AnnotationHandlerRegistar annotationRegistry) {
-        @SuppressWarnings("deprecation")
-        Class<?> deprecatedHasConvention = org.gradle.api.internal.HasConvention.class;
         ImmutableSet.Builder<Class<? extends Annotation>> builder = ImmutableSet.builder();
         builder.addAll(PROPERTY_TYPE_ANNOTATIONS);
         annotationRegistry.registerPropertyTypeAnnotations(builder);
@@ -145,14 +149,16 @@ public class ExecutionGlobalServices {
                 "kotlin"
             ),
             ImmutableSet.of(
-//                // model-core
-//                ClosureBackedAction.class,
-//                // model-core
-//                ConfigureUtil.WrappedConfigureAction.class,
-                // Used in gradle-base
-                Describable.class,
-                // core
-                ScriptOrigin.class
+                // Inputs can extend these classes,
+                // so we want to ignore get methods declared in these classes
+                DefaultDomainObjectCollection.class,
+                DefaultDomainObjectSet.class,
+                DefaultNamedDomainObjectCollection.class,
+                DefaultNamedDomainObjectList.class,
+                DefaultNamedDomainObjectSet.class,
+                DefaultPolymorphicDomainObjectContainer.class,
+                // Used in gradle-base so it can't have annotations anyway
+                Describable.class
             ),
             ImmutableSet.of(
                 GroovyObject.class,

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -24,8 +24,6 @@ import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.internal.DefaultDomainObjectCollection;
-import org.gradle.api.internal.DefaultNamedDomainObjectCollection;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
@@ -52,7 +50,6 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.internal.tasks.properties.annotations.TypeAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.UntrackedTaskTypeAnnotationHandler;
 import org.gradle.api.model.ReplacedBy;
-import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -148,15 +145,11 @@ public class ExecutionGlobalServices {
                 "kotlin"
             ),
             ImmutableSet.of(
-                // Getter called when there is a nested bean with action in a Task
+                // Used by a nested bean with action in a task, example:
+                // `NestedInputIntegrationTest.implementation of nested closure in decorated bean is tracked`
                 ConfigureUtil.WrappedConfigureAction.class,
-                // Inputs can extend these classes,
-                // so we want to ignore get methods declared in these classes
-                DefaultDomainObjectCollection.class,
-                DefaultNamedDomainObjectCollection.class,
+                // DefaultTestTaskReports used by AbstractTestTask extends this class
                 DefaultNamedDomainObjectSet.class,
-                // Task extends this interface
-                ExtensionAware.class,
                 // Used in gradle-base so it can't have annotations anyway
                 Describable.class
             ),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -24,14 +24,6 @@ import org.gradle.api.artifacts.transform.CacheableTransform;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.internal.DefaultDomainObjectCollection;
-import org.gradle.api.internal.DefaultDomainObjectSet;
-import org.gradle.api.internal.DefaultNamedDomainObjectCollection;
-import org.gradle.api.internal.DefaultNamedDomainObjectList;
-import org.gradle.api.internal.DefaultNamedDomainObjectSet;
-import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
-import org.gradle.api.internal.DynamicObjectAware;
-import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
@@ -57,7 +49,6 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.internal.tasks.properties.annotations.TypeAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.UntrackedTaskTypeAnnotationHandler;
 import org.gradle.api.model.ReplacedBy;
-import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
@@ -91,8 +82,6 @@ import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.reflect.annotations.TypeAnnotationMetadataStore;
 import org.gradle.internal.reflect.annotations.impl.DefaultTypeAnnotationMetadataStore;
 import org.gradle.internal.scripts.ScriptOrigin;
-import org.gradle.util.internal.ClosureBackedAction;
-import org.gradle.util.internal.ConfigureUtil;
 import org.gradle.work.DisableCachingByDefault;
 import org.gradle.work.Incremental;
 import org.gradle.work.NormalizeLineEndings;
@@ -162,26 +151,6 @@ public class ExecutionGlobalServices {
 //                ConfigureUtil.WrappedConfigureAction.class,
                 // Used in gradle-base
                 Describable.class,
-//                // core
-//                DefaultDomainObjectCollection.class,
-//                // core
-//                DefaultDomainObjectSet.class,
-//                // core
-//                DefaultNamedDomainObjectCollection.class,
-//                // core
-//                DefaultNamedDomainObjectList.class,
-//                // core
-//                DefaultNamedDomainObjectSet.class,
-//                // core
-//                DefaultPolymorphicDomainObjectContainer.class,
-//                // model-core
-//                DynamicObjectAware.class,
-//                // core-api
-//                ExtensionAware.class,
-//                // model-core
-//                deprecatedHasConvention,
-//                // model-core
-//                IConventionAware.class,
                 // core
                 ScriptOrigin.class
             ),


### PR DESCRIPTION
Removed:
- `DynamicObjectAware`: Implemented and methods marked as `@Internal` in `AbstractTask`
- `IConventionAware`: Implemented and methods marked as `@Internal` in `AbstractTask`
- `deprecatedHasConvention`: Removed, there is no impact
- `ClosureBackedAction`: Removed, there is no impact
- `ScriptOrigin`: Removed, there in no impact, also it's already defined in `ignoreMethodsFromTypes`
- `DefaultDomainObjectSet`
- `DefaultNamedDomainObjectList`
- `DefaultPolymorphicDomainObjectContainer`

Kept:
- `DefaultDomainObjectCollection`
- `DefaultNamedDomainObjectCollection`
- `DefaultNamedDomainObjectSet`
 removing these makes `Test` task fail with error:
`Type 'org.gradle.api.tasks.testing.Test' property 'reports.additionalProperties' is missing an input or output annotation.
and similar errors`
- `ExtensionAware`: `Task` class extends this interface, we could remove it if we mark the method as `@Internal`
- `Describable`: Used in `gradle-base` so it can't have annotations anyway
- `ConfigureUtil.WrappedConfigureAction`: `NestedInputIntegrationTest.implementation of nested closure in decorated bean is tracked` fails with
  `Type 'TaskWithNestedBeanWithAction' property 'bean.action.configureClosure' is missing an input or output annotation.`
  Example usage:
  ```
  extensions.create("bean", NestedBeanWithAction.class)
  bean {
      withAction { it.text = "hello" }
  }
  task myTask(type: TaskWithNestedBeanWithAction) {
      bean = project.bean
  }
  ```

Fixes #17543