### PR TITLE
Exit continuous build when not watching anything

### DIFF
--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/FileWatcherRegistry.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 
 public interface FileWatcherRegistry extends Closeable {
 
+    boolean isWatchingAnyLocations();
+
     interface ChangeHandler {
         void handleChange(Type type, Path path);
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -20,6 +20,7 @@ import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions;
 import net.rubygrapefruit.platform.internal.jni.NativeLogger;
+import org.gradle.internal.file.FileHierarchySet;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
@@ -136,6 +137,11 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
         });
         thread.start();
         return thread;
+    }
+
+    @Override
+    public boolean isWatchingAnyLocations() {
+        return !fileWatcherUpdater.getWatchedFiles().equals(FileHierarchySet.empty());
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/registry/impl/DefaultFileWatcherRegistry.java
@@ -20,7 +20,6 @@ import net.rubygrapefruit.platform.file.FileWatchEvent;
 import net.rubygrapefruit.platform.file.FileWatcher;
 import net.rubygrapefruit.platform.internal.jni.AbstractFileEventFunctions;
 import net.rubygrapefruit.platform.internal.jni.NativeLogger;
-import org.gradle.internal.file.FileHierarchySet;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
@@ -141,7 +140,7 @@ public class DefaultFileWatcherRegistry implements FileWatcherRegistry {
 
     @Override
     public boolean isWatchingAnyLocations() {
-        return !fileWatcherUpdater.getWatchedFiles().equals(FileHierarchySet.empty());
+        return !fileWatcherUpdater.getWatchedFiles().isEmpty();
     }
 
     @Override

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/BuildLifecycleAwareVirtualFileSystem.java
@@ -28,7 +28,7 @@ import java.io.File;
  * Controls the lifecycle and book-keeping for file system watching.
  */
 @ServiceScope(Scopes.UserHome.class)
-public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem {
+public interface BuildLifecycleAwareVirtualFileSystem extends VirtualFileSystem, FileSystemWatchingInformation {
 
     /**
      * Called when the build is started.

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/FileSystemWatchingInformation.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/FileSystemWatchingInformation.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.watch.vfs;
+
+public interface FileSystemWatchingInformation {
+    boolean isWatchingAnyLocations();
+}

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingNotSupportedVirtualFileSystem.java
@@ -28,6 +28,7 @@ import org.gradle.internal.watch.registry.WatchMode;
 import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType;
+import org.gradle.internal.watch.vfs.FileSystemWatchingInformation;
 import org.gradle.internal.watch.vfs.VfsLogging;
 import org.gradle.internal.watch.vfs.WatchLogging;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import java.io.File;
 /**
  * A {@link VirtualFileSystem} which is not able to register any watches.
  */
-public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSystem implements BuildLifecycleAwareVirtualFileSystem {
+public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSystem implements BuildLifecycleAwareVirtualFileSystem, FileSystemWatchingInformation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WatchingNotSupportedVirtualFileSystem.class);
 
@@ -102,5 +103,10 @@ public class WatchingNotSupportedVirtualFileSystem extends AbstractVirtualFileSy
                     .details(BuildFinishedFileSystemWatchingBuildOperationType.Details.INSTANCE);
             }
         }));
+    }
+
+    @Override
+    public boolean isWatchingAnyLocations() {
+        return false;
     }
 }

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/WatchingVirtualFileSystem.java
@@ -38,6 +38,7 @@ import org.gradle.internal.watch.vfs.BuildFinishedFileSystemWatchingBuildOperati
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.BuildStartedFileSystemWatchingBuildOperationType;
 import org.gradle.internal.watch.vfs.FileChangeListeners;
+import org.gradle.internal.watch.vfs.FileSystemWatchingInformation;
 import org.gradle.internal.watch.vfs.FileSystemWatchingStatistics;
 import org.gradle.internal.watch.vfs.VfsLogging;
 import org.gradle.internal.watch.vfs.WatchLogging;
