### PR TITLE
Expand generics on Provider.zip()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -225,11 +225,11 @@ public interface Provider<T> {
      *
      * @param right the second provider to combine with
      * @param combiner the combiner of values
-     * @param <B> the type of the second provider
+     * @param <U> the type of the second provider
      * @param <R> the type of the result of the combiner
      * @return a combined provider
      *
      * @since 6.6
      */
-    <B, R> Provider<R> zip(Provider<B> right, BiFunction<T, B, R> combiner);
+    <U, R> Provider<R> zip(Provider<U> right, BiFunction<? super T, ? super U, ? extends R> combiner);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -263,5 +263,5 @@ public interface ProviderFactory {
      *
      * @since 6.6
      */
-    <A, B, R> Provider<R> zip(Provider<A> first, Provider<B> second, BiFunction<A, B, R> combiner);
+    <A, B, R> Provider<R> zip(Provider<A> first, Provider<B> second, BiFunction<? super A, ? super B, ? extends R> combiner);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -22,11 +22,11 @@ import java.util.function.BiFunction;
 
 class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
 
-    private final BiFunction<A, B, R> combiner;
+    private final BiFunction<? super A, ? super B, ? extends R> combiner;
     private final ProviderInternal<A> left;
     private final ProviderInternal<B> right;
 
-    public BiProvider(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner) {
+    public BiProvider(Provider<A> left, Provider<B> right, BiFunction<? super A, ? super B, ? extends R> combiner) {
         this.combiner = combiner;
         this.left = Providers.internal(left);
         this.right = Providers.internal(right);

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -180,7 +180,7 @@ public class DefaultProviderFactory implements ProviderFactory {
     }
 
     @Override
-    public <A, B, R> Provider<R> zip(Provider<A> left, Provider<B> right, BiFunction<A, B, R> combiner) {
+    public <A, B, R> Provider<R> zip(Provider<A> left, Provider<B> right, BiFunction<? super A, ? super B, ? extends R> combiner) {
         return new BiProvider<>(left, right, combiner);
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -65,7 +65,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      */
     ExecutionTimeValue<? extends T> calculateExecutionTimeValue();
 
-    default <B, R> Provider<R> zip(Provider<B> right, BiFunction<T, B, R> combiner) {
+    default <U, R> Provider<R> zip(Provider<U> right, BiFunction<? super T, ? super U, ? extends R> combiner) {
         return new BiProvider<>(this, right, combiner);
     }
 }


### PR DESCRIPTION
This changes `Provider.zip()` from:

```java
    <B, R> Provider<R> zip(Provider<B> right, BiFunction<T, B, R> combiner);
```

to:

```java
    <B, R> Provider<R> zip(Provider<B> right, BiFunction<? super T, ? super B, ? extends R> combiner);
```

Same for `ProviderFactory.zip()`.