### PR TITLE
Fix change reporting tests on macOS

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/ContinuousBuildChangeReportingIntegrationTest.groovy
@@ -43,7 +43,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         def inputFile = inputDir.file("input.txt")
         when:
         succeeds("theTask")
-        inputFile.text = 'New input file'
+        inputFile.createFile()
 
         then:
         buildTriggeredAndSucceeded()
@@ -59,7 +59,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         def inputFiles = inputSubdirectories.collect { inputDir.file("input.txt") }
         when:
         succeeds("theTask")
-        inputFiles.each { it.text = 'New input file' }
+        inputFiles.each { it.createFile() }
 
         then:
         buildTriggeredAndSucceeded()
@@ -75,7 +75,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         def inputFiles = inputSubdirectories.collect { it.file("input.txt") }
         when:
         succeeds("theTask")
-        inputFiles.each { it.text = 'New input file' }
+        inputFiles.each { it.createFile() }
 
         then:
         buildTriggeredAndSucceeded()
@@ -86,7 +86,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
     def "should report the changes when files are removed with #changesCount"(changesCount) {
         given:
         def inputFiles = (1..changesCount).collect { inputDir.file("input${it}.txt") }
-        inputFiles.each { it.text = 'New input file' }
+        inputFiles.each { it.createFile() }
         boolean expectMoreChanges = (changesCount > changesLimit)
 
         when:
@@ -160,16 +160,16 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
     def "should report the changes when multiple changes are made at once"() {
         given:
         def inputFiles = (1..11).collect { inputDir.file("input${it}.txt") }
-        inputFiles.each { it.text = 'Input file' }
+        inputFiles.each { it.createFile() }
         def newfile1 = inputDir.file("input12.txt")
         def newfile2 = inputDir.file("input13.txt")
 
         when:
         succeeds("theTask")
-        newfile1.text = 'New Input file'
+        newfile1.createFile()
         inputFiles[2].text = 'Modified file'
         inputFiles[7].delete()
-        newfile2.text = 'New Input file'
+        newfile2.createFile()
 
         then:
         buildTriggeredAndSucceeded()
@@ -183,7 +183,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         buildFile << """
             gradle.taskGraph.afterTask { Task task ->
                 if(task.path == ':theTask' && !file('changetrigged').exists()) {
-                   file('inputDir/input.txt').text = 'New input file'
+                   file('inputDir/input.txt').createNewFile()
                    file('changetrigged').text = 'done'
                 }
             }
@@ -208,7 +208,7 @@ class ContinuousBuildChangeReportingIntegrationTest extends AbstractContinuousIn
         when:
         executer.withArgument("-q")
         succeeds("theTask")
-        inputFile.text = 'New input file'
+        inputFile.createFile()
 
         then:
         buildTriggeredAndSucceeded()

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileEventCollector.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileEventCollector.java
@@ -18,7 +18,6 @@ package org.gradle.tooling.internal.provider;
 
 import org.gradle.execution.plan.BuildInputHierarchy;
 import org.gradle.internal.logging.text.StyledTextOutput;
-import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.vfs.FileChangeListener;
 
@@ -28,7 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class FileEventCollector implements FileChangeListener {
-    private static final boolean IS_MAC_OSX = OperatingSystem.current().isMacOsX();
     private static final int SHOW_INDIVIDUAL_CHANGES_LIMIT = 3;
 
     private final Map<Path, FileWatcherRegistry.Type> aggregatedEvents = new LinkedHashMap<>();
@@ -67,18 +65,10 @@ public class FileEventCollector implements FileChangeListener {
 
         if (existingEvent != null || aggregatedEvents.size() < SHOW_INDIVIDUAL_CHANGES_LIMIT) {
             aggregatedEvents.put(path, type);
-        } else if (shouldIncreaseChangesCount(type, path)) {
+        } else {
             moreChangesCount++;
         }
     }
-
-    private boolean shouldIncreaseChangesCount(FileWatcherRegistry.Type type, Path path) {
-        // Count every event on macOS, since there is only one event for file creation.
-        return IS_MAC_OSX ||
-            // On other operating systems count only non-CREATE events, since creation also causes a modification event, unless the event is for a directory.
-            type != FileWatcherRegistry.Type.CREATED || Files.isDirectory(path);
-    }
-
 
     public void reportChanges(StyledTextOutput logger) {
         for (Map.Entry<Path, FileWatcherRegistry.Type> entry : aggregatedEvents.entrySet()) {


### PR DESCRIPTION
This fixes the reporting tests on macOS. Mostly because macOS shows modified when not using `createFile()`. It seems now that we use native watching on macOS, the special handling in `FileEventCollector` also can/should be removed.