### PR TITLE
Configure mirror for :kotlinNpmInstall task

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -55,6 +55,7 @@ import gradlebuild.basics.BuildParams.TEST_JAVA_VERSION
 import gradlebuild.basics.BuildParams.TEST_SPLIT_EXCLUDE_TEST_CLASSES
 import gradlebuild.basics.BuildParams.TEST_SPLIT_INCLUDE_TEST_CLASSES
 import gradlebuild.basics.BuildParams.TEST_SPLIT_ONLY_TEST_GRADLE_VERSION
+import gradlebuild.basics.BuildParams.YARNPKG_MIRROR_URL
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
@@ -116,6 +117,7 @@ object BuildParams {
     const val AUTO_DOWNLOAD_ANDROID_STUDIO = "autoDownloadAndroidStudio"
     const val RUN_ANDROID_STUDIO_IN_HEADLESS_MODE = "runAndroidStudioInHeadlessMode"
     const val STUDIO_HOME = "studioHome"
+    const val YARNPKG_MIRROR_URL = "YARNPKG_MIRROR_URL"
 }
 
 
@@ -325,3 +327,7 @@ val Project.runAndroidStudioInHeadlessMode: Boolean
 
 val Project.androidStudioHome: Provider<String>
     get() = propertyFromAnySource(STUDIO_HOME)
+
+
+val Project.yarnpkgMirrorUrl: Provider<String>
+    get() = environmentVariable(YARNPKG_MIRROR_URL)

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -46,6 +46,7 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by Gradle test infrastructure
     "REPO_MIRROR_URLS",
+    "YARNPKG_MIRROR_URL",
 
     // Used to find local java installations
     "SDKMAN_CANDIDATES_DIR",

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import gradlebuild.basics.yarnpkgMirrorUrl
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -48,6 +49,12 @@ rootProject.run {
     plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
         configure<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension> {
             lockFileDirectory = layout.buildDirectory.file("kotlin-js-store").get().asFile
+        }
+    }
+
+    yarnpkgMirrorUrl.orNull?.let { mirrorUrl ->
+        tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
+            args += listOf("--registry", mirrorUrl)
         }
     }
 }


### PR DESCRIPTION
Because it fails a lot: https://ge.gradle.org/scans/failures?failures.failureClassification=non_verification&failures.failureMessage=Execution%20failed%20for%20task%20%27:kotlinNpmInstall%27.%0A%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20Process%20%27Resolving%20NPM%20dependencies%20using%20yarn%27%20returns%201%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20yarn%20install%20v1.22.10%0A%20%20info%20No%20lockfile%20found.%0A%20%20%5B1/4%5D%20Resolving%20packages...%0A%20%20info%20Visit%20https://yarnpkg.com/en/docs/cli/install%20for%20documentation%20about%20this%20command.&search.relativeStartTime=P7D&search.timeZoneId=Europe/Berlin
