### PR TITLE
Remove TD team from internal subprojects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,21 @@
 # Execution team
-subprojects/base-annotations/       @gradle/execution @gradle/ge-test-distribution
+subprojects/base-annotations/       @gradle/execution
 subprojects/functional/             @gradle/execution @bamboo
 subprojects/build-cache/            @gradle/execution
-subprojects/build-cache-base/       @gradle/execution @gradle/ge-test-distribution
+subprojects/build-cache-base/       @gradle/execution
 subprojects/build-cache-http/       @gradle/execution
-subprojects/build-cache-packaging/  @gradle/execution @gradle/ge-test-distribution
-subprojects/build-operations/       @gradle/execution @gradle/ge-test-distribution
+subprojects/build-cache-packaging/  @gradle/execution
+subprojects/build-operations/       @gradle/execution
 subprojects/execution/              @gradle/execution
 subprojects/file-watching/          @gradle/execution
-subprojects/files/                  @gradle/execution @gradle/ge-test-distribution
-subprojects/hashing/                @gradle/execution @gradle/ge-test-distribution
-subprojects/normalization-java/     @gradle/execution @gradle/ge-test-distribution
-subprojects/snapshots/              @gradle/execution @gradle/ge-test-distribution
+subprojects/files/                  @gradle/execution
+subprojects/hashing/                @gradle/execution
+subprojects/normalization-java/     @gradle/execution
+subprojects/snapshots/              @gradle/execution
 
 # Gradle Enterprise
 subprojects/enterprise/             @ldaley @gradle/ge-test-distribution @gradle/ge-build-insights
-subprojects/enterprise-logging/     @gradle/ge-build-insights @marcphilipp
+subprojects/enterprise-logging/     @gradle/ge-build-insights @gradle/ge-test-distribution
 subprojects/enterprise-operations/  @gradle/ge-build-insights
 subprojects/enterprise-workers/     @gradle/ge-build-insights
 


### PR DESCRIPTION
Since runtime dependencies are now in enterprise* subprojects we no
longer need to watch internal projects. For those that are used as
libraries, we have nightly builds set up that will alert us of any
problems well in advance of a Gradle release.