### PR TITLE
Mark checkBinaryCompatibility as incompatible with configuration cache

### DIFF
--- a/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/cc-experiment-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -55,6 +55,8 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
         task.name.contains("Sample") -> true
         task.name.contains("Snippet") -> true
         task.name == "samplesMultiPage" -> true
+        // Changes to accepted-public-api-changes.json are not detected
+        task.name == "checkBinaryCompatibility" -> true
         task.typeSimpleName in listOf(
             "KtsProjectGeneratorTask",
             "JavaExecProjectGeneratorTask",


### PR DESCRIPTION
The binary compatibility check seems to have a problem with its inputs: When using the configuration cache, changes to `accepted-public-api-changes.json` are not detected.