### PR TITLE
Support configFailurePolicy for TestNG 7.x

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/TestNGCoverage.groovy
@@ -21,11 +21,13 @@ import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.internal.jvm.Jvm
 
 class TestNGCoverage {
-    final static String NEWEST = '7.4.0'
+    final static String NEWEST = '7.5'
     final static String INITIAL_BROKEN_ICLASS_LISTENER = '6.9.10' // introduces initial, buggy IClassListener
     final static String FIXED_ICLASS_LISTENER = '6.9.13.3' // introduces fixed IClassListener
     final static String[] STANDARD_COVERAGE = ['5.14.10', '6.2', '6.8.7', '6.9.13.6', NEWEST]
     final static String[] STANDARD_COVERAGE_WITH_INITIAL_ICLASS_LISTENER =  ObjectArrays.concat(INITIAL_BROKEN_ICLASS_LISTENER, STANDARD_COVERAGE)
+    final static String LEGACY =  '5.12.1' // lacks TestNG#setConfigFailurePolicy method
+    final static String[] STANDARD_COVERAGE_WITH_LEGACY =  ObjectArrays.concat(LEGACY, STANDARD_COVERAGE_WITH_INITIAL_ICLASS_LISTENER)
     final static String[] PRESERVE_ORDER = Jvm.current().javaVersion.java7Compatible ? ['5.14.6', '6.1.1', '6.9.4', NEWEST] : ['5.14.6', '6.1.1'] // skipped NEWEST (6.8.7) because of cbeust/testng#639
     final static String[] GROUP_BY_INSTANCES = ['6.1', '6.8.7', NEWEST]
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGVersionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGVersionIntegrationTest.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.testng
+
+import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.util.internal.VersionNumber
+
+import static org.gradle.testing.fixture.TestNGCoverage.*
+
+@TargetCoverage({ STANDARD_COVERAGE_WITH_LEGACY })
+class AbstractTestNGVersionIntegrationTest extends MultiVersionIntegrationSpec {
+
+    static boolean supportConfigFailurePolicy() {
+        return versionNumber >= VersionNumber.parse('5.13')
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -16,15 +16,15 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.TestClassExecutionResult
 import org.gradle.integtests.fixtures.TestNGExecutionResult
 import org.gradle.integtests.fixtures.TestResources
 import org.junit.Rule
 
-import static org.gradle.testing.fixture.TestNGCoverage.NEWEST
+import static org.junit.Assume.assumeFalse
+import static org.junit.Assume.assumeTrue
 
-class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
+class TestNGFailurePolicyIntegrationTest extends AbstractTestNGVersionIntegrationTest {
 
     @Rule public TestResources resources = new TestResources(testDirectoryProvider)
 
@@ -32,7 +32,7 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
         new TestNGExecutionResult(testDirectory).testClass("org.gradle.failurepolicy.TestWithFailureInConfigMethod")
     }
 
-    void usingTestNG(String version) {
+    def setup() {
         buildFile << """
             testing {
                 suites {
@@ -45,10 +45,7 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
     }
 
     def "skips tests after a config method failure by default"() {
-        when:
-        usingTestNG(NEWEST)
-
-        then:
+        expect:
         fails "test"
 
         and:
@@ -58,7 +55,8 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
 
     def "can be configured to continue executing tests after a config method failure"() {
         when:
-        usingTestNG('6.14.3') // TODO test fails with TestNG 7.x; see https://github.com/gradle/gradle/issues/10507
+        assumeTrue(supportConfigFailurePolicy())
+
         buildFile << """
             testing {
                 suites {
@@ -87,7 +85,8 @@ class TestNGFailurePolicyIntegrationTest extends AbstractSampleIntegrationTest {
 
     def "informative error is shown when trying to use config failure policy and a version that does not support it"() {
         when:
-        usingTestNG("5.12.1")
+        assumeFalse(supportConfigFailurePolicy())
+
         buildFile << """
             testing {
                 suites {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGUpToDateCheckIntegrationTest.groovy
@@ -108,7 +108,7 @@ class TestNGUpToDateCheckIntegrationTest extends AbstractIntegrationSpec {
         'threadCount'         | '= 2'
         'listeners'           | '= ["org.testng.reporters.FailedReporter"]'
         'useDefaultListeners' | '= true'
-        //'configFailurePolicy' | '= "continue"' // See https://github.com/gradle/gradle/issues/10507; API removed in TestNG v7
+        'configFailurePolicy' | '= "continue"'
         'preserveOrder'       | '= true'
         'groupByInstances'    | '= true'
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactory.java
@@ -35,6 +35,11 @@ class TestNGListenerAdapterFactory {
     }
 
     public ITestListener createAdapter(ITestListener listener) {
+        Class<?> testNG7Class = tryLoadClass("org.testng.IConfigurationListener");
+        if (testNG7Class != null) {
+            return createProxy(testNG7Class, listener);
+        }
+
         Class<?> testNG6Class = tryLoadClass("org.testng.IConfigurationListener2");
         if (testNG6Class != null) {
             return createProxy(testNG6Class, listener);
@@ -45,7 +50,7 @@ class TestNGListenerAdapterFactory {
             return createProxy(testNG5Class, listener);
         }
 
-        throw new UnsupportedOperationException("Neither found interface 'org.testng.IConfigurationListener2' nor interface 'org.testng.internal.IConfigurationListener'. Which version of TestNG are you using?");
+        throw new UnsupportedOperationException("Could not locate any of these interfaces: 'org.testng.IConfigurationListener', 'org.testng.IConfigurationListener2', 'org.testng.internal.IConfigurationListener'. Which version of TestNG are you using?");
     }
 
     private Class<?> tryLoadClass(String name) {

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactorySpec.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGListenerAdapterFactorySpec.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.internal.tasks.testing.testng
 
-import org.testng.IConfigurationListener2
+import org.testng.IConfigurationListener
 import org.testng.ITestContext
 import org.testng.ITestListener
 import org.testng.ITestResult
@@ -26,9 +26,9 @@ class TestNGListenerAdapterFactorySpec extends Specification {
     MyListener listener = Mock()
     MyListener2 otherListener = Mock()
 
-    def "adapts to IConfigurationListener2 interface if available on class path"() {
+    def "adapts to IConfigurationListener interface if available on class path"() {
         expect:
-        factory.createAdapter(listener) instanceof IConfigurationListener2
+        factory.createAdapter(listener) instanceof IConfigurationListener
     }
 
     def "equals and hashcode methods works as expected"() {
@@ -49,18 +49,16 @@ class TestNGListenerAdapterFactorySpec extends Specification {
      */
     def "adapts to internal IConfigurationListener interface if available on class path"() {}
 
-    def "adapter forwards all IConfigurationListener2 calls"() {
-        IConfigurationListener2 adapter = factory.createAdapter(listener)
+    def "adapter forwards all IConfigurationListener calls"() {
+        IConfigurationListener adapter = factory.createAdapter(listener)
         ITestResult result = Mock()
 
         when:
-        adapter.beforeConfiguration(result)
         adapter.onConfigurationSuccess(result)
         adapter.onConfigurationFailure(result)
         adapter.onConfigurationSkip(result)
 
         then:
-        1 * listener.beforeConfiguration(result)
         1 * listener.onConfigurationSuccess(result)
         1 * listener.onConfigurationFailure(result)
         1 * listener.onConfigurationSkip(result)
@@ -91,5 +89,5 @@ class TestNGListenerAdapterFactorySpec extends Specification {
     }
 }
 
-interface MyListener extends ITestListener, IConfigurationListener2 {}
-interface MyListener2 extends ITestListener, IConfigurationListener2 {}
+interface MyListener extends ITestListener, IConfigurationListener {}
+interface MyListener2 extends ITestListener, IConfigurationListener {}


### PR DESCRIPTION
See #10507 for context.

TestNG 7.x removed the `TestNG#setConfigFailurePolicy(String)` method in favor of `TestNG#setConfigFailurePolicy(org.testng.xml.XmlSuite$FailurePolicy)` (an enum argument).

Older (pre-5.12) TestNG libraries did not have this method at all, so we probe at configuration time to see if the user has configured this property on our `TestNGOptions` bean. So the first step was to update `TestNGTestFramework` to look for the newer API first, then fallback to String, finally failing if neither are present (this "probing" is skipped entirely if the [option](https://docs.gradle.org/7.4/javadoc/org/gradle/api/tasks/testing/testng/TestNGOptions.html#setConfigFailurePolicy-java.lang.String-) is not set/left as default.)

Next, when invoking the TestNG class we must actually invoke the method. Previously we just trusted that the String argument method existed since we've passed the configuration-time probing/validation. But since our spec bean stores a string, we must coerce its value to the enum value, if appropriate. So additional reflection is added to `TestNGTestClassProcessor`. The end result is we invoke the new API if available, otherwise fallback to String.

Lastly, we also probe for marker interfaces in `TestNGListenerAdapterFactory`. I updated this to probe for the newest/non-deprecated item in TestNG 7.x.

@big-guy and I discussed the following alternative approaches below, but ultimately don't want to make the additional investment at this point in time:

1. In `TestNGTestFramework`, avoid leveraging the `testClassLoader` entirely and instead try to extract the TestNG version from the associated dependency. Based on that, we can make assumptions about which APIs are OK to call based on the library version.
2. Build our own API adapter layer. Similar to above, but make our options/spec object smarter about which APIs we invoke.
3. Investigate [https://github.com/testng-team/testng-remote](testng-team/testng-remote). This came up in community discussions as a way to abstract the TestNG version from calls to invoke it.
4. Stop invoking TestNG directly; instead use JUnitPlatform and a custom runner for TestNG: [junit-team/testng-engine](https://github.com/junit-team/testng-engine)

If we decide to pursue further TestNG integration in the future, the above items deserve further exploration.