### PR TITLE
Revert expectation of parallel execution from tests in Gradle build

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginVersionIntegrationTest.groovy
@@ -146,8 +146,6 @@ class CheckstylePluginVersionIntegrationTest extends MultiVersionIntegrationSpec
         file("build/reports/checkstyle/main.xml").assertContents(containsClass("org.gradle.Class1"))
     }
 
-    // on parallel executer, there might be checkstyleMain/checkstyleTest running in parallel, resulting in non-deterministic result
-    @IgnoreIf({ GradleContextualExecuter.parallel })
     def "can suppress console output"() {
         def message = "Name 'class1' must match pattern"
 

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginDependenciesIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.quality.pmd
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
@@ -76,9 +75,6 @@ class PmdPluginDependenciesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         fails("check")
         failure.assertHasCause("Incremental analysis only supports PMD 6.0.0 and newer. Please upgrade from PMD 5.1.1 or disable incremental analysis.")
-        if (GradleContextualExecuter.isParallel()) {
-            failure.assertHasFailures(2)
-        }
     }
 
 

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -20,7 +20,6 @@ import groovy.xml.XmlSlurper
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -309,8 +308,7 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
         dsl << ['groovy', 'kotlin']
     }
 
-    // assertTaskOrder may fail with parallel executer
-    @Requires(adhoc = { TestPrecondition.JDK9_OR_LATER.fulfilled && !GradleContextualExecuter.isParallel() })
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     @UsesSample("java/basic")
     def "can run simple Java integration tests with #dsl dsl"() {
         given:

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/NestedSourceDependencyIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.vcs.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.plugin.PluginBuilder
 import org.gradle.util.internal.TextUtil
 import org.gradle.vcs.fixtures.GitFileRepository
 import org.junit.Rule
-import spock.lang.IgnoreIf
 
 class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
     @Rule
@@ -145,8 +143,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
         succeeds("resolve")
     }
 
-    // assertTasksExecutedInOrder may fail with parallel executer
-    @IgnoreIf({ GradleContextualExecuter.isParallel() })
     @ToBeFixedForConfigurationCache
     def "can use source mappings defined in nested builds"() {
         given:
@@ -233,7 +229,6 @@ class NestedSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @ToBeFixedForConfigurationCache
-    @IgnoreIf({ GradleContextualExecuter.isParallel() })
     def "prefers a source mapping defined in the root build to one defined in a nested build when they differ only by plugins"() {
         given:
         def pluginBuilder = new PluginBuilder(file("plugin"))


### PR DESCRIPTION
Reverts some tests which were failing due to unexpected changes causing tasks within a project to run in parallel. 