### PR TITLE
Fix configuration cache report after upgrade to Kotlin 1.6.20-M1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,11 @@ org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true
 
 systemProp.gradle.publish.skip.namespace.check=true
+
+# Kotlin settings
 kotlin.incremental.useClasspathSnapshot=true
+kotlin.stdlib.default.dependency=false
+kotlin.js.ir.output.granularity=whole-program
 
 # Temporarily force IDEs to produce build scans
 systemProp.org.gradle.internal.ide.scan=true
@@ -17,7 +21,6 @@ org.gradle.vfs.debug=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
 
-kotlin.stdlib.default.dependency=false
 
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=true


### PR DESCRIPTION
By setting the IR output granularity to `whole-program`.
