### PR TITLE
Make `:outgoingVariants` and `:resolvableConfigurations` tasks work with the configuration cache

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ExclusiveVariantsIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "matching attribute combinations and capabilities triggers a warning"() {
         given:
         buildFile << """
@@ -55,7 +53,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("outgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "matching attribute combinations using the default capability, triggers a warning"() {
         given:
         settingsFile << "rootProject.name = 'sample'"
@@ -95,7 +92,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("org.gradle:sample:1.0 (default capability)")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "matching attribute combinations, where one uses the default capability and one uses a matching explicit capability, triggers a warning"() {
         given:
         settingsFile << "rootProject.name = 'sample'"
@@ -140,7 +136,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         outputContains("org.gradle:sample:1.0 (default capability)")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute combinations can be repeated if capabilities differ without a warning"() {
         given:
         settingsFile << "rootProject.name = 'sample'"
@@ -182,7 +177,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("outgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute combinations can be repeated if capabilities differ, including the default capability without a warning"() {
         given:
         buildFile << """
@@ -224,7 +218,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("outgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute and capability combinations can be repeated across projects without a warning"() {
         given:
         def subADir = createDir("subA")
@@ -288,7 +281,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("allOutgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute and capability combinations, including the default capability, can be repeated across projects without a warning"() {
         given:
         def subADir = createDir("subA")
@@ -350,7 +342,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("allOutgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute combinations and capabilities on resolvable configurations can match without a warning"() {
         given:
         buildFile << """
@@ -382,7 +373,6 @@ class ExclusiveVariantsIntegrationTest extends AbstractIntegrationSpec {
         succeeds("outgoingVariants")
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "attribute combinations and capabilities on legacy resolvable configurations can match without a warning"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/LazyAttributesIntegrationTest.groovy
@@ -17,10 +17,8 @@
 package org.gradle.integtests.resolve.attributes
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "properties used as attribute values are read lazily"() {
         settingsFile << "rootProject.name = 'TestProject'"
 
@@ -60,7 +58,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
                 - org.gradle.usage = new value""".stripIndent())
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "providers used as attribute values with mismatched value types fail properly"() {
         buildFile << """
             plugins {
@@ -88,7 +85,6 @@ class LazyAttributesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Unexpected type for attribute 'org.gradle.usage' provided. Expected a value of type org.gradle.api.attributes.Usage but found a value of type java.lang.Integer.")
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "providers used as attribute values with mismatched Attribute types fail properly"() {
         buildFile << """
             plugins {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/derived/MultiProjectVariantResolutionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.derived
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 
 class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSpec {
@@ -133,7 +132,6 @@ class MultiProjectVariantResolutionIntegrationTest extends AbstractIntegrationSp
         '''
     }
 
-    @ToBeFixedForConfigurationCache(because = 'invokes outgoingVariants task')
     def 'producer has expected outgoingVariants'() {
         when:
         succeeds(':producer:outgoingVariants')

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/OutgoingVariantsReportTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InspectsConfigurationReport
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class OutgoingVariantsReportTaskIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
     def setup() {
@@ -28,14 +27,12 @@ class OutgoingVariantsReportTaskIntegrationTest extends AbstractIntegrationSpec 
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if no configurations present in project, task reports complete absence"() {
         expect:
         succeeds ':outgoingVariants'
         reportsCompleteAbsenceOfResolvableVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if only resolvable configurations present, task reports complete absence"() {
         given:
         buildFile << """
@@ -51,7 +48,6 @@ class OutgoingVariantsReportTaskIntegrationTest extends AbstractIntegrationSpec 
         reportsCompleteAbsenceOfResolvableVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if only legacy configuration present, and --all not specified, task produces empty report and prompts for rerun"() {
         given:
         buildFile << """
@@ -68,7 +64,6 @@ class OutgoingVariantsReportTaskIntegrationTest extends AbstractIntegrationSpec 
         promptsForRerunToFindMoreVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if only legacy configuration present, task reports it if --all flag is set"() {
         given:
         buildFile << """
@@ -95,7 +90,6 @@ My custom legacy configuration""")
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if single outgoing variant with no attributes or artifacts present, task reports it"() {
         given:
         buildFile << """
@@ -121,7 +115,6 @@ My custom configuration
         doesNotPromptForRerunToFindMoreVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "if single outgoing variant present with attributes, task reports it and them"() {
         given:
         buildFile << """
@@ -160,7 +153,6 @@ Attributes
         doesNotPromptForRerunToFindMoreVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "If multiple outgoing variants present with attributes, task reports them all, sorted alphabetically"() {
         given:
         buildFile << """
@@ -219,7 +211,6 @@ Attributes
         doesNotPromptForRerunToFindMoreVariants()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "reports outgoing variants of a Java Library"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -352,7 +343,6 @@ Artifacts
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "reports outgoing variants of a Java Library with documentation"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -520,7 +510,6 @@ Artifacts
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "reports outgoing variants of a Java Library with documentation including test data variants"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -690,7 +679,6 @@ Artifacts
         hasIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "reports a single outgoing variant of a Java Library"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -757,7 +745,6 @@ Secondary Variants (*)
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "can show all variants"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -913,7 +900,6 @@ Artifacts
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "can show all variants including test data variants"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -1068,7 +1054,6 @@ Artifacts
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "prints explicit capabilities"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -1094,7 +1079,6 @@ Capabilities
 """)
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "reports artifacts without explicit type"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -1169,7 +1153,6 @@ Secondary Variants (*)
         hasSecondaryVariantsLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "variants using custom VERIFICATION_TYPE attribute values are reported as incubating"() {
         buildFile << """
             plugins { id 'java-library' }
@@ -1323,7 +1306,6 @@ Artifacts
         hasIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "custom artifact with classifier is printed"() {
         given:
         buildFile << """

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ResolvableConfigurationsReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/ResolvableConfigurationsReportTaskIntegrationTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.diagnostics
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InspectsConfigurationReport
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class ResolvableConfigurationsReportTaskIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
     def setup() {
@@ -28,14 +27,12 @@ class ResolvableConfigurationsReportTaskIntegrationTest extends AbstractIntegrat
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if no configurations present in project, task reports complete absence"() {
         expect:
         succeeds ':resolvableConfigurations'
         reportsCompleteAbsenceOfResolvableConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if only consumable configurations present, task reports complete absence"() {
         given:
         buildFile << """
@@ -51,7 +48,6 @@ class ResolvableConfigurationsReportTaskIntegrationTest extends AbstractIntegrat
         reportsCompleteAbsenceOfResolvableConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if only legacy configuration present, and --all not specified, task produces empty report and prompts for rerun"() {
         given:
         buildFile << """
@@ -68,7 +64,6 @@ class ResolvableConfigurationsReportTaskIntegrationTest extends AbstractIntegrat
         promptsForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if only legacy configuration present, task reports it if --all flag is set"() {
         given:
         buildFile << """
@@ -95,7 +90,6 @@ My custom legacy configuration""")
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if single resolvable configuration with no attributes or artifacts present, task reports it"() {
         given:
         buildFile << """
@@ -122,7 +116,6 @@ My custom configuration
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "if single resolvable configuration present with attributes, task reports it and them"() {
         given:
         buildFile << """
@@ -160,7 +153,6 @@ Attributes
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "If multiple resolvable configurations present with attributes, task reports them all, sorted alphabetically"() {
         given:
         buildFile << """
@@ -216,7 +208,6 @@ Attributes
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "reports resolvable configurations of a Java Library with module dependencies"() {
         given:
         buildFile << """
@@ -328,7 +319,6 @@ Extended Configurations
         doesNotHaveIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "reports resolvable configurations of a Java Library with module dependencies if --all flag is set"() {
         given:
         buildFile << """
@@ -454,14 +444,12 @@ Extended Configurations
         doesNotHaveIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "specifying a missing config with no configs produces empty report"() {
         expect:
         succeeds ':resolvableConfigurations', '--configuration', 'missing'
         reportsCompleteAbsenceOfResolvableConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "specifying a missing config produces empty report"() {
         given:
         buildFile << """
@@ -478,7 +466,6 @@ Extended Configurations
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "specifying a missing config with --all and legacy configs available produces empty report and no suggestion"() {
         given:
         buildFile << """
@@ -501,7 +488,6 @@ Extended Configurations
         doesNotPromptForRerunToFindMoreConfigurations()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "compatibility rules are printed if present"() {
         given: "A compatibility rule applying to the alphabetically first named attribute in the list"
         buildFile << """
@@ -552,7 +538,6 @@ The following Attributes have compatibility rules defined.
         doesNotHaveIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "disambiguation rules are printed if present"() {
         given: "A disambiguation rule applying to the alphabetically first named attribute in the list"
         buildFile << """
@@ -605,7 +590,6 @@ The following Attributes have disambiguation rules defined.
         doesNotHaveIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "specifying --recursive includes transitively extended configurations"() {
         given:
         buildFile << """
@@ -658,7 +642,6 @@ Extended Configurations
         hasTransitiveLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "not specifying --recursive does not includes transitively extended configurations"() {
         given:
         buildFile << """
@@ -710,7 +693,6 @@ Extended Configurations
         doesNotHaveTransitiveLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":resolvableConfigurations")
     def "specifying --recursive with no transitively extended configurations does not print legend"() {
         given:
         buildFile << """

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -147,7 +147,6 @@ class JacocoPluginIntegrationTest extends AbstractIntegrationSpec implements Ins
         errorOutput.contains("JaCoCo destination file must not be null if output type is FILE")
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "jacoco plugin adds outgoing variants for default test suite"() {
         settingsFile << "rootProject.name = 'Test'"
 
@@ -177,7 +176,6 @@ Artifacts
         hasIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "jacoco plugin adds outgoing variants for custom test suite"() {
         settingsFile << "rootProject.name = 'Test'"
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.internal.component.BuildableJavaComponent
 import org.gradle.api.internal.component.ComponentRegistry
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InspectsConfigurationReport
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class JavaPluginIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
 
@@ -46,7 +45,6 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec implements Inspe
         succeeds "expect"
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "Java plugin adds outgoing variant for main source set"() {
         buildFile << """
             plugins {
@@ -77,7 +75,6 @@ Artifacts
         hasIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "Java plugin adds outgoing variant for main source set containing additional directories"() {
         buildFile << """
             plugins {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.test.fixtures.file.TestFile
 
 class JvmTestSuitePluginIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "JVM Test Suites plugin adds outgoing variants for default test suite"() {
         settingsFile << "rootProject.name = 'Test'"
 
@@ -66,7 +65,6 @@ Artifacts
         hasIncubatingLegend()
     }
 
-    @ToBeFixedForConfigurationCache(because = ":outgoingVariants")
     def "JVM Test Suites plugin adds outgoing variants for custom test suite"() {
         settingsFile << "rootProject.name = 'Test'"
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/jvm/JavaLibraryOutgoingElementsBuilderIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/jvm/JavaLibraryOutgoingElementsBuilderIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.jvm
 
 import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 
 class JavaLibraryOutgoingElementsBuilderIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
@@ -50,7 +49,6 @@ class JavaLibraryOutgoingElementsBuilderIntegrationTest extends AbstractIntegrat
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "configures an additional outgoing variant (#scenario, #capability)"() {
         buildFile << """
             def shadowJar = tasks.register("shadowJar", Jar) {
@@ -113,7 +111,6 @@ Artifacts
         capability = cgroup == null ? 'com.acme:mylib:1.4 (default capability)' : "${cgroup}:${cname}:${cversion}".replaceAll(/'/, '')
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "can configure an additional outgoing variant from a source set (with classes dir=#classesDir)"() {
         buildFile << """
             sourceSets {
@@ -179,7 +176,6 @@ Secondary Variants (*)
         classesDir << [false, true]
     }
 
-    @ToBeFixedForConfigurationCache(because = "outgoing variants report isn't compatible")
     def "can configure an outgoing elements configuration for documentation"() {
         buildFile << """
             def userguide = tasks.register('userguide') {


### PR DESCRIPTION
This one is pretty simple given the reporting model was already separated from the reporting logic.