### PR TITLE
Ignore missing roots in fingerprints

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileCollectionSymlinkIntegrationTest.groovy
@@ -29,7 +29,7 @@ import spock.lang.Issue
 
 import static org.gradle.util.internal.TextUtil.escapeString
 import static org.gradle.work.ChangeType.ADDED
-import static org.gradle.work.ChangeType.MODIFIED
+import static org.gradle.work.ChangeType.REMOVED
 
 @Requires(TestPrecondition.SYMLINKS)
 class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
@@ -335,7 +335,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec imple
         run 'inputBrokenLinkNameCollector'
         then:
         executedAndNotSkipped ':inputBrokenLinkNameCollector'
-        output.text == "${[ADDED]}"
+        output.text == "[]"
 
         when:
         run 'inputBrokenLinkNameCollector'
@@ -347,7 +347,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec imple
         run 'inputBrokenLinkNameCollector'
         then:
         executedAndNotSkipped ':inputBrokenLinkNameCollector'
-        output.text == "${[MODIFIED]}"
+        output.text == "${[ADDED]}"
 
         when:
         run 'inputBrokenLinkNameCollector'
@@ -359,7 +359,7 @@ class FileCollectionSymlinkIntegrationTest extends AbstractIntegrationSpec imple
         run 'inputBrokenLinkNameCollector'
         then:
         executedAndNotSkipped ':inputBrokenLinkNameCollector'
