### PR TITLE
Add '@' into supported project names to support run Gradle in Jenkins parallel job

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/typesafe/TypeSafeProjectAccessorsIntegrationTest.groovy
@@ -56,7 +56,7 @@ class TypeSafeProjectAccessorsIntegrationTest extends AbstractTypeSafeProjectAcc
         fails 'help'
 
         then:
-        failureDescriptionContains "Cannot generate project dependency accessors because project '1library' doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\\-_])*"
+        failureDescriptionContains "Cannot generate project dependency accessors because project '1library' doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\\-_@])*"
     }
 
     def "fails if two subprojects have the same java name"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultDependenciesAccessors.java
@@ -78,7 +78,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class DefaultDependenciesAccessors implements DependenciesAccessors {
-    private final static String SUPPORTED_PROJECT_NAMES = "[a-zA-Z]([A-Za-z0-9\\-_])*";
+    private final static String SUPPORTED_PROJECT_NAMES = "[a-zA-Z]([A-Za-z0-9\\-_@])*";
     private final static Pattern SUPPORTED_PATTERN = Pattern.compile(SUPPORTED_PROJECT_NAMES);
     private final static String ACCESSORS_PACKAGE = "org.gradle.accessors.dm";
     private final static String ACCESSORS_CLASSNAME_PREFIX = "LibrariesFor";


### PR DESCRIPTION
Signed-off-by: Tang HuaiZhe <tanghuaizhe@me.com>

<!--- The issue this PR addresses -->
Hi Gradle guys,

We tried to use the `TYPESAFE_PROJECT_ACCESSORS` feature in our project. When testing on our local machine, everything was fine, but when we ran CI check job such as UT in jenkins machine, we encountered the following error:

`FAILURE: Build failed with an exception. 16:25:31 16:25:31 * What went wrong: 16:25:31 org.gradle.api.InvalidUserDataException: Cannot generate project dependency accessors: 16:25:31 - Cannot generate project dependency accessors because project 'Android-PR-Check-AndroidTest@3' doesn't follow the naming convention: [a-zA-Z]([A-Za-z0-9\-_])`


This error occurs because:
1. There are parallel tasks in our jenkins job.
2. Jenkins will rename parallel tasks to jobName@1, jobName@2, and jobName@3... by default
3. The project name currently supported by Gradle does not contain the character `@`
4. Jenkins does not seem to support modifying the parallel renaming rule.

So I've submitted this PR, please let me know if I'm not thinking well, thanks.

### Context
<!--- Why do you believe many users will benefit from this change? -->
Jenkins is popular in the world. Many Gradle users are using Jenkins and parallel jobs.
So this change should be meaningful.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
