### PR TITLE
Defer looking at all artifacts in a variant until requested

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.EMPTY;
 
@@ -43,9 +44,9 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final CapabilitiesMetadata capabilities;
-    private final ResolvedArtifactSet artifacts;
+    private final Supplier<ResolvedArtifactSet> artifacts;
 
-    private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, ResolvedArtifactSet artifacts) {
+    private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<ResolvedArtifactSet> artifacts) {
         this.identifier = identifier;
         this.displayName = displayName;
         this.attributes = attributes;
@@ -53,18 +54,26 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
         this.artifacts = artifacts;
     }
 
-    public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Collection<? extends ResolvableArtifact> artifacts) {
-        if (artifacts.isEmpty()) {
-            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, EMPTY);
-        }
-        if (artifacts.size() == 1) {
-            return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, new SingleArtifactSet(displayName, attributes, capabilities, artifacts.iterator().next()));
-        }
-        List<SingleArtifactSet> artifactSets = new ArrayList<>(artifacts.size());
-        for (ResolvableArtifact artifact : artifacts) {
-            artifactSets.add(new SingleArtifactSet(displayName, attributes, capabilities, artifact));
-        }
-        return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, CompositeResolvedArtifactSet.of(artifactSets));
+    public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifacts) {
+        return new ArtifactBackedResolvedVariant(identifier, displayName, attributes, capabilities, supplyResolvedArtifactSet(identifier, displayName, attributes, capabilities, artifacts));
+    }
+
+    private static Supplier<ResolvedArtifactSet> supplyResolvedArtifactSet(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifactsSupplier) {
+        return () -> {
+            Collection<? extends ResolvableArtifact> artifacts = artifactsSupplier.get();
+            if (artifacts.isEmpty()) {
+                return EMPTY;
+            }
+            if (artifacts.size() == 1) {
+                return new SingleArtifactSet(displayName, attributes, capabilities, artifacts.iterator().next());
+            }
+
+            List<SingleArtifactSet> artifactSets = new ArrayList<>(artifacts.size());
+            for (ResolvableArtifact artifact : artifacts) {
+                artifactSets.add(new SingleArtifactSet(displayName, attributes, capabilities, artifact));
+            }
+            return CompositeResolvedArtifactSet.of(artifactSets);
+        };
     }
 
     @Override
