### PR TITLE
Upgrade tested AGP versions

### DIFF
--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -72,6 +72,7 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
         task.name == "login" -> true
 
         // Kotlin/JS
+        // https://youtrack.jetbrains.com/issue/KT-50881
         task.name in listOf("generateExternals") -> true
 
         // JMH plugin

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=4.1.3,4.2.2,7.0.4,7.1.1,7.2.0-beta01,7.3.0-alpha01
+latests=4.1.3,4.2.2,7.0.4,7.1.1,7.2.0-beta02,7.3.0-alpha02

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -43,9 +43,9 @@ For older Gradle versions, please see the table below which Java version is supp
 
 [[kotlin]]
 == Kotlin
-Gradle is tested with Kotlin 1.3.72 through 1.6.0.
+Gradle is tested with Kotlin 1.3.72 through 1.6.10.
 
-Gradle plugins written in Kotlin target Kotlin 1.4 for compatibility with Gradle and Kotlin DSL build scripts, even though the embedded Kotlin runtime is Kotlin 1.5.
+Gradle plugins written in Kotlin target Kotlin 1.4 for compatibility with Gradle and Kotlin DSL build scripts, even though the embedded Kotlin runtime is Kotlin 1.6.
 
 == Groovy
 Gradle is tested with Groovy 1.5.8 through 3.0.9.

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidPluginsSmokeTest.groovy
@@ -64,8 +64,7 @@ class AndroidPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implemen
         ].combinations()
     }
 
-    // TODO re-enable this test with AGP 7.3 once a version supporting CC is released
-    @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER, ".*agp=7\\.3\\..*"])
+    @UnsupportedWithConfigurationCache(iterationMatchers = AGP_NO_CC_ITERATION_MATCHER)
     def "android library and application APK assembly (agp=#agpVersion, ide=#ide)"() {
 
         given:


### PR DESCRIPTION
from 7.2.0-beta01 to 7.2.0-beta02
from 7.3.0-alpha01 to 7.3.0-alpha02