@@ -57,7 +58,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
-public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem implements BuildLifecycleAwareVirtualFileSystem, Closeable {
+public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem implements BuildLifecycleAwareVirtualFileSystem, FileSystemWatchingInformation, Closeable {
     private static final Logger LOGGER = LoggerFactory.getLogger(WatchingVirtualFileSystem.class);
     private static final String FILE_WATCHING_ERROR_MESSAGE_DURING_BUILD = "Unable to watch the file system for changes";
     private static final String FILE_WATCHING_ERROR_MESSAGE_AT_END_OF_BUILD = "Gradle was unable to watch the file system for changes";
@@ -322,6 +323,15 @@ public class WatchingVirtualFileSystem extends AbstractVirtualFileSystem impleme
             closeUnderLock();
             return currentRoot.empty();
         }
+    }
+
+    @Override
+    public boolean isWatchingAnyLocations() {
+        FileWatcherRegistry watchRegistry = this.watchRegistry;
+        if (watchRegistry != null) {
+            return watchRegistry.isWatchingAnyLocations();
+        }
+        return false;
     }
 
     private static class FilterChangesToOutputsChangesHandler implements FileWatcherRegistry.ChangeHandler {

--- a/subprojects/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
+++ b/subprojects/files/src/main/java/org/gradle/internal/file/FileHierarchySet.java
@@ -49,6 +49,11 @@ public abstract class FileHierarchySet {
     public abstract boolean contains(String path);
 
     /**
+     * Whether this hierarchy is empty, i.e. contains no directories.
+     */
+    public abstract boolean isEmpty();
+
+    /**
      * Returns a set that contains the union of this set and the given path. If the given path is a directory, the set will contain the directory itself, plus all its descendants.
      */
     @CheckReturnValue
@@ -85,6 +90,11 @@ public abstract class FileHierarchySet {
         @Override
         public boolean contains(String path) {
             return false;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
         }
 
         @Override
@@ -143,6 +153,11 @@ public abstract class FileHierarchySet {
         @Override
         public boolean contains(String path) {
             return rootNode.contains(path, 0);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
         }
 
         @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -285,6 +285,8 @@ $lastOutput
         } catch (AssertionError ignored) {
             // ok, what we want
         }
+        assert gradle.isRunning()
+        assert !output.contains("Exiting continuous build")
     }
 
     // should be private, but is accessed by closures in this class

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/continuous/SmokeContinuousIntegrationTest.groovy
@@ -560,7 +560,13 @@ class SmokeContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
     def "exit hint mentions enter when on windows"() {
         when:
         file("a").touch()
-        buildScript "task a { inputs.file 'a'; doLast {} }"
+        buildScript """
+            task a {
+                inputs.file 'a'
+                outputs.file 'build/b'
+                doLast {}
+            }
+        """
 
         then:
         succeeds "a"

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutor.java
@@ -179,7 +179,7 @@ public class ContinuousBuildActionExecutor implements BuildSessionActionExecutor
                 if (buildInputs.isEmpty()) {
                     logger.println().withStyle(StyledTextOutput.Style.Failure).println("Exiting continuous build as no executed tasks declared file system inputs.");
                     return lastResult;
-                } else if (!fileSystemWatchingInformation.isWatchingAnyLocations()) {
+                } else if (!continuousBuildTriggerHandler.hasBeenTriggered() && !fileSystemWatchingInformation.isWatchingAnyLocations()) {
                     logger.println().withStyle(StyledTextOutput.Style.Failure).println("Exiting continuous build as Gradle does not watch any file system locations.");
                     return lastResult;
                 } else {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildTriggerHandler.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ContinuousBuildTriggerHandler.java
@@ -32,6 +32,7 @@ public class ContinuousBuildTriggerHandler {
     private final CountDownLatch cancellationArrived = new CountDownLatch(1);
     private final long quietPeriod;
     private volatile long lastChangeAt = monotonicClockMillis();
+    private volatile boolean changeArrived;
 
     public ContinuousBuildTriggerHandler(
         BuildCancellationToken cancellationToken,
@@ -72,7 +73,12 @@ public class ContinuousBuildTriggerHandler {
         }
     }
 
+    public boolean hasBeenTriggered() {
+        return changeArrived;
+    }
+
     public void notifyFileChangeArrived() {
+        changeArrived = true;
         lastChangeAt = monotonicClockMillis();
         changeOrCancellationArrived.countDown();
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -59,6 +59,7 @@ import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.watch.vfs.BuildLifecycleAwareVirtualFileSystem;
 import org.gradle.internal.watch.vfs.FileChangeListeners;
+import org.gradle.internal.watch.vfs.FileSystemWatchingInformation;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner;
 import org.gradle.launcher.exec.BuildExecuter;
@@ -171,7 +172,8 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
             BuildTreeModelControllerServices buildModelServices,
             WorkerLeaseService workerLeaseService,
             BuildLayoutValidator buildLayoutValidator,
-            FileSystem fileSystem
+            FileSystem fileSystem,
+            FileSystemWatchingInformation fileSystemWatchingInformation
         ) {
             CaseSensitivity caseSensitivity = fileSystem.isCaseSensitive() ? CASE_SENSITIVE : CASE_INSENSITIVE;
             return new SubscribableBuildActionExecutor(
@@ -191,6 +193,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                     clock,
                     fileSystem,
                     caseSensitivity,
+                    fileSystemWatchingInformation,
                     new RunAsWorkerThreadBuildActionExecutor(
                         workerLeaseService,
                         new RunAsBuildOperationBuildActionExecutor(

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/ContinuousBuildActionExecutorTest.groovy
@@ -42,6 +42,7 @@ import org.gradle.internal.session.BuildSessionContext
 import org.gradle.internal.snapshot.CaseSensitivity
 import org.gradle.internal.time.Time
 import org.gradle.internal.watch.registry.FileWatcherRegistry
+import org.gradle.internal.watch.vfs.FileSystemWatchingInformation
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.util.internal.DisconnectableInputStream
 import spock.lang.Timeout
@@ -76,6 +77,10 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     def buildSessionContext = Mock(BuildSessionContext)
     def textOutputFactory = new TestStyledTextOutputFactory()
     def executorService = Executors.newCachedThreadPool()
+    def fileSystemIsWatchingAnyLocations = true
+    def fileSystemWatchingInformation = Stub(FileSystemWatchingInformation) {
+        isWatchingAnyLocations() >> fileSystemIsWatchingAnyLocations
+    }
 
     def executer = executer()
 
@@ -335,6 +340,20 @@ class ContinuousBuildActionExecutorTest extends ConcurrentSpec {
     }
 
     private ContinuousBuildActionExecutor executer() {
-        new ContinuousBuildActionExecutor(inputsListeners, changeListeners, textOutputFactory, executorFactory, requestContext, cancellationToken, deploymentRegistry, userHomeListenerManager.createChild(Scopes.BuildSession), buildExecutionTimer, Time.clock(), TestFiles.fileSystem(), CaseSensitivity.CASE_SENSITIVE, delegate)
+        new ContinuousBuildActionExecutor(
+            inputsListeners,
+            changeListeners,
+            textOutputFactory,
+            executorFactory,
+            requestContext,
+            cancellationToken,
+            deploymentRegistry,
+            userHomeListenerManager.createChild(Scopes.BuildSession),
+            buildExecutionTimer,
+            Time.clock(),
+            TestFiles.fileSystem(),
+            CaseSensitivity.CASE_SENSITIVE,
+            fileSystemWatchingInformation,
+            delegate)
     }
 }


### PR DESCRIPTION
There can be situations when Gradle would wait for changes to input files, but it is not actually watching anything. In that case Gradle should exit and report the situation.