### PR TITLE
Fix flakiness in ClassLoaderLeakAvoidanceSoakTest

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/ClassLoaderLeakAvoidanceSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/ClassLoaderLeakAvoidanceSoakTest.groovy
@@ -91,7 +91,7 @@ class ClassLoaderLeakAvoidanceSoakTest extends AbstractIntegrationSpec {
         expect:
         for(int i = 0; i < 35; i++) {
             buildFile.text = buildFile.text.replace("Foo$i", "Foo${i + 1}")
-            executer.withBuildJvmOpts("-Xms64m", "-Xmx128m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=64m")
+            executer.withBuildJvmOpts("-Xms64m", "-Xmx256m", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:MaxMetaspaceSize=64m")
             assert succeeds("myTask")
         }
     }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/ClassLoaderLeakAvoidanceSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/ClassLoaderLeakAvoidanceSoakTest.groovy
@@ -81,8 +81,9 @@ class ClassLoaderLeakAvoidanceSoakTest extends AbstractIntegrationSpec {
             interface Foo0 extends Named {
             }
             task myTask() {
+                def objFactory = project.objects
                 doLast {
-                    def instance = project.objects.named(Foo0, new String(new byte[10 * 1024 * 1024], "UTF-8"))
+                    def instance = objFactory.named(Foo0, new String(new byte[10 * 1024 * 1024], "UTF-8"))
                     println "\${instance.class.name}"
                 }
             }


### PR DESCRIPTION
Align memory limit with other tests

It seems that the test itself is fine but it no longer fits into 128M because other parts of Gradle got bigger. There is no indication of any leaks in GC logs even when running the test with >100 iterations.

The original failure seems to be triggered by the lack of Metaspace anyway.