### PR TITLE
Do not show VFS verbose logs by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,6 @@ systemProp.gradle.publish.skip.namespace.check=true
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
 
-# Show more VFS logging and statistics
-org.gradle.vfs.verbose=true
-org.gradle.vfs.debug=true
-
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
 


### PR DESCRIPTION
Since file system watching is now a well established feature, we don't need to have the debug logs for VFS enabled by default:

```text
VFS> Statistics since last build:
VFS> > Stat: Executed stat() x 0. getUnixMode() x 0
VFS> > FileHasher: Hashed 0 files (0 bytes)
VFS> > DirectorySnapshotter: Snapshot 0 directory hierarchies (visited 0 directories, 0 files and 0 failed files)
```