### PR TITLE
Fix WatchedDirectoriesFileSystemWatchingIntegrationTest flakiness

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -292,7 +292,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         def mavenRepository = maven("repo")
         def mavenHttpRepository = new MavenHttpRepository(server, mavenRepository)
         m2.generateGlobalSettingsFile()
-        String artifactId = "foo-${UUID.randomUUID().toString()}-${System.currentTimeMillis()}"
+        def artifactId = "foo-watch-test"
         def remoteModule = mavenHttpRepository.module('watched.directories.maven.local.test', artifactId, "1.0").publish()
         def m2Module = m2.mavenRepo().module('watched.directories.maven.local.test', artifactId, "1.0").publish()
 
@@ -304,7 +304,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
             }
             configurations { compile }
             dependencies {
-                compile 'watched.directories.maven.local.test:${artifactId}:1.0'
+                compile 'watched.directories.maven.local.test:$artifactId:1.0'
             }
             task retrieve(type: Sync) {
                 from configurations.compile
@@ -323,7 +323,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run 'retrieve', "--info"
 
         then:
-        projectDir.file("build/${artifactId}-1.0.jar").assertIsCopyOf(m2Module.artifactFile)
+        projectDir.file("build/$artifactId-1.0.jar").assertIsCopyOf(m2Module.artifactFile)
         assertWatchedHierarchies([projectDir])
     }
 

--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/WatchedDirectoriesFileSystemWatchingIntegrationTest.groovy
@@ -292,8 +292,9 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         def mavenRepository = maven("repo")
         def mavenHttpRepository = new MavenHttpRepository(server, mavenRepository)
         m2.generateGlobalSettingsFile()
-        def remoteModule = mavenHttpRepository.module('gradletest.maven.local.cache.test', "foo", "1.0").publish()
-        def m2Module = m2.mavenRepo().module('gradletest.maven.local.cache.test', "foo", "1.0").publish()
+        String artifactId = "foo-${UUID.randomUUID().toString()}-${System.currentTimeMillis()}"
+        def remoteModule = mavenHttpRepository.module('watched.directories.maven.local.test', artifactId, "1.0").publish()
+        def m2Module = m2.mavenRepo().module('watched.directories.maven.local.test', artifactId, "1.0").publish()
 
         def projectDir = file("projectDir")
 
@@ -303,7 +304,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
             }
             configurations { compile }
             dependencies {
-                compile 'gradletest.maven.local.cache.test:foo:1.0'
+                compile 'watched.directories.maven.local.test:${artifactId}:1.0'
             }
             task retrieve(type: Sync) {
                 from configurations.compile
@@ -322,7 +323,7 @@ class WatchedDirectoriesFileSystemWatchingIntegrationTest extends AbstractFileSy
         withWatchFs().run 'retrieve', "--info"
 
         then:
-        projectDir.file('build/foo-1.0.jar').assertIsCopyOf(m2Module.artifactFile)
+        projectDir.file("build/${artifactId}-1.0.jar").assertIsCopyOf(m2Module.artifactFile)
         assertWatchedHierarchies([projectDir])
     }
 


### PR DESCRIPTION
This makes setup different from `MavenM2CacheReuseIntegrationTest`.

Fixes flakiness of [WatchedDirectoriesFileSystemWatchingIntegrationTest](https://ge.gradle.org/s/c4jax7pjm77ma/tests/:file-watching:embeddedIntegTest/org.gradle.internal.watch.WatchedDirectoriesFileSystemWatchingIntegrationTest/does%20not%20watch%20mavenLocal%20when%20not%20declared%20and%20dependency%20is%20copied%20into%20cache).


