### PR TITLE
Allow options with the same name and signature

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/MethodSignature.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/MethodSignature.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.options;
+
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * A representation of a method signature. Contains the method name, erased parameter types and erased return type.
+ */
+public class MethodSignature {
+    public static MethodSignature from(Method method) {
+        return new MethodSignature(method.getName(), MethodType.methodType(
+            method.getReturnType(),
+            method.getParameterTypes()
+        ));
+    }
+
+    private final String methodName;
+    private final MethodType methodType;
+
+    public MethodSignature(String methodName, MethodType methodType) {
+        this.methodName = methodName;
+        this.methodType = methodType;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public MethodType getMethodType() {
+        return methodType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MethodSignature that = (MethodSignature) o;
+        return methodName.equals(that.methodName) && methodType.equals(that.methodType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(methodName, methodType);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class OptionReader {
@@ -56,15 +57,21 @@ public class OptionReader {
     }
 
     private void loadClassDescriptorInCache(Object target) {
-        final Collection<OptionElement> optionElements = getOptionElements(target);
+        final Collection<OptionElementAndSignature> optionElements = getOptionElements(target);
         List<JavaMethod<Object, Collection>> optionValueMethods = loadValueMethodForOption(target.getClass());
-        Set<String> processedOptionElements = new HashSet<String>();
-        for (OptionElement optionElement : optionElements) {
-            if (processedOptionElements.contains(optionElement.getOptionName())) {
-                throw new OptionValidationException(String.format("@Option '%s' linked to multiple elements in class '%s'.",
+        Map<String, MethodSignature> processedOptionElements = new HashMap<>();
+        for (OptionElementAndSignature optionElementAndSignature : optionElements) {
+            OptionElement optionElement = optionElementAndSignature.element;
+            MethodSignature signature = optionElementAndSignature.signature;
+
+            if (processedOptionElements.containsKey(optionElement.getOptionName())) {
+                MethodSignature existingSignature = processedOptionElements.get(optionElement.getOptionName());
+                if (!Objects.equals(signature, existingSignature)) {
+                    throw new OptionValidationException(String.format("@Option '%s' linked to multiple elements in class '%s'.",
                         optionElement.getOptionName(), target.getClass().getName()));
+                }
             }
-            processedOptionElements.add(optionElement.getOptionName());
+            processedOptionElements.put(optionElement.getOptionName(), signature);
             JavaMethod<Object, Collection> optionValueMethodForOption = getOptionValueMethodForOption(optionValueMethods, optionElement);
 
             cachedOptionElements.put(target.getClass(), optionElement);
@@ -95,8 +102,18 @@ public class OptionReader {
         return optionValues.value();
     }
 
-    private Collection<OptionElement> getOptionElements(Object target) {
-        List<OptionElement> allOptionElements = new ArrayList<OptionElement>();
+    private static final class OptionElementAndSignature {
+        final OptionElement element;
+        final MethodSignature signature;
+
+        OptionElementAndSignature(OptionElement element, MethodSignature signature) {
+            this.element = element;
+            this.signature = signature;
+        }
+    }
+
+    private Collection<OptionElementAndSignature> getOptionElements(Object target) {
+        List<OptionElementAndSignature> allOptionElements = new ArrayList<>();
         Set<Class<?>> visitedInterfaces = new HashSet<>();
         Deque<Class<?>> interfacesToCheck = new ArrayDeque<>();
 
@@ -104,7 +121,9 @@ public class OptionReader {
             interfacesToCheck.addAll(Arrays.asList(type.getInterfaces()));
 
             allOptionElements.addAll(getMethodAnnotations(type));
-            allOptionElements.addAll(getFieldAnnotations(type));
+            for (OptionElement element : getFieldAnnotations(type)) {
+                allOptionElements.add(new OptionElementAndSignature(element, null));
+            }
         }
 
         while (interfacesToCheck.size() > 0) {
@@ -144,14 +163,14 @@ public class OptionReader {
         return option;
     }
 
-    private List<OptionElement> getMethodAnnotations(Class<?> type) {
-        List<OptionElement> methodOptionElements = new ArrayList<OptionElement>();
+    private List<OptionElementAndSignature> getMethodAnnotations(Class<?> type) {
+        List<OptionElementAndSignature> methodOptionElements = new ArrayList<>();
         for (Method method : type.getDeclaredMethods()) {
             Option option = findOption(method);
             if (option != null) {
                 OptionElement methodOptionDescriptor = MethodOptionElement.create(option, method,
                     optionValueNotationParserFactory);
-                methodOptionElements.add(methodOptionDescriptor);
+                methodOptionElements.add(new OptionElementAndSignature(methodOptionDescriptor, MethodSignature.from(method)));
             }
         }
         return methodOptionElements;


### PR DESCRIPTION
This allows options defined in an interface and in a class to coexist, fixes #19868