### PR TITLE
Return adapted child for getNode(ancestor)

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotUtil.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotUtil.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public class SnapshotUtil {
 
@@ -78,8 +79,7 @@ public class SnapshotUtil {
 
             @Override
             public ReadOnlyFileSystemNode handleAsAncestorOfChild(String childPath, T child) {
-                // TODO: This is not correct, it should be a node with the child at targetPath.pathFromChild(childPath).
-                return child;
+                return new SingleChildReadOnlyFileSystemNode(targetPath.pathToChild(childPath), child);
             }
 
             @Override
@@ -104,5 +104,44 @@ public class SnapshotUtil {
             return SnapshotVisitResult.SKIP_SUBTREE;
         });
         return builder.build();
+    }
+
+    private static class SingleChildReadOnlyFileSystemNode implements ReadOnlyFileSystemNode {
+        private final String relativePath;
+        private final FileSystemNode child;
+
+        public SingleChildReadOnlyFileSystemNode(String relativePath, FileSystemNode child) {
+            this.relativePath = relativePath;
+            this.child = child;
+        }
+
+        @Override
+        public Optional<MetadataSnapshot> getSnapshot(VfsRelativePath targetPath, CaseSensitivity caseSensitivity) {
+            return SnapshotUtil.getMetadataFromChildren(getChildren(), targetPath, caseSensitivity, Optional::empty);
+        }
+
+        @Override
+        public boolean hasDescendants() {
+            return child.hasDescendants();
+        }
+
+        @Override
+        public ReadOnlyFileSystemNode getNode(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
+            return getChild(getChildren(), relativePath, caseSensitivity);
+        }
+
+        @Override
+        public Optional<MetadataSnapshot> getSnapshot() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Stream<FileSystemLocationSnapshot> rootSnapshots() {
+            return child.rootSnapshots();
+        }
+
+        private SingletonChildMap<FileSystemNode> getChildren() {
+            return new SingletonChildMap<>(relativePath, child);
+        }
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/AbstractIncompleteFileSystemNodeTest.groovy
@@ -18,6 +18,9 @@ package org.gradle.internal.snapshot
 
 import org.gradle.internal.file.FileType
 
+import java.util.stream.Collectors
+import java.util.stream.Stream
+
 import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 
 abstract class AbstractIncompleteFileSystemNodeTest<T extends FileSystemNode> extends AbstractFileSystemNodeWithChildrenTest<T, FileSystemNode> {
@@ -265,17 +268,39 @@ abstract class AbstractIncompleteFileSystemNodeTest<T extends FileSystemNode> ex
         vfsSpec << (NO_COMMON_PREFIX + COMMON_PREFIX).findAll { allowEmptyChildren || !it.childPaths.empty}
     }
 
-    def "querying for parent of child #vfsSpec.searchedPath finds adapted child (#vfsSpec)"() {
+    def "querying for parent #vfsSpec.searchedPath of child #vfsSpec.selectedChildPath finds adapted child (#vfsSpec)"() {
         setupTest(vfsSpec)
+        def expectedSnapshot = Mock(MetadataSnapshot)
+        def newPathToChild = VfsRelativePath.of(searchedPath.pathToChild(selectedChildPath))
 
         when:
         def resultRoot = initialRoot.getNode(searchedPath, CASE_SENSITIVE)
+
         then:
-        resultRoot == selectedChild
+        resultRoot.getNode(newPathToChild, CASE_SENSITIVE) == selectedChild
+        !resultRoot.snapshot.present
+        !resultRoot.getSnapshot(VfsRelativePath.of(""), CASE_SENSITIVE).present
         interaction {
-//            1 * selectedChild.withPathToParent(selectedChildPathFromCommonPrefix) >> selectedChild
             noMoreInteractions()
         }
+
+        when:
+        def rootSnapshots = resultRoot.rootSnapshots().collect(Collectors.toList())
+        then:
+        1 * selectedChild.rootSnapshots() >> Stream.of(expectedSnapshot)
+        rootSnapshots == [expectedSnapshot]
+
+        when:
+        def hasDescendants = resultRoot.hasDescendants()
+        then:
+        1 * selectedChild.hasDescendants() >> true
+        hasDescendants
+
+        when:
+        def snapshotFromChild = resultRoot.getSnapshot(newPathToChild, CASE_SENSITIVE)
+        then:
+        1 * selectedChild.snapshot >> Optional.of(expectedSnapshot)
+        snapshotFromChild.get() == expectedSnapshot
 
         where:
         vfsSpec << IS_PREFIX_OF_CHILD


### PR DESCRIPTION
to finally resolve the TODO in `SnapshotUtil`.