### PR TITLE
Issue: #12324 Resolve project dependencies for publications from configuration

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -16,7 +16,10 @@
 package org.gradle.api.component;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
+
+import java.util.Set;
 
 /**
  * A component which can declare additional variants corresponding to
@@ -46,4 +49,14 @@ public interface AdhocComponentWithVariants extends SoftwareComponent {
      */
     void withVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 
+
+    /**
+     * The configurations for which variants were created.
+     *
+     * @return the configurations this component is associated with, if any. Empty if none.
+     *
+     * @since 7.6
+     */
+    @Incubating
+    Set<? extends Configuration> getAssociatedConfigurations();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyPublicationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyPublicationResolveIntegrationTest.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import spock.lang.Issue
+
+import static org.gradle.util.TextUtil.escapeString
+
+@RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value="maven")
+class ProjectDependencyPublicationResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    @Issue("gradle/gradle#12324")
+    def "project dependency can resolve configuration from target project on publication"() {
+        given:
+        settingsFile.delete()
+        settingsKotlinFile << """
+            include("a")
+            include("b")
+        """
+        and:
+        buildFile.delete()
+        buildKotlinFile << """
+            allprojects {
+                group = "com.acme.foo"
+                version = "1.0"
+            }
+        """
+
+        and:
+        file("a/build.gradle.kts") << """
+            plugins {
+                `java-library`
+                `maven-publish`
+                id("client-server")
+            }
+            publishing {
+                publications {
+                    create<MavenPublication>("client") {
+                        from(components["client"])
+                        artifactId += "-client"
+                    }
+                    create<MavenPublication>("server") {
+                        from(components["server"])
+                        artifactId += "-server"
+                    }
+                }
+                repositories {
+                    maven { url = uri("${escapeString(mavenRepo.rootDir)}") }
+                }
+            }
+            dependencies { server(project(path = ":b", configuration = "server")) }
+        """
+
+        file("b/build.gradle.kts") << """
+            plugins {
+                `java-library`
+                `maven-publish`
+                id("client-server")
+            }
+
+            publishing {
+                publications {
+                    create<MavenPublication>("client") {
+                        from(components["client"])
+                        artifactId += "-client"
+                    }
+                    create<MavenPublication>("server") {
+                        from(components["server"])
+                        artifactId += "-server"
+                    }
+                }
+                repositories {
+                    maven { url = uri("${escapeString(mavenRepo.rootDir)}") }
+                }
+            }
+        """
+
+        //Plugin creating the components
+        and:
+        file("buildSrc/build.gradle.kts") << """
+            plugins {
+                `kotlin-dsl`
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            gradlePlugin {
+                plugins {
+                    register("clientServerPlugin") {
+                        id = "client-server"
+                        implementationClass = "TestPlugin"
+                    }
+                }
+            }
+        """
+        file("buildSrc/src/main/kotlin/TestPlugin.kt") << """
+        import org.gradle.api.Named
+        import org.gradle.api.Plugin
+        import org.gradle.api.Project
+        import org.gradle.api.artifacts.Configuration
+        import org.gradle.api.attributes.Usage
+        import org.gradle.api.component.SoftwareComponentFactory
+        import org.gradle.api.plugins.JavaPluginExtension
+        import org.gradle.api.tasks.SourceSet
+        import org.gradle.api.tasks.bundling.Jar
+        import org.gradle.kotlin.dsl.get
+        import org.gradle.kotlin.dsl.register
+        import javax.inject.Inject
+
+        class TestPlugin @Inject constructor(private val softwareComponentFactory: SoftwareComponentFactory) : Plugin<Project> {
+
+            override fun apply(project: Project) = project.run {
+                createComponent("server")
+                createComponent("client")
+            }
+
+            private fun Project.createComponent(name: String) {
+                val config = createConfiguration(name)
+                val sourceSet = addSourceSet(config)
+                attachArtifact(config, sourceSet)
+                configurePublication(config)
+            }
+
+            private fun Project.createConfiguration(configName: String): Configuration {
+                val implementation = configurations.getByName("implementation")
+                return configurations.create(configName) {
+                    isCanBeConsumed = true
+                    isCanBeResolved = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, namedAttribute(Usage.JAVA_RUNTIME))
+                    }
+                    extendsFrom(implementation)
+                }
+            }
+
+            private fun Project.addSourceSet(configuration: Configuration): SourceSet {
+                val convention = extensions.getByType(JavaPluginExtension::class.java)
+                return convention.sourceSets.create(configuration.name) {
+                    java.srcDir(configuration.name)
+                    compileClasspath += configuration
+                    runtimeClasspath += configuration
+                    resources.srcDir(configuration.name)
+                }
+            }
+
+            private fun Project.attachArtifact(config: Configuration, sourceSet: SourceSet) {
+                val jar = tasks.register<Jar>("\${config.name}Jar") {
+                    archiveFileName.set(project.name
+                        .replace(".", "_")
+                        .plus("_\${config.name}")
+                        .plus(".jar"))
+                    from(sourceSet.output)
+                }
+                artifacts { add(config.name, jar) }
+            }
+
+            private fun Project.configurePublication(config: Configuration) {
+                tasks.getByName("compileJava") {
+                    dependsOn(tasks["compile\${config.name.capitalize()}Java"])
+                }
+                val adhocComponent = softwareComponentFactory.adhoc(config.name)
+                components.add(adhocComponent)
+                adhocComponent.addVariantsFromConfiguration(config) {
+                    mapToMavenScope("runtime")
+                }
+            }
+        }
+
+        inline fun <reified T : Named> Project.namedAttribute(value: String) = objects.named(T::class.java, value)
+        """
+
+        when:
+        run "publishAllPublicationsToMavenRepository"
+
+        then:
+        def aClient = mavenRepo.module("com.acme.foo", "a-client", "1.0")
+        aClient.assertPublished()
+        def aServer = mavenRepo.module("com.acme.foo", "a-server", "1.0")
+        aServer.assertPublished()
+        def bClient = mavenRepo.module("com.acme.foo", "b-client", "1.0")
+        bClient.assertPublished()
+        def bServer = mavenRepo.module("com.acme.foo", "b-server", "1.0")
+        bServer.assertPublished()
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -60,6 +60,11 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
     }
 
     @Override
+    public Set<? extends Configuration> getAssociatedConfigurations() {
+        return variants.keySet();
+    }
+
+    @Override
     public Set<? extends UsageContext> getUsages() {
         ImmutableSet.Builder<UsageContext> builder = new ImmutableSet.Builder<>();
         for (ConfigurationVariantMapping variant : variants.values()) {


### PR DESCRIPTION
Allow DefaultProjectDependencyPublicationResolver to resolve publications of components in projects with multiple publications that were created for a specific configuration if the project dependency also specifies a configuration.

Signed-off-by: René Pasold <rene.pasold@jena.de>

<!--- The issue this PR addresses -->
Fixes #12324

### Context
<!--- Why do you believe many users will benefit from this change? -->
Allow DefaultProjectDependencyPublicationResolver to resolve publications of components in projects with multiple publications that were created for a specific configuration if the project dependency also specifies a configuration.
This led to "Publishing is not able to resolve a dependency on a project with multiple publications that have different coordinates." before, even though there was a 1:1 relationship between the configuration on the dependency and the configuration the SoftwareComponent was created for_
` dependencies.project(mapOf("path" to ":${plugin.group}.${plugin.name}", "configuration" to config.name))`
<=>
```
val adhocComponent = softwareComponentFactory.adhoc(config.name)
components.add(adhocComponent)
adhocComponent.addVariantsFromConfiguration(config)
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
