### PR TITLE
fix #19955: Eagerly configure existing container objects for aggregation plugins

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -95,7 +95,7 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         reporting.getReports().registerBinding(JacocoCoverageReport.class, DefaultJacocoCoverageReport.class);
 
         // iterate and configure each user-specified report, creating a <reportName>ExecutionData configuration for each
-        reporting.getReports().withType(JacocoCoverageReport.class).configureEach(report -> {
+        reporting.getReports().withType(JacocoCoverageReport.class).all(report -> {
             // A resolvable configuration to collect JaCoCo coverage data; typically named "testCodeCoverageReportExecutionData"
             Configuration executionDataConf = project.getConfigurations().create(report.getName() + "ExecutionData");
             executionDataConf.extendsFrom(jacocoAggregation);
@@ -127,7 +127,7 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
 
             TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
             ExtensiblePolymorphicDomainObjectContainer<TestSuite> testSuites = testing.getSuites();
-            testSuites.withType(JvmTestSuite.class).configureEach(testSuite -> {
+            testSuites.withType(JvmTestSuite.class).all(testSuite -> {
                 reporting.getReports().create(testSuite.getName() + "CodeCoverageReport", JacocoCoverageReport.class, report -> {
                     report.getTestType().convention(testSuite.getTestType());
                 });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/TestReportAggregationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/TestReportAggregationPlugin.java
@@ -73,7 +73,7 @@ public abstract class TestReportAggregationPlugin implements Plugin<Project> {
         });
 
         // iterate and configure each user-specified report, creating a <reportName>Results configuration for each
-        reporting.getReports().withType(AggregateTestReport.class).configureEach(report -> {
+        reporting.getReports().withType(AggregateTestReport.class).all(report -> {
             // A resolvable configuration to collect test results; typically named "testResults"
             Configuration testResultsConf = project.getConfigurations().create(report.getName() + "Results");
             testResultsConf.extendsFrom(testAggregation);
@@ -107,7 +107,7 @@ public abstract class TestReportAggregationPlugin implements Plugin<Project> {
             TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
             ExtensiblePolymorphicDomainObjectContainer<TestSuite> testSuites = testing.getSuites();
 
-            testSuites.withType(JvmTestSuite.class).configureEach(testSuite -> {
+            testSuites.withType(JvmTestSuite.class).all(testSuite -> {
                 reporting.getReports().create(testSuite.getName() + "AggregateTestReport", AggregateTestReport.class, report -> {
                     report.getTestType().convention(testSuite.getTestType());
                 });


### PR DESCRIPTION
@tresat Do you think it's appropriate that I also used `all` for the objects in the `suites` container on the `TestingExtension`?