### PR TITLE
Remove unsupported option from JAVA_OPTS documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -234,7 +234,7 @@ The `JAVA_OPTS` environment variable controls the command line client, which is 
 
 .Changing JVM settings for the client VM
 ----
-JAVA_OPTS="-Xmx64m -XX:MaxPermSize=64m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+JAVA_OPTS="-Xmx64m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 ----
 
 [NOTE]


### PR DESCRIPTION
Support for MaxPermSize was removed in Java 8.0. Starting with version
5.0, Gradle requires a minimum of Java 8.0. Specifying MaxPermSize in
the value for JAVA_OPTS prompts a warning from the JVM: "ignoring option
MaxPermSize=64m; support was removed in 8.0"

Remove reference to the unsupported JVM option from the example for
changing JVM settings for the client VM.