### PR TITLE
Clear no longer pending constraints always

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DirectDependencyMetadata.java
@@ -31,7 +31,7 @@ public interface DirectDependencyMetadata extends DependencyMetadata<DirectDepen
      * Endorse version constraints with {@link VersionConstraint#getStrictVersion()} strict versions} from the target module.
      *
      * Endorsing strict versions of another module/platform means that all strict versions will be interpreted during dependency
-     * resolution as if they where defined by the endorsing module itself.
+     * resolution as if they were defined by the endorsing module itself.
      *
      * @since 6.0
      */

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -17,8 +17,6 @@
 
 package org.gradle.integtests.resolve
 
-import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.Usage
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -1639,15 +1637,7 @@ configurations.all {
     def "constraint shouldn't be converted to hard dependency when a dependency subsitution applies on an external module"() {
         def fooModule = mavenRepo.module("org", "foo", "1.0")
         mavenRepo.module("org", "platform", "1.0")
-            .withModuleMetadata()
-            .adhocVariants()
-            .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
-                useDefaultArtifacts = false
-            }
-            .dependencyConstraint(fooModule)
-            .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
-                useDefaultArtifacts = false
-            }
+            .asGradlePlatform()
             .dependencyConstraint(fooModule)
             .publish()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.platforms
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.Category
-import org.gradle.api.attributes.Usage
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
@@ -235,13 +234,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
     // this is the case
     def "can enforce a published platform"() {
         def platform = mavenHttpRepo.module("org", "platform", "1.0")
-                .withModuleMetadata()
-                .adhocVariants()
-                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
-                .dependsOn("org", "foo", "1.0")
-                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
-                    useDefaultArtifacts = false
-                }
+                .asGradlePlatform()
                 .dependsOn("org", "foo", "1.0")
                 .publish()
         def foo10 = mavenHttpRepo.module("org", "foo", "1.0").withModuleMetadata().publish()
@@ -270,8 +263,8 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 module("org:platform:1.0") {
-                    configuration = "enforcedApiElements"
-                    variant("enforcedApiElements", [
+                    configuration = "enforcedApi"
+                    variant("enforcedApi", [
                             'org.gradle.usage': 'java-api',
                             'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
@@ -427,17 +420,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
 
     @Issue("gradle/gradle#11091")
     def "resolves to runtime platform variant of a platform with gradle metadata if no attributes are requested"() {
-        def platform = mavenHttpRepo.module("org", "platform", "1.0").withModuleMetadata().withoutDefaultVariants()
-            .withVariant('api') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }
-            .withVariant('runtime') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }.publish()
+        def platform = mavenHttpRepo.module("org", "platform", "1.0").asGradlePlatform().publish()
 
         when:
         buildFile << """
@@ -468,17 +451,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
 
     @Issue("gradle/gradle#11091")
     def "can enforce a platform that is already on the dependency graph on the #classpath classpath"() {
-        def platform = mavenHttpRepo.module("org", "platform", "1.0").withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }.publish()
+        def platform = mavenHttpRepo.module("org", "platform", "1.0").asGradlePlatform().publish()
 
         when:
         buildFile << """
@@ -495,8 +468,8 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
 
         then:
         def javaUsage = "java-${usage}"
-        def regularVariant = "${usage}Elements"
-        def enforcedVariant = "enforced${usage.capitalize()}Elements"
+        def regularVariant = "${usage}"
+        def enforcedVariant = "enforced${usage.capitalize()}"
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 module("org:platform:1.0") {
@@ -526,26 +499,17 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         given:
         file("src/main/java/SomeClass.java") << "public class SomeClass {}"
         platformModule('')
-        mavenHttpRepo.module("org.test", "platform", "1.9").withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+        mavenHttpRepo.module("org.test", "platform", "1.9").asGradlePlatform().publish()
+        def moduleA = mavenHttpRepo.module("org.test", "b", "1.9").withModuleMetadata()
+            .withVariant("runtime") {
+                dependsOn("org.test", "platform", "1.9") {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
+            }.withVariant("api") {
+                dependsOn("org.test", "platform", "1.9") {
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
             }.publish()
-        def moduleA = mavenHttpRepo.module("org.test", "b", "1.9").withModuleMetadata().withVariant("runtime") {
-            dependsOn("org.test", "platform", "1.9") {
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }
-        }.withVariant("api") {
-            dependsOn("org.test", "platform", "1.9") {
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-            }
-        }.publish()
 
         when:
         buildFile << """
@@ -575,13 +539,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         def foobar = mavenHttpRepo.module('org', 'foobar', '1.0').publish()
         def foo = mavenHttpRepo.module('org', 'foo', '1.0').dependsOn(foobar).dependsOn(foobaz).publish()
         def platformGMM = mavenHttpRepo.module("org", "other-platform", "1.0")
-            .withModuleMetadata()
-            .adhocVariants()
-            .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
-            .dependencyConstraint(foo)
-            .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
-                useDefaultArtifacts = false
-            }
+            .asGradlePlatform()
             .dependencyConstraint(foo)
             .publish()
         def mavenBom = mavenHttpRepo.module("org", "bom-platform", "1.0")
@@ -618,7 +576,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     }
                 } else if (platform == "'org:other-platform:1.0'") {
                     module('org:other-platform:1.0') {
-                        variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform', 'org.gradle.status': 'release'])
+                        variant("runtime", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform', 'org.gradle.status': 'release'])
                         constraint("org:foo:1.0")
                         noArtifacts()
                     }
@@ -649,21 +607,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         given:
         def depExcluded = mavenHttpRepo.module('org.test', 'excluded', '1.0').publish()
         def depA = mavenHttpRepo.module('org.test', 'depA', '1.0').publish()
-        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.0')
-                constraint('org.test', 'excluded', '1.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.0')
-                constraint('org.test', 'excluded', '1.0')
-            }.publish()
+        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').asGradlePlatform().dependencyConstraint(depA).dependencyConstraint(depExcluded).publish()
         def depC = mavenHttpRepo.module('org.test', 'depC', '1.0').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.0') {
@@ -726,21 +670,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
 
     def 'platform deselection does not cause orphan edges'() {
         given:
-        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.1')
-                constraint('org.test', 'depB', '1.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.1')
-                constraint('org.test', 'depB', '1.0')
-            }.publish()
         def depA = mavenHttpRepo.module('org.test', 'depA', '1.0').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.0') {
@@ -761,37 +690,6 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
             }.publish()
-
-        def otherPlatform10 = mavenHttpRepo.module('org.test', 'otherPlatform', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depD', '1.0')
-                constraint('org.test', 'test', '1.9')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depD', '1.0')
-                constraint('org.test', 'test', '1.9')
-            }.publish()
-        def otherPlatform11 = mavenHttpRepo.module('org.test', 'otherPlatform', '1.1').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depD', '1.0')
-                constraint('org.test', 'test', '1.9')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depD', '1.0')
-                constraint('org.test', 'test', '1.9')
-            }.publish()
         def depE = mavenHttpRepo.module('org.test', 'depE', '1.0').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'otherPlatform', '1.1') {
@@ -800,6 +698,10 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             }.publish()
         def depD = mavenHttpRepo.module('org.test', 'depD', '1.0').dependsOn(depE).publish()
         def depC = mavenHttpRepo.module('org.test', 'depC', '1.0').dependsOn(depD).publish()
+        def depTest = mavenHttpRepo.module('org.test', 'test', '1.9') // Not published as not resolved
+        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').asGradlePlatform().dependencyConstraint(depA11).dependencyConstraint(depB).publish()
+        def otherPlatform10 = mavenHttpRepo.module('org.test', 'otherPlatform', '1.0').asGradlePlatform().dependencyConstraint(depD).dependencyConstraint(depTest).publish()
+        def otherPlatform11 = mavenHttpRepo.module('org.test', 'otherPlatform', '1.1').asGradlePlatform().dependencyConstraint(depD).dependencyConstraint(depTest).publish()
 
         depA.allowAll()
         depA11.allowAll()
@@ -825,77 +727,20 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         checkConfiguration("conf")
         resolve.expectDefaultConfiguration("runtime")
 
-        when:
+        expect:
         succeeds 'checkDeps'
-
-        then:
-        resolve.expectGraph {
-            root(":", "org.test:test:1.9") {
-                edge('org.test:depA:1.0', 'org.test:depA:1.1') {
-                    module('org.test:platform:1.0') {
-                        noArtifacts()
-                        constraint('org.test:depA:1.1')
-                        constraint('org.test:depB:1.0')
-                    }
-                    module('org.test:depB:1.0') {
-                        module('org.test:platform:1.0')
-                    }
-                }
-                edge("org.test:otherPlatform:1.0", "org.test:otherPlatform:1.1") {
-                    noArtifacts()
-                    constraint('org.test:depD:1.0')
-                }
-                module("org.test:depC:1.0") {
-                    module('org.test:depD:1.0') {
-                        module('org.test:depE:1.0') {
-                            module('org.test:otherPlatform:1.1') {
-                                noArtifacts()
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        //Shape of the graph is not checked as bug was failing resolution altogether
     }
 
     def 'platform upgrade does not leave orphaned edges'() {
         given:
-        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.0')
-                constraint('org.test', 'depB', '1.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.0')
-                constraint('org.test', 'depB', '1.0')
-            }.publish()
-        def platform11 = mavenHttpRepo.module('org.test', 'platform', '1.1').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.1')
-                constraint('org.test', 'depB', '1.1')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'depA', '1.1')
-                constraint('org.test', 'depB', '1.1')
-            }.publish()
         def depA = mavenHttpRepo.module('org.test', 'depA', '1.0').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.0') {
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
             }.publish()
+        def depB = mavenHttpRepo.module('org.test', 'depB', '1.0') // Not published as not resolved
         def depA11 = mavenHttpRepo.module('org.test', 'depA', '1.1').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('org.test', 'platform', '1.1') {
@@ -910,6 +755,8 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                 }
                 dependsOn('org.test', 'depA', '1.1')
             }.publish()
+        def platform = mavenHttpRepo.module('org.test', 'platform', '1.0').asGradlePlatform().dependencyConstraint(depA).dependencyConstraint(depB).publish()
+        def platform11 = mavenHttpRepo.module('org.test', 'platform', '1.1').asGradlePlatform().dependencyConstraint(depA11).dependencyConstraint(depB11).publish()
 
         depA.allowAll()
         depA11.allowAll()
@@ -930,49 +777,21 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         checkConfiguration("conf")
         resolve.expectDefaultConfiguration("runtime")
 
-        when:
+        expect:
         succeeds 'checkDeps'
-
-        then:
-        resolve.expectGraph {
-            root(":", "org.test:test:1.9") {
-                edge('org.test:depA:1.0', 'org.test:depA:1.1') {
-                    module('org.test:platform:1.1') {
-                        noArtifacts()
-                        constraint('org.test:depA:1.1')
-                        constraint('org.test:depB:1.1')
-                    }
-                }
-                module('org.test:depB:1.1') {
-                    module('org.test:platform:1.1')
-                    module('org.test:depA:1.1')
-                }
-            }
-        }
+        //Shape of the graph is not checked as bug was failing resolution altogether
     }
 
     def "multiple platform deselection - reselection does not leave pending constraints in graph"() {
         given:
-        def depsPlatform = mavenHttpRepo.module('org.test', 'deps', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'dep', '1.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('org.test', 'dep', '1.0')
-            }.publish()
-        def extPlatform = mavenHttpRepo.module('org.test', 'platform', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('commons', 'other', '2.0')
-                constraint('commons', 'commons', '2.0')
+        def depCommonsOther = mavenHttpRepo.module('commons', 'other', '2.0').publish()
+        def depCommons2 = mavenHttpRepo.module('commons', 'commons', '2.0').publish()
+        def depSpring = mavenHttpRepo.module('spring', 'core', '1.0').dependsOn(depCommonsOther).publish()
+        def dep = mavenHttpRepo.module('org.test', 'dep', '1.0').dependsOn(depSpring).publish()
+        def depsPlatform = mavenHttpRepo.module('org.test', 'deps', '1.0').asGradlePlatform().dependencyConstraint(dep).publish()
+        def extPlatform = mavenHttpRepo.module('org.test', 'platform', '1.0').asGradlePlatform()
+            .dependencyConstraint(depCommonsOther).dependencyConstraint(depCommons2)
+            .withVariant('api') {
                 dependsOn('jack', 'bom', '1.0') {
                     endorseStrictVersions = true
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
@@ -982,92 +801,32 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
             }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('commons', 'other', '2.0')
-                constraint('commons', 'commons', '2.0')
-                dependsOn('jack', 'bom', '1.0') {
-                    endorseStrictVersions = true
-                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                }
-                dependsOn('spring', 'bom', '2.0') {
-                    endorseStrictVersions = true
-                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                }
-            }.publish()
-        def springBom = mavenHttpRepo.module('spring', 'bom', '2.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('spring', 'core', '2.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('spring', 'core', '2.0')
-            }.publish()
-        def jackBom = mavenHttpRepo.module('jack', 'bom', '1.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('jack', 'db', '1.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('jack', 'db', '1.0')
-            }.publish()
-        def jack2Bom = mavenHttpRepo.module('jack', 'bom', '2.0').withModuleMetadata().withoutDefaultVariants()
-            .withVariant('apiElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_API)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('jack', 'db', '2.0')
-            }
-            .withVariant('runtimeElements') {
-                useDefaultArtifacts = false
-                attribute(Usage.USAGE_ATTRIBUTE.name, Usage.JAVA_RUNTIME)
-                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
-                constraint('jack', 'db', '2.0')
-            }.publish()
-        def depSwag = mavenHttpRepo.module('org.test', 'swag', '1.0').withModuleMetadata()
             .withVariant('runtime') {
-                dependsOn('jack', 'db', '2.0')
-                dependsOn('org.test', 'swag-int', '1.0')
+                dependsOn('jack', 'bom', '1.0') {
+                    endorseStrictVersions = true
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
+                dependsOn('spring', 'bom', '2.0') {
+                    endorseStrictVersions = true
+                    attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
+                }
             }.publish()
+        def depSpring2 = mavenHttpRepo.module('spring', 'core', '2.0').publish()
+        def springBom = mavenHttpRepo.module('spring', 'bom', '2.0').asGradlePlatform().dependencyConstraint(depSpring2).publish()
+        def depJackDb1 = mavenHttpRepo.module('jack', 'db', '1.0') //Not published as not resolved
+        def jackBom = mavenHttpRepo.module('jack', 'bom', '1.0').asGradlePlatform().dependencyConstraint(depJackDb1).publish()
         def depJackDb = mavenHttpRepo.module('jack', 'db', '2.0').withModuleMetadata()
             .withVariant('runtime') {
                 dependsOn('jack', 'bom', '2.0') {
                     attribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
             }.publish()
-        def depSwagInt = mavenHttpRepo.module('org.test', 'swag-int', '1.0').withModuleMetadata()
-            .withVariant('runtime') {
-                dependsOn('org.test', 'swag-core', '1.0')
-            }.publish()
-        def depSwagCore = mavenHttpRepo.module('org.test', 'swag-core', '1.0').withModuleMetadata()
-            .withVariant('runtime') {
-                dependsOn('commons', 'commons', '1.0')
-                dependsOn('jack', 'db', '2.0')
-            }.publish()
-        def dep = mavenHttpRepo.module('org.test', 'dep', '1.0').withModuleMetadata()
-            .withVariant('runtime') {
-                dependsOn('spring', 'core', '1.0')
-            }.publish()
-        def depCommons = mavenHttpRepo.module('commons', 'commons', '1.0').withModuleMetadata().publish()
-        def depCommons2 = mavenHttpRepo.module('commons', 'commons', '2.0').withModuleMetadata().publish()
-        def depCommonsOther = mavenHttpRepo.module('commons', 'other', '2.0').withModuleMetadata().publish()
-        def depSpring = mavenHttpRepo.module('spring', 'core', '1.0').withModuleMetadata()
-            .withVariant('runtime') {
-                dependsOn('commons', 'other', '2.0')
-            }.publish()
-        def depSpring2 = mavenHttpRepo.module('spring', 'core', '2.0').withModuleMetadata().publish()
+        def jack2Bom = mavenHttpRepo.module('jack', 'bom', '2.0').asGradlePlatform().dependencyConstraint(depJackDb).publish()
+        def depCommons = mavenHttpRepo.module('commons', 'commons', '1.0').publish()
+        def depSwagCore = mavenHttpRepo.module('org.test', 'swag-core', '1.0').dependsOn(depCommons).dependsOn(depJackDb).publish()
+        def depSwagInt = mavenHttpRepo.module('org.test', 'swag-int', '1.0').dependsOn(depSwagCore).publish()
+        def depSwag = mavenHttpRepo.module('org.test', 'swag', '1.0').dependsOn(depJackDb).dependsOn(depSwagInt).publish()
+
 
         depsPlatform.allowAll()
         extPlatform.allowAll()
@@ -1100,44 +859,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         checkConfiguration("conf")
         resolve.expectDefaultConfiguration("runtime")
 
-        when:
+        expect:
         succeeds 'checkDeps'
-
-        then:
-        resolve.expectGraph {
-            root(":", "org.test:test:1.9") {
-                edge('org.test:dep', 'org.test:dep:1.0') {
-                    edge('spring:core:1.0', 'spring:core:2.0')
-                }
-                module('org.test:swag:1.0') {
-                    module('jack:db:2.0') {
-                        module('jack:bom:2.0') {
-                            noArtifacts()
-                            constraint('jack:db:2.0')
-                        }
-                    }
-                    module('org.test:swag-int:1.0') {
-                        module('org.test:swag-core:1.0') {
-                            edge('commons:commons:1.0', 'commons:commons:2.0')
-                            module('jack:db:2.0')
-                        }
-                    }
-                }
-                module('org.test:deps:1.0') {
-                    noArtifacts()
-                    constraint('org.test:dep:1.0')
-                }
-                module('org.test:platform:1.0') {
-                    noArtifacts()
-                    edge('jack:bom:1.0', 'jack:bom:2.0')
-                    module('spring:bom:2.0') {
-                        noArtifacts()
-                        constraint('spring:core:2.0')
-                    }
-                    constraint('commons:commons:2.0')
-                }
-            }
-        }
+        //Shape of the graph is not checked as bug was failing resolution altogether
     }
 
     private void checkConfiguration(String configuration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -275,11 +275,12 @@ public class NodeState implements DependencyGraphNode {
         // Clear previous traversal state, if any
         if (previousTraversalExclusions != null) {
             removeOutgoingEdges();
-            upcomingNoLongerPendingConstraints = null;
             edgesToRecompute = null;
             potentiallyActivatedConstraints = null;
             ownStrictVersionConstraints = null;
         }
+        // We are processing dependencies, anything in the previous state will be handled
+        upcomingNoLongerPendingConstraints = null;
 
         visitDependencies(resolutionFilter, discoveredEdges);
         visitOwners(discoveredEdges);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -763,6 +763,19 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     }
 
     @Override
+    MavenModule asGradlePlatform() {
+        variants.clear()
+        variant('api',  [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
+            useDefaultArtifacts = false
+        }
+        variant('runtime', [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
+            useDefaultArtifacts = false
+        }
+        hasType('pom')
+        withModuleMetadata()
+    }
+
+    @Override
     MavenModule withoutGradleMetadataRedirection() {
         gradleMetadataRedirect = false
         return this

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -286,6 +286,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public MavenModule asGradlePlatform() {
+        backingModule.asGradlePlatform();
+        return t();
+    }
+
+    @Override
     public boolean getUniqueSnapshots() {
         return backingModule.getUniqueSnapshots();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -53,6 +53,15 @@ interface MavenModule extends Module {
      */
     MavenModule withModuleMetadata()
 
+    /**
+     * Sets up this module and its variant to represent a publish Gradle platform.
+     * It implies the publication of the Gradle module metadata.
+     * This creates two platform variants named 'api' and 'runtime"
+     *
+     * @return this
+     */
+    MavenModule asGradlePlatform()
+
     MavenModule withoutGradleMetadataRedirection();
 
     MavenModule parent(String group, String artifactId, String version)


### PR DESCRIPTION
In some cases, we end up reprocessing a constraint source but we did not
clear the registered no longer pending constraints.
This would cause a double registration of the constraint when later
other constraints are also activated.