### PR TITLE
Fix integration test failing in Ready for Release build due to new tasks

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -586,7 +586,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             def schema = tasks.collectionSchema.elements.collectEntries { e ->
                 [ e.name, e.publicType.simpleName ]
             }
-            assert (schema.size() == 18 || schema.size() == 19)
+            assert (schema.size() == 18 || schema.size() == 20)
 
             assert schema["help"] == "Help"
 
@@ -602,7 +602,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             assert schema["model"] == "ModelReport"
             assert schema["dependentComponents"] == "DependentComponentsReport"
 
-            if (schema.size() == 19) {
+            if (schema.size() == 20) {
                 assert schema["init"] == "InitBuild"
                 assert schema["wrapper"] == "Wrapper"
             }


### PR DESCRIPTION
Fixes the broken integration test which failed the Ready for Release build here: https://ge.gradle.org/s/l7ohrd6cwgoju/tests/:core:noDaemonIntegTest/org.gradle.api.tasks.TaskDefinitionIntegrationTest/can%20extract%20schema%20from%20task%20container?top-execution=1