### PR TITLE
Add unit test for ContinuousBuildActionExecutor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultFileChangeListeners.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultFileChangeListeners.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import org.gradle.internal.event.AnonymousListenerBroadcast;
+import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.watch.registry.FileWatcherRegistry;
+import org.gradle.internal.watch.vfs.FileChangeListener;
+import org.gradle.internal.watch.vfs.FileChangeListeners;
+
+import java.nio.file.Path;
+
+public class DefaultFileChangeListeners implements FileChangeListeners {
+    private final AnonymousListenerBroadcast<FileChangeListener> broadcaster;
+
+    public DefaultFileChangeListeners(ListenerManager listenerManager) {
+        this.broadcaster = listenerManager.createAnonymousBroadcaster(FileChangeListener.class);
+    }
+
+    @Override
+    public void addListener(FileChangeListener listener) {
+        broadcaster.add(listener);
+    }
+
+    @Override
+    public void removeListener(FileChangeListener listener) {
+        broadcaster.remove(listener);
+    }
+
+    @Override
+    public void broadcastChange(FileWatcherRegistry.Type type, Path path) {
+        broadcaster.getSource().handleChange(type, path);
+    }
+
+    @Override
+    public void broadcastWatchingError() {
+        broadcaster.getSource().stopWatchingAfterError();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/VirtualFileSystemServices.java
@@ -49,7 +49,6 @@ import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.build.BuildAddedListener;
 import org.gradle.internal.classloader.ClasspathHasher;
-import org.gradle.internal.event.AnonymousListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.execution.OutputSnapshotter;
@@ -84,13 +83,11 @@ import org.gradle.internal.vfs.VirtualFileSystem;
 import org.gradle.internal.vfs.impl.DefaultFileSystemAccess;
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy;
 import org.gradle.internal.vfs.impl.VfsRootReference;
-import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.registry.FileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.impl.DarwinFileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.impl.LinuxFileWatcherRegistryFactory;
 import org.gradle.internal.watch.registry.impl.WindowsFileWatcherRegistryFactory;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
-import org.gradle.internal.watch.vfs.FileChangeListener;
 import org.gradle.internal.watch.vfs.FileChangeListeners;
 import org.gradle.internal.watch.vfs.WatchableFileSystemDetector;
 import org.gradle.internal.watch.vfs.impl.DefaultWatchableFileSystemDetector;
@@ -102,7 +99,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -339,33 +335,6 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
             return new DefaultFileChangeListeners(listenerManager);
         }
 
-        private static class DefaultFileChangeListeners implements FileChangeListeners {
-            private final AnonymousListenerBroadcast<FileChangeListener> broadcaster;
-
-            DefaultFileChangeListeners(ListenerManager listenerManager) {
-                this.broadcaster = listenerManager.createAnonymousBroadcaster(FileChangeListener.class);
-            }
-
-            @Override
-            public void addListener(FileChangeListener listener) {
-                broadcaster.add(listener);
-            }
-
-            @Override
-            public void removeListener(FileChangeListener listener) {
-                broadcaster.remove(listener);
-            }
-
-            @Override
-            public void broadcastChange(FileWatcherRegistry.Type type, Path path) {
-                broadcaster.getSource().handleChange(type, path);
-            }
-
-            @Override
-            public void broadcastWatchingError() {
-                broadcaster.getSource().stopWatchingAfterError();
-            }
-        }
     }
 
     @VisibleForTesting
