### PR TITLE
Make test tasks shouldRunAfter jar tasks in the same project by default

### DIFF
--- a/subprojects/docs/src/snippets/testing/test-suite-plugin/tests/checkTaskOutput.out
+++ b/subprojects/docs/src/snippets/testing/test-suite-plugin/tests/checkTaskOutput.out
@@ -1,11 +1,11 @@
 > Task :compileJava
 > Task :processResources NO-SOURCE
 > Task :classes
+> Task :jar
 > Task :compileTestJava
 > Task :processTestResources NO-SOURCE
 > Task :testClasses
 > Task :test
-> Task :jar
 > Task :compileIntegrationTestJava
 > Task :processIntegrationTestResources NO-SOURCE
 > Task :integrationTestClasses

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
@@ -132,22 +132,22 @@ public class BlockingHttpServer extends ExternalResource implements ResettableEx
         String streamVar = "inputStream" + count;
         StringWriter result = new StringWriter();
         PrintWriter writer = new PrintWriter(result);
-        writer.print("String " + urlVar + " = " + uriExpression + ";");
-        writer.print("System.out.println(\"[G] calling \" + " + urlVar + ");");
-        writer.print("try {");
-        writer.print("  java.net.URLConnection " + connectionVar + " = new java.net.URL(" + urlVar + ").openConnection();");
-        writer.print("  " + connectionVar + ".setReadTimeout(0);"); // to avoid silent retry
-        writer.print("  " + connectionVar + ".connect();");
-        writer.print("  java.io.InputStream " + streamVar + " = " + connectionVar + ".getInputStream();");
-        writer.print("  try {");
-        writer.print("    while (" + streamVar + ".read() >= 0) {}"); // read entire response
-        writer.print("  } finally {");
-        writer.print("    " + streamVar + ".close();");
-        writer.print("  }");
-        writer.print("} catch(Exception e) {");
-        writer.print("  System.out.println(\"[G] error response received for \" + " + urlVar + ");");
-        writer.print("  throw new RuntimeException(\"Received error response from \" + " + urlVar + ", e);");
-        writer.print("};");
+        writer.println("String " + urlVar + " = " + uriExpression + ";");
+        writer.println("System.out.println(\"[G] calling \" + " + urlVar + ");");
+        writer.println("try {");
+        writer.println("  java.net.URLConnection " + connectionVar + " = new java.net.URL(" + urlVar + ").openConnection();");
+        writer.println("  " + connectionVar + ".setReadTimeout(0);"); // to avoid silent retry
+        writer.println("  " + connectionVar + ".connect();");
+        writer.println("  java.io.InputStream " + streamVar + " = " + connectionVar + ".getInputStream();");
+        writer.println("  try {");
+        writer.println("    while (" + streamVar + ".read() >= 0) {}"); // read entire response
+        writer.println("  } finally {");
+        writer.println("    " + streamVar + ".close();");
+        writer.println("  }");
+        writer.println("} catch(Exception e) {");
+        writer.println("  System.out.println(\"[G] error response received for \" + " + urlVar + ");");
+        writer.println("  throw new RuntimeException(\"Received error response from \" + " + urlVar + ", e);");
+        writer.println("};");
         writer.println("System.out.println(\"[G] response received for \" + " + urlVar + ");");
         return result.toString();
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.component.BuildableJavaComponent
 import org.gradle.api.internal.component.ComponentRegistry
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.InspectsConfigurationReport
+import spock.lang.Issue
 
 class JavaPluginIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
 
@@ -229,5 +230,265 @@ Artifacts
 
         expect:
         succeeds('testResolve')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/19914")
