### PR TITLE
Add xfs to list of supported files systems

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/gradle_daemon.adoc
@@ -217,6 +217,7 @@ The feature supports the following file system types:
 - btrfs
 - ext3
 - ext4
+- XFS
 - HFS+
 - NTFS
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultWatchableFileSystemDetector.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultWatchableFileSystemDetector.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 public class DefaultWatchableFileSystemDetector implements WatchableFileSystemDetector {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultWatchableFileSystemDetector.class);
 
-    // !IMPORTANT! If changed, make sure to update the documentation in gradle_damon.adoc
+    // !IMPORTANT! If changed, make sure to update the documentation in gradle_daemon.adoc
     private static final ImmutableSet<String> SUPPORTED_FILE_SYSTEM_TYPES = ImmutableSet.of(
         // APFS on macOS
         "apfs",
@@ -38,6 +38,7 @@ public class DefaultWatchableFileSystemDetector implements WatchableFileSystemDe
         "ext3",
         "ext4",
         "btrfs",
+        "xfs",
         // NTFS on macOS
         "ntfs",
         // NTFS on Windows


### PR DESCRIPTION
Given that the native platform tests [pass on XFS as well](https://github.com/gradle/native-platform/pull/305), we can add XFS to the list of supported file systems for file system watchings.

Fixes #19786