### PR TITLE
Update Gradle Enterprise Gradle plugin to 3.8.1

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -15,7 +15,7 @@ val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
 dependencies {
     constraints {
         // Gradle Plugins
-        api("com.gradle:gradle-enterprise-gradle-plugin:3.8")
+        api("com.gradle:gradle-enterprise-gradle-plugin:3.8.1")
         api("com.gradle.enterprise:test-distribution-gradle-plugin:2.2.2") // Sync with `settings.gradle.kts`
         api("org.gradle.guides:gradle-guides-plugin:0.19.1")
         api("com.gradle.publish:plugin-publish-plugin:0.18.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise").version("3.8")
+    id("com.gradle.enterprise").version("3.8.1")
     id("com.gradle.enterprise.gradle-enterprise-conventions-plugin").version("0.7.5")
     id("gradlebuild.base.allprojects")
     id("com.gradle.enterprise.test-distribution").version("2.2.2") // Sync with `build-logic/build-platform/build.gradle.kts`

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedGradleEnterprisePlugin.java
@@ -28,7 +28,7 @@ public final class AutoAppliedGradleEnterprisePlugin {
 
     public static final String GROUP = "com.gradle";
     public static final String NAME = "gradle-enterprise-gradle-plugin";
-    public static final String VERSION = "3.8";
+    public static final String VERSION = "3.8.1";
 
     public static final PluginId ID = new DefaultPluginId("com.gradle.enterprise");
     public static final PluginId BUILD_SCAN_PLUGIN_ID = new DefaultPluginId("com.gradle.build-scan");

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -66,7 +66,8 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "3.7",
         "3.7.1",
         "3.7.2",
-        "3.8"
+        "3.8",
+        "3.8.1"
     ]
 
     private static final VersionNumber FIRST_VERSION_SUPPORTING_CONFIGURATION_CACHE = VersionNumber.parse("3.4")


### PR DESCRIPTION
(cherry picked from commit 32f626ad2ab0b4d7e05d539ab6b7ebe068e652ff)

If it's too late to update the Gradle Enterprise Gradle plugin into the upcoming release, then this can be merged to the `master` branch.