-        output.text == "${[MODIFIED]}"
+        output.text == "${[REMOVED]}"
     }
 
     @ValidationTestFor(

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -23,7 +23,6 @@ import org.gradle.api.internal.file.FileTreeInternal;
 import org.gradle.api.internal.file.collections.FileSystemMirroringFileTree;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
-import org.gradle.internal.file.FileType;
 import org.gradle.internal.file.Stat;
 import org.gradle.internal.fingerprint.GenericFileTreeSnapshotter;
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot;
@@ -94,11 +93,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
             fileSystemAccess.read(
                 root.getAbsolutePath(),
                 new PatternSetSnapshottingFilter(patterns, stat),
-                snapshot -> {
-                    if (snapshot.getType() != FileType.Missing) {
-                        roots.add(snapshot);
-                    }
-                }
+                roots::add
             );
             if (fileTreeOnly == null) {
                 fileTreeOnly = true;

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -68,16 +68,16 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
 
     def "retains order of elements in the snapshot"() {
         given:
-        TestFile file = tmpDir.createFile('file1')
-        TestFile noExist = tmpDir.file('file2')
-        TestFile file3 = tmpDir.createDir('file3')
-        TestFile file4 = tmpDir.createFile('file4')
+        TestFile file1 = tmpDir.createFile('file1')
+        TestFile missing = tmpDir.file('missing')
+        TestFile file2 = tmpDir.createDir('file2')
+        TestFile file3 = tmpDir.createFile('file3')
 
         when:
-        def fingerprint = fingerprinter.fingerprint(files(file, noExist, file3, file4))
+        def fingerprint = fingerprinter.fingerprint(files(file1, missing, file2, file3))
 
         then:
-        fingerprint.fingerprints.keySet().collect { new File(it) } == [file, file3, file4]
+        fingerprint.fingerprints.keySet().collect { new File(it) } == [file1, file2, file3]
     }
 
     def generatesEventWhenFileAdded() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/AbsolutePathFileCollectionFingerprinterTest.groovy
@@ -63,21 +63,21 @@ class AbsolutePathFileCollectionFingerprinterTest extends Specification {
         def fingerprint = fingerprinter.fingerprint(files(file, dir, noExist))
 
         then:
-        fingerprint.fingerprints.keySet().collect { new File(it) } == [file, dir, dir2, file2, noExist]
+        fingerprint.fingerprints.keySet().collect { new File(it) } == [file, dir, dir2, file2]
     }
 
     def "retains order of elements in the snapshot"() {
         given:
         TestFile file = tmpDir.createFile('file1')
-        TestFile file2 = tmpDir.file('file2')
-        TestFile file3 = tmpDir.file('file3')
+        TestFile noExist = tmpDir.file('file2')
+        TestFile file3 = tmpDir.createDir('file3')
         TestFile file4 = tmpDir.createFile('file4')
 
         when:
-        def fingerprint = fingerprinter.fingerprint(files(file, file2, file3, file4))
+        def fingerprint = fingerprinter.fingerprint(files(file, noExist, file3, file4))
 
         then:
-        fingerprint.fingerprints.keySet().collect { new File(it) } == [file, file2, file3, file4]
+        fingerprint.fingerprints.keySet().collect { new File(it) } == [file, file3, file4]
     }
 
     def generatesEventWhenFileAdded() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/tasks/AssemblerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/assembler/tasks/AssemblerTest.groovy
@@ -40,7 +40,8 @@ class AssemblerTest extends AbstractProjectBuilderSpec {
     }
 
     def "executes using the Assembler"() {
-        def inputDir = temporaryFolder.file("sourceFile")
+        def inputDir = temporaryFolder.file("sourceFile").createDir()
+        inputDir.createFile("blah.asm")
         def result = Mock(WorkResult)
         when:
         assembleTask.toolChain = toolChain

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMap;
+import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.fingerprint.FingerprintHashingStrategy;
@@ -63,6 +64,9 @@ public class AbsolutePathFingerprintingStrategy extends AbstractDirectorySensiti
         roots.accept(new RootTrackingFileSystemSnapshotHierarchyVisitor() {
             @Override
             public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
+                if (isRoot && snapshot.getType() == FileType.Missing) {
+                    return SnapshotVisitResult.CONTINUE;
+                }
                 String absolutePath = snapshot.getAbsolutePath();
                 if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
                     HashCode normalizedContentHash = getNormalizedContentHash(snapshot, normalizedContentHasher);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -26,6 +26,7 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot.FileSystemLocatio
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MissingFileSnapshot;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
+import org.gradle.internal.snapshot.RootTrackingFileSystemSnapshotHierarchyVisitor;
 import org.gradle.internal.snapshot.SnapshotVisitResult;
 
 import java.util.HashSet;
@@ -61,29 +62,34 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();
-        roots.accept(snapshot -> {
-            snapshot.accept(new FileSystemLocationSnapshotVisitor() {
-                @Override
-                public void visitRegularFile(RegularFileSnapshot fileSnapshot) {
-                    visitNonDirectoryEntry(snapshot);
-                }
+        roots.accept(new RootTrackingFileSystemSnapshotHierarchyVisitor() {
+            @Override
+            public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
+                snapshot.accept(new FileSystemLocationSnapshotVisitor() {
+                    @Override
+                    public void visitRegularFile(RegularFileSnapshot fileSnapshot) {
+                        visitNonDirectoryEntry(snapshot);
+                    }
 
-                @Override
-                public void visitMissing(MissingFileSnapshot missingSnapshot) {
-                    visitNonDirectoryEntry(snapshot);
-                }
-
-                private void visitNonDirectoryEntry(FileSystemLocationSnapshot snapshot) {
-                    String absolutePath = snapshot.getAbsolutePath();
-                    if (processedEntries.add(absolutePath)) {
-                        HashCode normalizedContentHash = getNormalizedContentHash(snapshot, normalizedContentHasher);
-                        if (normalizedContentHash != null) {
-                            builder.put(absolutePath, IgnoredPathFileSystemLocationFingerprint.create(snapshot.getType(), normalizedContentHash));
+                    @Override
+                    public void visitMissing(MissingFileSnapshot missingSnapshot) {
+                        if (!isRoot) {
+                            visitNonDirectoryEntry(snapshot);
                         }
                     }
-                }
-            });
-            return SnapshotVisitResult.CONTINUE;
+
+                    private void visitNonDirectoryEntry(FileSystemLocationSnapshot snapshot) {
+                        String absolutePath = snapshot.getAbsolutePath();
+                        if (processedEntries.add(absolutePath)) {
+                            HashCode normalizedContentHash = getNormalizedContentHash(snapshot, normalizedContentHasher);
+                            if (normalizedContentHash != null) {
+                                builder.put(absolutePath, IgnoredPathFileSystemLocationFingerprint.create(snapshot.getType(), normalizedContentHash));
+                            }
+                        }
+                    }
+                });
+                return SnapshotVisitResult.CONTINUE;
+            }
         });
         return builder.build();
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -64,6 +64,9 @@ public class NameOnlyFingerprintingStrategy extends AbstractDirectorySensitiveFi
             @Override
             public SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot, boolean isRoot) {
                 String absolutePath = snapshot.getAbsolutePath();
+                if (isRoot && snapshot.getType() == FileType.Missing) {
+                    return SnapshotVisitResult.CONTINUE;
+                }
                 if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
                     if (isRoot && snapshot.getType() == FileType.Directory) {
                         builder.put(absolutePath, IgnoredPathFileSystemLocationFingerprint.DIRECTORY);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -72,10 +72,10 @@ public class RelativePathFingerprintingStrategy extends AbstractDirectorySensiti
             if (processedEntries.add(absolutePath) && getDirectorySensitivity().shouldFingerprint(snapshot)) {
                 FileSystemLocationFingerprint fingerprint;
                 if (relativePath.isRoot()) {
-                    if (snapshot.getType() == FileType.Directory) {
-                        return SnapshotVisitResult.CONTINUE;
-                    } else {
+                    if (snapshot.getType() == FileType.RegularFile) {
                         fingerprint = fingerprint(snapshot.getName(), snapshot.getType(), snapshot);
+                    } else {
+                        return SnapshotVisitResult.CONTINUE;
                     }
                 } else {
                     fingerprint = fingerprint(stringInterner.intern(relativePath.toRelativePath()), snapshot.getType(), snapshot);

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -94,8 +94,10 @@ class PathNormalizationStrategyTest extends Specification {
 
     def "sensitivity NAME_ONLY (DirectorySensitivity: #strategy.directorySensitivity)"() {
         def fingerprints = collectFingerprints(strategy)
+        def expectedFingerprintedFiles = getAllFilesToFingerprint(strategy.directorySensitivity)
+        expectedFingerprintedFiles.size() == fingerprints.size()
         expect:
-        (getAllFilesToFingerprint(strategy.directorySensitivity) - emptyRootDir - resources).each { file ->
+        (expectedFingerprintedFiles - emptyRootDir - resources).each { file ->
             assert fingerprints[file] == file.name
         }
         fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
@@ -120,7 +122,7 @@ class PathNormalizationStrategyTest extends Specification {
         fingerprints[resources.file(subDirB)]       == directoryFingerprintFor(subDirB, strategy.directorySensitivity)
         fingerprints[resources.file(fileInSubdirB)] == fileInSubdirB
         fingerprints[emptyRootDir]                  == null
-        fingerprints[missingFile]                   == missingFile.name
+        fingerprints[missingFile]                   == null
 
         where:
         strategy << [

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -84,7 +84,7 @@ class PathNormalizationStrategyTest extends Specification {
         def fingerprints = collectFingerprints(IgnoredPathFingerprintingStrategy.DEFAULT)
         expect:
         allFilesToFingerprint.each { file ->
-            if (file.isFile() || !file.exists()) {
+            if (file.isFile()) {
                 assert fingerprints[file] == IGNORED
             } else {
                 assert fingerprints[file] == null
@@ -97,11 +97,12 @@ class PathNormalizationStrategyTest extends Specification {
         def expectedFingerprintedFiles = getAllFilesToFingerprint(strategy.directorySensitivity)
         expectedFingerprintedFiles.size() == fingerprints.size()
         expect:
-        (expectedFingerprintedFiles - emptyRootDir - resources).each { file ->
+        (expectedFingerprintedFiles - emptyRootDir - resources - missingFile).each { file ->
             assert fingerprints[file] == file.name
         }
         fingerprints[emptyRootDir] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
         fingerprints[resources] == rootDirectoryFingerprintFor(strategy.directorySensitivity)
+        fingerprints[missingFile] == null
 
         where:
         strategy << [
@@ -135,10 +136,11 @@ class PathNormalizationStrategyTest extends Specification {
         def fingerprints = collectFingerprints(strategy)
         expect:
         def allFilesToFingerprint = getAllFilesToFingerprint(strategy.directorySensitivity)
-        allFilesToFingerprint.each { file ->
+        (allFilesToFingerprint - missingFile).each { file ->
             assert fingerprints[file] == file.absolutePath
         }
-        fingerprints.size() == allFilesToFingerprint.size()
+        fingerprints[missingFile] == null
+        fingerprints.size() == allFilesToFingerprint.size() - 1
 
         where:
         strategy << [


### PR DESCRIPTION
Instead of having some fingerprinting strategies which consider missing roots and some which ignore them, this PR ensures all fingerprinting strategies ignore missing roots.

This is an extended version of https://github.com/gradle/gradle/pull/19877, which only ignored missing roots for relative path fingerprinting.