### PR TITLE
Remove ContinuousBuildProgressEventsCrossVersionSpec from quarantine

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ContinuousBuildProgressEventsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/ContinuousBuildProgressEventsCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r25
 import org.gradle.integtests.tooling.fixture.ContinuousBuildToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.tooling.BuildLauncher
-import org.gradle.test.fixtures.Flaky
 
 class ContinuousBuildProgressEventsCrossVersionSpec extends ContinuousBuildToolingApiSpecification {
 
@@ -29,7 +28,6 @@ class ContinuousBuildProgressEventsCrossVersionSpec extends ContinuousBuildTooli
         launcher.addProgressListener(events)
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3462")
     def "client can receive appropriate logging and progress events for subsequent builds"() {
         when:
         def javaSrcFile = sourceDir.file("Thing.java") << 'public class Thing {}'


### PR DESCRIPTION
The test didn't appear as flaky any more. The corresponding issue https://github.com/gradle/gradle-private/issues/3462 has already been closed.