### PR TITLE
Fix no daemon tests for continuous build changes

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/options/TaskOptionFailureIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/options/TaskOptionFailureIntegrationTest.groovy
@@ -27,7 +27,7 @@ class TaskOptionFailureIntegrationTest extends AbstractOptionIntegrationSpec {
         given:
         buildFile << """
             task sample(type: SampleTask)
-            
+
             ${taskWithMultipleOptionsForSingleProperty('String', 'hello', 'Some description')}
         """
 
@@ -99,7 +99,7 @@ class TaskOptionFailureIntegrationTest extends AbstractOptionIntegrationSpec {
 
     def "single dash user error yields decent error message"() {
         when:
-        runAndFail 'help', '-tsk'
+        runAndFail 'help', '-isk'
 
         then:
         failure.assertHasDescription("Problem configuring task :help from command line.")
@@ -200,21 +200,21 @@ class TaskOptionFailureIntegrationTest extends AbstractOptionIntegrationSpec {
             import org.gradle.api.tasks.options.Option;
 
             import java.util.List;
-            
+
             public class SampleTask extends DefaultTask {
                 private $optionType myProp;
-                
+
                 @Option(option = "$optionName", description = "$optionDescription")
                 @Option(option = "myProp", description = "Configures command line option 'myProp'.")
                 public void setMyProp($optionType myProp) {
                     this.myProp = myProp;
                 }
-                
+
                 @TaskAction
                 public void renderOptionValue() {
                     System.out.println("Value of myProp: " + myProp);
                 }
-                
+
                 private static enum TestEnum {
                     OPT_1, OPT_2, OPT_3
                 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -20,11 +20,13 @@ import com.google.common.util.concurrent.SimpleTimeLimiter
 import com.google.common.util.concurrent.UncheckedTimeoutException
 import org.gradle.integtests.fixtures.executer.ExecutionFailure
 import org.gradle.integtests.fixtures.executer.ExecutionResult
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.executer.GradleHandle
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.integtests.fixtures.executer.UnexpectedBuildFailure
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.junit.Assume
 import spock.lang.Retry
 
 import java.util.concurrent.ExecutorService
@@ -72,6 +74,7 @@ abstract class AbstractContinuousIntegrationTest extends AbstractIntegrationSpec
     }
 
     def setup() {
+        Assume.assumeFalse("Continuous build doesn't work with --no-daemon", GradleContextualExecuter.noDaemon)
         executer.beforeExecute {
             def initScript = file("init.gradle")
             initScript.text = buildLogicForMinimumBuildTime(minimumBuildTimeMillis)
@@ -298,7 +301,7 @@ $lastOutput
             }
             // if we get here it means that there was build output at some point while polling
             throw new UnexpectedBuildStartedException("Expected build not to start, but started with output: " + buildOutputSoFar())
-        } catch (AssertionError e) {
+        } catch (AssertionError ignored) {
             // ok, what we want
         }
     }

--- a/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
+++ b/subprojects/language-jvm/src/testFixtures/groovy/org/gradle/api/tasks/compile/AbstractCompilerContinuousIntegrationTest.groovy
@@ -24,10 +24,6 @@ abstract class AbstractCompilerContinuousIntegrationTest extends AbstractContinu
         executer.withWorkerDaemonsExpirationDisabled()
     }
 
-    def cleanup() {
-        gradle.cancel()
-    }
-
     abstract String getCompileTaskName()
     abstract String getCompileTaskType()
     abstract String getSourceFileName()

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/BuildSessionServiceReuseContinuousIntegrationTest.groovy
@@ -24,10 +24,6 @@ import org.gradle.process.internal.worker.child.WorkerProcessClassPathProvider
 
 
 class BuildSessionServiceReuseContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
-    def cleanup() {
-        gradle.cancel()
-    }
-
     @ToBeFixedForConfigurationCache
     def "reuses #service across continuous builds" () {
         def triggerFileName = "trigger"


### PR DESCRIPTION
Continuous build doesn't work any more with `--no-daemon` and emits an error.