### PR TITLE
Make gradlew fail early when xargs is not available

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -243,6 +243,13 @@ set -- \\
 <% } %>        ${mainClassName} \\
         "\$@"
 
+# Stop when "xargs" is not available.
+
+if ! command -v xargs &> /dev/null
+then
+    die "xargs is not available"
+fi
+
 # Use "xargs" to parse quoted args.
 #
 # With -n1 it outputs one arg per line, with the quotes and backslashes removed.


### PR DESCRIPTION
Fixes #19682