### PR TITLE
Do not treat parents of inputs as inputs for continuous build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/BuildInputHierarchy.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/BuildInputHierarchy.java
@@ -93,7 +93,11 @@ public class BuildInputHierarchy {
 
         @Override
         public void visitChildren(PersistentList<InputDeclaration> values, Supplier<String> relativePathSupplier) {
-            this.input = true;
+            // A parent directory to the input is not an input.
+            // As long as nothing within the input location changes we don't need to trigger a build.
+            // If we would consider the parents as inputs, then the creation of parent directories for
+            // an output file produced by the current build would directly trigger, though actually
+            // everything is up-to-date.
         }
 
         public boolean isInput() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SimpleJavaContinuousIntegrationTest.groovy
@@ -252,7 +252,8 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         executedAndNotSkipped ":compileJava"
     }
 
-    def "creation of initial source file triggers build"() {
+    @Requires(TestPrecondition.NOT_LINUX)
+    def "creation of initial source file triggers build for hierarchical watchers"() {
         expect:
         succeeds("build")
         skipped(":compileJava")
@@ -264,5 +265,23 @@ class SimpleJavaContinuousIntegrationTest extends AbstractContinuousIntegrationT
         then:
         buildTriggeredAndSucceeded()
         executedAndNotSkipped ":compileJava"
+    }
+
+    @Requires(TestPrecondition.LINUX)
+    def "creation of initial source file does not trigger build for non-hierarchical watchers"() {
+        expect:
+        succeeds("build")
+        skipped(":compileJava")
+        executed(":build")
+
+        when:
+        file("src/main/java/Thing.java") << "class Thing {}"
+
+        then:
+        // We watch the missing file `src/main/java`. As soon as `src` is created
+        // we invalidate everything below `src` and stop watching, since there is nothing more
+        // left in the VFS to watch. Though we don't consider the parent directory of
+        // `src/main/java` as an input, so we don't trigger a new build.
+        noBuildTriggered()
     }
 }

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
@@ -82,7 +82,7 @@ abstract class ContinuousBuildToolingApiSpecification extends ToolingApiSpecific
     def setup() {
         Assume.assumeTrue("Unsupported for the embedded runner", canUseContinuousBuildViaToolingApi())
         buildFile.text = "apply plugin: 'java'\n"
-        sourceDir = file("src/main/java")
+        sourceDir = file("src/main/java").createDir()
     }
 
     @Override


### PR DESCRIPTION
A parent directory of the input is not an input (at least for continuous build). As long as nothing within the input location changes we don't need to trigger a build. If we would consider the parents as inputs, then we wouldn't ignore the creation of parent directories for an output file produced by the current build and a change to it would directly trigger a rebuild, though actually everything is up-to-date.

This mainly happens for the creation of `GeneratedSingletonFileTree`, with is used to create the manifest for the `Jar` task. It registers the manifest it creates as something generated by the build, so we'd ignore any changes to it. The file is an input to the `Jar` task. When the manifest and the directory we use to generated the manifest doesn't exist in the build, the directory will be created (`build/tmp/jar`). So we receive the creation event of `build/tmp`, which we used to consider as an input since it was a parent of `build/tmp/jar/MANIFEST.MF`). That caused an immediate rebuild, which caused the macOS tests to fail.