### PR TITLE
Remove the incubating message for dependency accessors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -85,7 +85,7 @@ bar = {group="org.gradle.test", name="bar", version="1.0"}
 
         then: "extension is not regenerated"
         !operations.hasOperation("Executing generation of dependency accessors for libs")
-        !outputContains 'Type-safe dependency accessors is an incubating feature.'
+        outputDoesNotContain 'Type-safe dependency accessors is an incubating feature.'
     }
 
     def "can use the generated extension to declare a dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/TomlDependenciesExtensionIntegrationTest.groovy
@@ -85,7 +85,7 @@ bar = {group="org.gradle.test", name="bar", version="1.0"}
 
         then: "extension is not regenerated"
         !operations.hasOperation("Executing generation of dependency accessors for libs")
-        outputContains 'Type-safe dependency accessors is an incubating feature.'
+        !outputContains 'Type-safe dependency accessors is an incubating feature.'
     }
 
     def "can use the generated extension to declare a dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -85,7 +85,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
 
         then: "extension is not regenerated"
         !operations.hasOperation("Executing generation of dependency accessors for libs")
-        outputContains 'Type-safe dependency accessors is an incubating feature.'
+        !outputContains 'Type-safe dependency accessors is an incubating feature.'
 
         where:
         notation << [

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -85,7 +85,7 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
 
         then: "extension is not regenerated"
         !operations.hasOperation("Executing generation of dependency accessors for libs")
-        !outputContains 'Type-safe dependency accessors is an incubating feature.'
+        outputDoesNotContain 'Type-safe dependency accessors is an incubating feature.'
 
         where:
         notation << [

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -125,7 +125,6 @@ public class DefaultDependenciesAccessors implements DependenciesAccessors {
                 models.add(model);
             }
             if (models.stream().anyMatch(DefaultVersionCatalog::isNotEmpty)) {
-                IncubationLogger.incubatingFeatureUsed("Type-safe dependency accessors");
                 for (DefaultVersionCatalog model : models) {
                     if (model.isNotEmpty()) {
                         writeDependenciesAccessors(model);

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/declaring_dependencies.adoc
@@ -298,7 +298,7 @@ include::sample[dir="snippets/dependencyManagement/declaringDependencies-project
 
 [WARNING]
 ====
-Type-safe dependency accessors are an incubating feature which must be enabled explicitly.
+Type-safe project accessors are an incubating feature which must be enabled explicitly.
 Implementation may change at any time.
 To add support for type-safe project accessors, add this to your `settings.gradle(.kts)` file:
 ```


### PR DESCRIPTION
Fixes #19853

I also altered the docs for type-safe project accessors to have correct wording.