### PR TITLE
Store `FilteredMinimalFileTree` patterns to the configuration cache

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/collections/FilteredMinimalFileTree.java
@@ -44,6 +44,10 @@ public class FilteredMinimalFileTree implements MinimalFileTree, FileSystemMirro
         return tree;
     }
 
+    public PatternSet getPatterns() {
+        return patterns;
+    }
+
     @Override
     public DirectoryFileTree getMirror() {
         DirectoryFileTree mirror = tree.getMirror();


### PR DESCRIPTION
To enable file tree inputs like `zipTree(file).matching(patternSet)` to be correctly restored from the cache.

Follow-up to #19825 