### PR TITLE
Remove special case when snapshotting file trees with a missing root

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
-import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot;
@@ -94,11 +93,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             fileSystemAccess.read(
                 root.getAbsolutePath(),
                 new PatternSetSnapshottingFilter(patterns, stat),
-                snapshot -> {
-                    if (snapshot.getType() != FileType.Missing) {
-                        roots.add(snapshot);
-                    }
-                }
+                roots::add
             );
             if (fileTreeOnly == null) {
                 fileTreeOnly = true;

--- a/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/buildSrc/src/main/java/org/example/Instrument.java
+++ b/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/groovy/buildSrc/src/main/java/org/example/Instrument.java
@@ -10,6 +10,7 @@ public abstract class Instrument extends DefaultTask {
 
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public abstract ConfigurableFileCollection getClassFiles();
 

--- a/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/kotlin/buildSrc/src/main/java/org/example/Instrument.java
+++ b/subprojects/docs/src/snippets/tasks/incrementalBuild-incrementalBuildAdvanced/kotlin/buildSrc/src/main/java/org/example/Instrument.java
@@ -10,6 +10,7 @@ public abstract class Instrument extends DefaultTask {
 
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public abstract ConfigurableFileCollection getClassFiles();
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/tasks/AssemblerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/tasks/AssemblerTest.groovy
@@ -40,7 +40,8 @@ class AssemblerTest extends AbstractProjectBuilderSpec {
     }
 
     def "executes using the Assembler"() {
-        def inputDir = temporaryFolder.file("sourceFile")
+        def inputDir = temporaryFolder.file("sourceFile").createDir()
+        inputDir.createFile("blah.asm")
         def result = Mock(WorkResult)
         when:
         assembleTask.toolChain = toolChain

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -72,10 +72,10 @@ public class RelativePathFingerprintingStrategy extends AbstractDirectorySensiti
             if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
                 FileSystemLocationFingerprint fingerprint;
                 if (relativePath.isRoot()) {
-                    if (snapshot.getType() == FileType.Directory) {
-                        return SnapshotVisitResult.CONTINUE;
-                    } else {
+                    if (snapshot.getType() == FileType.RegularFile) {
                         fingerprint = fingerprint(snapshot.getName(), snapshot.getType(), snapshot);
+                    } else {
+                        return SnapshotVisitResult.CONTINUE;
                     }
                 } else {
                     fingerprint = fingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot.getType(), snapshot);

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -94,8 +94,10 @@ class PathNormalizationStrategyTest extends Specification {
 
     def "sensitivity NAME_ONLY (DirectorySensitivity: #strategy.directorySensitivity)"() {
         def fingerprints = collectFingerprints(strategy)
+        def expectedFingerprintedFiles = getAllFilesToFingerprint(strategy.directorySensitivity)
+        expectedFingerprintedFiles.size() == fingerprints.size()
         expect:
-        (getAllFilesToFingerprint(strategy.directorySensitivity) - emptyRootDir - resources).each { file ->
+        (expectedFingerprintedFiles - emptyRootDir - resources).each { file ->
             assert fingerprints[file] == file.name
         }
         fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
@@ -120,7 +122,7 @@ class PathNormalizationStrategyTest extends Specification {
         fingerprints[resources.file(subDirB)]       == directoryFingerprintFor(subDirB, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirB)] == fileInSubdirB
         fingerprints[emptyRootDir]                  == null
-        fingerprints[missingFile]                   == missingFile.name
+        fingerprints[missingFile]                   == null
 
         where:
         strategy << [


### PR DESCRIPTION
This moves us closer into the direction that relative path normalization takes over the meaning of using a file tree.