### PR TITLE
Fix build Java version assertion

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -84,21 +84,3 @@ include("packaging")
 include("performance-testing")
 include("profiling")
 include("publishing")
-
-fun remoteBuildCacheEnabled(settings: Settings) = settings.buildCache.remote?.isEnabled == true
-
-fun isAdoptOpenJDK() = true == System.getProperty("java.vendor")?.contains("AdoptOpenJDK")
-
-fun isAdoptOpenJDK11() = isAdoptOpenJDK() && JavaVersion.current().isJava11
-
-fun getBuildJavaHome() = System.getProperty("java.home")
-
-gradle.settingsEvaluated {
-    if ("true" == System.getProperty("org.gradle.ignoreBuildJavaVersionCheck")) {
-        return@settingsEvaluated
-    }
-
-    if (remoteBuildCacheEnabled(this) && !isAdoptOpenJDK11()) {
-        throw GradleException("Remote cache is enabled, which requires AdoptOpenJDK 11 to perform this build. It's currently ${getBuildJavaHome()}.")
-    }
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -175,3 +175,25 @@ FeaturePreviews.Feature.values().forEach { feature ->
         enableFeaturePreview(feature.name)
     }
 }
+
+fun remoteBuildCacheEnabled(settings: Settings) = settings.buildCache.remote?.isEnabled == true
+
+fun isAdoptOrAdoptiumOpenJDK() = true == System.getProperty("java.vendor")?.let { it.contains("AdoptOpenJDK") || it.contains("Adoptium") }
+
+fun isAdoptOrAdoptiumOpenJDK11() = isAdoptOrAdoptiumOpenJDK() && JavaVersion.current().isJava11
+
+fun getBuildJavaHome() = System.getProperty("java.home")
+
+gradle.settingsEvaluated {
+    if ("true" == System.getProperty("org.gradle.ignoreBuildJavaVersionCheck")) {
+        return@settingsEvaluated
+    }
+
+    if (!isAdoptOrAdoptiumOpenJDK()) {
+        if (remoteBuildCacheEnabled(this)) {
+            throw GradleException("Remote cache is enabled, which requires AdoptOpenJDK 11 to perform this build. It's currently ${getBuildJavaHome()}.")
+        } else {
+            println("WARNING: you're running this build on ${getBuildJavaHome()}, which is not officially supported")
+        }
+    }
+}


### PR DESCRIPTION
It didn't work before because it was in build-logic/settings script
and remote cache was configured in root settings script.

