### PR TITLE
Improve TestFilter reference for exclusions

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
@@ -52,6 +52,11 @@ import java.util.Set;
  *
  *          //only ui tests from integration tests, by some naming convention
  *          includeTestsMatching "*IntegTest*ui"
+ *
+ *          //exclude a specific test by its name
+ *          excludeTestsMatching "*canDoSomethingSpecific"
+ *          //excluding tests by name also works for test names which have spaces
+ *          excludeTestsMatching "*can do something specific"
  *       }
  *   }
  *
@@ -73,7 +78,7 @@ public interface TestFilter {
     /**
      * Appends a test name pattern to the exclusion filter. Wildcard '*' is supported, either test
      * method name or class name is supported. Examples of test names: "com.foo.FooTest.someMethod",
-     * "com.foo.FooTest", "*FooTest*", "com.foo*". See examples in the docs for {@link TestFilter}.
+     * "com.foo.FooTest", "*FooTest*", "com.foo*", "*someTestMethod". See examples in the docs for {@link TestFilter}.
      *
      * @param testNamePattern test name pattern to exclude, can be class or method name, can contain wildcard '*'
      * @return this filter object


### PR DESCRIPTION
it took me a while to make TestFilter work with exclusions. I was making a Test task which runs a quick subset of the unit tests.

Things I tried which did not work:
- `excludeTestsMatching("copy-images.sh copies images")` (so close!)
- `exclude("**/CopyImagesShTest.copy-images.sh copies images")`
- `excludeTest("com/whatever/CopyImagesShTest", "copy-images.sh copies images")`
- `excludeTest("com.whatever.CopyImagesShTest", "copy-images.sh copies images")`

What worked:
- `excludeTestsMatching("*copy-images.sh copies images")`

I thought it was a bit subtle, and the TestFilter reference needs a bit of TLC. Here is a very small amount of TLC.