### PR TITLE
Store 128-bit hashes more efficiently

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.classloader
 
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 class ConfigurableClassLoaderHierarchyHasherTest extends Specification {
@@ -39,7 +39,7 @@ class ConfigurableClassLoaderHierarchyHasherTest extends Specification {
 
     def "hashes hashed classloader"() {
         def hashedLoader = new DelegatingLoader(runtimeLoader)
-        def hashedLoaderHash = TestHashCode.fromInt(123456)
+        def hashedLoaderHash = TestHashCodes.hashCodeFrom(123456)
 
         when:
         hasher.getClassLoaderHash(hashedLoader) == hashFor(hashedLoaderHash)

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/ConfigurableClassLoaderHierarchyHasherTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.internal.classloader
 
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 class ConfigurableClassLoaderHierarchyHasherTest extends Specification {
@@ -38,7 +39,7 @@ class ConfigurableClassLoaderHierarchyHasherTest extends Specification {
 
     def "hashes hashed classloader"() {
         def hashedLoader = new DelegatingLoader(runtimeLoader)
-        def hashedLoaderHash = HashCode.fromInt(123456)
+        def hashedLoaderHash = TestHashCode.fromInt(123456)
 
         when:
         hasher.getClassLoaderHash(hashedLoader) == hashFor(hashedLoaderHash)

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.caching.internal.packaging.BuildCacheEntryPacker
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.CallableBuildOperation
@@ -79,10 +79,10 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
             prop("outputFile", FILE, outputFile)
         )
 
-        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, HashCode.fromInt(234), DefaultFileMetadata.file(15, 234, FileMetadata.AccessType.DIRECT))
+        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, TestHashCode.fromInt(234), DefaultFileMetadata.file(15, 234, FileMetadata.AccessType.DIRECT))
         def fileSnapshots = [
-            outputDir: new DirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, FileMetadata.AccessType.DIRECT, HashCode.fromInt(456), [
-                new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, HashCode.fromInt(123), DefaultFileMetadata.file(46, 123, FileMetadata.AccessType.DIRECT))
+            outputDir: new DirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, FileMetadata.AccessType.DIRECT, TestHashCode.fromInt(456), [
+                new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, TestHashCode.fromInt(123), DefaultFileMetadata.file(46, 123, FileMetadata.AccessType.DIRECT))
             ]),
             outputFile: outputFileSnapshot
         ]

--- a/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
+++ b/subprojects/build-cache/src/test/groovy/org/gradle/caching/internal/controller/DefaultBuildCacheControllerPackOperationExecutorTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.caching.internal.packaging.BuildCacheEntryPacker
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.TreeType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.CallableBuildOperation
@@ -79,10 +79,10 @@ class DefaultBuildCacheControllerPackOperationExecutorTest extends Specification
             prop("outputFile", FILE, outputFile)
         )
 
-        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, TestHashCode.fromInt(234), DefaultFileMetadata.file(15, 234, FileMetadata.AccessType.DIRECT))
+        def outputFileSnapshot = new RegularFileSnapshot(outputFile.absolutePath, outputFile.name, TestHashCodes.hashCodeFrom(234), DefaultFileMetadata.file(15, 234, FileMetadata.AccessType.DIRECT))
         def fileSnapshots = [
-            outputDir: new DirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, FileMetadata.AccessType.DIRECT, TestHashCode.fromInt(456), [
-                new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, TestHashCode.fromInt(123), DefaultFileMetadata.file(46, 123, FileMetadata.AccessType.DIRECT))
+            outputDir: new DirectorySnapshot(outputDir.getAbsolutePath(), outputDir.name, FileMetadata.AccessType.DIRECT, TestHashCodes.hashCodeFrom(456), [
+                new RegularFileSnapshot(outputDirFile.getAbsolutePath(), outputDirFile.name, TestHashCodes.hashCodeFrom(123), DefaultFileMetadata.file(46, 123, FileMetadata.AccessType.DIRECT))
             ]),
             outputFile: outputFileSnapshot
         ]

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -42,6 +42,7 @@ import org.gradle.configurationcache.serialization.runReadOperation
 import org.gradle.configurationcache.serialization.runWriteOperation
 import org.gradle.internal.Try
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.hamcrest.CoreMatchers.equalTo
@@ -59,12 +60,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("unchanged.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("unchanged.gradle.kts") to TestHashCode.fromInt(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(2),
-                    File("unchanged.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(2),
+                    File("unchanged.gradle.kts") to TestHashCode.fromInt(1)
                 )
             ),
             equalTo("init script 'init.gradle.kts' has changed")
@@ -76,14 +77,14 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("before.gradle.kts") to HashCode.fromInt(2),
-                    File("other.gradle.kts") to HashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("before.gradle.kts") to TestHashCode.fromInt(2),
+                    File("other.gradle.kts") to TestHashCode.fromInt(3)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("after.gradle.kts") to HashCode.fromInt(42),
-                    File("other.gradle.kts") to HashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("after.gradle.kts") to TestHashCode.fromInt(42),
+                    File("other.gradle.kts") to TestHashCode.fromInt(3)
                 )
             ),
             equalTo("content of 2nd init script, 'after.gradle.kts', has changed")
@@ -95,11 +96,11 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("added.init.gradle.kts") to HashCode.fromInt(2)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("added.init.gradle.kts") to TestHashCode.fromInt(2)
                 )
             ),
             equalTo("init script 'added.init.gradle.kts' has been added")
@@ -111,12 +112,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("added.init.gradle.kts") to HashCode.fromInt(2),
-                    File("another.init.gradle.kts") to HashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("added.init.gradle.kts") to TestHashCode.fromInt(2),
+                    File("another.init.gradle.kts") to TestHashCode.fromInt(3)
                 )
             ),
             equalTo("init script 'added.init.gradle.kts' and 1 more have been added")
@@ -128,11 +129,11 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("removed.init.gradle.kts") to HashCode.fromInt(2)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("removed.init.gradle.kts") to TestHashCode.fromInt(2)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1)
                 )
             ),
             equalTo("init script 'removed.init.gradle.kts' has been removed")
@@ -144,12 +145,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1),
-                    File("removed.init.gradle.kts") to HashCode.fromInt(2),
-                    File("another.init.gradle.kts") to HashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1),
+                    File("removed.init.gradle.kts") to TestHashCode.fromInt(2),
+                    File("another.init.gradle.kts") to TestHashCode.fromInt(3)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to HashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCode.fromInt(1)
                 )
             ),
             equalTo("init script 'removed.init.gradle.kts' and 1 more have been removed")
@@ -162,12 +163,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(scriptFile) } doReturn HashCode.fromInt(1)
+                    on { hashCodeOf(scriptFile) } doReturn TestHashCode.fromInt(1)
                     on { displayNameOf(scriptFile) } doReturn "displayNameOf(scriptFile)"
                 },
                 ConfigurationCacheFingerprint.InputFile(
                     scriptFile,
-                    HashCode.fromInt(2)
+                    TestHashCode.fromInt(2)
                 )
             ),
             equalTo("file 'displayNameOf(scriptFile)' has changed")

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -42,7 +42,7 @@ import org.gradle.configurationcache.serialization.runReadOperation
 import org.gradle.configurationcache.serialization.runWriteOperation
 import org.gradle.internal.Try
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.hamcrest.CoreMatchers.equalTo
@@ -60,12 +60,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("unchanged.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("unchanged.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(2),
-                    File("unchanged.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(2),
+                    File("unchanged.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 )
             ),
             equalTo("init script 'init.gradle.kts' has changed")
@@ -77,14 +77,14 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("before.gradle.kts") to TestHashCode.fromInt(2),
-                    File("other.gradle.kts") to TestHashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("before.gradle.kts") to TestHashCodes.hashCodeFrom(2),
+                    File("other.gradle.kts") to TestHashCodes.hashCodeFrom(3)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("after.gradle.kts") to TestHashCode.fromInt(42),
-                    File("other.gradle.kts") to TestHashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("after.gradle.kts") to TestHashCodes.hashCodeFrom(42),
+                    File("other.gradle.kts") to TestHashCodes.hashCodeFrom(3)
                 )
             ),
             equalTo("content of 2nd init script, 'after.gradle.kts', has changed")
@@ -96,11 +96,11 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("added.init.gradle.kts") to TestHashCode.fromInt(2)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("added.init.gradle.kts") to TestHashCodes.hashCodeFrom(2)
                 )
             ),
             equalTo("init script 'added.init.gradle.kts' has been added")
@@ -112,12 +112,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("added.init.gradle.kts") to TestHashCode.fromInt(2),
-                    File("another.init.gradle.kts") to TestHashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("added.init.gradle.kts") to TestHashCodes.hashCodeFrom(2),
+                    File("another.init.gradle.kts") to TestHashCodes.hashCodeFrom(3)
                 )
             ),
             equalTo("init script 'added.init.gradle.kts' and 1 more have been added")
@@ -129,11 +129,11 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("removed.init.gradle.kts") to TestHashCode.fromInt(2)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("removed.init.gradle.kts") to TestHashCodes.hashCodeFrom(2)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 )
             ),
             equalTo("init script 'removed.init.gradle.kts' has been removed")
@@ -145,12 +145,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             invalidationReasonForInitScriptsChange(
                 from = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1),
-                    File("removed.init.gradle.kts") to TestHashCode.fromInt(2),
-                    File("another.init.gradle.kts") to TestHashCode.fromInt(3)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1),
+                    File("removed.init.gradle.kts") to TestHashCodes.hashCodeFrom(2),
+                    File("another.init.gradle.kts") to TestHashCodes.hashCodeFrom(3)
                 ),
                 to = listOf(
-                    File("init.gradle.kts") to TestHashCode.fromInt(1)
+                    File("init.gradle.kts") to TestHashCodes.hashCodeFrom(1)
                 )
             ),
             equalTo("init script 'removed.init.gradle.kts' and 1 more have been removed")
