### PR TITLE
Fix AbstractMinimalProvider.toString()

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -24,7 +24,6 @@ import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
-import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -162,7 +162,8 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Override
     public String toString() {
         // NOTE: Do not realize the value of the Provider in toString().  The debugger will try to call this method and make debugging really frustrating.
-        return String.format("provider(%s)", GUtil.elvis(getType(), "?"));
+        Class<?> type = getType();
+        return String.format("provider(%s)", type == null ? "?" : type.getName());
     }
 
     @Override

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/AbstractMinimalProviderTest.groovy
@@ -130,6 +130,11 @@ class AbstractMinimalProviderTest extends ProviderSpec<String> {
         e.message == 'Cannot query the value of this provider because it has no value available.'
     }
 
+    def "toString() displays nice things"() {
+        expect:
+        new TestProvider().toString() == "provider(java.lang.String)"
+    }
+
     static class TestProvider extends AbstractMinimalProvider {
         @Nullable
         String value


### PR DESCRIPTION
This used to display Class.toString() instead of Class.getName().
