### PR TITLE
Let signature verification detect keyrings file and useKeyServers flag changes

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1443,6 +1443,7 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
 This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums. Key servers are disabled, this can indicate that you need to update the local keyring with the missing keys."""
     }
 
+    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle/issues/19663")
     def "fails when disabling reaching out to key servers after previous successful build and no key rings file"() {
         given:
@@ -1489,6 +1490,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
 This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums. Key servers are disabled, this can indicate that you need to update the local keyring with the missing keys."""
     }
 
+    @ToBeFixedForConfigurationCache
     @Issue("https://github.com/gradle/gradle/issues/18440")
     def "fails on a bad verification file change after previous successful build when key servers are disabled"() {
         def keyring = newKeyRing()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
@@ -79,5 +79,4 @@ public class BuildTreeDefinedKeys {
     public BuildTreeDefinedKeys dryRun() {
         return new BuildTreeDefinedKeys(new File(keyringsFile.getParentFile(), VERIFICATION_KEYRING_DRYRUN_GPG));
     }
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/BuildTreeDefinedKeys.java
@@ -56,6 +56,10 @@ public class BuildTreeDefinedKeys {
         return SecuritySupport.asciiArmoredFileFor(keyringsFile);
     }
 
+    public File getEffectiveKeyringsFile() {
+        return effectiveKeyringsFile;
+    }
+
     public List<PGPPublicKeyRing> loadKeys() throws IOException {
         if (effectiveKeyringsFile != null) {
             return SecuritySupport.loadKeyRingFile(effectiveKeyringsFile);
@@ -75,4 +79,5 @@ public class BuildTreeDefinedKeys {
     public BuildTreeDefinedKeys dryRun() {
         return new BuildTreeDefinedKeys(new File(keyringsFile.getParentFile(), VERIFICATION_KEYRING_DRYRUN_GPG));
     }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
@@ -27,6 +27,7 @@ import org.gradle.cache.scopes.BuildScopedCache;
 import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.hash.FileHasher;
+import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.service.scopes.Scopes;
@@ -52,6 +53,9 @@ import static org.gradle.security.internal.SecuritySupport.toLongIdHexString;
 
 @ServiceScope(Scopes.Build.class)
 public class DefaultSignatureVerificationServiceFactory implements SignatureVerificationServiceFactory {
+
+    private static final HashCode NO_KEYRING_FILE_HASH = HashCode.fromInt(Boolean.hashCode(false));
+
     private final RepositoryTransportFactory transportFactory;
     private final GlobalScopedCache cacheRepository;
     private final InMemoryCacheDecoratorFactory decoratorFactory;
@@ -91,6 +95,10 @@ public class DefaultSignatureVerificationServiceFactory implements SignatureVeri
             keyService = EmptyPublicKeyService.getInstance();
         }
         keyService = keyrings.applyTo(keyService);
+        File effectiveKeyringsFile = keyrings.getEffectiveKeyringsFile();
+        HashCode keyringFileHash = effectiveKeyringsFile != null && effectiveKeyringsFile.exists()
+            ? fileHasher.hash(effectiveKeyringsFile)
+            : NO_KEYRING_FILE_HASH;
         DefaultSignatureVerificationService delegate = new DefaultSignatureVerificationService(keyService);
         return new CrossBuildSignatureVerificationService(
             delegate,
@@ -98,7 +106,9 @@ public class DefaultSignatureVerificationServiceFactory implements SignatureVeri
             buildScopedCache,
             decoratorFactory,
             timeProvider,
-            refreshKeys
+            refreshKeys,
+            useKeyServers,
+            keyringFileHash
         );
     }
 


### PR DESCRIPTION
By using `keyrings file hash` and `useKeyServers flag`  in the cache key.

Fixes #19663, #18440