### PR TITLE
Ignore small regressions for JavaIDEModelPerformanceTest

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/BaselineVersion.groovy
@@ -100,7 +100,8 @@ class BaselineVersion implements VersionResults {
     }
 
     private static boolean differenceIsSignificant(DataSeries<Duration> myTime, DataSeries<Duration> otherTime, double minConfidence) {
-        DataSeries.confidenceInDifference(myTime, otherTime) > minConfidence
+        return (myTime.median - otherTime.median).abs() > Duration.millis(10) &&
+            DataSeries.confidenceInDifference(myTime, otherTime) > minConfidence
     }
 
     private static boolean differenceInMedianIsSignificant(DataSeries<Duration> myTime, DataSeries<Duration> otherTime, double minRelativeMedianDifference) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceResults.groovy
@@ -79,6 +79,15 @@ class CrossVersionPerformanceResults extends PerformanceTestResult {
         }
     }
 
+    void assertCurrentVersionHasNotRegressedWithHighRelativeMedianDifference() {
+        if (hasRegressionChecks()) {
+            def slower = checkBaselineVersion({ it.significantlyFasterThan(current) && it.significantlyFasterByMedianThan(current) }, { it.getSpeedStatsAgainst(displayName, current) })
+            if (slower) {
+                throw new AssertionError(Object.cast(slower))
+            }
+        }
+    }
+
     private String checkBaselineVersion(Transformer<Boolean, BaselineVersion> fails, Transformer<String, BaselineVersion> provideMessage) {
         def failed = false
         def failure = new StringBuilder()

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/BaselineVersionTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/BaselineVersionTest.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results
+
+import org.gradle.performance.measure.DataSeries
+import org.gradle.performance.measure.Duration
+import org.gradle.performance.measure.MeasuredOperation
+import spock.lang.Specification
+
+class BaselineVersionTest extends Specification {
+    def baseline = new BaselineVersion("7.5")
+    def current = new BaselineVersion("7.6")
+
+    def "does consider changes with high confidence"() {
+        baseline.results.addAll([millis(100)] * 10)
+        current.results.addAll([millis(115)] * 10)
+        def confidence = calculateConfidence(baseline, current)
+        def minConfidence = confidence - 0.01
+
+        expect:
+        baseline.significantlyFasterThan(current.results, minConfidence)
+        baseline.significantlyFasterByMedianThan(current.results, 0.14)
+        current.significantlySlowerThan(baseline.results, minConfidence)
+    }
+
+    def "does not consider changes with less then 10 milliseconds as significant"() {
+        baseline.results.addAll([millis(100)] * 10)
+        current.results.addAll([millis(105)] * 10)
+        def confidence = calculateConfidence(baseline, current)
+        def minConfidence = confidence - 0.01
+
+        expect:
+        !baseline.significantlyFasterThan(current.results, minConfidence)
+        !current.significantlySlowerThan(baseline.results, minConfidence)
+    }
+
+    def "always considers changes with more than 20% difference as significant"() {
+        baseline.results.addAll([millis(100)] * 10)
+        current.results.addAll([millis(121)] * 10)
+        def confidence = calculateConfidence(baseline, current)
+        def tooHighConfidence = confidence + 0.01
+
+        expect:
+        baseline.significantlyFasterThan(current.results, tooHighConfidence)
+        current.significantlySlowerThan(baseline.results, tooHighConfidence)
+    }
+
+    private double calculateConfidence(BaselineVersion first, BaselineVersion second) {
+        DataSeries.confidenceInDifference(first.results.getTotalTime(), second.results.totalTime)
+    }
+
+    MeasuredOperation millis(long millis) {
+        new MeasuredOperation(totalTime: Duration.millis(millis))
+    }
+}

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -86,7 +86,7 @@ class JavaIDEModelPerformanceTest extends AbstractCrossVersionPerformanceTest {
         def result = runner.run()
 
         then:
-        result.assertCurrentVersionHasNotRegressed()
+        result.assertCurrentVersionHasNotRegressedWithHighRelativeMedianDifference()
     }
 
     def "get IDE model for IDEA"() {
@@ -134,7 +134,7 @@ class JavaIDEModelPerformanceTest extends AbstractCrossVersionPerformanceTest {
         def result = runner.run()
 
         then:
-        result.assertCurrentVersionHasNotRegressed()
+        result.assertCurrentVersionHasNotRegressedWithHighRelativeMedianDifference()
     }
 
     private setupRunner() {


### PR DESCRIPTION
The test is very flaky, no matter how much we rebaseline it. Let's ignore any regressions below 5% for it.

This PR also ignores regressions below 10ms median difference and always detects regressions above 20% median difference, no matter the confidence.