+    def "calling jar task doesn't force realization of test task"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                ${mavenCentralRepository()}
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            tasks.withType(Test).configureEach {
+                throw new RuntimeException("Test task should not have been realized")
+            }""".stripIndent()
+
+        file("src/main/java/com/example/SampleClass.java") << """
+            package com.example;
+
+            public class SampleClass {
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.stripIndent()
+
+        file("src/test/java/com/example/SampleTest.java") << """
+            package com.example;
+
+            import org.junit.Test;
+            import static org.junit.Assert.assertEquals;
+
+            public class SampleTest {
+                @Test
+                public void checkHello() {
+                    SampleClass sampleClass = new SampleClass();
+                    assertEquals("hello", sampleClass.hello());
+                }
+            }""".stripIndent()
+
+        expect:
+        succeeds "jar"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/19914")
+    def "calling test task doesn't force execution of jar task"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                ${mavenCentralRepository()}
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            tasks.withType(Jar).configureEach {
+                doLast {
+                    throw new RuntimeException("Jar task should not have been executed")
+                }
+            }""".stripIndent()
+
+        file("src/main/java/com/example/SampleClass.java") << """
+            package com.example;
+
+            public class SampleClass {
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.stripIndent()
+
+        file("src/test/java/com/example/SampleTest.java") << """
+            package com.example;
+
+            import org.junit.Test;
+            import static org.junit.Assert.assertEquals;
+
+            public class SampleTest {
+                @Test
+                public void checkHello() {
+                    SampleClass sampleClass = new SampleClass();
+                    assertEquals("hello", sampleClass.hello());
+                }
+            }""".stripIndent()
+
+        expect:
+        succeeds "test"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/19914")
+    def "running test and jar tasks in that order should result in jar running first"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                ${mavenCentralRepository()}
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            jar {
+                doLast {
+                    assert !tasks.getByName("test").getState().executed
+                }
+            }
+
+            test {
+                doLast {
+                    assert tasks.getByName("jar").getState().executed
+                }
+            }""".stripIndent()
+
+        file("src/main/java/com/example/SampleClass.java") << """
+            package com.example;
+
+            public class SampleClass {
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.stripIndent()
+
+        file("src/test/java/com/example/SampleTest.java") << """
+            package com.example;
+
+            import org.junit.Test;
+            import static org.junit.Assert.assertEquals;
+
+            public class SampleTest {
+                @Test
+                public void checkHello() {
+                    SampleClass sampleClass = new SampleClass();
+                    assertEquals("hello", sampleClass.hello());
+                }
+            }""".stripIndent()
+
+        expect:
+        succeeds "test", "jar"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/19914")
+    def "when project B depends on A, running tests in B should cause A's jar task to run prior to A's tests"() {
+        given:
+        settingsFile << """
+            include ':subA'
+            include ':subB'
+        """.stripIndent()
+
+        def subADir = createDir("subA")
+        subADir.file("build.gradle") << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                ${mavenCentralRepository()}
+            }
+
+            dependencies {
+                testImplementation 'junit:junit:4.13'
+            }
+
+            jar {
+                doLast {
+                    assert !tasks.getByName("test").getState().executed
+                }
+            }
+
+            test {
+                doLast {
+                    assert tasks.getByName("jar").getState().executed
+                }
+            }""".stripIndent()
+
+
+        subADir.file("src/main/java/com/exampleA/SampleClassA.java") << """
+            package com.exampleA;
+
+            public class SampleClassA {
+                public String hello() {
+                    return "hello";
+                }
+            }
+            """.stripIndent()
+
+        file(subADir, "src/test/java/com/exampleA/SampleTestA.java") << """
+            package com.exampleA;
+
+            import org.junit.Test;
+            import static org.junit.Assert.assertEquals;
+
+            public class SampleTestA {
+                @Test
+                public void checkHello() {
+                    SampleClassA sampleClass = new SampleClassA();
+                    assertEquals("hello", sampleClass.hello());
+                }
+            }""".stripIndent()
+
+        def subBDir = createDir("subB")
+        subBDir.file("build.gradle") << """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                ${mavenCentralRepository()}
+            }
+
+            dependencies {
+                implementation project(':subA')
+                testImplementation 'junit:junit:4.13'
+            }
+            """.stripIndent()
+
+        subBDir.file("src/main/java/com/exampleB/SampleClassB.java") << """
+            package com.exampleB;
+
+            import com.exampleA.SampleClassA;
+
+            public class SampleClassB {
+                public String hello() {
+                    SampleClassA sampleClassA = new SampleClassA();
+                    return sampleClassA.hello() + " there";
+                }
+            }
+            """.stripIndent()
+
+        file(subBDir, "src/test/java/com/exampleB/SampleTestB.java") << """
+            package com.exampleB;
+
+            import org.junit.Test;
+            import static org.junit.Assert.assertEquals;
+
+            public class SampleTestB {
+                @Test
+                public void checkHello() {
+                    SampleClassB sampleClass = new SampleClassB();
+                    assertEquals("hello there", sampleClass.hello());
+                }
+            }""".stripIndent()
+
+        expect:
+        succeeds ":subB:test"
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -340,7 +340,7 @@ public class JavaBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(test -> configureTestDefaults(test, project, javaPluginExtension));
         project.getTasks().withType(Jar.class).configureEach(jar -> {
             TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
-            testTasks.forEach(test -> jar.shouldRunAfter(test));
+            testTasks.forEach(test -> test.shouldRunAfter(jar));
         });
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -42,9 +42,7 @@ import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -338,10 +336,6 @@ public class JavaBasePlugin implements Plugin<Project> {
 
     private void configureTest(final Project project, final JavaPluginExtension javaPluginExtension) {
         project.getTasks().withType(Test.class).configureEach(test -> configureTestDefaults(test, project, javaPluginExtension));
-        project.getTasks().withType(Jar.class).configureEach(jar -> {
-            TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
-            testTasks.forEach(test -> test.shouldRunAfter(jar));
-        });
     }
 
     private void configureTestDefaults(final Test test, Project project, final JavaPluginExtension javaPluginExtension) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -42,7 +42,9 @@ import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -336,6 +338,10 @@ public class JavaBasePlugin implements Plugin<Project> {
 
     private void configureTest(final Project project, final JavaPluginExtension javaPluginExtension) {
         project.getTasks().withType(Test.class).configureEach(test -> configureTestDefaults(test, project, javaPluginExtension));
+        project.getTasks().withType(Jar.class).configureEach(jar -> {
+            TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
+            testTasks.forEach(test -> jar.shouldRunAfter(test));
+        });
     }
 
     private void configureTestDefaults(final Test test, Project project, final JavaPluginExtension javaPluginExtension) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -344,8 +344,15 @@ public class JavaPlugin implements Plugin<Project> {
             jar.from(mainSourceSetOf(pluginExtension).getOutput());
         });
 
-        // Prefer to run jar tasks prior to test tasks, this might offer a small performance improvement for common usage
+        /* Unless there are other concerns, we'd prefer to run jar tasks prior to test tasks, as this might offer a small performance improvement
+           for common usage.  In practice, running test tasks tends to take longer than building a jar; especially as a project matures. If tasks
+            in downstream projects require the jar from this project, and the jar and test tasks in this project are available to be run in either order,
+            running jar first so that other projects can continue executing tasks in parallel while this project runs its tests could be an improvement.
+            However, while we want to prioritize cross-project dependencies to maximize parallelism if possible, we don't want to add an explicit
+            dependsOn() relationship between the jar task and the test task, so that any projects which need to run test tasks first will not need modification.
+         */
         project.getTasks().withType(Test.class).configureEach(test -> {
+            // Attempt to avoid configuring jar task if possible, it will likely be configured anyway the by apiElements variant
             test.shouldRunAfter(project.getTasks().withType(Jar.class));
         });
 


### PR DESCRIPTION
This seems like the behavior that would be preferred most of the time.  Why wait for tests to complete prior to making a jar (which might be required by another project).