### PR TITLE
Force-enable watching when using continuous build

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -148,7 +148,6 @@ ${result.error}
             .withTasks(tasks)
             .withForceInteractive(true)
             .withArgument("--full-stacktrace")
-            .withArgument("--watch-fs")
         if (!withoutContinuousArg) {
             executer.withArgument("--continuous")
         }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunner.java
@@ -77,6 +77,10 @@ public class FileSystemWatchingBuildActionRunner implements BuildActionRunner {
             : WatchLogging.NORMAL;
 
         LOGGER.info("Watching the file system is configured to be {}", watchFileSystemMode.getDescription());
+        if (startParameter.isContinuous() && watchFileSystemMode == WatchMode.DEFAULT) {
+            // Try to watch as much as possible when using continuous build.
+            watchFileSystemMode = WatchMode.ENABLED;
+        }
         if (watchFileSystemMode.isEnabled()) {
             dropVirtualFileSystemIfRequested(startParameter, virtualFileSystem);
         }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/LauncherServices.java
@@ -212,6 +212,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
             BuildRequestMetaData buildRequestMetaData,
             GradleEnterprisePluginManager gradleEnterprisePluginManager,
             BuildLifecycleAwareVirtualFileSystem virtualFileSystem,
+            DeploymentRegistryInternal deploymentRegistry,
             StatStatistics.Collector statStatisticsCollector,
             FileHasherStatistics.Collector fileHasherStatisticsCollector,
             DirectorySnapshotterStatistics.Collector directorySnapshotterStatisticsCollector,
@@ -227,6 +228,7 @@ public class LauncherServices extends AbstractPluginServiceRegistry {
                     new FileSystemWatchingBuildActionRunner(
                         eventEmitter,
                         virtualFileSystem,
+                        deploymentRegistry,
                         statStatisticsCollector,
                         fileHasherStatisticsCollector,
                         directorySnapshotterStatisticsCollector,

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FileSystemWatchingBuildActionRunnerTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.tooling.internal.provider
 
 import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.changedetection.state.FileHasherStatistics
+import org.gradle.deployment.internal.Deployment
+import org.gradle.deployment.internal.DeploymentRegistryInternal
 import org.gradle.internal.buildtree.BuildActionRunner
 import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.file.StatStatistics
@@ -35,6 +37,10 @@ import spock.lang.Specification
 class FileSystemWatchingBuildActionRunnerTest extends Specification {
 
     def watchingHandler = Mock(BuildLifecycleAwareVirtualFileSystem)
+    List<Deployment> deployments = []
+    def deploymentRegistry = Stub(DeploymentRegistryInternal) {
+        getRunningDeployments() >> deployments
+    }
     def startParameter = Stub(StartParameterInternal)
     def buildOperationRunner = Mock(BuildOperationRunner)
     def buildController = Stub(BuildTreeLifecycleController)
@@ -45,6 +51,7 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
     def runner = new FileSystemWatchingBuildActionRunner(
         buildOperationProgressEventEmitter,
         watchingHandler,
+        deploymentRegistry,
         Stub(StatStatistics.Collector),
         Stub(FileHasherStatistics.Collector),
         Stub(DirectorySnapshotterStatistics.Collector),
@@ -127,5 +134,58 @@ class FileSystemWatchingBuildActionRunnerTest extends Specification {
         then:
         def ex = thrown IllegalStateException
         ex.message == "Enabling file system watching via --watch-fs (or via the org.gradle.vfs.watch property) with --project-cache-dir also specified is not supported; remove either option to fix this problem"
+    }
+
+    def "force-enables watching when #description"() {
+        _ * startParameter.watchFileSystemMode >> WatchMode.DEFAULT
+        _ * startParameter.projectCacheDir >> null
+        _ * startParameter.continuous >> isContinuousBuild
+        if (hasDeployment) {
+            deployments.add(Stub(Deployment))
+        }
+
+        when:
+        runner.run(buildAction, buildController)
+
+        then:
+        1 * watchingHandler.afterBuildStarted(WatchMode.ENABLED, _, _, buildOperationRunner) >> true
+
+        then:
+        1 * buildOperationProgressEventEmitter.emitNowForCurrent({ FileSystemWatchingSettingsFinalizedProgressDetails details -> details.enabled })
+
+        then:
+        1 * delegate.run(buildAction, buildController)
+
+        then:
+        1 * watchingHandler.beforeBuildFinished(WatchMode.ENABLED, _, _, buildOperationRunner, _)
+
+        then:
+        0 * _
+
+        where:
+        description               | hasDeployment | isContinuousBuild
+        "using continuous build"  | false         | true
+        "a deployment is running" | true          | false
+    }
+
+    def "fails when #description and file system watching is disabled"() {
+        _ * startParameter.watchFileSystemMode >> WatchMode.DISABLED
+        _ * startParameter.projectCacheDir >> null
+        _ * startParameter.continuous >> isContinuousBuild
+        if (hasDeployment) {
+            deployments.add(Stub(Deployment))
+        }
+
+        when:
+        runner.run(buildAction, buildController)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == "Continuous build does not work when file system watching is disabled"
+
+        where:
+        description               | hasDeployment | isContinuousBuild
+        "using continuous build"  | false         | true
+        "a deployment is running" | true          | false
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r26/TestLauncherCrossVersionSpec.groovy
@@ -163,11 +163,9 @@ class TestLauncherCrossVersionSpec extends TestLauncherSpec {
             withCancellation { cancellationToken ->
                 launchTests(connection, new TestResultHandler(), cancellationToken) { TestLauncher launcher ->
                     def testsToLaunch = testDescriptors("example.MyTest", null, ":secondTest")
-                    def arguments = ["-t"]
-                    ContinuousBuildToolingApiSpecification.addWatchFsArgumentIfNecessary(arguments, targetVersion)
                     launcher
                         .withTests(testsToLaunch.toArray(new TestOperationDescriptor[testsToLaunch.size()]))
-                        .withArguments(arguments)
+                        .withArguments("-t")
                 }
 
                 waitingForBuild()

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ContinuousBuildToolingApiSpecification.groovy
@@ -29,7 +29,6 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.CancellationToken
 import org.gradle.tooling.ProjectConnection
-import org.gradle.util.GradleVersion
 import org.hamcrest.Matcher
 import org.junit.Assume
 import org.junit.Rule
@@ -54,14 +53,6 @@ abstract class ContinuousBuildToolingApiSpecification extends ToolingApiSpecific
     // We could try to fix this problems, though this is only a problem for testing.
     static boolean canUseContinuousBuildViaToolingApi() {
         return  !GradleContextualExecuter.embedded
-    }
-
-    static void addWatchFsArgumentIfNecessary(List<String> arguments, GradleVersion targetVersion) {
-        if (targetVersion.baseVersion >= GradleVersion.version("7.5")) {
-            // Although file system watching is enabled by default, we may run the test via test distribution
-            // on Docker, which has an unsupported file system. So we need to explicitly enable it.
-            arguments.add("--watch-fs")
-        }
     }
 
     private static final boolean OS_IS_WINDOWS = OperatingSystem.current().isWindows()
@@ -125,10 +116,8 @@ abstract class ContinuousBuildToolingApiSpecification extends ToolingApiSpecific
                     |}
                 """.stripMargin()
 
-                def arguments = ["--continuous", "-I", initScript.absolutePath]
-                addWatchFsArgumentIfNecessary(arguments, targetVersion)
                 BuildLauncher launcher = projectConnection.newBuild()
-                    .withArguments(arguments)
+                    .withArguments(["--continuous", "-I", initScript.absolutePath])
                     .forTasks(tasks as String[])
                     .withCancellationToken(token)
 


### PR DESCRIPTION
Continuous build doesn't make sense when file system watching is disabled for whatever reason. Gradle should even try to watch unsupported file systems as much as possible when the user request continuous build. That way, the user doesn't need to pass `--watch-fs` additionally on the command line.