### PR TITLE
Trim proxy port from System property

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
@@ -58,11 +58,12 @@ public abstract class JavaSystemPropertiesProxySettings implements HttpProxySett
             return defaultPort;
         }
         try {
+            proxyPortString = proxyPortString.trim();
             return Integer.parseInt(proxyPortString);
         } catch (NumberFormatException e) {
             String key = propertyPrefix + ".proxyPort";
-            LOGGER.warn("Invalid value for java system property '{}': {}. Default port '{}' will be used.",
-                    key, System.getProperty(key), defaultPort);
+            LOGGER.warn("Invalid value for java system property '{}': '{}'. Value is not a valid number. Default port '{}' will be used.",
+                key, proxyPortString, defaultPort);
             return defaultPort;
         }
     }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettings.java
@@ -35,11 +35,12 @@ public abstract class JavaSystemPropertiesProxySettings implements HttpProxySett
 
     public JavaSystemPropertiesProxySettings(String propertyPrefix, int defaultPort) {
         this(propertyPrefix, defaultPort,
-                System.getProperty(propertyPrefix + ".proxyHost"),
-                System.getProperty(propertyPrefix + ".proxyPort"),
-                System.getProperty(propertyPrefix + ".proxyUser"),
-                System.getProperty(propertyPrefix + ".proxyPassword"),
-                System.getProperty(propertyPrefix + ".nonProxyHosts"));
+            getAndTrimSystemProperty(propertyPrefix + ".proxyHost"),
+            getAndTrimSystemProperty(propertyPrefix + ".proxyPort"),
+            getAndTrimSystemProperty(propertyPrefix + ".proxyUser"),
+            getAndTrimSystemProperty(propertyPrefix + ".proxyPassword"),
+            getAndTrimSystemProperty(propertyPrefix + ".nonProxyHosts")
+        );
     }
 
     JavaSystemPropertiesProxySettings(String propertyPrefix, int defaultPort, String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
@@ -58,7 +59,6 @@ public abstract class JavaSystemPropertiesProxySettings implements HttpProxySett
             return defaultPort;
         }
         try {
-            proxyPortString = proxyPortString.trim();
             return Integer.parseInt(proxyPortString);
         } catch (NumberFormatException e) {
             String key = propertyPrefix + ".proxyPort";
@@ -76,7 +76,7 @@ public abstract class JavaSystemPropertiesProxySettings implements HttpProxySett
         LOGGER.debug("Found java system property 'http.nonProxyHosts': {}. Will ignore proxy settings for these hosts.", nonProxyHostsString);
         List<Pattern> patterns = new ArrayList<Pattern>();
         for (String nonProxyHost : nonProxyHostsString.split("\\|")) {
-            patterns.add(createHostMatcher(nonProxyHost));
+            patterns.add(createHostMatcher(nonProxyHost.trim()));
         }
         return patterns;
     }
@@ -119,5 +119,10 @@ public abstract class JavaSystemPropertiesProxySettings implements HttpProxySett
 
     public int getDefaultPort() {
         return defaultPort;
+    }
+
+    private static String getAndTrimSystemProperty(String key) {
+        String value = System.getProperty(key);
+        return value != null ? value.trim() : null;
     }
 }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.resource.transport.http
 
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
 
 class JavaSystemPropertiesProxySettingsTest extends Specification {
 
@@ -87,6 +88,7 @@ class JavaSystemPropertiesProxySettingsTest extends Specification {
         null   | "anything" | null      | null
     }
 
+    @RestoreSystemProperties
     def "trims system properties"() {
         given:
         System.setProperty("test.proxyHost", " test.hostname ")

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
@@ -65,12 +65,16 @@ class JavaSystemPropertiesProxySettingsTest extends Specification {
         settings("proxyHost", prop, null).getProxy("host").port == value
 
         where:
-        prop     | value
-        null     | 80
-        ""       | 80
-        "notInt" | 80
-        "0"      | 0
-        "111"    | 111
+        prop      | value
+        null      | 80
+        ""        | 80
+        " "       | 80
+        "notInt"  | 80
+        "0"       | 0
+        "111"     | 111
+        "  111  " | 111
+        "  111"   | 111
+        "111  "   | 111
     }
 
     def "uses specified proxy user and password"() {

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/JavaSystemPropertiesProxySettingsTest.groovy
@@ -65,16 +65,12 @@ class JavaSystemPropertiesProxySettingsTest extends Specification {
         settings("proxyHost", prop, null).getProxy("host").port == value
 
         where:
-        prop      | value
-        null      | 80
-        ""        | 80
-        " "       | 80
-        "notInt"  | 80
-        "0"       | 0
-        "111"     | 111
-        "  111  " | 111
-        "  111"   | 111
-        "111  "   | 111
+        prop     | value
+        null     | 80
+        ""       | 80
+        "notInt" | 80
+        "0"      | 0
+        "111"    | 111
     }
 
     def "uses specified proxy user and password"() {
@@ -91,9 +87,33 @@ class JavaSystemPropertiesProxySettingsTest extends Specification {
         null   | "anything" | null      | null
     }
 
+    def "trims system properties"() {
+        given:
+        System.setProperty("test.proxyHost", " test.hostname ")
+        System.setProperty("test.proxyPort", " 100 ")
+        System.setProperty("test.proxyUser", " test-user ")
+        System.setProperty("test.proxyPassword", " test-password ")
+        System.setProperty("test.nonProxyHosts", " test-host1|test-host2 | test-host3 ")
+
+        when:
+        def properties = new TestSystemProperties("test", 80)
+
+        then:
+        properties.getProxy().host == "test.hostname"
+        properties.getProxy().port == 100
+        properties.getProxy().credentials.username == "test-user"
+        properties.getProxy().credentials.password == "test-password"
+        properties.getProxy("test-host1") == null
+        properties.getProxy("test-host2") == null
+        properties.getProxy("test-host3") == null
+    }
+
     class TestSystemProperties extends JavaSystemPropertiesProxySettings {
+        TestSystemProperties(String propertyPrefix, int defaultPort) {
+            super(propertyPrefix, defaultPort)
+        }
         TestSystemProperties(String proxyHost, String proxyPortString, String proxyUser, String proxyPassword, String nonProxyHostsString) {
-            super('http', 80, proxyHost, proxyPortString, proxyUser, proxyPassword, nonProxyHostsString);
+            super('http', 80, proxyHost, proxyPortString, proxyUser, proxyPassword, nonProxyHostsString)
         }
     }
 }


### PR DESCRIPTION
A small fix that trims ports for http(s) proxy. It seems it's easy to have an empty space at the end and it's hard to identify the issue:
https://gradle-community.slack.com/archives/CAHSN3LDN/p1641377705434300