### PR TITLE
Do not assert that task schema has a specific number of tasks

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -586,29 +586,14 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             def schema = tasks.collectionSchema.elements.collectEntries { e ->
                 [ e.name, e.publicType.simpleName ]
             }
-            assert (schema.size() == 18 || schema.size() == 20)
-
+            
+            // check some built-in tasks
             assert schema["help"] == "Help"
-
             assert schema["projects"] == "ProjectReportTask"
             assert schema["tasks"] == "TaskReportTask"
             assert schema["properties"] == "PropertyReportTask"
 
-            assert schema["dependencyInsight"] == "DependencyInsightReportTask"
-            assert schema["dependencies"] == "DependencyReportTask"
-            assert schema["buildEnvironment"] == "BuildEnvironmentReportTask"
-
-            assert schema["components"] == "ComponentReport"
-            assert schema["model"] == "ModelReport"
-            assert schema["dependentComponents"] == "DependentComponentsReport"
-
-            if (schema.size() == 20) {
-                assert schema["init"] == "InitBuild"
-                assert schema["wrapper"] == "Wrapper"
-            }
-
-            assert schema["prepareKotlinBuildScriptModel"] == "DefaultTask"
-
+            // check some tasks from the project itself
             assert schema["foo"] == "Foo"
             assert schema["bar"] == "Foo"
             assert schema["builtInTask"] == "Copy"


### PR DESCRIPTION
I have an explanation for #19824. It's a side effect of the way our testing infrastructure works.

- We have different executers (embedded, forking, parallel, configCache, noDaemon and some others).
- We have different distributions (full distributions and partial distributions) that is roughly based on the dependencies of the project we're testing.
- We use these executers for different levels of feedback. e.g., QuickFeedback is based on the embedded executer. PullRequestFeedback uses forking and configCache. Those different executers require different distributions.

For all executers except noDaemon, we use a partial distribution. You can see that here:
https://ge.gradle.org/s/jez6oqga4au4k/timeline?details=ruowzi5zbkota&expanded=WyIwLjExNjkiXQ&show=Predecessors&task-path=forkingInteg

noDaemon uses a full distribution. You can see that here:
https://ge.gradle.org/s/l7ohrd6cwgoju/timeline?details=6fjfqdy5mxagi&expanded=WyIwLjEyNDciXQ&show=Predecessors&task-path=noDaemonInte

For the most part, if you were missing something important from the distribution, the test would fail. But the wrapper, help and build-init plugins are special in the way they're automatically applied to a build/project. We look for classes with a particular type and if they exist, we end up applying plugins. If they don't exist, we don't find them.

So up until the noDaemon tests ran, we were running with a partial distribution and that distribution did not include build-init or wrapper plugins, so they were not applied to the project in the test. That's why there are extra tasks when running with noDaemon. 

It seems like there are a few tests that have adjusted expectations due to this. In this particular case, we don't really need to know that all the tasks are in the schema. I think checking for the tasks that are declared in the project plus a few well known tasks (e.g., help) are good enough.

This makes it one less place we have to touch whenever we rename/remove/add a task that applies to all projects.