### PR TITLE
Remove mention of Android build cache

### DIFF
--- a/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build-cache/build_cache.adoc
@@ -17,8 +17,6 @@
 
 TIP: Want to learn the tips and tricks top engineering teams use to keep builds fast and performant? https://gradle.com/training/build-cache-deep-dive/?bid=docs-build-cache[Register here] for our Build Cache Training.
 
-NOTE: The build cache feature described here is different from the https://developer.android.com/studio/build/build-cache.html[Android plugin build cache].
-
 [[sec:build_cache_intro]]
 == Overview
 


### PR DESCRIPTION
The page and the Android build cache don't exist any more. The Gradle Build cache is now well known enough that there is no reason to point out the difference.