@@ -479,4 +448,5 @@ public class VirtualFileSystemServices extends AbstractPluginServiceRegistry {
 
     interface WatchFilter extends Predicate<String> {
     }
+
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
@@ -87,6 +87,8 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     }
 
     def cleanup() {
+        println("Build Output:")
+        println(textOutputFactory)
         executorService.shutdownNow()
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
@@ -20,32 +20,38 @@ import org.gradle.api.execution.internal.DefaultTaskInputsListeners
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.deployment.internal.Deployment
+import org.gradle.deployment.internal.DeploymentInternal
 import org.gradle.deployment.internal.DeploymentRegistryInternal
 import org.gradle.initialization.BuildRequestMetaData
 import org.gradle.initialization.DefaultBuildCancellationToken
 import org.gradle.initialization.DefaultBuildRequestContext
+import org.gradle.initialization.DefaultContinuousExecutionGate
 import org.gradle.initialization.NoOpBuildEventConsumer
 import org.gradle.integtests.fixtures.RedirectStdIn
 import org.gradle.internal.buildevents.BuildStartedTime
+import org.gradle.internal.buildtree.BuildActionRunner
 import org.gradle.internal.event.DefaultListenerManager
-import org.gradle.internal.filewatch.FileSystemChangeWaiter
-import org.gradle.internal.filewatch.FileSystemChangeWaiterFactory
 import org.gradle.internal.invocation.BuildAction
 import org.gradle.internal.logging.text.TestStyledTextOutputFactory
+import org.gradle.internal.service.scopes.DefaultFileChangeListeners
 import org.gradle.internal.service.scopes.Scope
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.session.BuildSessionActionExecutor
 import org.gradle.internal.session.BuildSessionContext
+import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.time.Time
+import org.gradle.internal.watch.registry.FileWatcherRegistry
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.internal.DisconnectableInputStream
-import spock.lang.Ignore
 import spock.lang.Timeout
+import spock.util.concurrent.PollingConditions
 
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 @RedirectStdIn
-@Ignore("TODO wolfs: Fix the unit test")
 class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
 
     def delegate = Mock(BuildSessionActionExecutor)
@@ -55,20 +61,32 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     def requestMetadata = Stub(BuildRequestMetaData)
     def requestContext = new DefaultBuildRequestContext(requestMetadata, cancellationToken, new NoOpBuildEventConsumer())
     def startParameter = new StartParameterInternal()
-    def waiterFactory = Mock(FileSystemChangeWaiterFactory)
-    def waiter = Mock(FileSystemChangeWaiter)
-    def listenerManager = new DefaultListenerManager(Scope.Global)
-    def inputsListeners = new DefaultTaskInputsListeners(listenerManager)
-    def deploymentRegistry = Mock(DeploymentRegistryInternal)
+    def globalListenerManager = new DefaultListenerManager(Scope.Global)
+    def userHomeListenerManager = globalListenerManager.createChild(Scopes.UserHome)
+    def inputsListeners = new DefaultTaskInputsListeners(globalListenerManager)
+    def changeListeners = new DefaultFileChangeListeners(userHomeListenerManager)
+    List<Deployment> deployments = []
+    def continuousExecutionGate = new DefaultContinuousExecutionGate()
+    def deploymentRegistry = Stub(DeploymentRegistryInternal) {
+        runningDeployments >> deployments
+        executionGate >> continuousExecutionGate
+    }
     def buildSessionContext = Mock(BuildSessionContext)
-    def executer = executer()
+    def textOutputFactory = new TestStyledTextOutputFactory()
+    def executorService = Executors.newCachedThreadPool()
 
-    private File file = new File('file')
+    def executer = executer()
+    Future<?> runningBuild
+
+    private File file = new File('file').absoluteFile
+    PollingConditions conditions = new PollingConditions(timeout: 60, initialDelay: 0, factor: 1.25)
 
     def setup() {
         action.startParameter >> startParameter
-        waiterFactory.createChangeWaiter(_, _, _) >> waiter
-        waiter.isWatching() >> true
+    }
+
+    def cleanup() {
+        executorService.shutdownNow()
     }
 
     def "uses underlying executer when continuous build is not enabled"() {
@@ -78,8 +96,6 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
 
         then:
         1 * delegate.execute(action, buildSessionContext)
-        1 * deploymentRegistry.runningDeployments >> []
-        0 * waiterFactory._
     }
 
     def "allows exceptions to propagate for single builds"() {
@@ -103,35 +119,152 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
 
         then:
         1 * delegate.execute(action, buildSessionContext)
-        1 * deploymentRegistry.runningDeployments >> []
-        0 * waiterFactory._
         System.in instanceof DisconnectableInputStream
         System.in.read() == -1
     }
 
-    def "waits for waiter"() {
+    def "can cancel the build"() {
         when:
-        continuousBuild()
-        1 * delegate.execute(action, buildSessionContext) >> {
-            declareInput(file)
-        }
-        executeBuild()
+        continuousBuildWithInputs()
+        runningBuild = startBuild()
 
         then:
-        1 * waiter.wait(_, _) >> {
-            cancellationToken.cancel()
+        conditions.eventually {
+            lastLogLine == "Waiting for changes to input files of tasks..."
         }
+
+        when:
+        cancellationToken.cancel()
+
+        then:
+        buildExits()
+        lastLogLine == "Build cancelled."
+    }
+
+    def "runs a new build on file change"() {
+        when:
+        continuousBuildWithInputs()
+        startBuild()
+
+        then:
+        conditions.eventually {
+            waitingForChanges()
+        }
+
+        when:
+        changeListeners.broadcastChange(FileWatcherRegistry.Type.MODIFIED, file.toPath())
+
+        then:
+        conditions.eventually {
+            rebuiltBecauseOfChange()
+        }
+
+        when:
+        cancellationToken.cancel()
+        then:
+        buildExits()
+    }
+
+    def "only triggers the build when the gatekeeper is open"() {
+        when:
+        buildWithDeployment()
+        def gatekeeper = continuousExecutionGate.createGateKeeper()
+        startBuild()
+
+        then:
+        conditions.eventually {
+            reloadableDeploymentDetected()
+        }
+
+        when:
+        changeListeners.broadcastChange(FileWatcherRegistry.Type.MODIFIED, file.toPath())
+        // Wait to make sure the build is not triggered
+        Thread.sleep(500)
+        then:
+        waitingForChanges()
+        !changeDetected()
+
+        when:
+        gatekeeper.open()
+        then:
+        conditions.eventually {
+            rebuiltBecauseOfChange()
+        }
+
+        when:
+        cancellationToken.cancel()
+        then:
+        buildExits()
+
+        cleanup:
+        println(textOutputFactory)
     }
 
     def "exits if there are no file system inputs"() {
         when:
         continuousBuild()
         1 * delegate.execute(action, buildSessionContext)
-        executeBuild()
-
         then:
-        waiter.isWatching() >> false
-        0 * waiter.wait(_, _)
+        executeBuild()
+    }
+
+    private void buildExits() {
+        runningBuild.get(1, TimeUnit.SECONDS)
+    }
+
+    private Future<?> startBuild() {
+        runningBuild = executorService.submit {
+            executeBuild()
+        }
+        return runningBuild
+    }
+
+    private void continuousBuildWithInputs() {
+        buildWithInputs()
+        continuousBuild()
+    }
+
+    private void buildWithDeployment() {
+        buildWithInputs()
+        deployments.add(Stub(DeploymentInternal))
+    }
+
+    private void buildWithInputs() {
+        delegate = new BuildSessionActionExecutor() {
+            @Override
+            BuildActionRunner.Result execute(BuildAction action, BuildSessionContext context) {
+                declareInput(file)
+                return BuildActionRunner.Result.of(null)
+            }
+        }
+        executer = executer()
+    }
+
+    private boolean waitingForChanges() {
+        return lastLogLine == "Waiting for changes to input files of tasks..."
+    }
+
+    private void reloadableDeploymentDetected() {
+        assert logLines[-2] == "Reloadable deployment detected. Entering continuous build."
+        assert lastLogLine == "Waiting for changes to input files of tasks..."
+    }
+
+    private void rebuiltBecauseOfChange() {
+        assert changeDetected()
+        assert waitingForChanges()
+    }
+
+    private boolean changeDetected() {
+        logLines[-2] == "Change detected, executing build..." ||
+            lastLogLine == "Change detected, executing build..."
+    }
+
+    private String getLastLogLine() {
+        return logLines.last()
+    }
+
+    private List<String> getLogLines() {
+        return textOutputFactory.toString().readLines().findAll { !it.empty }
     }
 
     private void singleBuild() {
@@ -155,6 +288,6 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     }
 
     private ContinuousBuildActionExecutor executer() {
-        new ContinuousBuildActionExecutor(waiterFactory, inputsListeners, new TestStyledTextOutputFactory(), executorFactory, requestContext, cancellationToken, deploymentRegistry, listenerManager.createChild(Scopes.BuildSession), buildExecutionTimer, Time.clock(), _, delegate)
+        new ContinuousBuildActionExecutor(inputsListeners, changeListeners, textOutputFactory, executorFactory, requestContext, cancellationToken, deploymentRegistry, userHomeListenerManager.createChild(Scopes.BuildSession), buildExecutionTimer, Time.clock(), TestFiles.fileSystem(), CaseSensitivity.CASE_SENSITIVE, delegate)
     }
 }


### PR DESCRIPTION
Re-enables and extends the unit test for `ContinuousBuildActionExecutor`.