### PR TITLE
Remove "used by scan plugin" annotations for enterprise subprojects

### DIFF
--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/artifacts/ResolveArtifactsBuildOperationType.java
@@ -16,9 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
-
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Details about an artifact set being resolved.
@@ -27,7 +25,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  */
 public final class ResolveArtifactsBuildOperationType implements BuildOperationType<ResolveArtifactsBuildOperationType.Details, ResolveArtifactsBuildOperationType.Result> {
 
-    @UsedByScanPlugin
     public interface Details {
 
         String getConfigurationPath();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationType.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -35,7 +34,6 @@ import java.util.Set;
  */
 public final class SnapshotTaskInputsBuildOperationType implements BuildOperationType<SnapshotTaskInputsBuildOperationType.Details, SnapshotTaskInputsBuildOperationType.Result> {
 
-    @UsedByScanPlugin
     public interface Details {
     }
 
@@ -45,7 +43,6 @@ public final class SnapshotTaskInputsBuildOperationType implements BuildOperatio
      * If the inputs were not snapshotted, all fields are null.
      * This may occur if the task had no outputs.
      */
-    @UsedByScanPlugin
     public interface Result {
 
         /**

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheArchivePackBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheArchivePackBuildOperationType.java
@@ -17,11 +17,9 @@
 package org.gradle.caching.internal.operations;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 public final class BuildCacheArchivePackBuildOperationType implements BuildOperationType<BuildCacheArchivePackBuildOperationType.Details, BuildCacheArchivePackBuildOperationType.Result> {
 
-    @UsedByScanPlugin
     public interface Details {
 
         /**
@@ -31,7 +29,6 @@ public final class BuildCacheArchivePackBuildOperationType implements BuildOpera
 
     }
 
-    @UsedByScanPlugin
     public interface Result {
 
         long getArchiveSize();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheArchiveUnpackBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheArchiveUnpackBuildOperationType.java
@@ -17,11 +17,9 @@
 package org.gradle.caching.internal.operations;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 public final class BuildCacheArchiveUnpackBuildOperationType implements BuildOperationType<BuildCacheArchiveUnpackBuildOperationType.Details, BuildCacheArchiveUnpackBuildOperationType.Result> {
 
-    @UsedByScanPlugin
     public interface Details {
 
         /**
@@ -33,7 +31,6 @@ public final class BuildCacheArchiveUnpackBuildOperationType implements BuildOpe
 
     }
 
-    @UsedByScanPlugin
     public interface Result {
 
         long getArchiveEntryCount();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheRemoteStoreBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/caching/internal/operations/BuildCacheRemoteStoreBuildOperationType.java
@@ -17,7 +17,6 @@
 package org.gradle.caching.internal.operations;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A store operation to a build cache.
@@ -27,7 +26,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  */
 public final class BuildCacheRemoteStoreBuildOperationType implements BuildOperationType<BuildCacheRemoteStoreBuildOperationType.Details, BuildCacheRemoteStoreBuildOperationType.Result> {
 
-    @UsedByScanPlugin
     public interface Details {
 
         /**
@@ -42,7 +40,6 @@ public final class BuildCacheRemoteStoreBuildOperationType implements BuildOpera
 
     }
 
-    @UsedByScanPlugin
     public interface Result {
 
         boolean isStored();

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/RunNestedBuildBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/initialization/RunNestedBuildBuildOperationType.java
@@ -17,9 +17,7 @@
 package org.gradle.initialization;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
-@UsedByScanPlugin
 public final class RunNestedBuildBuildOperationType implements BuildOperationType<RunNestedBuildBuildOperationType.Details, RunNestedBuildBuildOperationType.Result> {
 
     public interface Details {

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/taskgraph/CalculateTaskGraphBuildOperationType.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.taskgraph;
 
 import org.gradle.internal.operations.BuildOperationType;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.util.List;
 
@@ -33,7 +32,6 @@ public final class CalculateTaskGraphBuildOperationType implements BuildOperatio
      * @since 6.2
      *
      * */
-    @UsedByScanPlugin
     public interface TaskIdentity {
 
         String getBuildPath();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBuildState.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginBuildState.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.enterprise;
 
 import org.gradle.StartParameter;
-import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 
 import javax.annotation.Nullable;
@@ -25,7 +24,6 @@ import javax.annotation.Nullable;
 /**
  * Information about the current build invocation or build invocation environment required by the plugin.
  */
-@UsedByScanPlugin
 public interface GradleEnterprisePluginBuildState {
 
     long getBuildStartedTime();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInResult.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInResult.java
@@ -16,11 +16,8 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 import javax.annotation.Nullable;
 
-@UsedByScanPlugin
 public interface GradleEnterprisePluginCheckInResult {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInService.java
@@ -16,14 +16,11 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * The plugin uses this to announce its presence and provide its service.
  *
  * It is obtained via the settings object's service registry for the root build only.
  */
-@UsedByScanPlugin
 public interface GradleEnterprisePluginCheckInService {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginConfig.java
@@ -16,12 +16,9 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * Information eagerly conveyed about the plugin from Gradle to the plugin.
  */
-@UsedByScanPlugin
 public interface GradleEnterprisePluginConfig {
 
     enum BuildScanRequest {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildListener.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginEndOfBuildListener.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 import javax.annotation.Nullable;
 
 /**
@@ -25,8 +23,9 @@ import javax.annotation.Nullable;
  *
  * Uses a specific listener to guarantee being invoked after user buildFinished callbacks.
  * Expected to be invoked once for a build tree.
+ *
+ * Implemented by the Enterprise plugin.
  */
-@UsedByScanPlugin("implemented by plugin")
 public interface GradleEnterprisePluginEndOfBuildListener {
 
     interface BuildResult {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginMetadata.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginMetadata.java
@@ -16,12 +16,11 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * Information about the plugin to be conveyed to Gradle.
+ *
+ * Implemented by the Enterprise plugin.
  */
-@UsedByScanPlugin("implemented by plugin")
 public interface GradleEnterprisePluginMetadata {
 
     String getVersion();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServices.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginRequiredServices.java
@@ -18,12 +18,10 @@ package org.gradle.internal.enterprise;
 
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
 import org.gradle.internal.logging.text.StyledTextOutputFactory;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Infrastructure like services used by the plugin.
  */
-@UsedByScanPlugin
 public interface GradleEnterprisePluginRequiredServices {
 
     UserInputHandler getUserInputHandler();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginService.java
@@ -17,12 +17,12 @@
 package org.gradle.internal.enterprise;
 
 import org.gradle.internal.operations.notify.BuildOperationNotificationListener;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * A service for a particular build invocation
+ *
+ * Implemented by the Enterprise plugin.
  */
-@UsedByScanPlugin("implemented by plugin")
 public interface GradleEnterprisePluginService {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceFactory.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceFactory.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 import java.io.Serializable;
 
 /**
@@ -25,7 +23,6 @@ import java.io.Serializable;
  *
  * Gradle is responsible for creating the service via this factory for each build invocation.
  */
-@UsedByScanPlugin("implemented by plugin")
 public interface GradleEnterprisePluginServiceFactory extends Serializable {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceRef.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginServiceRef.java
@@ -16,15 +16,12 @@
 
 package org.gradle.internal.enterprise;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * A service that provides the plugin service for the current build invocation.
  *
  * The plugin uses this to encapsulate its service in user facing code that may be cached.
  * This allows such cached code to use the plugin service for the current build when used from-cache.
  */
-@UsedByScanPlugin
 public interface GradleEnterprisePluginServiceRef {
 
     GradleEnterprisePluginService get();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanConfig.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanConfig.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.scan.config;
 
 import org.gradle.StartParameter;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Represents the aspects of build scan configuration that Gradle contributes.
@@ -26,7 +25,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  *
  * @since 4.0
  */
-@UsedByScanPlugin
 public interface BuildScanConfig {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanConfigProvider.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanConfigProvider.java
@@ -16,14 +16,13 @@
 
 package org.gradle.internal.scan.config;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * A service that provides the build scan configuration.
  *
+ * Obtained via the root project's gradle object's service registry.
+ *
  * @since 4.0
  */
-@UsedByScanPlugin("Obtained via the root project's gradle object's service registry")
 public interface BuildScanConfigProvider {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanPluginMetadata.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/config/BuildScanPluginMetadata.java
@@ -16,14 +16,13 @@
 
 package org.gradle.internal.scan.config;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * Information about the build scan plugin in use.
  *
+ * Implemented by the Enterprise plugin.
+ *
  * @since 4.0
  */
-@UsedByScanPlugin("Implemented by plugin")
 public interface BuildScanPluginMetadata {
 
     /**

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifier.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifier.java
@@ -16,14 +16,11 @@
 
 package org.gradle.internal.scan.eob;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 import javax.annotation.Nullable;
 
 /**
  * Used by the scan plugin to register a listener to be notified about the build finishing.
  */
-@UsedByScanPlugin
 public interface BuildScanEndOfBuildNotifier {
 
     interface BuildResult {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/scopeids/BuildScanScopeIds.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/scopeids/BuildScanScopeIds.java
@@ -16,14 +16,12 @@
 
 package org.gradle.internal.scan.scopeids;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
 
 /**
  * Obtained from the Gradle object services.
  * Exists to remove linkage against types such as {@link BuildInvocationScopeId} and friends.
  */
-@UsedByScanPlugin
 public interface BuildScanScopeIds {
 
     String getBuildInvocationId();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanBuildStartedTime.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanBuildStartedTime.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.scan.time;
 
 import org.gradle.internal.buildevents.BuildStartedTime;
-import org.gradle.internal.scan.UsedByScanPlugin;
 
 /**
  * Used to determine when the build was started.
@@ -25,7 +24,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  * This is effectively a build scan specific view of {@link BuildStartedTime}.
  * @since 4.2
  */
-@UsedByScanPlugin
 public interface BuildScanBuildStartedTime {
 
     long getBuildStartedTime();

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanClock.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/scan/time/BuildScanClock.java
@@ -16,8 +16,6 @@
 
 package org.gradle.internal.scan.time;
 
-import org.gradle.internal.scan.UsedByScanPlugin;
-
 /**
  * A view of the Gradle runtime's clock used by build scans.
  *
@@ -25,7 +23,6 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  *
  * @since 4.2
  */
-@UsedByScanPlugin
 public interface BuildScanClock {
 
     /**


### PR DESCRIPTION
These subproijects are by definition used by the scan plugin. The goal is to move all the code directly referenced by the enterprise plugin to these subprojects, and thus remove all the `@UsedByScanPlugin` annotations.
