### PR TITLE
Introduce `Task.doNotCacheConfigurationIf`

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncompatibleTasksIntegrationTest.groovy
@@ -21,6 +21,33 @@ import org.gradle.integtests.fixtures.configurationcache.ConfigurationCacheFixtu
 class ConfigurationCacheIncompatibleTasksIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
     ConfigurationCacheFixture fixture = new ConfigurationCacheFixture(this)
 
+    def "doesn't cache configuration when non cacheable task scheduled"() {
+        given:
+        buildFile """
+            task nonCacheable {
+                doNotCacheConfigurationIf("whatever") {
+                    true
+                }
+                doLast {
+                }
+            }
+        """
+
+        when:
+        configurationCacheRun("nonCacheable")
+
+        then:
+        result.assertTasksExecuted(":nonCacheable")
+        fixture.assertNoConfigurationCache()
+
+        when:
+        configurationCacheRun("nonCacheable")
+
+        then:
+        result.assertTasksExecuted(":nonCacheable")
+        fixture.assertNoConfigurationCache()
+    }
+
     def "reports incompatible task serialization and execution problems and discards cache entry when task is scheduled"() {
         addTasksWithProblems()
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -293,6 +293,19 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     void notCompatibleWithConfigurationCache(String reason);
 
     /**
+     * <p>Disables caching the configuration of the task if the given spec is satisfied. The spec will be evaluated at configuration time,
+     * before task execution time.</p>
+     *
+     * <p>You may add multiple such predicates. The configuration of the task is not cached if any of the predicates return {@code true}.
+     *
+     * @param cachingDisabledReason the reason why caching would be disabled by the spec.
+     * @param spec specifies if the configuration of the task should not be cached.
+     * @since 7.4
+     */
+    @Incubating
+    void doNotCacheConfigurationIf(String cachingDisabledReason, Spec<? super Task> spec);
+
+    /**
      * <p>Execute the task only if the given spec is satisfied. The spec will be evaluated at task execution time, not
      * during configuration. If the Spec is not satisfied, the task will be skipped.</p>
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TaskInternal.java
@@ -21,6 +21,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction;
 import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.specs.Spec;
@@ -69,6 +70,9 @@ public interface TaskInternal extends Task, Configurable<Task> {
 
     @Internal
     Optional<String> getReasonTaskIsIncompatibleWithConfigurationCache();
+
+    @Internal
+    List<SelfDescribingSpec<TaskInternal>> getDoNotCacheConfigurationIfSpecs();
 
     @Internal
     StandardOutputCapture getStandardOutputCapture();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/configurationcache/ConfigurationCacheFixture.groovy
@@ -51,6 +51,10 @@ class ConfigurationCacheFixture {
         assertHasNoProblems()
     }
 
+    void assertNoConfigurationCache() {
+        configurationCacheBuildOperations.assertNoConfigurationCache()
+    }
+
     /**
      * Asserts that the cache entry was written with no problems.
      *


### PR DESCRIPTION
For optimistic incremental adoption of the configuration cache.

The new API supports the scenario where one would like to use the configuration
cache whenever it just works via the `configuration-cache-problems=warn` setting
and have it automatically disabled whenever tasks for which configuration
caching has been proven problematic are scheduled.