@@ -84,7 +93,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
     @Override
     public ResolvedArtifactSet getArtifacts() {
-        return artifacts;
+        return artifacts.get();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.VariantResolveMetadata;
+import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationQueue;
@@ -44,15 +45,14 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final DisplayName displayName;
     private final AttributeContainerInternal attributes;
     private final CapabilitiesMetadata capabilities;
-    private final Supplier<ResolvedArtifactSet> artifacts;
-    private ResolvedArtifactSet resolvedArtifacts;
+    private final Lazy<ResolvedArtifactSet> artifacts;
 
     private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<ResolvedArtifactSet> artifacts) {
         this.identifier = identifier;
         this.displayName = displayName;
         this.attributes = attributes;
         this.capabilities = capabilities;
-        this.artifacts = artifacts;
+        this.artifacts = Lazy.locking().of(artifacts);
     }
 
     public static ResolvedVariant create(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<Collection<? extends ResolvableArtifact>> artifacts) {
@@ -94,10 +94,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
     @Override
     public ResolvedArtifactSet getArtifacts() {
-        if (resolvedArtifacts == null) {
-            resolvedArtifacts = artifacts.get();
-        }
-        return resolvedArtifacts;
+        return artifacts.get();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -45,6 +45,7 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
     private final AttributeContainerInternal attributes;
     private final CapabilitiesMetadata capabilities;
     private final Supplier<ResolvedArtifactSet> artifacts;
+    private ResolvedArtifactSet resolvedArtifacts;
 
     private ArtifactBackedResolvedVariant(@Nullable VariantResolveMetadata.Identifier identifier, DisplayName displayName, AttributeContainerInternal attributes, CapabilitiesMetadata capabilities, Supplier<ResolvedArtifactSet> artifacts) {
         this.identifier = identifier;
@@ -93,7 +94,10 @@ public class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
     @Override
     public ResolvedArtifactSet getArtifacts() {
-        return artifacts.get();
+        if (resolvedArtifacts == null) {
+            resolvedArtifacts = artifacts.get();
+        }
+        return resolvedArtifacts;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -42,8 +42,6 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentConfigurationIdentifier;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSources;
@@ -96,12 +94,6 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
     public static ArtifactSet createFromVariants(ComponentIdentifier componentIdentifier, ImmutableSet<ResolvedVariant> variants, AttributesSchemaInternal schema, ImmutableAttributes selectionAttributes) {
         return new MultipleVariantArtifactSet(componentIdentifier, schema, variants, selectionAttributes);
-    }
-
-    public static ArtifactSet createForConfiguration(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ConfigurationMetadata configuration, ImmutableList<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes, CalculatedValueContainerFactory calculatedValueContainerFactory) {
-        VariantResolveMetadata variantMetadata = new DefaultVariantMetadata(configuration.getName(), new ComponentConfigurationIdentifier(componentIdentifier, configuration.getName()), configuration.asDescribable(), configuration.getAttributes(), artifacts, configuration.getCapabilities());
-        ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSources, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry, calculatedValueContainerFactory);
-        return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
     }
 
     public static ArtifactSet adHocVariant(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, Collection<? extends ComponentArtifactMetadata> artifacts, ModuleSources moduleSources, ExcludeSpec exclusions, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes variantAttributes, ImmutableAttributes selectionAttributes, CalculatedValueContainerFactory calculatedValueContainerFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -43,7 +43,6 @@ import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.DefaultVariantMetadata;
-import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.ModuleSources;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 import org.gradle.internal.model.CalculatedValue;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -209,8 +209,8 @@ class ArtifactBackedResolvedVariantTest extends Specification {
         0 * visitor._
     }
 
-    ResolvedVariant of(artifacts) {
-        return ArtifactBackedResolvedVariant.create(id, variantDisplayName, variant, ImmutableCapabilities.EMPTY, artifacts)
+    ResolvedVariant of(List<ResolvableArtifact> artifacts) {
+        return ArtifactBackedResolvedVariant.create(id, variantDisplayName, variant, ImmutableCapabilities.EMPTY, { artifacts })
     }
 
     interface TestArtifact extends ResolvableArtifact, Buildable {}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -16,14 +16,29 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 
+import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.simple.DefaultExcludeFactory
 import org.gradle.api.internal.artifacts.transform.VariantSelector
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.Describables
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.external.model.ImmutableCapabilities
+import org.gradle.internal.component.external.model.ImmutableCapability
+import org.gradle.internal.component.external.model.ModuleComponentOptionalArtifactMetadata
+import org.gradle.internal.component.model.ComponentArtifactMetadata
+import org.gradle.internal.component.model.DefaultIvyArtifactName
+import org.gradle.internal.component.model.DefaultVariantMetadata
+import org.gradle.internal.component.model.ModuleSources
 import org.gradle.internal.component.model.VariantResolveMetadata
 import org.gradle.internal.model.CalculatedValueContainerFactory
+import org.gradle.internal.resolve.resolver.ArtifactResolver
+import org.gradle.internal.resolve.result.BuildableArtifactResolveResult
 import spock.lang.Specification
 
 class DefaultArtifactSetTest extends Specification {
@@ -54,6 +69,57 @@ class DefaultArtifactSetTest extends Specification {
         artifacts1.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
         artifacts2.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
         artifacts3.select({ false }, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
+    }
+
+    def "does not access all artifacts when selecting one variant"() {
+        def ownerId = DefaultModuleVersionIdentifier.newId("group", "name", "1.0")
+
+        def variant1 = makeVariantNamed("variant1", ownerId)
+        def variant2 = makeVariantNamed("variant2", ownerId)
+
+        def artifactResolver = Mock(ArtifactResolver)
+
+        def moduleSources = Mock(ModuleSources)
+        def exclusions = new DefaultExcludeFactory().nothing()
+
+        when:
+        def artifactSet = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, moduleSources, exclusions, [variant1, variant2] as Set, schema, artifactResolver, new HashMap<ComponentArtifactIdentifier, ResolvableArtifact>(), artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
+        then:
+        artifactSet.select({ true }, new VariantSelector() {
+            @Override
+            ResolvedArtifactSet select(ResolvedVariantSet candidates, VariantSelector.Factory factory) {
+                assert candidates.variants.size() == 2
+                // select the first variant
+                // TODO: this should trigger resolveArtifact?
+                return candidates.variants[0].artifacts
+            }
+
+            @Override
+            ImmutableAttributes getRequestedAttributes() {
+                return ImmutableAttributes.EMPTY
+            }
+        })
+        1 * artifactResolver.resolveArtifact(variant1.artifacts[0], moduleSources, _) >> { args ->
+            ComponentArtifactMetadata artifact = args[0]
+            BuildableArtifactResolveResult result = args[2]
+            result.notFound(artifact.getId())
+        }
+
+        // TODO: This shouldn't be called for every artifact
+        1 * artifactResolver.resolveArtifact(variant2.artifacts[0], moduleSources, _) >> { args ->
+            ComponentArtifactMetadata artifact = args[0]
+            BuildableArtifactResolveResult result = args[2]
+            result.notFound(artifact.getId())
+        }
+        0 * _
+    }
+
+    private static DefaultVariantMetadata makeVariantNamed(String name, ModuleVersionIdentifier ownerId) {
+        def id = DefaultModuleComponentIdentifier.newId(ownerId)
+        def capabilities = ImmutableCapabilities.of(ImmutableCapability.defaultCapabilityForComponent(ownerId))
+        def artifact = new ModuleComponentOptionalArtifactMetadata(id, new DefaultIvyArtifactName(name, "jar", "jar"))
+        def artifacts = ImmutableList.of(artifact)
+        return new DefaultVariantMetadata(name, null, Describables.of(name), ImmutableAttributes.EMPTY, artifacts, capabilities)
     }
 
     def "selects artifacts when component id matches spec"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -89,7 +89,6 @@ class DefaultArtifactSetTest extends Specification {
             ResolvedArtifactSet select(ResolvedVariantSet candidates, VariantSelector.Factory factory) {
                 assert candidates.variants.size() == 2
                 // select the first variant
-                // TODO: this should trigger resolveArtifact?
                 return candidates.variants[0].artifacts
             }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -84,7 +84,6 @@ class DefaultArtifactSetTest extends Specification {
 
         when:
         def artifactSet = DefaultArtifactSet.createFromVariantMetadata(componentId, ownerId, moduleSources, exclusions, [variant1, variant2] as Set, schema, artifactResolver, new HashMap<ComponentArtifactIdentifier, ResolvableArtifact>(), artifactTypeRegistry, ImmutableAttributes.EMPTY, calculatedValueContainerFactory)
-        then:
         artifactSet.select({ true }, new VariantSelector() {
             @Override
             ResolvedArtifactSet select(ResolvedVariantSet candidates, VariantSelector.Factory factory) {
@@ -99,14 +98,9 @@ class DefaultArtifactSetTest extends Specification {
                 return ImmutableAttributes.EMPTY
             }
         })
-        1 * artifactResolver.resolveArtifact(variant1.artifacts[0], moduleSources, _) >> { args ->
-            ComponentArtifactMetadata artifact = args[0]
-            BuildableArtifactResolveResult result = args[2]
-            result.notFound(artifact.getId())
-        }
 
-        // TODO: This shouldn't be called for every artifact
-        1 * artifactResolver.resolveArtifact(variant2.artifacts[0], moduleSources, _) >> { args ->
+        then: 'artifactResolver.resolveArtifact should only be invoked once by DefaultArtifactSet#createFromVariantMetadata and ArtifactSet#select'
+        1 * artifactResolver.resolveArtifact(variant1.artifacts[0], moduleSources, _) >> { args ->
             ComponentArtifactMetadata artifact = args[0]
             BuildableArtifactResolveResult result = args[2]
             result.notFound(artifact.getId())


### PR DESCRIPTION
Historically, `DefaultArtifactSet` eagerly processed all variants in order to resolve their artifacts. In nearly all cases, only a single variant was selected, and therefore the artifacts of a single variant were eagerly resolved.

Recent changes to dependency management allow Gradle to resolve the graphs of all variants - even variants which are not selected. The existing logic to eagerly process all variants is intact, but now truly iterates over multiple variants. This causes the artifacts of each variant to be eagerly resolved. This is undesirable and reduces performance.

This change wraps the logic to eagerly resolve the artifacts of each variant in a callback, deferring resolution until `ArtifactSet#getArtifacts()` is invoked.