### PR TITLE
Fix disambiguation rule for Usage with Java projects

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -152,17 +152,19 @@ public abstract class JavaEcosystemSupport {
                     } else if (candidateValues.contains(javaRuntime)) {
                         details.closestMatch(javaRuntime);
                     }
-                } else if (candidateValues.contains(consumerValue)) {
-                    details.closestMatch(consumerValue);
                 } else if (javaApi.equals(consumerValue)) {
                     // we're asking for an API variant, prefer -jars first for runtime
                     if (candidateValues.contains(javaApiJars)) {
                         details.closestMatch(javaApiJars);
+                    } else if (candidateValues.contains(javaApi)) {
+                        details.closestMatch(javaApi);
                     } else if (candidateValues.contains(javaRuntimeJars)) {
                         details.closestMatch(javaRuntimeJars);
                     } else if (candidateValues.contains(javaRuntime)) {
                         details.closestMatch(javaRuntime);
                     }
+                } else if (candidateValues.contains(consumerValue)) {
+                    details.closestMatch(consumerValue);
                 }
             }
         }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.component.model.DefaultMultipleCandidateResult
 import org.gradle.internal.jvm.Jvm
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -444,15 +445,17 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
                 usage(Usage.JAVA_RUNTIME),
                 usage(Usage.JAVA_RUNTIME_JARS)
         )
-        MultipleCandidatesDetails details = Mock()
+        MultipleCandidatesDetails details = new DefaultMultipleCandidateResult(usage(consumer), candidates.collect { usage(it)} as Set)
 
         when:
         rules.execute(details)
 
         then:
-        1 * details.getConsumerValue() >> usage(consumer)
-        1 * details.getCandidateValues() >> candidates.collect { usage(it) }
-        1 * details.closestMatch(usage(preferred))
+        details.hasResult()
+        !details.matches.empty
+        details.matches == [usage(preferred)] as Set
+
+        details
 
         where: // not exhaustive, tests pathological cases
         consumer                | candidates                                     | preferred
@@ -462,6 +465,10 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         //Temporary compatibility
         Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_API_JARS
         Usage.JAVA_RUNTIME      | [Usage.JAVA_API, Usage.JAVA_RUNTIME_JARS]      | Usage.JAVA_RUNTIME_JARS
+
+        // while unlikely that a candidate would expose both JAVA_API_JARS and JAVA_API,
+        // this confirms that JAVA_API_JARS takes precedence, per JavaEcosystemSupport
+        Usage.JAVA_API          | [Usage.JAVA_API_JARS, Usage.JAVA_API, Usage.JAVA_RUNTIME_JARS] | Usage.JAVA_API_JARS
 
     }
 


### PR DESCRIPTION
Otherwise we would never fall into the javaApi arm of this conditional logic