### PR TITLE
Transformer#transform can return null, for example when used in CopySpec#filter

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/Transformer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Transformer.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>A {@code Transformer} transforms objects of type.</p>
  *
@@ -30,5 +32,6 @@ public interface Transformer<OUT, IN> {
      * @param in The object to transform.
      * @return The transformed object.
      */
+    @Nullable
     OUT transform(IN in);
 }


### PR DESCRIPTION
### Context
While doing
```kts
tasks.processResources {
    filter { it.ifBlank { null } }
}
```
actually works as expected, IntelliJ highlights the `null` as error (https://youtrack.jetbrains.com/issue/KTIJ-21089).
Actually I'm not sure why it works when Kotlin thinks this is a non-null-returning method,
but it is probably more appropriate to mark the method as nullable as that's the actual truth.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
