### PR TITLE
Fix vendor dropdown for RerunFlakyTest

### DIFF
--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -94,7 +94,7 @@ class RerunFlakyTest(os: Os) : BuildType({
             "openjdk",
             display = ParameterDisplay.PROMPT,
             description = "Java vendor to run the test with",
-            options = listOf(JvmVendor.values().map { it.displayName to it.name })
+            options = JvmVendor.values().map { it.displayName to it.name }
         )
         text(
             testTaskOptionsParameterName,


### PR DESCRIPTION
The dropdown ended up being a list of a list, though it should only be a list.