### PR TITLE
Rebaseline JavaFirstUsePerformanceTest

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.5-20220118231504+0000"]
+        runner.targetVersions = ["7.5-20220201231431+0000"]
     }
 
     def "first use"() {


### PR DESCRIPTION
`clean checkout` for `largeJavaMultiProject` seems to have a small regression (1% / 100ms). I took a quick look at the changes and nothing jumped my eye. It doesn't seem worth to investigate further.

![image](https://user-images.githubusercontent.com/423186/152116555-37920112-1b03-4dd7-ba15-b393bdf6c3c1.png)