@@ -163,12 +163,12 @@ class ConfigurationCacheFingerprintCheckerTest {
         assertThat(
             checkFingerprintGiven(
                 mock {
-                    on { hashCodeOf(scriptFile) } doReturn TestHashCode.fromInt(1)
+                    on { hashCodeOf(scriptFile) } doReturn TestHashCodes.hashCodeFrom(1)
                     on { displayNameOf(scriptFile) } doReturn "displayNameOf(scriptFile)"
                 },
                 ConfigurationCacheFingerprint.InputFile(
                     scriptFile,
-                    TestHashCode.fromInt(2)
+                    TestHashCodes.hashCodeFrom(2)
                 )
             ),
             equalTo("file 'displayNameOf(scriptFile)' has changed")

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -116,6 +116,9 @@ dependencies {
     testFixturesApi(project(":process-services")) {
         because("test fixtures expose exec handler types")
     }
+    testFixturesApi(testFixtures(project(":hashing"))) {
+        because("test fixtures expose test hash codes")
+    }
     testFixturesImplementation(project(":messaging"))
     testFixturesImplementation(project(":persistent-cache"))
     testFixturesImplementation(project(":snapshots"))

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.FileHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -35,8 +35,8 @@ class CachingFileHasherTest extends Specification {
     def cache = Mock(PersistentIndexedCache)
     def cacheAccess = Mock(CrossBuildFileHashCache)
     def timeStampInspector = Mock(FileTimeStampInspector)
-    def hash = TestHashCode.fromInt(0x0123)
-    def oldHash = TestHashCode.fromInt(0x0321)
+    def hash = TestHashCodes.hashCodeFrom(0x0123)
+    def oldHash = TestHashCodes.hashCodeFrom(0x0321)
     def file = tmpDir.createFile("testfile")
     def fileSystem = TestFiles.fileSystem()
     def statisticsCollector = Mock(FileHasherStatistics.Collector)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingFileHasherTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.FileHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -35,8 +35,8 @@ class CachingFileHasherTest extends Specification {
     def cache = Mock(PersistentIndexedCache)
     def cacheAccess = Mock(CrossBuildFileHashCache)
     def timeStampInspector = Mock(FileTimeStampInspector)
-    def hash = HashCode.fromInt(0x0123)
-    def oldHash = HashCode.fromInt(0x0321)
+    def hash = TestHashCode.fromInt(0x0123)
+    def oldHash = TestHashCode.fromInt(0x0321)
     def file = tmpDir.createFile("testfile")
     def fileSystem = TestFiles.fileSystem()
     def statisticsCollector = Mock(FileHasherStatistics.Collector)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheServiceTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.testfixtures.internal.TestInMemoryPersistentIndexedCache
@@ -30,12 +31,12 @@ import spock.lang.Specification
 class DefaultResourceSnapshotterCacheServiceTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def path = "some"
-    def snapshot = new RegularFileSnapshot(path, "path", HashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
+    def snapshot = new RegularFileSnapshot(path, "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path}, snapshot)
     def snapshotterCache = new DefaultResourceSnapshotterCacheService(new TestInMemoryPersistentIndexedCache(new HashCodeSerializer()))
 
     def "returns result from delegate"() {
-        def expectedHash = HashCode.fromInt(123)
+        def expectedHash = TestHashCode.fromInt(123)
 
         when:
         def actualHash = snapshotterCache.hashFile(snapshotContext, delegate, configurationHash)
@@ -46,7 +47,7 @@ class DefaultResourceSnapshotterCacheServiceTest extends Specification {
     }
 
     def "caches the result"() {
-        def expectedHash = HashCode.fromInt(123)
+        def expectedHash = TestHashCode.fromInt(123)
         when:
         def actualHash = snapshotterCache.hashFile(snapshotContext, delegate, configurationHash)
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheServiceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/state/DefaultResourceSnapshotterCacheServiceTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.HashCodeSerializer
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.testfixtures.internal.TestInMemoryPersistentIndexedCache
@@ -31,12 +31,12 @@ import spock.lang.Specification
 class DefaultResourceSnapshotterCacheServiceTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def path = "some"
-    def snapshot = new RegularFileSnapshot(path, "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
+    def snapshot = new RegularFileSnapshot(path, "path", TestHashCodes.hashCodeFrom(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path}, snapshot)
     def snapshotterCache = new DefaultResourceSnapshotterCacheService(new TestInMemoryPersistentIndexedCache(new HashCodeSerializer()))
 
     def "returns result from delegate"() {
-        def expectedHash = TestHashCode.fromInt(123)
+        def expectedHash = TestHashCodes.hashCodeFrom(123)
 
         when:
         def actualHash = snapshotterCache.hashFile(snapshotContext, delegate, configurationHash)
@@ -47,7 +47,7 @@ class DefaultResourceSnapshotterCacheServiceTest extends Specification {
     }
 
     def "caches the result"() {
-        def expectedHash = TestHashCode.fromInt(123)
+        def expectedHash = TestHashCodes.hashCodeFrom(123)
         when:
         def actualHash = snapshotterCache.hashFile(snapshotContext, delegate, configurationHash)
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.internal.classloader.DefaultHashingClassLoaderFactory
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -63,9 +63,9 @@ class DefaultClassLoaderCacheTest extends Specification {
         def root = classLoader(classPath("root"))
         cache.get(id1, classPath("c1"), root, null) == cache.get(id1, classPath("c1"), root, null)
         cache.get(id1, classPath("c1"), root, null) != cache.get(id1, classPath("c1", "c2"), root, null)
-        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) == cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100))
-        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) != cache.get(id1, classPath("c1", "c2"), root, null, TestHashCode.fromInt(200))
-        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) != cache.get(id1, classPath("c1"), root, null, null)
+        cache.get(id1, classPath("c1"), root, null, TestHashCodes.hashCodeFrom(100)) == cache.get(id1, classPath("c1"), root, null, TestHashCodes.hashCodeFrom(100))
+        cache.get(id1, classPath("c1"), root, null, TestHashCodes.hashCodeFrom(100)) != cache.get(id1, classPath("c1", "c2"), root, null, TestHashCodes.hashCodeFrom(200))
+        cache.get(id1, classPath("c1"), root, null, TestHashCodes.hashCodeFrom(100)) != cache.get(id1, classPath("c1"), root, null, null)
         cache.get(id1, classPath("c1"), root, null, classpathHasher.hash(classPath("c1"))) == cache.get(id1, classPath("c1"), root, null, null)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCacheTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.api.internal.initialization.loadercache
 
-
 import org.gradle.internal.classloader.DefaultHashingClassLoaderFactory
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -64,9 +63,9 @@ class DefaultClassLoaderCacheTest extends Specification {
         def root = classLoader(classPath("root"))
         cache.get(id1, classPath("c1"), root, null) == cache.get(id1, classPath("c1"), root, null)
         cache.get(id1, classPath("c1"), root, null) != cache.get(id1, classPath("c1", "c2"), root, null)
-        cache.get(id1, classPath("c1"), root, null, HashCode.fromInt(100)) == cache.get(id1, classPath("c1"), root, null, HashCode.fromInt(100))
-        cache.get(id1, classPath("c1"), root, null, HashCode.fromInt(100)) != cache.get(id1, classPath("c1", "c2"), root, null, HashCode.fromInt(200))
-        cache.get(id1, classPath("c1"), root, null, HashCode.fromInt(100)) != cache.get(id1, classPath("c1"), root, null, null)
+        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) == cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100))
+        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) != cache.get(id1, classPath("c1", "c2"), root, null, TestHashCode.fromInt(200))
+        cache.get(id1, classPath("c1"), root, null, TestHashCode.fromInt(100)) != cache.get(id1, classPath("c1"), root, null, null)
         cache.get(id1, classPath("c1"), root, null, classpathHasher.hash(classPath("c1"))) == cache.get(id1, classPath("c1"), root, null, null)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -50,7 +50,7 @@ import org.gradle.internal.fingerprint.NameOnlyInputNormalizer
 import org.gradle.internal.fingerprint.OutputNormalizer
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.TestSnapshotFixture
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -130,10 +130,10 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('foo',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> TestHashCode.fromInt(345)
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
                     getFingerprints() >> [
-                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCode.fromInt(123)),
-                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCode.fromInt(234)),
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
                     ]
                     getSnapshot() >> snapshots
                 }
@@ -189,9 +189,9 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('inputFiles',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> TestHashCode.fromInt(345)
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
                     getFingerprints() >> [
-                        '/input/foo': new DefaultFileSystemLocationFingerprint('/input/foo', FileType.Directory, TestHashCode.fromInt(123))
+                        '/input/foo': new DefaultFileSystemLocationFingerprint('/input/foo', FileType.Directory, TestHashCodes.hashCodeFrom(123))
                     ]
                     getSnapshot() >> snapshots
                 }
@@ -247,14 +247,14 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('foo',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> TestHashCode.fromInt(345)
+                    getHash() >> TestHashCodes.hashCodeFrom(345)
                     getFingerprints() >> [
-                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCode.fromInt(123)),
-                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCode.fromInt(234)),
-                        '/foo': new DefaultFileSystemLocationFingerprint('/foo', FileType.Directory, TestHashCode.fromInt(123)),
-                        '/foo/empty': new DefaultFileSystemLocationFingerprint('/foo/empty', FileType.Directory, TestHashCode.fromInt(123)),
-                        '/foo/empty/empty': new DefaultFileSystemLocationFingerprint('/foo/empty/empty', FileType.Directory, TestHashCode.fromInt(123)),
-                        '/foo/sub': new DefaultFileSystemLocationFingerprint('/foo/sub', FileType.Directory, TestHashCode.fromInt(123)),
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
+                        '/foo': new DefaultFileSystemLocationFingerprint('/foo', FileType.Directory, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/empty': new DefaultFileSystemLocationFingerprint('/foo/empty', FileType.Directory, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/empty/empty': new DefaultFileSystemLocationFingerprint('/foo/empty/empty', FileType.Directory, TestHashCodes.hashCodeFrom(123)),
+                        '/foo/sub': new DefaultFileSystemLocationFingerprint('/foo/sub', FileType.Directory, TestHashCodes.hashCodeFrom(123)),
                     ]
                     getSnapshot() >> snapshots
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResultTest.groovy
@@ -50,7 +50,7 @@ import org.gradle.internal.fingerprint.NameOnlyInputNormalizer
 import org.gradle.internal.fingerprint.OutputNormalizer
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.TestSnapshotFixture
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -130,10 +130,10 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('foo',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> HashCode.fromInt(345)
+                    getHash() >> TestHashCode.fromInt(345)
                     getFingerprints() >> [
-                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, HashCode.fromInt(123)),
-                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, HashCode.fromInt(234)),
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCode.fromInt(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCode.fromInt(234)),
                     ]
                     getSnapshot() >> snapshots
                 }
@@ -189,9 +189,9 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('inputFiles',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> HashCode.fromInt(345)
+                    getHash() >> TestHashCode.fromInt(345)
                     getFingerprints() >> [
-                        '/input/foo': new DefaultFileSystemLocationFingerprint('/input/foo', FileType.Directory, HashCode.fromInt(123))
+                        '/input/foo': new DefaultFileSystemLocationFingerprint('/input/foo', FileType.Directory, TestHashCode.fromInt(123))
                     ]
                     getSnapshot() >> snapshots
                 }
@@ -247,14 +247,14 @@ class SnapshotTaskInputsBuildOperationResultTest extends Specification implement
         def beforeExecutionState = Mock(BeforeExecutionState) {
             getInputFileProperties() >> ImmutableSortedMap.of('foo',
                 Mock(CurrentFileCollectionFingerprint) {
-                    getHash() >> HashCode.fromInt(345)
+                    getHash() >> TestHashCode.fromInt(345)
                     getFingerprints() >> [
-                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, HashCode.fromInt(123)),
-                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, HashCode.fromInt(234)),
-                        '/foo': new DefaultFileSystemLocationFingerprint('/foo', FileType.Directory, HashCode.fromInt(123)),
-                        '/foo/empty': new DefaultFileSystemLocationFingerprint('/foo/empty', FileType.Directory, HashCode.fromInt(123)),
-                        '/foo/empty/empty': new DefaultFileSystemLocationFingerprint('/foo/empty/empty', FileType.Directory, HashCode.fromInt(123)),
-                        '/foo/sub': new DefaultFileSystemLocationFingerprint('/foo/sub', FileType.Directory, HashCode.fromInt(123)),
+                        '/foo/one.txt': new DefaultFileSystemLocationFingerprint('/foo/one.txt', FileType.RegularFile, TestHashCode.fromInt(123)),
+                        '/foo/sub/two.txt': new DefaultFileSystemLocationFingerprint('/foo/sub/two.txt', FileType.RegularFile, TestHashCode.fromInt(234)),
+                        '/foo': new DefaultFileSystemLocationFingerprint('/foo', FileType.Directory, TestHashCode.fromInt(123)),
+                        '/foo/empty': new DefaultFileSystemLocationFingerprint('/foo/empty', FileType.Directory, TestHashCode.fromInt(123)),
+                        '/foo/empty/empty': new DefaultFileSystemLocationFingerprint('/foo/empty/empty', FileType.Directory, TestHashCode.fromInt(123)),
+                        '/foo/sub': new DefaultFileSystemLocationFingerprint('/foo/sub', FileType.Directory, TestHashCode.fromInt(123)),
                     ]
                     getSnapshot() >> snapshots
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -76,6 +76,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.logging.StandardOutputCapture
 import org.gradle.internal.operations.BuildOperationContext
@@ -104,10 +105,10 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def task = Mock(TaskInternal)
     def taskOutputs = Mock(TaskOutputsInternal)
     def action1 = Mock(InputChangesAwareTaskAction) {
-        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action1", HashCode.fromInt(1234))
+        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action1", TestHashCode.fromInt(1234))
     }
     def action2 = Mock(InputChangesAwareTaskAction) {
-        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action2", HashCode.fromInt(1234))
+        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action2", TestHashCode.fromInt(1234))
     }
     def state = new TaskStateInternal()
     def taskProperties = Stub(TaskProperties) {
@@ -150,7 +151,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def classloaderHierarchyHasher = new ClassLoaderHierarchyHasher() {
         @Override
         HashCode getClassLoaderHash(ClassLoader classLoader) {
-            return HashCode.fromInt(1234)
+            return TestHashCode.fromInt(1234)
         }
     }
     def valueSnapshotter = new DefaultValueSnapshotter([], classloaderHierarchyHasher)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -76,7 +76,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.logging.StandardOutputCapture
 import org.gradle.internal.operations.BuildOperationContext
@@ -105,10 +105,10 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def task = Mock(TaskInternal)
     def taskOutputs = Mock(TaskOutputsInternal)
     def action1 = Mock(InputChangesAwareTaskAction) {
-        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action1", TestHashCode.fromInt(1234))
+        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action1", TestHashCodes.hashCodeFrom(1234))
     }
     def action2 = Mock(InputChangesAwareTaskAction) {
-        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action2", TestHashCode.fromInt(1234))
+        getActionImplementation(_ as ClassLoaderHierarchyHasher) >> ImplementationSnapshot.of("Action2", TestHashCodes.hashCodeFrom(1234))
     }
     def state = new TaskStateInternal()
     def taskProperties = Stub(TaskProperties) {
@@ -151,7 +151,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def classloaderHierarchyHasher = new ClassLoaderHierarchyHasher() {
         @Override
         HashCode getClassLoaderHash(ClassLoader classLoader) {
-            return TestHashCode.fromInt(1234)
+            return TestHashCodes.hashCodeFrom(1234)
         }
     }
     def valueSnapshotter = new DefaultValueSnapshotter([], classloaderHierarchyHasher)

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.cache.internal.scopes.DefaultGlobalScopedCache
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.vfs.FileSystemAccess
@@ -238,7 +238,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
 
         and:
         interaction {
-            snapshotRegularFile(file, TestHashCode.fromInt(123))
+            snapshotRegularFile(file, TestHashCodes.hashCodeFrom(123))
         }
         1 * calculator.calculate(file, true) >> 12
         0 * _
@@ -252,13 +252,13 @@ class DefaultFileContentCacheFactoryTest extends Specification {
 
         and:
         interaction {
-            snapshotRegularFile(file, TestHashCode.fromInt(321))
+            snapshotRegularFile(file, TestHashCodes.hashCodeFrom(321))
         }
         1 * calculator.calculate(file, true) >> 10
         0 * _
     }
 
-    def snapshotRegularFile(File file, HashCode hashCode = TestHashCode.fromInt(123)) {
+    def snapshotRegularFile(File file, HashCode hashCode = TestHashCodes.hashCodeFrom(123)) {
         1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), _) >> { location, function ->
             return Optional.ofNullable(function.apply(hashCode))
         }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.cache.internal.scopes.DefaultGlobalScopedCache
 import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.execution.OutputChangeListener
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.service.scopes.Scopes
 import org.gradle.internal.vfs.FileSystemAccess
@@ -237,7 +238,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
 
         and:
         interaction {
-            snapshotRegularFile(file, HashCode.fromInt(123))
+            snapshotRegularFile(file, TestHashCode.fromInt(123))
         }
         1 * calculator.calculate(file, true) >> 12
         0 * _
@@ -251,13 +252,13 @@ class DefaultFileContentCacheFactoryTest extends Specification {
 
         and:
         interaction {
-            snapshotRegularFile(file, HashCode.fromInt(321))
+            snapshotRegularFile(file, TestHashCode.fromInt(321))
         }
         1 * calculator.calculate(file, true) >> 10
         0 * _
     }
 
-    def snapshotRegularFile(File file, HashCode hashCode = HashCode.fromInt(123)) {
+    def snapshotRegularFile(File file, HashCode hashCode = TestHashCode.fromInt(123)) {
         1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), _) >> { location, function ->
             return Optional.ofNullable(function.apply(hashCode))
         }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.groovy.scripts.internal.NoDataCompileOperation
 import org.gradle.internal.Factory
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -83,7 +83,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurations.getByName(ScriptHandler.CLASSPATH_CONFIGURATION) >> configuration
         configuration.getFiles() >> Collections.emptySet()
         baseScope.getExportClassLoader() >> baseChildClassLoader
-        classpathHasher.hash(_ as ClassPath) >> TestHashCode.fromInt(123)
+        classpathHasher.hash(_ as ClassPath) >> TestHashCodes.hashCodeFrom(123)
 
         1 * autoAppliedPluginHandler.mergeWithAutoAppliedPlugins(_, _) >> PluginRequests.EMPTY
     }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultScriptPluginFactoryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.groovy.scripts.internal.NoDataCompileOperation
 import org.gradle.internal.Factory
 import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -83,7 +83,7 @@ class DefaultScriptPluginFactoryTest extends Specification {
         configurations.getByName(ScriptHandler.CLASSPATH_CONFIGURATION) >> configuration
         configuration.getFiles() >> Collections.emptySet()
         baseScope.getExportClassLoader() >> baseChildClassLoader
-        classpathHasher.hash(_ as ClassPath) >> HashCode.fromInt(123)
+        classpathHasher.hash(_ as ClassPath) >> TestHashCode.fromInt(123)
 
         1 * autoAppliedPluginHandler.mergeWithAutoAppliedPlugins(_, _) >> PluginRequests.EMPTY
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/DefaultClasspathFingerprinterTest.groovy
@@ -121,7 +121,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
         then:
 
         fileCollectionFingerprint == [
-            ['library.jar', '', '397fdb436f96f0ebac6c1e147eb1cc51'],
+            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
             ['fourthFile.txt', 'fourthFile.txt', '37b040e234b12a70145edbdb79683ee9'],
             ['build.log', 'subdir/build.log', '224c45bdc38a7e3c52cdcc6126d78946'],
             ['thirdFile.txt', 'thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
@@ -129,7 +129,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         resourceHashesCache.keySet().size() == 1
         def key = resourceHashesCache.keySet().iterator().next()
-        resourceHashesCache.getIfPresent(key).toString() == '397fdb436f96f0ebac6c1e147eb1cc51'
+        resourceHashesCache.getIfPresent(key).toString() == 'e3f8c5a79d138a40570261fa7de40642'
     }
 
     def "detects moving of files in jars and directories"() {
@@ -147,7 +147,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
         def fileCollectionFingerprint = fingerprint(zipFile, classes)
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', '23f0ce5817e3d0db8abc266027e0793d'],
+            ['library.jar', '', 'eaafc4a09214a09ffe2de2d02d5abd3c'],
             ['thirdFile.txt', 'thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
         ]
 
@@ -160,7 +160,7 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', '78a21c0d0074d113b7446695184fb8e0'],
+            ['library.jar', '', 'c23694a1b7e494fab2aa21f5d644d0bc'],
             ['thirdFile.txt', 'subdir/thirdFile.txt', '138f1960a77eecec5f03362421bf967a'],
         ]
     }
@@ -189,12 +189,12 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', '397fdb436f96f0ebac6c1e147eb1cc51'],
-            ['another-library.jar', '', 'e9fa562dd3fd73bfa315b0f9876c2b6e']
+            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
+            ['another-library.jar', '', '5d9e97561e1c86c891600c8df838f7de']
         ]
         resourceHashesCache.keySet().size() == 2
         def values = resourceHashesCache.keySet().collect { resourceHashesCache.getIfPresent(it).toString() } as Set
-        values == ['397fdb436f96f0ebac6c1e147eb1cc51', 'e9fa562dd3fd73bfa315b0f9876c2b6e'] as Set
+        values == ['e3f8c5a79d138a40570261fa7de40642', '5d9e97561e1c86c891600c8df838f7de'] as Set
 
         when:
         fileCollectionFingerprint = fingerprint(zipFile, zipFile2)
@@ -202,11 +202,11 @@ class DefaultClasspathFingerprinterTest extends Specification {
 
         then:
         fileCollectionFingerprint == [
-            ['library.jar', '', '397fdb436f96f0ebac6c1e147eb1cc51'],
-            ['another-library.jar', '', 'e9fa562dd3fd73bfa315b0f9876c2b6e']
+            ['library.jar', '', 'e3f8c5a79d138a40570261fa7de40642'],
+            ['another-library.jar', '', '5d9e97561e1c86c891600c8df838f7de']
         ]
         resourceHashesCache.keySet().size() == 2
-        values == ['397fdb436f96f0ebac6c1e147eb1cc51', 'e9fa562dd3fd73bfa315b0f9876c2b6e'] as Set
+        values == ['e3f8c5a79d138a40570261fa7de40642', '5d9e97561e1c86c891600c8df838f7de'] as Set
     }
 
     def "empty jars are not ignored"() {
@@ -221,8 +221,8 @@ class DefaultClasspathFingerprinterTest extends Specification {
         def classpathFingerprint = fingerprint(emptyJar, nonEmptyJar)
         then:
         classpathFingerprint == [
-            ['empty.jar', '', 'b4ffe6c04c447ca2bf8e1659ba078d13'],
-            ['nonEmpty.jar', '', '02e567c3be8a015bbcad37ec10d32b45']
+            ['empty.jar', '', '73aaa2573075495cce6048c54637763c'],
+            ['nonEmpty.jar', '', '252a9e49dedde612c99dd76008d11b03']
         ]
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.FileHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.RegularFileSnapshot
@@ -30,8 +30,8 @@ import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.gradle.util.internal.TextUtil
 import org.gradle.util.UsesNativeServices
+import org.gradle.util.internal.TextUtil
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -47,7 +47,7 @@ class FileSystemSnapshotBuilderTest extends Specification {
     }
     def hasher = Stub(FileHasher) {
         hash(_, _, _) >> {
-            HashCode.fromInt(1234)
+            TestHashCode.fromInt(1234)
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/impl/FileSystemSnapshotBuilderTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.FileHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.RegularFileSnapshot
@@ -47,7 +47,7 @@ class FileSystemSnapshotBuilderTest extends Specification {
     }
     def hasher = Stub(FileHasher) {
         hash(_, _, _) >> {
-            TestHashCode.fromInt(1234)
+            TestHashCodes.hashCodeFrom(1234)
         }
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
@@ -19,6 +19,7 @@ package org.gradle.util
 
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.isolation.IsolatableFactory
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.internal.snapshot.impl.DefaultIsolatableFactory
@@ -44,7 +45,7 @@ class SnapshotTestUtil {
         return new ClassLoaderHierarchyHasher() {
             @Override
             HashCode getClassLoaderHash(ClassLoader classLoader) {
-                return HashCode.fromInt(classLoader.hashCode())
+                return TestHashCode.fromInt(classLoader.hashCode())
             }
         };
     }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/SnapshotTestUtil.groovy
@@ -19,7 +19,7 @@ package org.gradle.util
 
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.isolation.IsolatableFactory
 import org.gradle.internal.snapshot.ValueSnapshotter
 import org.gradle.internal.snapshot.impl.DefaultIsolatableFactory
@@ -45,7 +45,7 @@ class SnapshotTestUtil {
         return new ClassLoaderHierarchyHasher() {
             @Override
             HashCode getClassLoaderHash(ClassLoader classLoader) {
-                return TestHashCode.fromInt(classLoader.hashCode())
+                return TestHashCodes.hashCodeFrom(classLoader.hashCode())
             }
         };
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/DefaultSignatureVerificationServiceFactory.java
@@ -28,6 +28,7 @@ import org.gradle.cache.scopes.GlobalScopedCache;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resource.ExternalResourceRepository;
 import org.gradle.internal.service.scopes.Scopes;
@@ -54,7 +55,7 @@ import static org.gradle.security.internal.SecuritySupport.toLongIdHexString;
 @ServiceScope(Scopes.Build.class)
 public class DefaultSignatureVerificationServiceFactory implements SignatureVerificationServiceFactory {
 
-    private static final HashCode NO_KEYRING_FILE_HASH = HashCode.fromInt(Boolean.hashCode(false));
+    private static final HashCode NO_KEYRING_FILE_HASH = Hashing.signature(DefaultSignatureVerificationServiceFactory.class);
 
     private final RepositoryTransportFactory transportFactory;
     private final GlobalScopedCache cacheRepository;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import org.gradle.internal.file.FileAccessTracker
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.Serializer
@@ -52,7 +52,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def key = new ArtifactAtRepositoryKey("RepoID", Stub(ModuleComponentArtifactIdentifier))
 
         when:
-        index.store(key, null, HashCode.fromInt(0))
+        index.store(key, null, TestHashCode.fromInt(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -61,7 +61,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
 
     def "artifact key must be provided"() {
         when:
-        index.store(null, Stub(File), HashCode.fromInt(0))
+        index.store(null, Stub(File), TestHashCode.fromInt(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -75,14 +75,14 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def testFile = folder.createFile("aTestFile")
 
         when:
-        index.store(key, testFile, HashCode.fromInt(10))
+        index.store(key, testFile, TestHashCode.fromInt(10))
 
         then:
         1 * cacheLockingManager.useCache(_) >> { Runnable action -> action.run() }
         1 * timeProvider.currentTime >> 123
         1 * persistentIndexedCache.put(key, _) >> { k, v ->
             assert v.cachedAt == 123
-            assert v.descriptorHash == HashCode.fromInt(10)
+            assert v.descriptorHash == TestHashCode.fromInt(10)
             assert v.cachedFile == testFile
         }
     }
@@ -139,7 +139,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         2 * cachedArtifact.isMissing() >> false
         1 * cachedArtifact.cachedAt >> 42L
-        1 * cachedArtifact.getDescriptorHash() >> HashCode.fromInt(42)
+        1 * cachedArtifact.getDescriptorHash() >> TestHashCode.fromInt(42)
         1 * cachedArtifact.getCachedFile() >> commonRootPath.resolve("file.txt").toFile()
 
         1 * encoder.writeString("file.txt")
@@ -157,7 +157,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         1 * decoder.readBoolean() >> false
         1 * decoder.readLong() >> 42L
-        1 * decoder.readBinary() >> HashCode.fromInt(42).toByteArray()
+        1 * decoder.readBinary() >> TestHashCode.fromInt(42).toByteArray()
         1 * decoder.readString() >> fileName
 
         cachedArtifact.getCachedFile() == commonRootPath.resolve(fileName).toFile()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/artifacts/DefaultModuleArtifactCacheTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.cache.PersistentIndexedCache
 import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import org.gradle.internal.file.FileAccessTracker
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.Encoder
 import org.gradle.internal.serialize.Serializer
@@ -52,7 +52,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def key = new ArtifactAtRepositoryKey("RepoID", Stub(ModuleComponentArtifactIdentifier))
 
         when:
-        index.store(key, null, TestHashCode.fromInt(0))
+        index.store(key, null, TestHashCodes.hashCodeFrom(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -61,7 +61,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
 
     def "artifact key must be provided"() {
         when:
-        index.store(null, Stub(File), TestHashCode.fromInt(0))
+        index.store(null, Stub(File), TestHashCodes.hashCodeFrom(0))
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -75,14 +75,14 @@ class DefaultModuleArtifactCacheTest extends Specification {
         def testFile = folder.createFile("aTestFile")
 
         when:
-        index.store(key, testFile, TestHashCode.fromInt(10))
+        index.store(key, testFile, TestHashCodes.hashCodeFrom(10))
 
         then:
         1 * cacheLockingManager.useCache(_) >> { Runnable action -> action.run() }
         1 * timeProvider.currentTime >> 123
         1 * persistentIndexedCache.put(key, _) >> { k, v ->
             assert v.cachedAt == 123
-            assert v.descriptorHash == TestHashCode.fromInt(10)
+            assert v.descriptorHash == TestHashCodes.hashCodeFrom(10)
             assert v.cachedFile == testFile
         }
     }
@@ -139,7 +139,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         2 * cachedArtifact.isMissing() >> false
         1 * cachedArtifact.cachedAt >> 42L
-        1 * cachedArtifact.getDescriptorHash() >> TestHashCode.fromInt(42)
+        1 * cachedArtifact.getDescriptorHash() >> TestHashCodes.hashCodeFrom(42)
         1 * cachedArtifact.getCachedFile() >> commonRootPath.resolve("file.txt").toFile()
 
         1 * encoder.writeString("file.txt")
@@ -157,7 +157,7 @@ class DefaultModuleArtifactCacheTest extends Specification {
         then:
         1 * decoder.readBoolean() >> false
         1 * decoder.readLong() >> 42L
-        1 * decoder.readBinary() >> TestHashCode.fromInt(42).toByteArray()
+        1 * decoder.readBinary() >> TestHashCodes.hashCodeFrom(42).toByteArray()
         1 * decoder.readString() >> fileName
 
         cachedArtifact.getCachedFile() == commonRootPath.resolve(fileName).toFile()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -60,6 +60,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -80,7 +81,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     def mutableTransformsStoreDirectory = temporaryFolder.file("child/build/transforms")
 
     def classloaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_ as ClassLoader) >> HashCode.fromInt(1234)
+        getClassLoaderHash(_ as ClassLoader) >> TestHashCode.fromInt(1234)
     }
     def valueSnapshotter = new DefaultValueSnapshotter([], classloaderHasher)
 
@@ -170,7 +171,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         private final HashCode secondaryInputsHash
         private final BiFunction<File, File, List<File>> transformationAction
 
-        static TestTransformer create(HashCode secondaryInputsHash = HashCode.fromInt(1234), BiFunction<File, File, List<File>> transformationAction) {
+        static TestTransformer create(HashCode secondaryInputsHash = TestHashCode.fromInt(1234), BiFunction<File, File, List<File>> transformationAction) {
             return new TestTransformer(secondaryInputsHash, transformationAction)
         }
 
@@ -382,8 +383,8 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer1 = TestTransformer.create(HashCode.fromInt(1234), transformationAction)
-        def transformer2 = TestTransformer.create(HashCode.fromInt(4321), transformationAction)
+        def transformer1 = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
+        def transformer2 = TestTransformer.create(TestHashCode.fromInt(4321), transformationAction)
 
         def subject = dependency(transformationType, inputArtifact)
         when:
@@ -409,7 +410,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(HashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
         when:
         invoke(transformer, inputArtifact1, dependencies, dependency(transformationType, inputArtifact1), inputFingerprinter)
         then:
@@ -436,7 +437,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(HashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
         def subject = immutableDependency(inputArtifact)
 
         when:
@@ -462,7 +463,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(HashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
         def subject = mutableDependency(inputArtifact)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -60,7 +60,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.operations.CurrentBuildOperationRef
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -81,7 +81,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     def mutableTransformsStoreDirectory = temporaryFolder.file("child/build/transforms")
 
     def classloaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_ as ClassLoader) >> TestHashCode.fromInt(1234)
+        getClassLoaderHash(_ as ClassLoader) >> TestHashCodes.hashCodeFrom(1234)
     }
     def valueSnapshotter = new DefaultValueSnapshotter([], classloaderHasher)
 
@@ -171,7 +171,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         private final HashCode secondaryInputsHash
         private final BiFunction<File, File, List<File>> transformationAction
 
-        static TestTransformer create(HashCode secondaryInputsHash = TestHashCode.fromInt(1234), BiFunction<File, File, List<File>> transformationAction) {
+        static TestTransformer create(HashCode secondaryInputsHash = TestHashCodes.hashCodeFrom(1234), BiFunction<File, File, List<File>> transformationAction) {
             return new TestTransformer(secondaryInputsHash, transformationAction)
         }
 
@@ -383,8 +383,8 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer1 = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
-        def transformer2 = TestTransformer.create(TestHashCode.fromInt(4321), transformationAction)
+        def transformer1 = TestTransformer.create(TestHashCodes.hashCodeFrom(1234), transformationAction)
+        def transformer2 = TestTransformer.create(TestHashCodes.hashCodeFrom(4321), transformationAction)
 
         def subject = dependency(transformationType, inputArtifact)
         when:
@@ -410,7 +410,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCodes.hashCodeFrom(1234), transformationAction)
         when:
         invoke(transformer, inputArtifact1, dependencies, dependency(transformationType, inputArtifact1), inputFingerprinter)
         then:
@@ -437,7 +437,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCodes.hashCodeFrom(1234), transformationAction)
         def subject = immutableDependency(inputArtifact)
 
         when:
@@ -463,7 +463,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
             outputFile.text = input.text + " transformed"
             return ImmutableList.of(outputFile)
         }
-        def transformer = TestTransformer.create(TestHashCode.fromInt(1234), transformationAction)
+        def transformer = TestTransformer.create(TestHashCodes.hashCodeFrom(1234), transformationAction)
         def subject = mutableDependency(inputArtifact)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.execution.fingerprint.InputFingerprinter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.isolation.TestIsolatableFactory
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.service.ServiceLookup
@@ -102,7 +102,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, Stub(ServiceRegistry), registryFactory, instantiatorFactory.injectScheme())
 
     def "setup"() {
-        _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> HashCode.fromInt(123)
+        _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> TestHashCode.fromInt(123)
     }
 
     def "creates legacy registration without parameters"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -36,7 +36,7 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.execution.fingerprint.InputFingerprinter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.isolation.TestIsolatableFactory
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.service.ServiceLookup
@@ -102,7 +102,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, Stub(ServiceRegistry), registryFactory, instantiatorFactory.injectScheme())
 
     def "setup"() {
-        _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> TestHashCode.fromInt(123)
+        _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> TestHashCodes.hashCodeFrom(123)
     }
 
     def "creates legacy registration without parameters"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
@@ -43,7 +43,7 @@ import org.gradle.internal.component.external.model.VariantDerivationStrategy
 import org.gradle.internal.component.model.MutableModuleSources
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.snapshot.ValueSnapshot
@@ -105,7 +105,7 @@ class ComponentMetadataRuleExecutorTest extends Specification {
     @Unroll("Cache expiry check refresh = #mustRefresh - #scenario - #ruleClass")
     def "expires entry when cache policy tells us to"() {
         def id = DefaultModuleVersionIdentifier.newId('org', 'foo', '1.0')
-        def hashValue = TestHashCode.fromInt(42)
+        def hashValue = TestHashCodes.hashCodeFrom(42)
         def key = Mock(ModuleComponentResolveMetadata)
         def inputsSnapshot = new StringValueSnapshot("1")
         def hasher = Hashing.newHasher()
@@ -139,14 +139,14 @@ class ComponentMetadataRuleExecutorTest extends Specification {
         if (expired) {
             // should check that the recorded service call returns the same value
             1 * record.getInput() >> '124'
-            1 * record.getOutput() >> TestHashCode.fromInt(10000)
+            1 * record.getOutput() >> TestHashCodes.hashCodeFrom(10000)
             1 * cachedResult.isChanging() >> changing
             1 * cachedResult.getModuleVersionId() >> id
             1 * cachePolicy.moduleExpiry({ it.id == id }, Duration.ZERO, changing) >> Stub(Expiry) {
                 isMustCheck() >> false
             }
             // we make it return false, this should invalidate the cache
-            1 * someService.isUpToDate('124', TestHashCode.fromInt(10000)) >> false
+            1 * someService.isUpToDate('124', TestHashCodes.hashCodeFrom(10000)) >> false
         } else {
             1 * cachedResult.isChanging() >> changing
             1 * cachedResult.getModuleVersionId() >> id

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/caching/ComponentMetadataRuleExecutorTest.groovy
@@ -43,6 +43,7 @@ import org.gradle.internal.component.external.model.VariantDerivationStrategy
 import org.gradle.internal.component.model.MutableModuleSources
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.Serializer
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.snapshot.ValueSnapshot
@@ -104,7 +105,7 @@ class ComponentMetadataRuleExecutorTest extends Specification {
     @Unroll("Cache expiry check refresh = #mustRefresh - #scenario - #ruleClass")
     def "expires entry when cache policy tells us to"() {
         def id = DefaultModuleVersionIdentifier.newId('org', 'foo', '1.0')
-        def hashValue = HashCode.fromInt(42)
+        def hashValue = TestHashCode.fromInt(42)
         def key = Mock(ModuleComponentResolveMetadata)
         def inputsSnapshot = new StringValueSnapshot("1")
         def hasher = Hashing.newHasher()
@@ -138,14 +139,14 @@ class ComponentMetadataRuleExecutorTest extends Specification {
         if (expired) {
             // should check that the recorded service call returns the same value
             1 * record.getInput() >> '124'
-            1 * record.getOutput() >> HashCode.fromInt(10000)
+            1 * record.getOutput() >> TestHashCode.fromInt(10000)
             1 * cachedResult.isChanging() >> changing
             1 * cachedResult.getModuleVersionId() >> id
             1 * cachePolicy.moduleExpiry({ it.id == id }, Duration.ZERO, changing) >> Stub(Expiry) {
                 isMustCheck() >> false
             }
             // we make it return false, this should invalidate the cache
-            1 * someService.isUpToDate('124', HashCode.fromInt(10000)) >> false
+            1 * someService.isUpToDate('124', TestHashCode.fromInt(10000)) >> false
         } else {
             1 * cachedResult.isChanging() >> changing
             1 * cachedResult.getModuleVersionId() >> id

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.cached
 
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
 import org.gradle.internal.file.FileAccessTracker
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -68,7 +68,7 @@ class DefaultArtifactResolutionCacheTest extends Specification {
 
         where:
         lastModified | contentType | etag   | sha1
-        new Date()   | "something" | "etag" | HashCode.fromInt(123456)
+        new Date()   | "something" | "etag" | TestHashCode.fromInt(123456)
         null         | null        | null   | null
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/cached/DefaultArtifactResolutionCacheTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.resource.cached
 
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManagerStub
 import org.gradle.internal.file.FileAccessTracker
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.resource.metadata.DefaultExternalResourceMetaData
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -68,7 +68,7 @@ class DefaultArtifactResolutionCacheTest extends Specification {
 
         where:
         lastModified | contentType | etag   | sha1
-        new Date()   | "something" | "etag" | TestHashCode.fromInt(123456)
+        new Date()   | "something" | "etag" | TestHashCodes.hashCodeFrom(123456)
         null         | null        | null   | null
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -11,7 +11,9 @@ We would like to thank the following community members for their contributions t
 [Stefan Neuhaus](https://github.com/stefanneuhaus),
 [George Thomas](https://github.com/smoothreggae),
 [Anja Papatola](https://github.com/apalopta),
-[Björn Kautler](https://github.com/Vampire)
+[Björn Kautler](https://github.com/Vampire),
+[David Burström](https://github.com/davidburstrom),
+[Vladimir Sitnikov](https://github.com/vlsi)
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -68,6 +68,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.reflect.problems.ValidationProblemId
@@ -115,7 +116,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def classloaderHierarchyHasher = new ClassLoaderHierarchyHasher() {
         @Override
         HashCode getClassLoaderHash(ClassLoader classLoader) {
-            return HashCode.fromInt(1234)
+            return TestHashCode.fromInt(1234)
         }
     }
     def outputFilesRepository = Stub(OutputFilesRepository) {
@@ -423,7 +424,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         expect:
         execute(unitOfWork)
         outOfDate(
-            builder.withImplementation(ImplementationSnapshot.of("DifferentType", HashCode.fromInt(1234))).build(),
+            builder.withImplementation(ImplementationSnapshot.of("DifferentType", TestHashCode.fromInt(1234))).build(),
             "The type of ${unitOfWork.displayName} has changed from 'org.gradle.internal.execution.UnitOfWork' to 'DifferentType'."
         )
     }
@@ -758,7 +759,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         private Map<String, ? extends File> outputFiles = IncrementalExecutionIntegrationTest.this.outputFiles
         private Map<String, ? extends File> outputDirs = IncrementalExecutionIntegrationTest.this.outputDirs
         private Collection<? extends TestFile> create = createFiles
-        private ImplementationSnapshot implementation = ImplementationSnapshot.of(UnitOfWork.name, HashCode.fromInt(1234))
+        private ImplementationSnapshot implementation = ImplementationSnapshot.of(UnitOfWork.name, TestHashCode.fromInt(1234))
         private Consumer<WorkValidationContext> validator
 
         UnitOfWorkBuilder withWork(Supplier<UnitOfWork.WorkResult> closure) {

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -68,7 +68,7 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionSnapshotter
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.reflect.problems.ValidationProblemId
@@ -116,7 +116,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def classloaderHierarchyHasher = new ClassLoaderHierarchyHasher() {
         @Override
         HashCode getClassLoaderHash(ClassLoader classLoader) {
-            return TestHashCode.fromInt(1234)
+            return TestHashCodes.hashCodeFrom(1234)
         }
     }
     def outputFilesRepository = Stub(OutputFilesRepository) {
@@ -424,7 +424,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         expect:
         execute(unitOfWork)
         outOfDate(
-            builder.withImplementation(ImplementationSnapshot.of("DifferentType", TestHashCode.fromInt(1234))).build(),
+            builder.withImplementation(ImplementationSnapshot.of("DifferentType", TestHashCodes.hashCodeFrom(1234))).build(),
             "The type of ${unitOfWork.displayName} has changed from 'org.gradle.internal.execution.UnitOfWork' to 'DifferentType'."
         )
     }
@@ -759,7 +759,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         private Map<String, ? extends File> outputFiles = IncrementalExecutionIntegrationTest.this.outputFiles
         private Map<String, ? extends File> outputDirs = IncrementalExecutionIntegrationTest.this.outputDirs
         private Collection<? extends TestFile> create = createFiles
-        private ImplementationSnapshot implementation = ImplementationSnapshot.of(UnitOfWork.name, TestHashCode.fromInt(1234))
+        private ImplementationSnapshot implementation = ImplementationSnapshot.of(UnitOfWork.name, TestHashCodes.hashCodeFrom(1234))
         private Consumer<WorkValidationContext> validator
 
         UnitOfWorkBuilder withWork(Supplier<UnitOfWork.WorkResult> closure) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.execution.history.impl.SerializableFileCollectionFing
 import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 class ClasspathCompareStrategyTest extends Specification {
@@ -171,19 +171,19 @@ class ClasspathCompareStrategyTest extends Specification {
 
     def changes(Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
         def visitor = new CollectingChangeVisitor()
-        def strategyConfigurationHash = TestHashCode.fromInt(1234)
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCode.fromInt(1234)), strategyConfigurationHash)
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCode.fromInt(4321)), strategyConfigurationHash)
+        def strategyConfigurationHash = TestHashCodes.hashCodeFrom(1234)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCodes.hashCodeFrom(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCodes.hashCodeFrom(4321)), strategyConfigurationHash)
         CLASSPATH.visitChangesSince(previousFingerprint, currentFingerprint, "test", visitor)
         visitor.getChanges().toList()
     }
 
     def fingerprint(String normalizedPath, def hashCode = 0x1234abcd) {
-        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCode.fromInt((int) hashCode))
+        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCodes.hashCodeFrom((int) hashCode))
     }
 
     def jar(int hashCode) {
-        return new DefaultFileSystemLocationFingerprint("", FileType.RegularFile, TestHashCode.fromInt(hashCode))
+        return new DefaultFileSystemLocationFingerprint("", FileType.RegularFile, TestHashCodes.hashCodeFrom(hashCode))
     }
 
     def added(String path) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ClasspathCompareStrategyTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.execution.history.impl.SerializableFileCollectionFing
 import org.gradle.internal.file.FileType
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 class ClasspathCompareStrategyTest extends Specification {
@@ -171,19 +171,19 @@ class ClasspathCompareStrategyTest extends Specification {
 
     def changes(Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
         def visitor = new CollectingChangeVisitor()
-        def strategyConfigurationHash = HashCode.fromInt(1234)
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)), strategyConfigurationHash)
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", HashCode.fromInt(4321)), strategyConfigurationHash)
+        def strategyConfigurationHash = TestHashCode.fromInt(1234)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCode.fromInt(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCode.fromInt(4321)), strategyConfigurationHash)
         CLASSPATH.visitChangesSince(previousFingerprint, currentFingerprint, "test", visitor)
         visitor.getChanges().toList()
     }
 
     def fingerprint(String normalizedPath, def hashCode = 0x1234abcd) {
-        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, HashCode.fromInt((int) hashCode))
+        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCode.fromInt((int) hashCode))
     }
 
     def jar(int hashCode) {
-        return new DefaultFileSystemLocationFingerprint("", FileType.RegularFile, HashCode.fromInt(hashCode))
+        return new DefaultFileSystemLocationFingerprint("", FileType.RegularFile, TestHashCode.fromInt(hashCode))
     }
 
     def added(String path) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.EmptyCurrentFileCollectionFingerprint
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 class FingerprintCompareStrategyTest extends Specification {
@@ -268,10 +268,10 @@ class FingerprintCompareStrategyTest extends Specification {
     def "comparing regular snapshot to empty snapshot shows entries removed (strategy: #strategy)"() {
         def fingerprint = Mock(FileCollectionFingerprint) {
             getFingerprints() >> [
-                "file1.txt": new DefaultFileSystemLocationFingerprint("file1.txt", FileType.RegularFile, TestHashCode.fromInt(123)),
-                "file2.txt": new DefaultFileSystemLocationFingerprint("file2.txt", FileType.RegularFile, TestHashCode.fromInt(234)),
+                "file1.txt": new DefaultFileSystemLocationFingerprint("file1.txt", FileType.RegularFile, TestHashCodes.hashCodeFrom(123)),
+                "file2.txt": new DefaultFileSystemLocationFingerprint("file2.txt", FileType.RegularFile, TestHashCodes.hashCodeFrom(234)),
             ]
-            getRootHashes() >> ImmutableMultimap.of('/dir', TestHashCode.fromInt(456))
+            getRootHashes() >> ImmutableMultimap.of('/dir', TestHashCodes.hashCodeFrom(456))
         }
         def emptyFingerprint = new EmptyCurrentFileCollectionFingerprint("test")
         expect:
@@ -297,9 +297,9 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def changes(FingerprintCompareStrategy strategy, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
-        def strategyConfigurationHash = TestHashCode.fromInt(5432)
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCode.fromInt(1234)), strategyConfigurationHash)
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCode.fromInt(4321)), strategyConfigurationHash)
+        def strategyConfigurationHash = TestHashCodes.hashCodeFrom(5432)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCodes.hashCodeFrom(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCodes.hashCodeFrom(4321)), strategyConfigurationHash)
         changes(strategy, currentFingerprint, previousFingerprint)
     }
 
@@ -310,7 +310,7 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def fingerprint(String normalizedPath, def hashCode = 0x1234abcd) {
-        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCode.fromInt((int) hashCode))
+        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCodes.hashCodeFrom((int) hashCode))
     }
 
     def added(String path) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/FingerprintCompareStrategyTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.EmptyCurrentFileCollectionFingerprint
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 class FingerprintCompareStrategyTest extends Specification {
@@ -268,10 +268,10 @@ class FingerprintCompareStrategyTest extends Specification {
     def "comparing regular snapshot to empty snapshot shows entries removed (strategy: #strategy)"() {
         def fingerprint = Mock(FileCollectionFingerprint) {
             getFingerprints() >> [
-                "file1.txt": new DefaultFileSystemLocationFingerprint("file1.txt", FileType.RegularFile, HashCode.fromInt(123)),
-                "file2.txt": new DefaultFileSystemLocationFingerprint("file2.txt", FileType.RegularFile, HashCode.fromInt(234)),
+                "file1.txt": new DefaultFileSystemLocationFingerprint("file1.txt", FileType.RegularFile, TestHashCode.fromInt(123)),
+                "file2.txt": new DefaultFileSystemLocationFingerprint("file2.txt", FileType.RegularFile, TestHashCode.fromInt(234)),
             ]
-            getRootHashes() >> ImmutableMultimap.of('/dir', HashCode.fromInt(456))
+            getRootHashes() >> ImmutableMultimap.of('/dir', TestHashCode.fromInt(456))
         }
         def emptyFingerprint = new EmptyCurrentFileCollectionFingerprint("test")
         expect:
@@ -297,9 +297,9 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def changes(FingerprintCompareStrategy strategy, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
-        def strategyConfigurationHash = HashCode.fromInt(5432)
-        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", HashCode.fromInt(1234)), strategyConfigurationHash)
-        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", HashCode.fromInt(4321)), strategyConfigurationHash)
+        def strategyConfigurationHash = TestHashCode.fromInt(5432)
+        def currentFingerprint = new SerializableFileCollectionFingerprint(current, ImmutableMultimap.of("some", TestHashCode.fromInt(1234)), strategyConfigurationHash)
+        def previousFingerprint = new SerializableFileCollectionFingerprint(previous, ImmutableMultimap.of("some", TestHashCode.fromInt(4321)), strategyConfigurationHash)
         changes(strategy, currentFingerprint, previousFingerprint)
     }
 
@@ -310,7 +310,7 @@ class FingerprintCompareStrategyTest extends Specification {
     }
 
     def fingerprint(String normalizedPath, def hashCode = 0x1234abcd) {
-        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, HashCode.fromInt((int) hashCode))
+        return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, TestHashCode.fromInt((int) hashCode))
     }
 
     def added(String path) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ImplementationChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ImplementationChangesTest.groovy
@@ -23,12 +23,13 @@ import org.gradle.api.Task
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 import org.gradle.internal.snapshot.impl.KnownImplementationSnapshot
 import spock.lang.Specification
 
 class ImplementationChangesTest extends Specification {
-    def taskLoaderHash = HashCode.fromInt(123)
+    def taskLoaderHash = TestHashCode.fromInt(123)
     def executable = Stub(Describable) {
         getDisplayName() >> "task ':test'"
     }
@@ -50,7 +51,7 @@ class ImplementationChangesTest extends Specification {
     }
 
     def "not up-to-date when class-loader has changed"() {
-        def previousHash = HashCode.fromInt(987)
+        def previousHash = TestHashCode.fromInt(987)
         expect:
         changesBetween(
             impl(SimpleTask, previousHash), [impl(TestAction)],
@@ -59,7 +60,7 @@ class ImplementationChangesTest extends Specification {
     }
 
     def "not up-to-date when action class-loader has changed"() {
-        def previousHash = HashCode.fromInt(987)
+        def previousHash = TestHashCode.fromInt(987)
         expect:
         changesBetween(
             impl(SimpleTask), [impl(TestAction, previousHash)],

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ImplementationChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/ImplementationChangesTest.groovy
@@ -23,13 +23,13 @@ import org.gradle.api.Task
 import org.gradle.api.internal.tasks.InputChangesAwareTaskAction
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 import org.gradle.internal.snapshot.impl.KnownImplementationSnapshot
 import spock.lang.Specification
 
 class ImplementationChangesTest extends Specification {
-    def taskLoaderHash = TestHashCode.fromInt(123)
+    def taskLoaderHash = TestHashCodes.hashCodeFrom(123)
     def executable = Stub(Describable) {
         getDisplayName() >> "task ':test'"
     }
@@ -51,7 +51,7 @@ class ImplementationChangesTest extends Specification {
     }
 
     def "not up-to-date when class-loader has changed"() {
-        def previousHash = TestHashCode.fromInt(987)
+        def previousHash = TestHashCodes.hashCodeFrom(987)
         expect:
         changesBetween(
             impl(SimpleTask, previousHash), [impl(TestAction)],
@@ -60,7 +60,7 @@ class ImplementationChangesTest extends Specification {
     }
 
     def "not up-to-date when action class-loader has changed"() {
-        def previousHash = TestHashCode.fromInt(987)
+        def previousHash = TestHashCodes.hashCodeFrom(987)
         expect:
         changesBetween(
             impl(SimpleTask), [impl(TestAction, previousHash)],

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -33,7 +33,7 @@ class NonIncrementalInputChangesTest extends Specification {
 
     def "can iterate changes more than once"() {
         def fingerprint = DefaultCurrentFileCollectionFingerprint.from(
-            new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
+            new RegularFileSnapshot("/some/where", "where", TestHashCode.fromInt(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
             AbsolutePathFingerprintingStrategy.DEFAULT,
             null
         )

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -33,7 +33,7 @@ class NonIncrementalInputChangesTest extends Specification {
 
     def "can iterate changes more than once"() {
         def fingerprint = DefaultCurrentFileCollectionFingerprint.from(
-            new RegularFileSnapshot("/some/where", "where", TestHashCode.fromInt(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
+            new RegularFileSnapshot("/some/where", "where", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(4, 5, AccessType.DIRECT)),
             AbsolutePathFingerprintingStrategy.DEFAULT,
             null
         )

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetectorTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetectorTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.history.impl
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.MissingFileSnapshot
@@ -41,7 +41,7 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
     }
 
     def "detects overlap when there is a stale root"() {
-        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", TestHashCode.fromInt(1234), DefaultFileMetadata.file(0, 0, AccessType.DIRECT))
+        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(0, 0, AccessType.DIRECT))
         def previousOutputFiles = ImmutableSortedMap.<String, FileSystemSnapshot>of(
             "output", FileSystemSnapshot.EMPTY
         )
@@ -58,8 +58,8 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
     }
 
     def "detects overlap when there is a stale #type in an output directory"() {
-        def emptyDirectory = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCode.fromInt(0x1234), [])
-        def directoryWithStaleBrokenSymlink = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCode.fromInt(0x5678), [
+        def emptyDirectory = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCodes.hashCodeFrom(0x1234), [])
+        def directoryWithStaleBrokenSymlink = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCodes.hashCodeFrom(0x5678), [
             staleEntry
         ])
         def previousOutputFiles = ImmutableSortedMap.<String, FileSystemSnapshot> of(
@@ -78,8 +78,8 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
 
         where:
         type             | staleEntry
-        "file"           | new RegularFileSnapshot("/absolute/path", "path", TestHashCode.fromInt(123), DefaultFileMetadata.file(0L, 0L, AccessType.DIRECT))
-        "directory"      | new DirectorySnapshot("/absolute/path", "path", AccessType.DIRECT, TestHashCode.fromInt(123), [])
+        "file"           | new RegularFileSnapshot("/absolute/path", "path", TestHashCodes.hashCodeFrom(123), DefaultFileMetadata.file(0L, 0L, AccessType.DIRECT))
+        "directory"      | new DirectorySnapshot("/absolute/path", "path", AccessType.DIRECT, TestHashCodes.hashCodeFrom(123), [])
         "broken symlink" | new MissingFileSnapshot("/absolute/path", "path", AccessType.VIA_SYMLINK)
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetectorTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOverlappingOutputDetectorTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.history.impl
 import com.google.common.collect.ImmutableSortedMap
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.MissingFileSnapshot
@@ -41,7 +41,7 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
     }
 
     def "detects overlap when there is a stale root"() {
-        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", HashCode.fromInt(1234), DefaultFileMetadata.file(0, 0, AccessType.DIRECT))
+        def staleFileAddedBetweenExecutions = new RegularFileSnapshot("/absolute/path", "path", TestHashCode.fromInt(1234), DefaultFileMetadata.file(0, 0, AccessType.DIRECT))
         def previousOutputFiles = ImmutableSortedMap.<String, FileSystemSnapshot>of(
             "output", FileSystemSnapshot.EMPTY
         )
@@ -58,8 +58,8 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
     }
 
     def "detects overlap when there is a stale #type in an output directory"() {
-        def emptyDirectory = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, HashCode.fromInt(0x1234), [])
-        def directoryWithStaleBrokenSymlink = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, HashCode.fromInt(0x5678), [
+        def emptyDirectory = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCode.fromInt(0x1234), [])
+        def directoryWithStaleBrokenSymlink = new DirectorySnapshot("/absolute", "absolute", AccessType.DIRECT, TestHashCode.fromInt(0x5678), [
             staleEntry
         ])
         def previousOutputFiles = ImmutableSortedMap.<String, FileSystemSnapshot> of(
@@ -78,8 +78,8 @@ class DefaultOverlappingOutputDetectorTest extends Specification {
 
         where:
         type             | staleEntry
-        "file"           | new RegularFileSnapshot("/absolute/path", "path", HashCode.fromInt(123), DefaultFileMetadata.file(0L, 0L, AccessType.DIRECT))
-        "directory"      | new DirectorySnapshot("/absolute/path", "path", AccessType.DIRECT, HashCode.fromInt(123), [])
+        "file"           | new RegularFileSnapshot("/absolute/path", "path", TestHashCode.fromInt(123), DefaultFileMetadata.file(0L, 0L, AccessType.DIRECT))
+        "directory"      | new DirectorySnapshot("/absolute/path", "path", AccessType.DIRECT, TestHashCode.fromInt(123), [])
         "broken symlink" | new MissingFileSnapshot("/absolute/path", "path", AccessType.VIA_SYMLINK)
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.IgnoredPathFileSystemLocationFingerprint
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.SerializerSpec
 
 class FileCollectionFingerprintSerializerTest extends SerializerSpec {
@@ -40,13 +40,13 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
     }
 
     def "reads and writes fingerprints"() {
-        def hash = HashCode.fromInt(1234)
+        def hash = TestHashCode.fromInt(1234)
 
         def rootHashes = ImmutableMultimap.of(
             "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE,
-            "/2", HashCode.fromInt(5678),
-            "/3", HashCode.fromInt(1234))
-        def strategyConfigurationHash = HashCode.fromInt(6543)
+            "/2", TestHashCode.fromInt(5678),
+            "/3", TestHashCode.fromInt(1234))
+        def strategyConfigurationHash = TestHashCode.fromInt(6543)
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
             '/1': new DefaultFileSystemLocationFingerprint("1", FileType.Directory, FileSystemLocationFingerprint.DIR_SIGNATURE),
@@ -79,14 +79,14 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
     def "should retain order in serialization"() {
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
-            "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, HashCode.fromInt(1234)),
-            "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, HashCode.fromInt(5678)),
+            "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, TestHashCode.fromInt(1234)),
+            "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, TestHashCode.fromInt(5678)),
             "/1": new DefaultFileSystemLocationFingerprint('1', FileType.Missing, FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
             ImmutableMultimap.of(
-                "/3", HashCode.fromInt(1234),
-                "/2", HashCode.fromInt(5678),
+                "/3", TestHashCode.fromInt(1234),
+                "/2", TestHashCode.fromInt(5678),
                 "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
-            HashCode.fromInt(5432)
+            TestHashCode.fromInt(5432)
         ), serializer)
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileCollectionFingerprintSerializerTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.fingerprint.FileCollectionFingerprint
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.DefaultFileSystemLocationFingerprint
 import org.gradle.internal.fingerprint.impl.IgnoredPathFileSystemLocationFingerprint
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.SerializerSpec
 
 class FileCollectionFingerprintSerializerTest extends SerializerSpec {
@@ -40,13 +40,13 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
     }
 
     def "reads and writes fingerprints"() {
-        def hash = TestHashCode.fromInt(1234)
+        def hash = TestHashCodes.hashCodeFrom(1234)
 
         def rootHashes = ImmutableMultimap.of(
             "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE,
-            "/2", TestHashCode.fromInt(5678),
-            "/3", TestHashCode.fromInt(1234))
-        def strategyConfigurationHash = TestHashCode.fromInt(6543)
+            "/2", TestHashCodes.hashCodeFrom(5678),
+            "/3", TestHashCodes.hashCodeFrom(1234))
+        def strategyConfigurationHash = TestHashCodes.hashCodeFrom(6543)
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
             '/1': new DefaultFileSystemLocationFingerprint("1", FileType.Directory, FileSystemLocationFingerprint.DIR_SIGNATURE),
@@ -79,14 +79,14 @@ class FileCollectionFingerprintSerializerTest extends SerializerSpec {
     def "should retain order in serialization"() {
         when:
         def out = serialize(new SerializableFileCollectionFingerprint(
-            "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, TestHashCode.fromInt(1234)),
-            "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, TestHashCode.fromInt(5678)),
+            "/3": new DefaultFileSystemLocationFingerprint('3', FileType.RegularFile, TestHashCodes.hashCodeFrom(1234)),
+            "/2": new DefaultFileSystemLocationFingerprint('/2', FileType.RegularFile, TestHashCodes.hashCodeFrom(5678)),
             "/1": new DefaultFileSystemLocationFingerprint('1', FileType.Missing, FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
             ImmutableMultimap.of(
-                "/3", TestHashCode.fromInt(1234),
-                "/2", TestHashCode.fromInt(5678),
+                "/3", TestHashCodes.hashCodeFrom(1234),
+                "/2", TestHashCodes.hashCodeFrom(5678),
                 "/1", FileSystemLocationFingerprint.MISSING_FILE_SIGNATURE),
-            TestHashCode.fromInt(5432)
+            TestHashCodes.hashCodeFrom(5432)
         ), serializer)
 
         then:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializerTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.snapshot.TestSnapshotFixture
 import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT
 import static org.gradle.internal.file.FileMetadata.AccessType.VIA_SYMLINK
 import static org.gradle.internal.file.impl.DefaultFileMetadata.file
-import static org.gradle.internal.hash.TestHashCode.fromInt
+import static org.gradle.internal.hash.TestHashCodes.hashCodeFrom
 import static org.gradle.internal.snapshot.FileSystemSnapshot.EMPTY
 import static org.gradle.internal.snapshot.SnapshotUtil.index
 
@@ -51,7 +51,7 @@ class FileSystemSnapshotSerializerTest extends SerializerSpec implements TestSna
     }
 
     def "reads and writes file snapshots"() {
-        def snapshots = new RegularFileSnapshot("/home/lptr/dev/one.txt", "one.txt", fromInt(1234), file(1, 1, DIRECT))
+        def snapshots = new RegularFileSnapshot("/home/lptr/dev/one.txt", "one.txt", hashCodeFrom(1234), file(1, 1, DIRECT))
 
         when:
         def out = serialize(snapshots, serializer)
@@ -61,7 +61,7 @@ class FileSystemSnapshotSerializerTest extends SerializerSpec implements TestSna
     }
 
     def "reads and writes directory snapshots"() {
-        def snapshots =  new DirectorySnapshot("/home/lptr/dev", "dev", DIRECT, fromInt(1111), [])
+        def snapshots =  new DirectorySnapshot("/home/lptr/dev", "dev", DIRECT, hashCodeFrom(1111), [])
 
         when:
         def out = serialize(snapshots, serializer)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializerTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/FileSystemSnapshotSerializerTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.snapshot.TestSnapshotFixture
 import static org.gradle.internal.file.FileMetadata.AccessType.DIRECT
 import static org.gradle.internal.file.FileMetadata.AccessType.VIA_SYMLINK
 import static org.gradle.internal.file.impl.DefaultFileMetadata.file
-import static org.gradle.internal.hash.HashCode.fromInt
+import static org.gradle.internal.hash.TestHashCode.fromInt
 import static org.gradle.internal.snapshot.FileSystemSnapshot.EMPTY
 import static org.gradle.internal.snapshot.SnapshotUtil.index
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.internal.execution.history.PreviousExecutionState
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
@@ -112,8 +113,8 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<BeforeExecutionContext
     def "overlapping outputs are captured"() {
         def delegateDuration = Duration.ofMillis(123)
 
-        def staleFile = fileSnapshot("stale", HashCode.fromInt(123))
-        def outputFile = fileSnapshot("outputs", HashCode.fromInt(345))
+        def staleFile = fileSnapshot("stale", TestHashCode.fromInt(123))
+        def outputFile = fileSnapshot("outputs", TestHashCode.fromInt(345))
 
         def emptyDirectory = directorySnapshot()
         def directoryWithStaleFile = directorySnapshot(staleFile)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.internal.execution.history.PreviousExecutionState
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
@@ -113,8 +113,8 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<BeforeExecutionContext
     def "overlapping outputs are captured"() {
         def delegateDuration = Duration.ofMillis(123)
 
-        def staleFile = fileSnapshot("stale", TestHashCode.fromInt(123))
-        def outputFile = fileSnapshot("outputs", TestHashCode.fromInt(345))
+        def staleFile = fileSnapshot("stale", TestHashCodes.hashCodeFrom(123))
+        def outputFile = fileSnapshot("outputs", TestHashCodes.hashCodeFrom(345))
 
         def emptyDirectory = directorySnapshot()
         def directoryWithStaleFile = directorySnapshot(staleFile)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.internal.execution.history.OverlappingOutputDetector
 import org.gradle.internal.execution.history.PreviousExecutionState
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.ValueSnapshot
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
@@ -40,7 +40,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
     def classloaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def outputSnapshotter = Mock(OutputSnapshotter)
     def inputFingerprinter = Mock(InputFingerprinter)
-    def implementationSnapshot = ImplementationSnapshot.of("MyWorkClass", TestHashCode.fromInt(1234))
+    def implementationSnapshot = ImplementationSnapshot.of("MyWorkClass", TestHashCodes.hashCodeFrom(1234))
     def overlappingOutputDetector = Mock(OverlappingOutputDetector)
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
@@ -73,8 +73,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
 
     def "implementations are snapshotted"() {
         def additionalImplementations = [
-            ImplementationSnapshot.of("FirstAction", TestHashCode.fromInt(2345)),
-            ImplementationSnapshot.of("SecondAction", TestHashCode.fromInt(3456))
+            ImplementationSnapshot.of("FirstAction", TestHashCodes.hashCodeFrom(2345)),
+            ImplementationSnapshot.of("SecondAction", TestHashCodes.hashCodeFrom(3456))
         ]
 
         when:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.internal.execution.history.OverlappingOutputDetector
 import org.gradle.internal.execution.history.PreviousExecutionState
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.ValueSnapshot
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
@@ -40,7 +40,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
     def classloaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def outputSnapshotter = Mock(OutputSnapshotter)
     def inputFingerprinter = Mock(InputFingerprinter)
-    def implementationSnapshot = ImplementationSnapshot.of("MyWorkClass", HashCode.fromInt(1234))
+    def implementationSnapshot = ImplementationSnapshot.of("MyWorkClass", TestHashCode.fromInt(1234))
     def overlappingOutputDetector = Mock(OverlappingOutputDetector)
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
@@ -73,8 +73,8 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
 
     def "implementations are snapshotted"() {
         def additionalImplementations = [
-            ImplementationSnapshot.of("FirstAction", HashCode.fromInt(2345)),
-            ImplementationSnapshot.of("SecondAction", HashCode.fromInt(3456))
+            ImplementationSnapshot.of("FirstAction", TestHashCode.fromInt(2345)),
+            ImplementationSnapshot.of("SecondAction", TestHashCode.fromInt(3456))
         ]
 
         when:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.BeforeExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.PreviousExecutionState
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 
@@ -34,7 +34,7 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
 
     def originMetadata = Mock(OriginMetadata)
     def beforeExecutionState = Stub(BeforeExecutionState) {
-        getImplementation() >> ImplementationSnapshot.of("Test", HashCode.fromInt(123))
+        getImplementation() >> ImplementationSnapshot.of("Test", TestHashCode.fromInt(123))
         getAdditionalImplementations() >> ImmutableList.of()
         getInputProperties() >> ImmutableSortedMap.of()
         getInputFileProperties() >> ImmutableSortedMap.of()

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.BeforeExecutionState
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 import org.gradle.internal.execution.history.PreviousExecutionState
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 
@@ -34,7 +34,7 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
 
     def originMetadata = Mock(OriginMetadata)
     def beforeExecutionState = Stub(BeforeExecutionState) {
-        getImplementation() >> ImplementationSnapshot.of("Test", TestHashCode.fromInt(123))
+        getImplementation() >> ImplementationSnapshot.of("Test", TestHashCodes.hashCodeFrom(123))
         getAdditionalImplementations() >> ImmutableList.of()
         getInputProperties() >> ImmutableSortedMap.of()
         getInputFileProperties() >> ImmutableSortedMap.of()

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -256,14 +256,14 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
         @Override
         public int hashCode() {
             if (hashCode == 0) {
-                hashCode = (bytes[0] & 0xFF)
+                hashCode = (int) ((bytes[0] & 0xFF)
                     | ((bytes[1] & 0xFF) << 8)
                     | ((bytes[2] & 0xFF) << 16)
                     | ((bytes[3] & 0xFF) << 24)
                     // Make sure it's always > 0 but without affecting the lower 32 bits
-                    | (1L << 32);
+                    | (1L << 32));
             }
-            return (int) hashCode;
+            return hashCode;
         }
 
         @Override

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -32,14 +32,12 @@ import static org.gradle.internal.hash.HashCode.Usage.SAFE_TO_REUSE_BYTES;
  * <h3>Memory considerations</h3>
  *
  * <p>Hashes by default are stored in {@link ByteArrayBackedHashCode a byte array}.
- * Their {@link #hashCode()} is cached in a field for faster retrieval.
- * For a 128-bit hash on a 64-bit platform this results in 68 bytes of memory used for each {code HashCode}.
- * Aligned on 8-byte boundaries these objects take up 72 bytes of memory each.
+ * For a 128-bit hash this results in 64 bytes of memory used for each {code HashCode}.
  * This implementation also requires GC to track two separate objects (the {@code HashCode} object and its {code byte[]}).</p>
  *
  * <p>Because Gradle uses a lot of MD5 hashes, for 128-bit hashes we have a more efficient implementation.
  * {@link HashCode128} uses two longs to store the bits of the hash, and does not need to cache the {@link #hashCode()} either.
- * This results in a memory footprint of 32 bytes on a 64-bit platform.
+ * This results in a memory footprint of 32 bytes.
  * Moreover, there is only one object for GC to keep track of.</p>
  *
  * Inspired by the Google Guava project – https://github.com/google/guava.

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -213,7 +213,7 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
 
     static class ByteArrayBackedHashCode extends HashCode {
         private final byte[] bytes;
-        private long hashCode;
+        private int hashCode;
 
         public ByteArrayBackedHashCode(byte[] bytes) {
             this.bytes = bytes;

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.hash;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -150,6 +152,7 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
 
     abstract byte[] bytes();
 
+    @VisibleForTesting
     static class HashCode128 extends HashCode {
         private final long bits1;
         private final long bits2;
@@ -219,7 +222,7 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
         }
     }
 
-    static class ByteArrayBackedHashCode extends HashCode {
+    private static class ByteArrayBackedHashCode extends HashCode {
         private final byte[] bytes;
         private int hashCode;
 

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -16,10 +16,6 @@
 
 package org.gradle.internal.hash;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -79,18 +75,6 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
             throw new IllegalArgumentException(String.format("Invalid hash code length: %d bytes", bytes.length));
         }
         return fromBytes(bytes, CLONE_BYTES_IF_NECESSARY);
-    }
-
-    @VisibleForTesting
-    public static HashCode fromInt(int value) {
-        byte[] bytes = Ints.toByteArray(value); // Big-endian
-        return fromBytes(bytes, SAFE_TO_REUSE_BYTES);
-    }
-
-    @VisibleForTesting
-    public static HashCode fromLong(long value) {
-        byte[] bytes = Longs.toByteArray(value); // Big-endian
-        return fromBytes(bytes, SAFE_TO_REUSE_BYTES);
     }
 
     public static HashCode fromString(String string) {

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -27,6 +27,20 @@ import java.math.BigInteger;
 
 /**
  * An immutable hash code. Must be 4-255 bytes long.
+ *
+ * <h3>Memory considerations</h3>
+ *
+ * <p>Hashes by default are stored in {@link ByteArrayBackedHashCode a byte array}.
+ * Their {@link #hashCode()} is cached in a field for faster retrieval.
+ * For a 128-bit hash on a 64-bit platform this results in 68 bytes of memory used for each {code HashCode}.
+ * Aligned on 8-byte boundaries these objects take up 72 bytes of memory each.
+ * This implementation also requires GC to track two separate objects (the {@code HashCode} object and its {code byte[]}).</p>
+ *
+ * <p>Because Gradle uses a lot of MD5 hashes, for 128-bit hashes we have a more efficient implementation.
+ * {@link HashCode128} uses two longs to store the bits of the hash, and does not need to cache the {@link #hashCode()} either.
+ * This results in a memory footprint of 32 bytes on a 64-bit platform.
+ * Moreover, there is only one object for GC to keep track of.</p>
+ *
  * Inspired by the Google Guava project – https://github.com/google/guava.
  */
 public abstract class HashCode implements Serializable, Comparable<HashCode> {

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -224,7 +224,6 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
 
     private static class ByteArrayBackedHashCode extends HashCode {
         private final byte[] bytes;
-        private int hashCode;
 
         public ByteArrayBackedHashCode(byte[] bytes) {
             this.bytes = bytes;
@@ -252,15 +251,10 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
 
         @Override
         public int hashCode() {
-            if (hashCode == 0) {
-                hashCode = (int) ((bytes[0] & 0xFF)
-                    | ((bytes[1] & 0xFF) << 8)
-                    | ((bytes[2] & 0xFF) << 16)
-                    | ((bytes[3] & 0xFF) << 24)
-                    // Make sure it's always > 0 but without affecting the lower 32 bits
-                    | (1L << 32));
-            }
-            return hashCode;
+            return (bytes[0] & 0xFF)
+                | ((bytes[1] & 0xFF) << 8)
+                | ((bytes[2] & 0xFF) << 16)
+                | ((bytes[3] & 0xFF) << 24);
         }
 
         @Override
@@ -314,7 +308,6 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
         }
         return len1 - len2;
     }
-
 
     private static long bytesToLong(byte[] bytes, int offset) {
         return (bytes[offset] & 0xFFL)

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -185,8 +185,8 @@ public class HashCode implements Serializable, Comparable<HashCode> {
         return new BigInteger(1, bytes).toString(36);
     }
 
-    // Package private accessor used by MessageDigestHasher.putHash for performance reasons
-    byte[] getBytes() {
-        return bytes;
+    // Package private accessor used by MessageDigestHasher.putHash()
+    void appendToHasher(PrimitiveHasher hasher) {
+        hasher.putBytes(bytes);
     }
 }

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -314,14 +314,14 @@ public abstract class HashCode implements Serializable, Comparable<HashCode> {
 
 
     private static long bytesToLong(byte[] bytes, int offset) {
-        return (long) (bytes[offset] & 0xFF)
-            | (long) (bytes[offset + 1] & 0xFF) << 8
-            | (long) (bytes[offset + 2] & 0xFF) << 16
-            | (long) (bytes[offset + 3] & 0xFF) << 24
-            | (long) (bytes[offset + 4] & 0xFF) << 32
-            | (long) (bytes[offset + 5] & 0xFF) << 40
-            | (long) (bytes[offset + 6] & 0xFF) << 48
-            | (long) (bytes[offset + 7] & 0xFF) << 56;
+        return (bytes[offset] & 0xFFL)
+            | ((bytes[offset + 1] & 0xFFL) << 8)
+            | ((bytes[offset + 2] & 0xFFL) << 16)
+            | ((bytes[offset + 3] & 0xFFL) << 24)
+            | ((bytes[offset + 4] & 0xFFL) << 32)
+            | ((bytes[offset + 5] & 0xFFL) << 40)
+            | ((bytes[offset + 6] & 0xFFL) << 48)
+            | ((bytes[offset + 7] & 0xFFL) << 56);
     }
 
     private static void longToBytes(long value, byte[] bytes, int offset) {

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -29,6 +29,8 @@ import java.nio.ByteOrder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import static org.gradle.internal.hash.HashCode.Usage.SAFE_TO_REUSE_BYTES;
+
 /**
  * Some popular hash functions. Replacement for Guava's hashing utilities.
  * Inspired by the Google Guava project – https://github.com/google/guava.
@@ -347,7 +349,7 @@ public class Hashing {
         public HashCode hash() {
             byte[] bytes = getDigest().digest();
             digest = null;
-            return HashCode.fromBytesNoCopy(bytes);
+            return HashCode.fromBytes(bytes, SAFE_TO_REUSE_BYTES);
         }
     }
 

--- a/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/hashing/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -340,7 +340,7 @@ public class Hashing {
 
         @Override
         public void putHash(HashCode hashCode) {
-            putBytes(hashCode.getBytes());
+            hashCode.appendToHasher(this);
         }
 
         @Override

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.hash
 
+import org.gradle.internal.hash.HashCode.ByteArrayBackedHashCode
+import org.gradle.internal.hash.HashCode.HashCode128
 import spock.lang.Specification
 
 class HashCodeTest extends Specification {
@@ -23,18 +25,20 @@ class HashCodeTest extends Specification {
         def hash = HashCode.fromString(input)
 
         expect:
-        hash.toString() == toString
+        hash.toString() == input.toLowerCase(Locale.ROOT)
         hash.toByteArray() == bytes
         hash.length() == length
         hash.hashCode() == (int) hashCode
+        type.isInstance(hash)
 
         where:
-        input          | length | toString       | hashCode   | bytes
-        "12345678"     | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        "CAFEBABE"     | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        "abbaabba"     | 4      | "abbaabba"     | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
-        "abbaabbaabba" | 6      | "abbaabbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 3)
-        "aB" * 255     | 255    | "ab" * 255     | 0xABABABAB | toBytes([0xAB] * 255)
+        input                              | type                    | length | hashCode   | bytes
+        "12345678"                         | ByteArrayBackedHashCode | 4      | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
+        "CAFEBABE"                         | ByteArrayBackedHashCode | 4      | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
+        "abbaabba"                         | ByteArrayBackedHashCode | 4      | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
+        "abbaabbaabba"                     | ByteArrayBackedHashCode | 6      | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 3)
+        "aB" * 255                         | ByteArrayBackedHashCode | 255    | 0xABABABAB | toBytes([0xAB] * 255)
+        "e5b7d1919156335a9c453a4956bbe775" | HashCode128             | 16     | 0x91D1B7E5 | toBytes([0xE5, 0xB7, 0xD1, 0x91, 0x91, 0x56, 0x33, 0x5A, 0x9C, 0x45, 0x3A, 0x49, 0x56, 0xBB, 0xE7, 0x75])
     }
 
     def "can parse int: #input"() {
@@ -45,12 +49,13 @@ class HashCodeTest extends Specification {
         hash.toByteArray() == bytes
         hash.length() == length
         hash.hashCode() == (int) hashCode
+        type.isInstance(hash)
 
         where:
-        input          | length | toString       | hashCode   | bytes
-        0x12345678     | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        0xCAFEBABE     | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        0xabbaabba     | 4      | "abbaabba"     | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
+        input      | type                    | length | toString   | hashCode   | bytes
+        0x12345678 | ByteArrayBackedHashCode | 4      | "12345678" | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
+        0xCAFEBABE | ByteArrayBackedHashCode | 4      | "cafebabe" | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
+        0xabbaabba | ByteArrayBackedHashCode | 4      | "abbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
     }
 
     def "can parse bytes: #input"() {
@@ -58,16 +63,18 @@ class HashCodeTest extends Specification {
 
         expect:
         hash.toString() == toString
-        hash.toByteArray() == bytes
+        hash.toByteArray() == input
         hash.length() == length
         hash.hashCode() == (int) hashCode
+        type.isInstance(hash)
 
         where:
-        input                           | length | toString       | hashCode   | bytes
-        toBytes(0x12, 0x34, 0x56, 0x78) | 4      | "12345678"     | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        toBytes(0xCA, 0xFE, 0xBA, 0xBE) | 4      | "cafebabe"     | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        toBytes([0xAB, 0xBA] * 3)       | 6      | "abbaabbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 3)
-        toBytes([0xAB] * 255)           | 255    | "ab" * 255     | 0xABABABAB | toBytes([0xAB] * 255)
+        input                                                                                                     | type                    | length | toString                           | hashCode
+        toBytes(0x12, 0x34, 0x56, 0x78)                                                                           | ByteArrayBackedHashCode | 4      | "12345678"                         | 0x78563412
+        toBytes(0xCA, 0xFE, 0xBA, 0xBE)                                                                           | ByteArrayBackedHashCode | 4      | "cafebabe"                         | 0xBEBAFECA
+        toBytes([0xAB, 0xBA] * 3)                                                                                 | ByteArrayBackedHashCode | 6      | "abbaabbaabba"                     | 0xBAABBAAB
+        toBytes([0xAB] * 255)                                                                                     | ByteArrayBackedHashCode | 255    | "ab" * 255                         | 0xABABABAB
+        toBytes([0xE5, 0xB7, 0xD1, 0x91, 0x91, 0x56, 0x33, 0x5A, 0x9C, 0x45, 0x3A, 0x49, 0x56, 0xBB, 0xE7, 0x75]) | HashCode128             | 16     | "e5b7d1919156335a9c453a4956bbe775" | 0x91D1B7E5
     }
 
     def "#a == #b: #equals"() {
@@ -79,10 +86,13 @@ class HashCodeTest extends Specification {
         (hashB == hashA) == equals
 
         where:
-        a            | b            | equals
-        "abcdef12"   | "abcdef12"   | true
-        "abcdef12"   | "abcdef1234" | false
-        "abcdef1234" | "abcdef12"   | false
+        a                                  | b                                  | equals
+        "abcdef12"                         | "abcdef12"                         | true
+        "abcdef12"                         | "abcdef1234"                       | false
+        "abcdef1234"                       | "abcdef12"                         | false
+        "e5b7d1919156335a9c453a4956bbe775" | "e5b7d1919156335a9c453a4956bbe775" | true
+        "e5b7d1919156335a9c453a4956bbe775" | "f5b7d1919156335a9c453a4956bbe775" | false
+        "e5b7d1919156335a9c453a4956bbe775" | "f5b7d191"                         | false
     }
 
     def "#a <=> #b: #expected"() {
@@ -96,12 +106,19 @@ class HashCodeTest extends Specification {
         Math.signum(compareBA) == -expected
 
         where:
-        a            | b            | expected
-        "abcdef12"   | "abcdef12"   | 0
-        "abcdef12"   | "abcdef1234" | -1
-        "abcdef1234" | "abcdef12"   | 1
-        "abcdef1234" | "bcdef123"   | -1
-        "bcdef123"   | "abcdef12"   | 1
+        a                                    | b                                    | expected
+        "abcdef12"                           | "abcdef12"                           | 0
+        "abcdef12"                           | "abcdef1234"                         | -1
+        "abcdef1234"                         | "abcdef12"                           | 1
+        "abcdef1234"                         | "bcdef123"                           | -1
+        "bcdef123"                           | "abcdef12"                           | 1
+        "e5b7d1919156335a9c453a4956bbe775"   | "e5b7d1919156335a9c453a4956bbe775"   | 0
+        "e5b7d1919156335a9c453a4956bbe775"   | "f5b7d1919156335a9c453a4956bbe775"   | -1
+        "e5b7d1919156335a9c453a4956bbe775"   | "f5b7d1919156335a9c453a4956bbe77512" | -1
+        "e5b7d1919156335a9c453a4956bbe775"   | "f5b7d191"                           | -1
+        "f5b7d1919156335a9c453a4956bbe775"   | "e5b7d1919156335a9c453a4956bbe775"   | 1
+        "f5b7d1919156335a9c453a4956bbe77512" | "e5b7d1919156335a9c453a4956bbe775"   | 1
+        "f5b7d191"                           | "e5b7d1919156335a9c453a4956bbe775"   | 1
     }
 
     def "not equals with null"() {
@@ -181,6 +198,7 @@ class HashCodeTest extends Specification {
         HashCode.fromString("12345678").toZeroPaddedString(0) == "12345678"
         HashCode.fromString("12345678").toZeroPaddedString(9) == "012345678"
         HashCode.fromString("12345678").toZeroPaddedString(16) == "0000000012345678"
+        Hashing.md5().hashString("").toZeroPaddedString(40) == "00000000d41d8cd98f00b204e9800998ecf8427e"
     }
 
     private static byte[] toBytes(int ... elements) {

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
@@ -41,23 +41,6 @@ class HashCodeTest extends Specification {
         "e5b7d1919156335a9c453a4956bbe775" | HashCode128             | 16     | 0x91D1B7E5 | toBytes([0xE5, 0xB7, 0xD1, 0x91, 0x91, 0x56, 0x33, 0x5A, 0x9C, 0x45, 0x3A, 0x49, 0x56, 0xBB, 0xE7, 0x75])
     }
 
-    def "can parse int: #input"() {
-        def hash = HashCode.fromInt((int) input)
-
-        expect:
-        hash.toString() == toString
-        hash.toByteArray() == bytes
-        hash.length() == length
-        hash.hashCode() == (int) hashCode
-        type.isInstance(hash)
-
-        where:
-        input      | type                    | length | toString   | hashCode   | bytes
-        0x12345678 | ByteArrayBackedHashCode | 4      | "12345678" | 0x78563412 | toBytes(0x12, 0x34, 0x56, 0x78)
-        0xCAFEBABE | ByteArrayBackedHashCode | 4      | "cafebabe" | 0xBEBAFECA | toBytes(0xCA, 0xFE, 0xBA, 0xBE)
-        0xabbaabba | ByteArrayBackedHashCode | 4      | "abbaabba" | 0xBAABBAAB | toBytes([0xAB, 0xBA] * 2)
-    }
-
     def "can parse bytes: #input"() {
         def hash = HashCode.fromBytes(input)
 
@@ -123,8 +106,8 @@ class HashCodeTest extends Specification {
 
     def "not equals with null"() {
         expect:
-        HashCode.fromInt(0x12345678) != null
-        null != HashCode.fromInt(0x12345678)
+        TestHashCode.fromInt(0x12345678) != null
+        null != TestHashCode.fromInt(0x12345678)
     }
 
     def "won't parse string with odd length"() {

--- a/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
+++ b/subprojects/hashing/src/test/groovy/org/gradle/internal/hash/HashCodeTest.groovy
@@ -106,8 +106,8 @@ class HashCodeTest extends Specification {
 
     def "not equals with null"() {
         expect:
-        TestHashCode.fromInt(0x12345678) != null
-        null != TestHashCode.fromInt(0x12345678)
+        TestHashCodes.hashCodeFrom(0x12345678) != null
+        null != TestHashCodes.hashCodeFrom(0x12345678)
     }
 
     def "won't parse string with odd length"() {

--- a/subprojects/hashing/src/testFixtures/groovy/org/gradle/internal/hash/TestHashCode.groovy
+++ b/subprojects/hashing/src/testFixtures/groovy/org/gradle/internal/hash/TestHashCode.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.hash
+
+class TestHashCode {
+    static HashCode fromInt(int value) {
+        return fromLong(value)
+    }
+
+    static HashCode fromLong(long value) {
+        return new HashCode.HashCode128(value, 0)
+    }
+}

--- a/subprojects/hashing/src/testFixtures/groovy/org/gradle/internal/hash/TestHashCodes.groovy
+++ b/subprojects/hashing/src/testFixtures/groovy/org/gradle/internal/hash/TestHashCodes.groovy
@@ -16,12 +16,12 @@
 
 package org.gradle.internal.hash
 
-class TestHashCode {
-    static HashCode fromInt(int value) {
-        return fromLong(value)
-    }
-
-    static HashCode fromLong(long value) {
+class TestHashCodes {
+    /**
+     * Create a 128-bit {@link HashCode} using the given value.
+     * The higher 64 bits are set to {@code 0}.
+     */
+    static HashCode hashCodeFrom(long value) {
         return new HashCode.HashCode128(value, 0)
     }
 }

--- a/subprojects/kotlin-dsl/build.gradle.kts
+++ b/subprojects/kotlin-dsl/build.gradle.kts
@@ -107,6 +107,8 @@ dependencies {
     testFixturesImplementation(project(":internal-testing"))
     testFixturesImplementation(project(":internal-integ-testing"))
 
+    testFixturesImplementation(testFixtures(project(":hashing")))
+
     testFixturesImplementation(libs.junit)
     testFixturesImplementation(libs.mockitoKotlin)
     testFixturesImplementation(libs.jacksonKotlin)

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -29,6 +29,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.Describables
 import org.gradle.internal.classpath.ClassPath
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.resource.TextResource
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.kotlin.dsl.fixtures.DummyCompiledScript

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -29,7 +29,7 @@ import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.Describables
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.resource.TextResource
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.kotlin.dsl.fixtures.DummyCompiledScript
@@ -62,8 +62,8 @@ class InterpreterTest : TestWithTempFiles() {
 
         """.trimIndent()
 
-        val sourceHash = TestHashCode.fromInt(42)
-        val compilationClassPathHash = TestHashCode.fromInt(11)
+        val sourceHash = TestHashCodes.hashCodeFrom(42)
+        val compilationClassPathHash = TestHashCodes.hashCodeFrom(11)
         val stage1TemplateId = "Settings/TopLevel/stage1"
         val stage2TemplateId = "Settings/TopLevel/stage2"
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/InterpreterTest.kt
@@ -23,29 +23,21 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
-
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.file.temp.GradleUserHomeTemporaryFileProvider
 import org.gradle.api.internal.initialization.ClassLoaderScope
-
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.Describables
 import org.gradle.internal.classpath.ClassPath
-
-import org.gradle.internal.hash.HashCode
 import org.gradle.internal.resource.TextResource
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.kotlin.dsl.fixtures.DummyCompiledScript
-
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
 import org.gradle.kotlin.dsl.fixtures.classLoaderFor
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
-
 import org.junit.Test
-
 import java.io.File
-
 import java.net.URLClassLoader
 
 
@@ -69,8 +61,8 @@ class InterpreterTest : TestWithTempFiles() {
 
         """.trimIndent()
 
-        val sourceHash = HashCode.fromInt(42)
-        val compilationClassPathHash = HashCode.fromInt(11)
+        val sourceHash = TestHashCode.fromInt(42)
+        val compilationClassPathHash = TestHashCode.fromInt(11)
         val stage1TemplateId = "Settings/TopLevel/stage1"
         val stage2TemplateId = "Settings/TopLevel/stage2"
 

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
@@ -23,14 +23,30 @@ import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.same
 import com.nhaarman.mockito_kotlin.verify
-
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
-
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode.fromInt
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Dynamic
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyBasePlugins
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyDefaultPluginRequests
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyPluginRequestsOf
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.CloseTargetScope
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.Eval
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.SetupEmbeddedKotlin
+import org.gradle.kotlin.dsl.execution.ResidualProgram.Static
+import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
+import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
+import org.gradle.plugin.management.internal.PluginRequests
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.mockito.InOrder
+import java.util.Arrays.fill
+
+(.fromInt(
 
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Dynamic
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyBasePlugins
@@ -142,7 +158,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
     fun `Dynamic(Static(CloseTargetScope))`() {
 
         val source = ProgramSource("settings.gradle.kts", "include(\"foo\", \"bar\")")
-        val sourceHash = HashCode.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(.fromInt(.fromInt(42)
         val target = mock<Settings>()
         val programHost = safeMockProgramHost()
         val scriptHost = scriptHostWith(target)
@@ -195,7 +211,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
             "task(\"precompiled stage 2\")"
         )
 
-        val sourceHash = HashCode.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(.fromInt(42)
         val target = mock<Project>()
         val scriptHost = scriptHostWith(target)
         val accessorsClassPath = mock<ClassPath>()
@@ -241,7 +257,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
         val scriptSource =
             buildscriptFragment.source.map { text("println(\"stage 2\")") }
 
-        val sourceHash = HashCode.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(42)
 
         val scriptHandler = mock<ScriptHandlerInternal> {
             on { repositories } doReturn mock<RepositoryHandler>()
@@ -602,7 +618,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
         target: T,
         val programTarget: ProgramTarget
     ) {
-        val sourceHash = HashCode.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(42)
         val scriptHost = scriptHostWith(target = target)
         val accessorsClassPath = mock<ClassPath>()
         val programHost = safeMockProgramHost {

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Dynamic
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyBasePlugins
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyDefaultPluginRequests
@@ -134,7 +134,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
     fun `Dynamic(Static(CloseTargetScope))`() {
 
         val source = ProgramSource("settings.gradle.kts", "include(\"foo\", \"bar\")")
-        val sourceHash = TestHashCode.fromInt(42)
+        val sourceHash = TestHashCodes.hashCodeFrom(42)
         val target = mock<Settings>()
         val programHost = safeMockProgramHost()
         val scriptHost = scriptHostWith(target)
@@ -187,7 +187,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
             "task(\"precompiled stage 2\")"
         )
 
-        val sourceHash = TestHashCode.fromInt(42)
+        val sourceHash = TestHashCodes.hashCodeFrom(42)
         val target = mock<Project>()
         val scriptHost = scriptHostWith(target)
         val accessorsClassPath = mock<ClassPath>()
@@ -233,7 +233,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
         val scriptSource =
             buildscriptFragment.source.map { text("println(\"stage 2\")") }
 
-        val sourceHash = TestHashCode.fromInt(42)
+        val sourceHash = TestHashCodes.hashCodeFrom(42)
 
         val scriptHandler = mock<ScriptHandlerInternal> {
             on { repositories } doReturn mock<RepositoryHandler>()
@@ -594,7 +594,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
         target: T,
         val programTarget: ProgramTarget
     ) {
-        val sourceHash = TestHashCode.fromInt(42)
+        val sourceHash = TestHashCodes.hashCodeFrom(42)
         val scriptHost = scriptHostWith(target = target)
         val accessorsClassPath = mock<ClassPath>()
         val programHost = safeMockProgramHost {

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/ResidualProgramCompilerTest.kt
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.initialization.Settings
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.hash.TestHashCode.fromInt
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Dynamic
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyBasePlugins
 import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyDefaultPluginRequests
@@ -44,30 +44,6 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.mockito.InOrder
-import java.util.Arrays.fill
-
-(.fromInt(
-
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Dynamic
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyBasePlugins
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyDefaultPluginRequests
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.ApplyPluginRequestsOf
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.CloseTargetScope
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.Eval
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Instruction.SetupEmbeddedKotlin
-import org.gradle.kotlin.dsl.execution.ResidualProgram.Static
-
-import org.gradle.kotlin.dsl.fixtures.assertInstanceOf
-import org.gradle.kotlin.dsl.fixtures.assertStandardOutputOf
-
-import org.gradle.plugin.management.internal.PluginRequests
-
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
-
-import org.junit.Test
-import org.mockito.InOrder
-
 import java.util.Arrays.fill
 
 
@@ -158,7 +134,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
     fun `Dynamic(Static(CloseTargetScope))`() {
 
         val source = ProgramSource("settings.gradle.kts", "include(\"foo\", \"bar\")")
-        val sourceHash = TestHashCode.fromInt(.fromInt(.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(42)
         val target = mock<Settings>()
         val programHost = safeMockProgramHost()
         val scriptHost = scriptHostWith(target)
@@ -211,7 +187,7 @@ class ResidualProgramCompilerTest : TestWithCompiler() {
             "task(\"precompiled stage 2\")"
         )
 
-        val sourceHash = TestHashCode.fromInt(.fromInt(42)
+        val sourceHash = TestHashCode.fromInt(42)
         val target = mock<Project>()
         val scriptHost = scriptHostWith(target)
         val accessorsClassPath = mock<ClassPath>()

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
@@ -27,6 +27,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
@@ -46,7 +47,7 @@ abstract class TestWithCompiler : TestWithTempFiles() {
     internal
     inline fun withExecutableProgramFor(
         program: ResidualProgram,
-        sourceHash: HashCode = HashCode.fromInt(0),
+        sourceHash: HashCode = TestHashCode.fromInt(0),
         programKind: ProgramKind = ProgramKind.TopLevel,
         programTarget: ProgramTarget = ProgramTarget.Settings,
         action: ExecutableProgram.() -> Unit

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/execution/TestWithCompiler.kt
@@ -27,7 +27,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.kotlin.dsl.fixtures.TestWithTempFiles
 import org.gradle.kotlin.dsl.fixtures.testRuntimeClassPath
 import org.gradle.kotlin.dsl.fixtures.withClassLoaderFor
@@ -47,7 +47,7 @@ abstract class TestWithCompiler : TestWithTempFiles() {
     internal
     inline fun withExecutableProgramFor(
         program: ResidualProgram,
-        sourceHash: HashCode = TestHashCode.fromInt(0),
+        sourceHash: HashCode = TestHashCodes.hashCodeFrom(0),
         programKind: ProgramKind = ProgramKind.TopLevel,
         programTarget: ProgramTarget = ProgramTarget.Settings,
         action: ExecutableProgram.() -> Unit

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -29,6 +29,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.resource.StringTextResource
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -190,7 +191,7 @@ class SimplifiedKotlinScriptEvaluator(
         override fun closeTargetScopeOf(scriptHost: KotlinScriptHost<*>) = Unit
 
         override fun hashOf(classPath: ClassPath): HashCode =
-            HashCode.fromInt(0)
+            TestHashCode.fromInt(0)
 
         override fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String =
             action()

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/SimplifiedKotlinScriptEvaluator.kt
@@ -29,7 +29,7 @@ import org.gradle.internal.classpath.ClassPath
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.resource.StringTextResource
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceRegistry
@@ -191,7 +191,7 @@ class SimplifiedKotlinScriptEvaluator(
         override fun closeTargetScopeOf(scriptHost: KotlinScriptHost<*>) = Unit
 
         override fun hashOf(classPath: ClassPath): HashCode =
-            TestHashCode.fromInt(0)
+            TestHashCodes.hashCodeFrom(0)
 
         override fun runCompileBuildOperation(scriptPath: String, stage: String, action: () -> String): String =
             action()

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
@@ -18,12 +18,12 @@ package org.gradle.api.internal.tasks.compile.incremental.deps
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.fastutil.ints.IntSets
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 class ClassDependentsAccumulatorTest extends Specification {
 
-    def hash = HashCode.fromInt(0)
+    def hash = TestHashCode.fromInt(0)
     def accumulator = new ClassDependentsAccumulator()
 
     def "dependents map is empty by default"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
@@ -18,12 +18,12 @@ package org.gradle.api.internal.tasks.compile.incremental.deps
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import it.unimi.dsi.fastutil.ints.IntSets
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 class ClassDependentsAccumulatorTest extends Specification {
 
-    def hash = TestHashCode.fromInt(0)
+    def hash = TestHashCodes.hashCodeFrom(0)
     def accumulator = new ClassDependentsAccumulator()
 
     def "dependents map is empty by default"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -22,6 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntSets
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.tasks.compile.incremental.serialization.HierarchicalNameSerializer
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.InputStreamBackedDecoder
 import org.gradle.internal.serialize.OutputStreamBackedEncoder
 import spock.lang.Specification
@@ -32,7 +33,7 @@ import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps
 
 class ClassSetAnalysisDataSerializerTest extends Specification {
 
-    HashCode hash = HashCode.fromInt(0)
+    HashCode hash = TestHashCode.fromInt(0)
     @Subject serializer = new ClassSetAnalysisData.Serializer({ new HierarchicalNameSerializer(new StringInterner())})
 
     def "serializes"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.ints.IntSets
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.tasks.compile.incremental.serialization.HierarchicalNameSerializer
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.InputStreamBackedDecoder
 import org.gradle.internal.serialize.OutputStreamBackedEncoder
 import spock.lang.Specification
@@ -33,7 +33,7 @@ import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps
 
 class ClassSetAnalysisDataSerializerTest extends Specification {
 
-    HashCode hash = TestHashCode.fromInt(0)
+    HashCode hash = TestHashCodes.hashCodeFrom(0)
     @Subject serializer = new ClassSetAnalysisData.Serializer({ new HierarchicalNameSerializer(new StringInterner())})
 
     def "serializes"() {

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.C
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps.DependentsSet
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingData
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps.DependentsSet.dependentClasses
@@ -30,7 +31,7 @@ import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps
 
 class ClassSetAnalysisTest extends Specification {
 
-    static def hash = HashCode.fromInt(0)
+    static def hash = TestHashCode.fromInt(0)
 
     ClassSetAnalysis analysis(Map<String, DependentsSet> dependents,
                               Map<String, IntSet> classToConstants = [:],
@@ -47,16 +48,16 @@ class ClassSetAnalysisTest extends Specification {
     }
 
     def "knows when there are no affected classes since some other snapshot"() {
-        ClassSetAnalysis s1 = snapshot(["A": HashCode.fromInt(0xaa), "B": HashCode.fromInt(0xbb)])
-        ClassSetAnalysis s2 = snapshot(["A": HashCode.fromInt(0xaa), "B": HashCode.fromInt(0xbb)])
+        ClassSetAnalysis s1 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb)])
+        ClassSetAnalysis s2 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb)])
 
         expect:
         s1.findChangesSince(s2).dependents.isEmpty()
     }
 
     def "knows when there are changed classes since other snapshot"() {
-        ClassSetAnalysis s1 = snapshot(["A": HashCode.fromInt(0xaa), "B": HashCode.fromInt(0xbb), "C": HashCode.fromInt(0xcc)])
-        ClassSetAnalysis s2 = snapshot(["A": HashCode.fromInt(0xaa), "B": HashCode.fromInt(0xbbbb)])
+        ClassSetAnalysis s1 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb), "C": TestHashCode.fromInt(0xcc)])
+        ClassSetAnalysis s2 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbbbb)])
 
         expect:
         s1.findChangesSince(s2).dependents.allDependentClasses == ["B"] as Set

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.internal.tasks.compile.incremental.compilerapi.constants.C
 import org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps.DependentsSet
 import org.gradle.api.internal.tasks.compile.incremental.processing.AnnotationProcessingData
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps.DependentsSet.dependentClasses
@@ -31,7 +31,7 @@ import static org.gradle.api.internal.tasks.compile.incremental.compilerapi.deps
 
 class ClassSetAnalysisTest extends Specification {
 
-    static def hash = TestHashCode.fromInt(0)
+    static def hash = TestHashCodes.hashCodeFrom(0)
 
     ClassSetAnalysis analysis(Map<String, DependentsSet> dependents,
                               Map<String, IntSet> classToConstants = [:],
@@ -48,16 +48,16 @@ class ClassSetAnalysisTest extends Specification {
     }
 
     def "knows when there are no affected classes since some other snapshot"() {
-        ClassSetAnalysis s1 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb)])
-        ClassSetAnalysis s2 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb)])
+        ClassSetAnalysis s1 = snapshot(["A": TestHashCodes.hashCodeFrom(0xaa), "B": TestHashCodes.hashCodeFrom(0xbb)])
+        ClassSetAnalysis s2 = snapshot(["A": TestHashCodes.hashCodeFrom(0xaa), "B": TestHashCodes.hashCodeFrom(0xbb)])
 
         expect:
         s1.findChangesSince(s2).dependents.isEmpty()
     }
 
     def "knows when there are changed classes since other snapshot"() {
-        ClassSetAnalysis s1 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbb), "C": TestHashCode.fromInt(0xcc)])
-        ClassSetAnalysis s2 = snapshot(["A": TestHashCode.fromInt(0xaa), "B": TestHashCode.fromInt(0xbbbb)])
+        ClassSetAnalysis s1 = snapshot(["A": TestHashCodes.hashCodeFrom(0xaa), "B": TestHashCodes.hashCodeFrom(0xbb), "C": TestHashCodes.hashCodeFrom(0xcc)])
+        ClassSetAnalysis s2 = snapshot(["A": TestHashCodes.hashCodeFrom(0xaa), "B": TestHashCodes.hashCodeFrom(0xbbbb)])
 
         expect:
         s1.findChangesSince(s2).dependents.allDependentClasses == ["B"] as Set

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializerTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.language.nativeplatform.internal.incremental
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.SerializerSpec
 
 class CompilationStateSerializerTest extends SerializerSpec {
@@ -39,10 +39,10 @@ class CompilationStateSerializerTest extends SerializerSpec {
         when:
         def fileEmpty = new File("empty")
         def fileStates = [:]
-        fileStates.put(fileEmpty, compilationFileState(TestHashCode.fromInt(0x12345678), []))
+        fileStates.put(fileEmpty, compilationFileState(TestHashCodes.hashCodeFrom(0x12345678), []))
 
         def fileTwo = new File("two")
-        def stateTwo = compilationFileState(TestHashCode.fromInt(0x23456789), ["ONE","TWO"])
+        def stateTwo = compilationFileState(TestHashCodes.hashCodeFrom(0x23456789), ["ONE", "TWO"])
         fileStates.put(fileTwo, stateTwo)
         def state = compilationState(fileStates)
 
@@ -51,11 +51,11 @@ class CompilationStateSerializerTest extends SerializerSpec {
         newState.fileStates.size() == 2
 
         def emptyCompileState = newState.getState(fileEmpty)
-        emptyCompileState.hash == TestHashCode.fromInt(0x12345678)
+        emptyCompileState.hash == TestHashCodes.hashCodeFrom(0x12345678)
         emptyCompileState.edges.empty
 
         def otherCompileState = newState.getState(fileTwo)
-        otherCompileState.hash == TestHashCode.fromInt(0x23456789)
+        otherCompileState.hash == TestHashCodes.hashCodeFrom(0x23456789)
         otherCompileState.edges == stateTwo.edges
     }
 
@@ -63,11 +63,11 @@ class CompilationStateSerializerTest extends SerializerSpec {
         when:
         def fileOne = new File("one")
         def fileStates = [:]
-        def stateOne = compilationFileState(TestHashCode.fromInt(0x12345678), ["ONE", "TWO"])
+        def stateOne = compilationFileState(TestHashCodes.hashCodeFrom(0x12345678), ["ONE", "TWO"])
         fileStates.put(fileOne, stateOne)
 
         def fileTwo = new File("two")
-        def stateTwo = compilationFileState(TestHashCode.fromInt(0x23456789), ["TWO", "THREE"])
+        def stateTwo = compilationFileState(TestHashCodes.hashCodeFrom(0x23456789), ["TWO", "THREE"])
         fileStates.put(fileTwo, stateTwo)
         def state = compilationState(fileStates)
 
@@ -76,16 +76,16 @@ class CompilationStateSerializerTest extends SerializerSpec {
         newState.fileStates.size() == 2
 
         def emptyCompileState = newState.getState(fileOne)
-        emptyCompileState.hash == TestHashCode.fromInt(0x12345678)
+        emptyCompileState.hash == TestHashCodes.hashCodeFrom(0x12345678)
         emptyCompileState.edges == stateOne.edges
 
         def otherCompileState = newState.getState(fileTwo)
-        otherCompileState.hash == TestHashCode.fromInt(0x23456789)
+        otherCompileState.hash == TestHashCodes.hashCodeFrom(0x23456789)
         otherCompileState.edges == stateTwo.edges
     }
 
     private SourceFileState compilationFileState(HashCode hash, Collection<String> includes) {
-        return new SourceFileState(hash, true, ImmutableSet.copyOf(includes.collect { new IncludeFileEdge(it, null, TestHashCode.fromInt(123) )}))
+        return new SourceFileState(hash, true, ImmutableSet.copyOf(includes.collect { new IncludeFileEdge(it, null, TestHashCodes.hashCodeFrom(123) )}))
     }
 
     private CompilationState compilationState(Map<File, SourceFileState> states) {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializerTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.language.nativeplatform.internal.incremental
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.SerializerSpec
 
 class CompilationStateSerializerTest extends SerializerSpec {
@@ -38,10 +39,10 @@ class CompilationStateSerializerTest extends SerializerSpec {
         when:
         def fileEmpty = new File("empty")
         def fileStates = [:]
-        fileStates.put(fileEmpty, compilationFileState(HashCode.fromInt(0x12345678), []))
+        fileStates.put(fileEmpty, compilationFileState(TestHashCode.fromInt(0x12345678), []))
 
         def fileTwo = new File("two")
-        def stateTwo = compilationFileState(HashCode.fromInt(0x23456789), ["ONE","TWO"])
+        def stateTwo = compilationFileState(TestHashCode.fromInt(0x23456789), ["ONE","TWO"])
         fileStates.put(fileTwo, stateTwo)
         def state = compilationState(fileStates)
 
@@ -50,11 +51,11 @@ class CompilationStateSerializerTest extends SerializerSpec {
         newState.fileStates.size() == 2
 
         def emptyCompileState = newState.getState(fileEmpty)
-        emptyCompileState.hash == HashCode.fromInt(0x12345678)
+        emptyCompileState.hash == TestHashCode.fromInt(0x12345678)
         emptyCompileState.edges.empty
 
         def otherCompileState = newState.getState(fileTwo)
-        otherCompileState.hash == HashCode.fromInt(0x23456789)
+        otherCompileState.hash == TestHashCode.fromInt(0x23456789)
         otherCompileState.edges == stateTwo.edges
     }
 
@@ -62,11 +63,11 @@ class CompilationStateSerializerTest extends SerializerSpec {
         when:
         def fileOne = new File("one")
         def fileStates = [:]
-        def stateOne = compilationFileState(HashCode.fromInt(0x12345678), ["ONE", "TWO"])
+        def stateOne = compilationFileState(TestHashCode.fromInt(0x12345678), ["ONE", "TWO"])
         fileStates.put(fileOne, stateOne)
 
         def fileTwo = new File("two")
-        def stateTwo = compilationFileState(HashCode.fromInt(0x23456789), ["TWO", "THREE"])
+        def stateTwo = compilationFileState(TestHashCode.fromInt(0x23456789), ["TWO", "THREE"])
         fileStates.put(fileTwo, stateTwo)
         def state = compilationState(fileStates)
 
@@ -75,16 +76,16 @@ class CompilationStateSerializerTest extends SerializerSpec {
         newState.fileStates.size() == 2
 
         def emptyCompileState = newState.getState(fileOne)
-        emptyCompileState.hash == HashCode.fromInt(0x12345678)
+        emptyCompileState.hash == TestHashCode.fromInt(0x12345678)
         emptyCompileState.edges == stateOne.edges
 
         def otherCompileState = newState.getState(fileTwo)
-        otherCompileState.hash == HashCode.fromInt(0x23456789)
+        otherCompileState.hash == TestHashCode.fromInt(0x23456789)
         otherCompileState.edges == stateTwo.edges
     }
 
     private SourceFileState compilationFileState(HashCode hash, Collection<String> includes) {
-        return new SourceFileState(hash, true, ImmutableSet.copyOf(includes.collect { new IncludeFileEdge(it, null, HashCode.fromInt(123) )}))
+        return new SourceFileState(hash, true, ImmutableSet.copyOf(includes.collect { new IncludeFileEdge(it, null, TestHashCode.fromInt(123) )}))
     }
 
     private CompilationState compilationState(Map<File, SourceFileState> states) {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultIsolatableFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultIsolatableFactoryTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.instantiation.ManagedTypeFactory
 import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
@@ -36,7 +36,7 @@ import spock.lang.Specification
 class DefaultIsolatableFactoryTest extends Specification {
 
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> HashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
     }
     def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
     def snapshotter = new DefaultValueSnapshotter([], classLoaderHasher)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultIsolatableFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultIsolatableFactoryTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.classloader.ClasspathUtil
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.instantiation.ManagedTypeFactory
 import org.gradle.internal.state.ManagedFactoryRegistry
 import org.gradle.util.TestUtil
@@ -36,7 +36,7 @@ import spock.lang.Specification
 class DefaultIsolatableFactoryTest extends Specification {
 
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCodes.hashCodeFrom(123)
     }
     def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
     def snapshotter = new DefaultValueSnapshotter([], classLoaderHasher)

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.snapshot.impl
 import org.gradle.api.Named
 import org.gradle.api.internal.provider.Providers
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.DefaultSerializerRegistry
 import org.gradle.internal.serialize.Encoder
@@ -32,7 +32,7 @@ import spock.lang.Specification
 
 class DefaultValueSnapshotterTest extends Specification {
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCodes.hashCodeFrom(123)
     }
     def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
     def valueSnapshotSerializerRegistry = new TestValueSnapshotSerializerRegistry().tap {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.snapshot.impl
 import org.gradle.api.Named
 import org.gradle.api.internal.provider.Providers
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.Decoder
 import org.gradle.internal.serialize.DefaultSerializerRegistry
 import org.gradle.internal.serialize.Encoder
@@ -32,7 +32,7 @@ import spock.lang.Specification
 
 class DefaultValueSnapshotterTest extends Specification {
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> HashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
     }
     def managedFactoryRegistry = Mock(ManagedFactoryRegistry)
     def valueSnapshotSerializerRegistry = new TestValueSnapshotSerializerRegistry().tap {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.serialize.InputStreamBackedDecoder
 import org.gradle.internal.serialize.OutputStreamBackedEncoder
 import org.gradle.internal.snapshot.ValueSnapshot
@@ -74,7 +74,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     def "serializes hash properties"() {
-        def value = new HashCodeSnapshot(TestHashCode.fromInt(123))
+        def value = new HashCodeSnapshot(TestHashCodes.hashCodeFrom(123))
 
         when:
         write(value)
@@ -211,7 +211,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     def "serializes implementation properties with lambda"() {
-        def original = ImplementationSnapshot.of('someClassName$$Lambda$12/312454364', TestHashCode.fromInt(1234))
+        def original = ImplementationSnapshot.of('someClassName$$Lambda$12/312454364', TestHashCodes.hashCodeFrom(1234))
         write(original)
 
         expect:
@@ -243,7 +243,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     private JavaSerializedValueSnapshot snapshot(byte[] value) {
-        return new JavaSerializedValueSnapshot(TestHashCode.fromInt(123), value)
+        return new JavaSerializedValueSnapshot(TestHashCodes.hashCodeFrom(123), value)
     }
 
     private ValueSnapshot getWritten() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableSet
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.serialize.InputStreamBackedDecoder
 import org.gradle.internal.serialize.OutputStreamBackedEncoder
 import org.gradle.internal.snapshot.ValueSnapshot
@@ -73,7 +74,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     def "serializes hash properties"() {
-        def value = new HashCodeSnapshot(HashCode.fromInt(123))
+        def value = new HashCodeSnapshot(TestHashCode.fromInt(123))
 
         when:
         write(value)
@@ -210,7 +211,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     def "serializes implementation properties with lambda"() {
-        def original = ImplementationSnapshot.of('someClassName$$Lambda$12/312454364', HashCode.fromInt(1234))
+        def original = ImplementationSnapshot.of('someClassName$$Lambda$12/312454364', TestHashCode.fromInt(1234))
         write(original)
 
         expect:
@@ -242,7 +243,7 @@ class SnapshotSerializerTest extends Specification {
     }
 
     private JavaSerializedValueSnapshot snapshot(byte[] value) {
-        return new JavaSerializedValueSnapshot(HashCode.fromInt(123), value)
+        return new JavaSerializedValueSnapshot(TestHashCode.fromInt(123), value)
     }
 
     private ValueSnapshot getWritten() {

--- a/subprojects/normalization-java/build.gradle.kts
+++ b/subprojects/normalization-java/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
 
     testImplementation(project(":base-services"))
     testImplementation(project(":internal-testing"))
+    testImplementation(testFixtures(project(":snapshots")))
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -50,6 +50,7 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
 
     private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar");
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipHasher.class);
+    private static final HashCode EMPTY_HASH_MARKER = Hashing.signature(ZipHasher.class);
 
     public static boolean isZipFile(final String name) {
         return KNOWN_ZIP_EXTENSIONS.contains(FilenameUtils.getExtension(name).toLowerCase(Locale.ROOT));
@@ -133,7 +134,7 @@ public class ZipHasher implements RegularFileSnapshotContextHasher, Configurable
     }
 
     private DefaultFileSystemLocationFingerprint newZipMarker(String relativePath) {
-        return new DefaultFileSystemLocationFingerprint(relativePath, FileType.RegularFile, HashCode.fromInt(0));
+        return new DefaultFileSystemLocationFingerprint(relativePath, FileType.RegularFile, EMPTY_HASH_MARKER);
     }
 
     public interface HashingExceptionReporter {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.internal.file.archive.ZipEntry
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -28,13 +28,13 @@ class CachingResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def path = "some"
     def snapshotterCacheService = Mock(ResourceSnapshotterCacheService)
-    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", HashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, AccessType.DIRECT))
+    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path}, snapshot)
     def cachingHasher = new CachingResourceHasher(delegate, snapshotterCacheService)
 
 
     def "uses cache service for snapshots"() {
-        def expectedHash = HashCode.fromInt(123)
+        def expectedHash = TestHashCode.fromInt(123)
         when:
         cachingHasher.hash(snapshotContext)
         then:
@@ -43,7 +43,7 @@ class CachingResourceHasherTest extends Specification {
     }
 
     def "does not cache zip entries"() {
-        def expectedHash = HashCode.fromInt(123)
+        def expectedHash = TestHashCode.fromInt(123)
         def zipEntry = Mock(ZipEntry)
         def zipEntryContext = new DefaultZipEntryContext(zipEntry, "foo", "foo.zip")
 

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/CachingResourceHasherTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.internal.file.archive.ZipEntry
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -28,13 +28,13 @@ class CachingResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def path = "some"
     def snapshotterCacheService = Mock(ResourceSnapshotterCacheService)
-    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, AccessType.DIRECT))
+    private RegularFileSnapshot snapshot = new RegularFileSnapshot(path, "path", TestHashCodes.hashCodeFrom(456), DefaultFileMetadata.file(3456, 456, AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path}, snapshot)
     def cachingHasher = new CachingResourceHasher(delegate, snapshotterCacheService)
 
 
     def "uses cache service for snapshots"() {
-        def expectedHash = TestHashCode.fromInt(123)
+        def expectedHash = TestHashCodes.hashCodeFrom(123)
         when:
         cachingHasher.hash(snapshotContext)
         then:
@@ -43,7 +43,7 @@ class CachingResourceHasherTest extends Specification {
     }
 
     def "does not cache zip entries"() {
-        def expectedHash = TestHashCode.fromInt(123)
+        def expectedHash = TestHashCodes.hashCodeFrom(123)
         def zipEntry = Mock(ZipEntry)
         def zipEntryContext = new DefaultZipEntryContext(zipEntry, "foo", "foo.zip")
 

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
@@ -19,17 +19,16 @@ package org.gradle.api.internal.changedetection.state
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
-import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hasher
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
-
 
 class IgnoringResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def resourceFilter = Mock(ResourceFilter)
     def hasher = new IgnoringResourceHasher(delegate, resourceFilter)
-    def snapshot = new RegularFileSnapshot("path", "path", HashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
+    def snapshot = new RegularFileSnapshot("path", "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path.split('/')}, snapshot)
 
     def "allows all resources when resource filter does not match"() {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/IgnoringResourceHasherTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
 import org.gradle.internal.hash.Hasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import spock.lang.Specification
 
@@ -28,7 +28,7 @@ class IgnoringResourceHasherTest extends Specification {
     def delegate = Mock(ResourceHasher)
     def resourceFilter = Mock(ResourceFilter)
     def hasher = new IgnoringResourceHasher(delegate, resourceFilter)
-    def snapshot = new RegularFileSnapshot("path", "path", TestHashCode.fromInt(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
+    def snapshot = new RegularFileSnapshot("path", "path", TestHashCodes.hashCodeFrom(456), DefaultFileMetadata.file(3456, 456, FileMetadata.AccessType.DIRECT))
     def snapshotContext = new DefaultRegularFileSnapshotContext({path.split('/')}, snapshot)
 
     def "allows all resources when resource filter does not match"() {

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotContext
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -176,6 +176,6 @@ class ZipHasherTest extends Specification {
     }
 
     private static RegularFileSnapshotContext snapshotContext(TestFile file) {
-        return new DefaultRegularFileSnapshotContext({ }, new RegularFileSnapshot(file.path, file.name, HashCode.fromInt(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
+        return new DefaultRegularFileSnapshotContext({ }, new RegularFileSnapshot(file.path, file.name, TestHashCode.fromInt(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
     }
 }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/ZipHasherTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.hashing.RegularFileSnapshotContext
 import org.gradle.internal.fingerprint.hashing.ResourceHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.RegularFileSnapshot
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -176,6 +176,6 @@ class ZipHasherTest extends Specification {
     }
 
     private static RegularFileSnapshotContext snapshotContext(TestFile file) {
-        return new DefaultRegularFileSnapshotContext({ }, new RegularFileSnapshot(file.path, file.name, TestHashCode.fromInt(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
+        return new DefaultRegularFileSnapshotContext({ }, new RegularFileSnapshot(file.path, file.name, TestHashCodes.hashCodeFrom(0), DefaultFileMetadata.file(0, 0, AccessType.DIRECT)))
     }
 }

--- a/subprojects/snapshots/build.gradle.kts
+++ b/subprojects/snapshots/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     testImplementation(testFixtures(project(":file-collections")))
     testImplementation(testFixtures(project(":messaging")))
 
+    testFixturesApi(testFixtures(project(":hashing")))
+
     testFixturesImplementation(project(":base-services"))
     testFixturesImplementation(project(":core-api"))
     testFixturesImplementation(project(":file-collections"))

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/DirectoryNodeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/DirectoryNodeTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.internal.snapshot
 
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.FileType
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 
 import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 
 class DirectoryNodeTest extends AbstractFileSystemNodeWithChildrenTest<FileSystemNode, FileSystemLocationSnapshot> {
     @Override
     protected FileSystemNode createInitialRootNode(ChildMap<FileSystemLocationSnapshot> children) {
-        return new DirectorySnapshot("/root/some/path", PathUtil.getFileName("path"), AccessType.DIRECT, TestHashCode.fromInt(1234), children).asFileSystemNode()
+        return new DirectorySnapshot("/root/some/path", PathUtil.getFileName("path"), AccessType.DIRECT, TestHashCodes.hashCodeFrom(1234), children).asFileSystemNode()
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/DirectoryNodeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/DirectoryNodeTest.groovy
@@ -18,14 +18,14 @@ package org.gradle.internal.snapshot
 
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.FileType
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 
 import static org.gradle.internal.snapshot.CaseSensitivity.CASE_SENSITIVE
 
 class DirectoryNodeTest extends AbstractFileSystemNodeWithChildrenTest<FileSystemNode, FileSystemLocationSnapshot> {
     @Override
     protected FileSystemNode createInitialRootNode(ChildMap<FileSystemLocationSnapshot> children) {
-        return new DirectorySnapshot("/root/some/path", PathUtil.getFileName("path"), AccessType.DIRECT, HashCode.fromInt(1234), children).asFileSystemNode()
+        return new DirectorySnapshot("/root/some/path", PathUtil.getFileName("path"), AccessType.DIRECT, TestHashCode.fromInt(1234), children).asFileSystemNode()
     }
 
     @Override

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.internal.snapshot
 
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 
 class RegularFileSnapshotTest extends AbstractFileSystemLeafSnapshotTest {
     @Override
     protected RegularFileSnapshot createInitialRootNode(String absolutePath) {
-        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), TestHashCode.fromInt(1235), DefaultFileMetadata.file(1, 2, AccessType.DIRECT))
+        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), TestHashCodes.hashCodeFrom(1235), DefaultFileMetadata.file(1, 2, AccessType.DIRECT))
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/RegularFileSnapshotTest.groovy
@@ -18,11 +18,11 @@ package org.gradle.internal.snapshot
 
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 
 class RegularFileSnapshotTest extends AbstractFileSystemLeafSnapshotTest {
     @Override
     protected RegularFileSnapshot createInitialRootNode(String absolutePath) {
-        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), HashCode.fromInt(1235), DefaultFileMetadata.file(1, 2, AccessType.DIRECT))
+        return new RegularFileSnapshot(absolutePath, PathUtil.getFileName(absolutePath), TestHashCode.fromInt(1235), DefaultFileMetadata.file(1, 2, AccessType.DIRECT))
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.MutableReference
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.impl.PatternSetSnapshottingFilter
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -76,7 +76,7 @@ class FileSystemSnapshotFilterTest extends Specification {
 
     def "root directory is always matched"() {
         def root = temporaryFolder.createFile("root")
-        def unfiltered = new DirectorySnapshot(root.absolutePath, root.name, AccessType.DIRECT, TestHashCode.fromInt(789), [])
+        def unfiltered = new DirectorySnapshot(root.absolutePath, root.name, AccessType.DIRECT, TestHashCodes.hashCodeFrom(789), [])
 
         expect:
         filteredPaths(unfiltered, include("different")) == [root] as Set
@@ -84,7 +84,7 @@ class FileSystemSnapshotFilterTest extends Specification {
 
     def "root file can be filtered"() {
         def root = temporaryFolder.createFile("root")
-        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, TestHashCode.fromInt(1234), DefaultFileMetadata.file(5, 1234, AccessType.DIRECT))
+        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(5, 1234, AccessType.DIRECT))
 
         expect:
         filteredPaths(regularFileSnapshot, include("different")) == [] as Set

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.MutableReference
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.impl.PatternSetSnapshottingFilter
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -76,7 +76,7 @@ class FileSystemSnapshotFilterTest extends Specification {
 
     def "root directory is always matched"() {
         def root = temporaryFolder.createFile("root")
-        def unfiltered = new DirectorySnapshot(root.absolutePath, root.name, AccessType.DIRECT, HashCode.fromInt(789), [])
+        def unfiltered = new DirectorySnapshot(root.absolutePath, root.name, AccessType.DIRECT, TestHashCode.fromInt(789), [])
 
         expect:
         filteredPaths(unfiltered, include("different")) == [root] as Set
@@ -84,7 +84,7 @@ class FileSystemSnapshotFilterTest extends Specification {
 
     def "root file can be filtered"() {
         def root = temporaryFolder.createFile("root")
-        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, HashCode.fromInt(1234), DefaultFileMetadata.file(5, 1234, AccessType.DIRECT))
+        def regularFileSnapshot = new RegularFileSnapshot(root.absolutePath, root.name, TestHashCode.fromInt(1234), DefaultFileMetadata.file(5, 1234, AccessType.DIRECT))
 
         expect:
         filteredPaths(regularFileSnapshot, include("different")) == [] as Set

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/ImplementationSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/ImplementationSnapshotTest.groovy
@@ -17,13 +17,13 @@
 package org.gradle.internal.snapshot.impl
 
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import spock.lang.Specification
 
 class ImplementationSnapshotTest extends Specification {
 
     def "class name #className is lambda: #lambda"() {
-        HashCode classloaderHash = TestHashCode.fromInt(1234)
+        HashCode classloaderHash = TestHashCodes.hashCodeFrom(1234)
 
         expect:
         ImplementationSnapshot.of(className, classloaderHash).unknown == lambda
@@ -38,7 +38,7 @@ class ImplementationSnapshotTest extends Specification {
     }
 
     def "implementation snapshots are not equal when unknown"() {
-        HashCode classloaderHash = TestHashCode.fromInt(1234)
+        HashCode classloaderHash = TestHashCodes.hashCodeFrom(1234)
         String lambdaClassName = 'SomeClass$$Lambda$3/23501234324'
         def className = "SomeClass"
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/ImplementationSnapshotTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/ImplementationSnapshotTest.groovy
@@ -17,12 +17,13 @@
 package org.gradle.internal.snapshot.impl
 
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import spock.lang.Specification
 
 class ImplementationSnapshotTest extends Specification {
 
     def "class name #className is lambda: #lambda"() {
-        HashCode classloaderHash = HashCode.fromInt(1234)
+        HashCode classloaderHash = TestHashCode.fromInt(1234)
 
         expect:
         ImplementationSnapshot.of(className, classloaderHash).unknown == lambda
@@ -37,7 +38,7 @@ class ImplementationSnapshotTest extends Specification {
     }
 
     def "implementation snapshots are not equal when unknown"() {
-        HashCode classloaderHash = HashCode.fromInt(1234)
+        HashCode classloaderHash = TestHashCode.fromInt(1234)
         String lambdaClassName = 'SomeClass$$Lambda$3/23501234324'
         def className = "SomeClass"
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.FileType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.snapshot.AbstractIncompleteFileSystemNode
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -485,7 +485,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
         Assume.assumeTrue("Root is only defined for the file separator '/'", File.separator == '/')
 
         when:
-        def set = EMPTY.store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(1111), [new RegularFileSnapshot("/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
+        def set = EMPTY.store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCodes.hashCodeFrom(1111), [new RegularFileSnapshot("/root.txt", "root.txt", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
         then:
         set.findMetadata("/root.txt").get().type == FileType.RegularFile
         set.hasDescendantsUnder("/root.txt")
@@ -494,7 +494,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
         collectSnapshots(set, "/")[0].type == FileType.Directory
 
         when:
-        set = set.invalidate("/root.txt", diffListener).store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(2222), [new RegularFileSnapshot("/base.txt", "base.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
+        set = set.invalidate("/root.txt", diffListener).store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCodes.hashCodeFrom(2222), [new RegularFileSnapshot("/base.txt", "base.txt", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
         then:
         set.findMetadata("/base.txt").get().type == FileType.RegularFile
     }
@@ -729,15 +729,15 @@ class DefaultSnapshotHierarchyTest extends Specification {
     }
 
     private static DirectorySnapshot rootDirectorySnapshot() {
-        new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(1111), [
-            new RegularFileSnapshot("/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT)),
-            new RegularFileSnapshot("/other.txt", "other.txt", TestHashCode.fromInt(4321), DefaultFileMetadata.file(5, 28, AccessType.DIRECT))
+        new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCodes.hashCodeFrom(1111), [
+            new RegularFileSnapshot("/root.txt", "root.txt", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT)),
+            new RegularFileSnapshot("/other.txt", "other.txt", TestHashCodes.hashCodeFrom(4321), DefaultFileMetadata.file(5, 28, AccessType.DIRECT))
         ])
     }
 
     private static DirectorySnapshot directorySnapshotForPath(String absolutePath) {
-        new DirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), AccessType.DIRECT, TestHashCode.fromInt(1111), [
-            new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))
+        new DirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), AccessType.DIRECT, TestHashCodes.hashCodeFrom(1111), [
+            new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", TestHashCodes.hashCodeFrom(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))
         ])
     }
 

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/DefaultSnapshotHierarchyTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.FileType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.snapshot.AbstractIncompleteFileSystemNode
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
@@ -484,7 +485,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
         Assume.assumeTrue("Root is only defined for the file separator '/'", File.separator == '/')
 
         when:
-        def set = EMPTY.store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, HashCode.fromInt(1111), [new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
+        def set = EMPTY.store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(1111), [new RegularFileSnapshot("/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
         then:
         set.findMetadata("/root.txt").get().type == FileType.RegularFile
         set.hasDescendantsUnder("/root.txt")
@@ -493,7 +494,7 @@ class DefaultSnapshotHierarchyTest extends Specification {
         collectSnapshots(set, "/")[0].type == FileType.Directory
 
         when:
-        set = set.invalidate("/root.txt", diffListener).store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, HashCode.fromInt(2222), [new RegularFileSnapshot("/base.txt", "base.txt", HashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
+        set = set.invalidate("/root.txt", diffListener).store("/", new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(2222), [new RegularFileSnapshot("/base.txt", "base.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))]), diffListener)
         then:
         set.findMetadata("/base.txt").get().type == FileType.RegularFile
     }
@@ -728,15 +729,15 @@ class DefaultSnapshotHierarchyTest extends Specification {
     }
 
     private static DirectorySnapshot rootDirectorySnapshot() {
-        new DirectorySnapshot("/", "", AccessType.DIRECT, HashCode.fromInt(1111), [
-            new RegularFileSnapshot("/root.txt", "root.txt", HashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT)),
-            new RegularFileSnapshot("/other.txt", "other.txt", HashCode.fromInt(4321), DefaultFileMetadata.file(5, 28, AccessType.DIRECT))
+        new DirectorySnapshot("/", "", AccessType.DIRECT, TestHashCode.fromInt(1111), [
+            new RegularFileSnapshot("/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT)),
+            new RegularFileSnapshot("/other.txt", "other.txt", TestHashCode.fromInt(4321), DefaultFileMetadata.file(5, 28, AccessType.DIRECT))
         ])
     }
 
     private static DirectorySnapshot directorySnapshotForPath(String absolutePath) {
-        new DirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), AccessType.DIRECT, HashCode.fromInt(1111), [
-            new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", HashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))
+        new DirectorySnapshot(absolutePath, PathUtil.getFileName(absolutePath), AccessType.DIRECT, TestHashCode.fromInt(1111), [
+            new RegularFileSnapshot("${absolutePath}/root.txt", "root.txt", TestHashCode.fromInt(1234), DefaultFileMetadata.file(1, 1, AccessType.DIRECT))
         ])
     }
 

--- a/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/TestSnapshotFixture.groovy
+++ b/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/TestSnapshotFixture.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.snapshot
 
 import org.apache.commons.io.FilenameUtils
 import org.gradle.internal.file.FileMetadata
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 
 import javax.annotation.Nullable
@@ -36,7 +36,7 @@ trait TestSnapshotFixture {
             FilenameUtils.separatorsToSystem(absolutePath),
             FilenameUtils.getName(absolutePath),
             accessType,
-            TestHashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
+            TestHashCodes.hashCodeFrom(hashCode ?: pseudoRandom.nextLong()),
             children as List
         )
     }
@@ -53,7 +53,7 @@ trait TestSnapshotFixture {
         new RegularFileSnapshot(
             FilenameUtils.separatorsToSystem(absolutePath),
             FilenameUtils.getName(absolutePath),
-            TestHashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
+            TestHashCodes.hashCodeFrom(hashCode ?: pseudoRandom.nextLong()),
             file(abs(pseudoRandom.nextLong()), abs(pseudoRandom.nextLong()), accessType))
     }
 

--- a/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/TestSnapshotFixture.groovy
+++ b/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/TestSnapshotFixture.groovy
@@ -18,7 +18,7 @@ package org.gradle.internal.snapshot
 
 import org.apache.commons.io.FilenameUtils
 import org.gradle.internal.file.FileMetadata
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.vfs.impl.DefaultSnapshotHierarchy
 
 import javax.annotation.Nullable
@@ -36,7 +36,7 @@ trait TestSnapshotFixture {
             FilenameUtils.separatorsToSystem(absolutePath),
             FilenameUtils.getName(absolutePath),
             accessType,
-            HashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
+            TestHashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
             children as List
         )
     }
@@ -53,7 +53,7 @@ trait TestSnapshotFixture {
         new RegularFileSnapshot(
             FilenameUtils.separatorsToSystem(absolutePath),
             FilenameUtils.getName(absolutePath),
-            HashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
+            TestHashCode.fromLong(hashCode ?: pseudoRandom.nextLong()),
             file(abs(pseudoRandom.nextLong()), abs(pseudoRandom.nextLong()), accessType))
     }
 

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.attributes.Attribute
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.TestHashCode
+import org.gradle.internal.hash.TestHashCodes
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.isolation.Isolatable
 import org.gradle.internal.isolation.IsolatableFactory
@@ -37,7 +37,7 @@ import spock.lang.Specification
 class IsolatableSerializerRegistryTest extends Specification {
     def managedFactoryRegistry = TestUtil.managedFactoryRegistry()
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCodes.hashCodeFrom(123)
     }
     IsolatableFactory isolatableFactory = new DefaultIsolatableFactory(classLoaderHasher, managedFactoryRegistry)
     InstantiatorFactory instantiatorFactory = TestUtil.instantiatorFactory()

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/IsolatableSerializerRegistryTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.workers.internal
 
 import org.gradle.api.attributes.Attribute
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher
-import org.gradle.internal.hash.HashCode
+import org.gradle.internal.hash.TestHashCode
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.isolation.Isolatable
 import org.gradle.internal.isolation.IsolatableFactory
@@ -28,8 +28,8 @@ import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookup
 import org.gradle.internal.snapshot.impl.DefaultIsolatableFactory
 import org.gradle.internal.snapshot.impl.IsolatedImmutableManagedValue
-import org.gradle.internal.snapshot.impl.IsolatedManagedValue
 import org.gradle.internal.snapshot.impl.IsolatedJavaSerializedValueSnapshot
+import org.gradle.internal.snapshot.impl.IsolatedManagedValue
 import org.gradle.util.TestUtil
 import org.gradle.workers.fixtures.TestManagedTypes
 import spock.lang.Specification
@@ -37,7 +37,7 @@ import spock.lang.Specification
 class IsolatableSerializerRegistryTest extends Specification {
     def managedFactoryRegistry = TestUtil.managedFactoryRegistry()
     def classLoaderHasher = Stub(ClassLoaderHierarchyHasher) {
-        getClassLoaderHash(_) >> HashCode.fromInt(123)
+        getClassLoaderHash(_) >> TestHashCode.fromInt(123)
     }
     IsolatableFactory isolatableFactory = new DefaultIsolatableFactory(classLoaderHasher, managedFactoryRegistry)
     InstantiatorFactory instantiatorFactory = TestUtil.instantiatorFactory()


### PR DESCRIPTION
Gradle stores a large number of `HashCode` objects in memory, especially 128-bit MD5 hashes. Altogether hashes can take up gigabytes of heap in a large build.

We currently store the bits in a `byte[]` that is quite inefficient for a few reasons:

- the `byte[16]` actually takes up 40 bytes of heap (12 header + 4 length + 16 data)
- the `HashCode` object needs to track the reference to the `byte[]` worth 8 bytes
- as `HashCode.hashCode()` is somewhat expensive to compute, we cache it in an ~`int`~ `long` adding another 8 bytes

With some additional JVM bookkeeping this adds up to 72 bytes per object when aligned on an 8-byte boundary. There are also two objects (`HashCode` and the `byte[]`) for the GC to track.

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/495366/155185383-59883a5c-10d6-4357-ba98-1fe83bc9e30b.png">

Since the vast majority of `HashCode` objects are made up by the MD5 hashes used in snapshotting and fingerprinting inputs, it makes sense to add a more efficient format for this specific use case.

This PR introduces an alternative `HashCode128` implementation that uses two `long`s to keep track of the bits instead of the `byte[]`. This results in a single object to track for GC that takes up only 32 bytes of memory. (Note that there's no need to cache the `hashCode()` value either.)

Going from 72 bytes to 32 is a 55% reduction in memory consumption worth several hundreds of megabytes of heap in a large build.

When [compressed oops is used](https://docs.oracle.com/javase/7/docs/technotes/guides/vm/performance-enhancements-7.html#compressedOop) (which is likely, given that Gradle daemons rarely use more than 32 GB of heap) the reduction is somewhat less dramatic, from 56 bytes to 32, which is still 38.5% less memory being used.

Thanks for @davidburstrom for the idea.

*Further changes*

- `HashCode.fromInt()` and `fromLong()` are now only available in tests via `TestHashCode.fromInt()` and `fromLong()`. They also produce 128-bit hashes instead of 32/64-bit ones. Production code should use `Hashing.signature()` methods to create constant hashes.

*Why only 128-bit hashes*

Currently our use of `HashCode` is dominated by MD5 hashes used in snapshotting inputs and outputs and cache key calculations. We also use `HashCode` around binary dependencies to store SHA1 and SHA256 and even SHA512 values (with 160, 256 and 512 bits respectively). However, while in a large build there might be millions of MD5 hashes, typically there are a lot fewer dependencies (~thousands), so the savings on SHA* hashes are comparatively small.

Should we switch to SHA256 for the snapshotting and caching in the future, then we should add a 256-bit variant with four `long`s, too.