### PR TITLE
Add intentionally unwelcoming flag to make execution history read-only

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
@@ -30,6 +30,7 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.hash.ClassLoaderHierarchyHasher;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -39,6 +40,7 @@ import static com.google.common.collect.Maps.transformValues;
 public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
 
     private final PersistentIndexedCache<String, PreviousExecutionState> store;
+    private final boolean isReadOnly = Objects.equals(System.getProperty("org.gradle.unsafe.executionhistory.readonly"), "true");
 
     public DefaultExecutionHistoryStore(
         Supplier<PersistentCache> cache,
@@ -66,6 +68,9 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
 
     @Override
     public void store(String key, boolean successful, AfterExecutionState executionState) {
+        if (isReadOnly) {
+            return;
+        }
         store.put(key, new DefaultPreviousExecutionState(
             executionState.getOriginMetadata(),
             executionState.getImplementation(),
@@ -79,6 +84,9 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
 
     @Override
     public void remove(String key) {
+        if (isReadOnly) {
+            return;
+        }
         store.remove(key);
     }
 


### PR DESCRIPTION
This would be a big performance boost for certain CI environments,
but could cause problems if used in more generic use cases. See the
associated issue (#20005).

Fixes #20005

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
