### PR TITLE
Rebasline JavaIDEModelPerformanceTest

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class JavaIDEModelPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.5-20220106231428+0000"]
+        runner.targetVersions = ["7.5-20220216231956+0000"]
         runner.minimumBaseVersion = "2.11"
     }
 


### PR DESCRIPTION
JavaIDEModelPerformanceTest seems to be quite flaky: sometimes it says
10% regression, sometime it passes. Let's rebaseline to unblock people,
then investigate it.
