### PR TITLE
Fix the type of the processResources task in the documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/building_java_projects.adoc
@@ -337,7 +337,7 @@ Either way, the Java Library Plugin adds a specific link:{groovyDslPath}/org.gra
 
 The task's name follows the convention of `process__SourceSet__Resources` — or `processResources` for the `main` source set — and it will automatically copy any files in _src/[sourceSet]/resources_ to a directory that will be included in the production JAR. This target directory will also be included in the runtime classpath of the tests.
 
-Since `processResources` is an instance of the `Copy` task, you can perform any of the processing described in the <<working_with_files.adoc#sec:copying_files,Working With Files>> chapter.
+Since `processResources` is an instance of the `ProcessResources` task, you can perform any of the processing described in the <<working_with_files.adoc#sec:copying_files,Working With Files>> chapter.
 
 [[sec:properties_files]]
 === Java properties files and reproducible builds

--- a/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_plugin.adoc
@@ -47,7 +47,7 @@ _Depends on_: All tasks which contribute to the compilation classpath, including
 +
 Compiles production Java source files using the JDK compiler.
 
-`processResources` — link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy]::
+`processResources` — link:{groovyDslPath}/org.gradle.language.jvm.tasks.ProcessResources.html[ProcessResources]::
 Copies production resources into the production resources directory.
 
 `classes`::

--- a/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/migrating_from_maven.adoc
@@ -486,8 +486,8 @@ Maven has a phase called `process-resources` that has the goal `resources:resour
 This gives the build author an opportunity to perform variable substitution on various files, such as web resources, packaged properties files, etc.
 
 The Java plugin for Gradle provides a `processResources` task to do the same thing.
-This is a link:{groovyDslPath}/org.gradle.api.tasks.Copy.html[Copy] task that copies files from the configured resources directory -- `src/main/resources` by default -- to an output directory.
-And as with any `Copy` task, you can configure it to perform <<working_with_files#filtering_files,file filtering>>, <<working_with_files#sec:renaming_files,renaming>>, and <<working_with_files#sec:filtering_files,content filtering>>.
+This is a link:{groovyDslPath}/org.gradle.language.jvm.tasks.ProcessResources.html[ProcessResources] task that copies files from the configured resources directory -- `src/main/resources` by default -- to an output directory.
+And as with any `ProcessResources` or `Copy` task, you can configure it to perform <<working_with_files#filtering_files,file filtering>>, <<working_with_files#sec:renaming_files,renaming>>, and <<working_with_files#sec:filtering_files,content filtering>>.
 
 As an example, here's a configuration that treats the source files as https://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_simpletemplateengine[Groovy `SimpleTemplateEngine`] templates, providing `version` and `buildNumber` properties to those templates:
 


### PR DESCRIPTION
Signed-off-by: Björn Kautler <Bjoern@Kautler.net>

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- n/a Provide unit tests (under `<subproject>/src/test`) to verify logic
- n/a Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
