### PR TITLE
Fix retry support of CrossVersionTestEngine

### DIFF
--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/CrossVersionTestEngine.java
@@ -43,11 +43,15 @@ import org.spockframework.runtime.SpockEngine;
 import org.spockframework.runtime.SpockEngineDescriptor;
 import org.spockframework.runtime.SpockExecutionContext;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.gradle.integtests.fixtures.compatibility.AbstractContextualMultiVersionTestInterceptor.VERSIONS_SYSPROP_NAME;
 
@@ -98,6 +102,9 @@ public class CrossVersionTestEngine extends HierarchicalTestEngine<SpockExecutio
 }
 
 class TestVariant {
+
+    static final String SEGMENT_TYPE = "variant";
+
     private final UniqueId id;
     private final EngineDiscoveryRequest discoveryRequest;
     private final Map<String, String> systemProperties = new HashMap<String, String>();
@@ -113,13 +120,14 @@ class TestVariant {
     }
 
     static TestVariant tapiTargetLoaded(UniqueId rootId, EngineDiscoveryRequest discoveryRequest) {
-        TestVariant testVariant = new TestVariant(rootId, "tapi", new ToolingApiClassloaderDiscoveryRequest(discoveryRequest));
+        String variant = "tapi";
+        TestVariant testVariant = new TestVariant(rootId, variant, new ToolingApiClassloaderDiscoveryRequest(discoveryRequest, variant));
         testVariant.systemProperties.put("org.gradle.integtest.currentVersion", GradleVersion.current().getVersion());
         return testVariant;
     }
 
     private TestVariant(UniqueId rootId, String variant, EngineDiscoveryRequest request) {
-        this.id = rootId.append("variant", variant);
+        this.id = rootId.append(SEGMENT_TYPE, variant);
         this.discoveryRequest = request;
     }
 
@@ -185,10 +193,12 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
     private static final GradleVersion MIN_LOADABLE_TAPI_VERSION = GradleVersion.version("2.6");
 
     private final String toolingApiVersionToLoad;
+    private final String variant;
     private ToolingApiDistribution toolingApi;
 
-    ToolingApiClassloaderDiscoveryRequest(EngineDiscoveryRequest delegate) {
+    ToolingApiClassloaderDiscoveryRequest(EngineDiscoveryRequest delegate, String variant) {
         super(delegate);
+        this.variant = variant;
         this.toolingApiVersionToLoad = getToolingApiVersionToLoad();
         if (toolingApiVersionToLoad == null) {
             return;
@@ -217,29 +227,51 @@ class ToolingApiClassloaderDiscoveryRequest extends DelegatingDiscoveryRequest {
     public <T extends DiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
         List<T> selectors = super.getSelectorsByType(selectorType);
         if (selectorType.equals(DiscoverySelector.class)) {
-            List<ClassSelector> result = new ArrayList<ClassSelector>();
+            Set<DiscoverySelector> result = new LinkedHashSet<DiscoverySelector>();
             for (T selector : selectors) {
-                // Test distribution uses UniqueIdSelectors and we have to set the correct classloader for this thread that will run the test
+                DiscoverySelector newSelector = selector;
                 if (selector instanceof UniqueIdSelector) {
-                    UniqueIdSelector uniqueIdSelector = (UniqueIdSelector) selectors.get(0);
-                    if (toolingApiVersionToLoad != null && uniqueIdSelector.toString().contains("[variant:selected]")) {
-                        String classToLoad = uniqueIdSelector.getUniqueId().getLastSegment().getValue();
-                        try {
-                            Class<?> testClass = Class.forName(classToLoad);
-                            if (ToolingApiSpecification.class.isAssignableFrom(testClass)) {
-                                result.add(DiscoverySelectors.selectClass(toolingApiClassLoaderForTest(testClass).loadClass(classToLoad)));
-                            }
-                        } catch (ClassNotFoundException e) {
-                            throw new RuntimeException(e);
-                        }
+                    // Test distribution uses UniqueIdSelectors and we have to set the correct classloader for this thread that will run the test
+                    Class<?> testClass = maybeLoadClassWithToolingApiClassLoaderForTest(((UniqueIdSelector) selector).getUniqueId());
+                    if (testClass != null) {
+                        newSelector = DiscoverySelectors.selectClass(testClass);
                     }
-                } else {
-                    return selectors;
                 }
+                result.add(newSelector);
             }
-            return Cast.uncheckedCast(result);
+            return new ArrayList<T>(Cast.<Collection<T>>uncheckedCast(result));
         }
         return selectors;
+    }
+
+    @Nullable
+    Class<?> maybeLoadClassWithToolingApiClassLoaderForTest(UniqueId uniqueId) {
+
+        // `segments` typically contains sth. like this:
+        // 0: [engine:cross-version-test-engine]
+        // 1: [variant:tapi]
+        // 2: [spec:org.gradle.kotlin.dsl.tooling.builders.r54.KotlinSettingsScriptModelCrossVersionSpec]
+        // 3: [feature:$spock_feature_2_0]
+        List<UniqueId.Segment> segments = uniqueId.getSegments();
+
+        if (toolingApiVersionToLoad != null && segments.size() >= 3 && isVariantSelected(segments.get(1))) {
+            String classToLoad = segments.get(2).getValue();
+            try {
+                Class<?> testClass = Class.forName(classToLoad);
+                if (ToolingApiSpecification.class.isAssignableFrom(testClass)) {
+                    return toolingApiClassLoaderForTest(testClass).loadClass(classToLoad);
+                }
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isVariantSelected(UniqueId.Segment candidate) {
+        return TestVariant.SEGMENT_TYPE.equals(candidate.getType())
+            && variant.equals(candidate.getValue());
     }
 
     private ClassLoader toolingApiClassLoaderForTest(Class<?> testClass) {


### PR DESCRIPTION
UniqueIdSelectors that are used by retries from the Test Distribution
plugin were not handled correctly prior to this change.