### PR TITLE
Mark `:docs:samplesMultiPage` as `notCompatibleWithConfigurationCache`

### DIFF
--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -54,6 +54,7 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
         task.name.startsWith("userguide") -> true
         task.name.contains("Sample") -> true
         task.name.contains("Snippet") -> true
+        task.name == "samplesMultiPage" -> true
         task.typeSimpleName in listOf(
             "KtsProjectGeneratorTask",
             "JavaExecProjectGeneratorTask",


### PR DESCRIPTION
This is still not enough to get it to run without `--no-configuration-cache` due to a current limitation of `notCompatibleWithConfigurationCache`.

While `notCompatibleWithConfigurationCache` makes Gradle ignore any serialization problems the task might have, execution time problems like `invocation of 'Task.project' at execution time is unsupported` can still pile up and cause the build to fail with `Maximum number of configuration cache problems has been reached.`