### PR TITLE
Reduce cost of scheduling nodes when there are many idle workers

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/AbstractTrackedResourceLock.java
@@ -34,6 +34,11 @@ public abstract class AbstractTrackedResourceLock implements ResourceLock {
     }
 
     @Override
+    public String toString() {
+        return getClass().getSimpleName() + " " + getDisplayName();
+    }
+
+    @Override
     public boolean tryLock() {
         if (!isLockedByCurrentThread()) {
             if (acquireLock()) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/DefaultResourceLockCoordinationService.java
@@ -18,21 +18,60 @@ package org.gradle.internal.resources;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.internal.UncheckedException;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public class DefaultResourceLockCoordinationService implements ResourceLockCoordinationService {
+public class DefaultResourceLockCoordinationService implements ResourceLockCoordinationService, Closeable {
     private final Object lock = new Object();
+    private final Set<Action<ResourceLock>> releaseHandlers = new LinkedHashSet<Action<ResourceLock>>();
     private final ThreadLocal<List<ResourceLockState>> currentState = new ThreadLocal<List<ResourceLockState>>() {
         @Override
         protected List<ResourceLockState> initialValue() {
             return Lists.newArrayList();
         }
     };
+
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            if (!releaseHandlers.isEmpty()) {
+                throw new IllegalStateException("Some lock release listeners have not been removed.");
+            }
+        }
+    }
+
+    @Override
+    public void assertHasStateLock() {
+        synchronized (lock) {
+            if (getCurrent() == null) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    @Override
+    public void addLockReleaseListener(Action<ResourceLock> listener) {
+        synchronized (lock) {
+            releaseHandlers.add(listener);
+        }
+    }
+
+    @Override
+    public void removeLockReleaseListener(Action<ResourceLock> listener) {
+        synchronized (lock) {
+            releaseHandlers.remove(listener);
+        }
+    }
 
     @Override
     public boolean withStateLock(Transformer<ResourceLockState.Disposition, ResourceLockState> stateLockAction) {
@@ -85,8 +124,14 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
     }
 
     private void maybeNotifyStateChange(DefaultResourceLockState resourceLockState) {
-        if (resourceLockState.hasUnlockedResources()) {
+        Collection<ResourceLock> unlockedResources = resourceLockState.getUnlockedResources();
+        if (!unlockedResources.isEmpty()) {
             notifyStateChange();
+            for (ResourceLock resource : unlockedResources) {
+                for (Action<ResourceLock> releaseHandler : releaseHandlers) {
+                    releaseHandler.execute(resource);
+                }
+            }
         }
     }
 
@@ -122,8 +167,8 @@ public class DefaultResourceLockCoordinationService implements ResourceLockCoord
             }
         }
 
-        boolean hasUnlockedResources() {
-            return unlockedResources != null && !unlockedResources.isEmpty();
+        Collection<ResourceLock> getUnlockedResources() {
+            return unlockedResources == null ? Collections.<ResourceLock>emptyList() : unlockedResources;
         }
 
         @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockCoordinationService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ResourceLockCoordinationService.java
@@ -16,11 +16,12 @@
 
 package org.gradle.internal.resources;
 
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
-import org.gradle.internal.service.scopes.Scope;
+import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
-@ServiceScope(Scope.Global.class)
+@ServiceScope(Scopes.BuildSession.class)
 public interface ResourceLockCoordinationService {
     /**
      * Gets the current {@link ResourceLockState} active in this thread.  This must be called in the context
@@ -41,8 +42,6 @@ public interface ResourceLockCoordinationService {
      * RETRY - One or more locks were not acquired, roll back any locks that were acquired and block waiting for the
      * state to change, then run the transform again
      *
-     * @param stateLockAction
-     *
      * @return true if the lock state changes finished successfully, otherwise false.
      */
     boolean withStateLock(Transformer<ResourceLockState.Disposition, ResourceLockState> stateLockAction);
@@ -51,4 +50,13 @@ public interface ResourceLockCoordinationService {
      * Notify other threads about changes to resource locks.
      */
     void notifyStateChange();
+
+    void assertHasStateLock();
+
+    /**
+     * Adds a listener that is notified when a lock is released. Called while the state lock is held.
+     */
+    void addLockReleaseListener(Action<ResourceLock> listener);
+
+    void removeLockReleaseListener(Action<ResourceLock> listener);
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildClassPathInitializer.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.initialization.ScriptClassPathInitializer;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.execution.plan.TaskNode;
 import org.gradle.internal.build.BuildState;
 
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public class CompositeBuildClassPathInitializer implements ScriptClassPathInitia
                 // running tasks at the same time
                 BuildState targetBuild = ((ProjectInternal) task.getProject()).getOwner().getOwner();
                 assert targetBuild != currentBuild;
-                tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task, TaskNode.UNKNOWN_ORDINAL));
+                tasksToBuild.add(TaskIdentifier.of(targetBuild.getBuildIdentifier(), (TaskInternal) task));
             }
         }
         if (!tasksToBuild.isEmpty()) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -28,7 +28,6 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildWorkGraph;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.build.ExportedTaskNode;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.graph.CachingDirectedGraphWalker;
 import org.gradle.internal.graph.DirectedGraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
@@ -48,7 +47,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
-class DefaultBuildController implements BuildController, Stoppable {
+class DefaultBuildController implements BuildController {
     private enum State {
         DiscoveringTasks, ReadyToRun, RunningTasks, Finished
     }
@@ -141,6 +140,7 @@ class DefaultBuildController implements BuildController, Stoppable {
         if (state == State.RunningTasks) {
             throw new IllegalStateException("Build is currently running tasks.");
         }
+        workGraph.stop();
     }
 
     private void doAwaitCompletion() {
@@ -182,7 +182,7 @@ class DefaultBuildController implements BuildController, Stoppable {
             }));
             StringWriter writer = new StringWriter();
             graphRenderer.renderTo(task, writer);
-            throw new CircularReferenceException(String.format("Circular dependency between the following tasks:%n%s", writer.toString()));
+            throw new CircularReferenceException(String.format("Circular dependency between the following tasks:%n%s", writer));
         }
         visitDependenciesOf(task, dep -> checkForCyclesFor(dep, visited, visiting));
         visiting.remove(task);

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultBuildController.java
@@ -191,7 +191,7 @@ class DefaultBuildController implements BuildController, Stoppable {
 
     private void visitDependenciesOf(TaskInternal task, Consumer<TaskInternal> consumer) {
         TaskNodeFactory taskNodeFactory = ((GradleInternal) task.getProject().getGradle()).getServices().get(TaskNodeFactory.class);
-        TaskNode node = taskNodeFactory.getOrCreateNode(task, TaskNode.UNKNOWN_ORDINAL);
+        TaskNode node = taskNodeFactory.getOrCreateNode(task);
         for (Node dependency : node.getAllSuccessors()) {
             if (dependency instanceof TaskNode) {
                 consumer.accept(((TaskNode) dependency).getTask());

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -214,6 +214,11 @@ public class DefaultIncludedBuildTaskGraph implements BuildTreeWorkGraphControll
         }
 
         @Override
+        public void onComplete(Runnable action) {
+            taskNode.onComplete(action);
+        }
+
+        @Override
         public TaskInternal getTask() {
             return taskNode.getTask();
         }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -16,11 +16,9 @@
 
 package org.gradle.composite.internal
 
-
 import org.gradle.api.artifacts.component.BuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.internal.build.BuildState
-import org.gradle.execution.plan.TaskNode
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.BuildWorkGraph
 import org.gradle.internal.build.BuildWorkGraphController

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphTest.groovy
@@ -172,6 +172,6 @@ class DefaultIncludedBuildTaskGraphTest extends ConcurrentSpec {
     }
 
     static TaskIdentifier taskIdentifier(BuildIdentifier id, String taskPath) {
-        return TaskIdentifier.of(id, taskPath, TaskNode.UNKNOWN_ORDINAL)
+        return TaskIdentifier.of(id, taskPath)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
@@ -32,20 +32,17 @@ class TaskInAnotherBuildCodec(
     override suspend fun WriteContext.encode(value: TaskInAnotherBuild) {
         value.run {
             writeString(taskPath)
-            writeInt(ordinal)
             write(targetBuild)
         }
     }
 
     override suspend fun ReadContext.decode(): TaskInAnotherBuild {
         val taskPath = readString()
-        val ordinal = readInt()
         val targetBuild = readNonNull<BuildIdentifier>()
         return TaskInAnotherBuild.of(
             taskPath,
             targetBuild,
-            includedTaskGraph,
-            ordinal
+            includedTaskGraph
         )
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
@@ -69,13 +69,11 @@ class TaskNodeCodec(
     override suspend fun WriteContext.encode(value: LocalTaskNode) {
         val task = value.task
         writeTask(task)
-        writeInt(value.ordinal)
     }
 
     override suspend fun ReadContext.decode(): LocalTaskNode {
         val task = readTask()
-        val ordinal = readInt()
-        val node = taskNodeFactory.getOrCreateNode(task, ordinal) as LocalTaskNode
+        val node = taskNodeFactory.getOrCreateNode(task) as LocalTaskNode
         node.isolated()
         return node
     }

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/BuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/BuildController.java
@@ -18,11 +18,12 @@ package org.gradle.composite.internal;
 import org.gradle.internal.build.BuildLifecycleController;
 import org.gradle.internal.build.ExecutionResult;
 import org.gradle.internal.build.ExportedTaskNode;
+import org.gradle.internal.concurrent.Stoppable;
 
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
-public interface BuildController {
+public interface BuildController extends Stoppable {
     /**
      * Adds tasks and nodes to the work graph of this build.
      */

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskResource.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/IncludedBuildTaskResource.java
@@ -17,6 +17,7 @@
 package org.gradle.composite.internal;
 
 import org.gradle.api.internal.TaskInternal;
+import org.gradle.execution.plan.Node;
 
 import java.util.function.Consumer;
 
@@ -39,9 +40,14 @@ public interface IncludedBuildTaskResource {
     }
 
     /**
-     * Queues a task for execution, but does not schedule it. Use {@link org.gradle.internal.buildtree.BuildTreeWorkGraph#scheduleWork(Consumer)} to schedule queued tasks.
+     * Queues the task for execution, but does not schedule it. Use {@link org.gradle.internal.buildtree.BuildTreeWorkGraph#scheduleWork(Consumer)} to schedule queued tasks.
      */
     void queueForExecution();
+
+    /**
+     * Invokes the given action when this task completes (as per {@link Node#isComplete()}). Does nothing if this task has already completed.
+     */
+    void onComplete(Runnable action);
 
     TaskInternal getTask();
 

--- a/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
+++ b/subprojects/core/src/main/java/org/gradle/composite/internal/TaskIdentifier.java
@@ -21,23 +21,18 @@ import org.gradle.api.internal.TaskInternal;
 
 public interface TaskIdentifier {
     BuildIdentifier getBuildIdentifier();
-    int getOrdinal();
+
     String getTaskPath();
 
     interface TaskBasedTaskIdentifier extends TaskIdentifier {
         TaskInternal getTask();
     }
 
-    static TaskBasedTaskIdentifier of(BuildIdentifier buildIdentifier, TaskInternal task, int ordinal) {
+    static TaskBasedTaskIdentifier of(BuildIdentifier buildIdentifier, TaskInternal task) {
         return new TaskBasedTaskIdentifier() {
             @Override
             public BuildIdentifier getBuildIdentifier() {
                 return buildIdentifier;
-            }
-
-            @Override
-            public int getOrdinal() {
-                return ordinal;
             }
 
             @Override
@@ -52,7 +47,7 @@ public interface TaskIdentifier {
         };
     }
 
-    static TaskIdentifier of(BuildIdentifier buildIdentifier, String taskPath, int ordinal) {
+    static TaskIdentifier of(BuildIdentifier buildIdentifier, String taskPath) {
         return new TaskIdentifier() {
             @Override
             public BuildIdentifier getBuildIdentifier() {
@@ -62,11 +57,6 @@ public interface TaskIdentifier {
             @Override
             public String getTaskPath() {
                 return taskPath;
-            }
-
-            @Override
-            public int getOrdinal() {
-                return ordinal;
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -54,10 +54,6 @@ public class ActionNode extends Node implements SelfExecutingNode {
     }
 
     @Override
-    public void prepareForExecution() {
-    }
-
-    @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
         TaskDependencyContainer dependencies = action::visitDependencies;
         for (Node node : dependencyResolver.resolveDependenciesFor(null, dependencies)) {
@@ -78,16 +74,6 @@ public class ActionNode extends Node implements SelfExecutingNode {
 
     public WorkNodeAction getAction() {
         return action;
-    }
-
-    @Override
-    public boolean isPublicNode() {
-        return false;
-    }
-
-    @Override
-    public boolean requiresMonitoring() {
-        return false;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
@@ -16,5 +16,11 @@
 
 package org.gradle.execution.plan;
 
+import java.util.function.Consumer;
+
 public interface BuildWorkPlan {
+    /**
+     * Invokes the given action when a task completes (as per {@link Node#isComplete()}). Does nothing for tasks that have already completed.
+     */
+    void onComplete(Consumer<LocalTaskNode> handler);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/BuildWorkPlan.java
@@ -16,9 +16,11 @@
 
 package org.gradle.execution.plan;
 
+import org.gradle.internal.concurrent.Stoppable;
+
 import java.util.function.Consumer;
 
-public interface BuildWorkPlan {
+public interface BuildWorkPlan extends Stoppable {
     /**
      * Invokes the given action when a task completes (as per {@link Node#isComplete()}). Does nothing for tasks that have already completed.
      */

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -150,7 +150,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         final Deque<Node> queue = new ArrayDeque<>();
 
         for (Task task : sorted(tasks)) {
-            TaskNode node = taskNodeFactory.getOrCreateNode(task, ordinal);
+            TaskNode node = taskNodeFactory.getOrCreateNode(task);
+            node.maybeSetOrdinal(ordinal);
             if (node.isMustNotRun()) {
                 requireWithDependencies(node);
             } else if (filter.isSatisfiedBy(task)) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -21,6 +21,7 @@ import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 
 import javax.annotation.Nullable;
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,7 +31,7 @@ import java.util.function.Consumer;
 /**
  * Represents a graph of dependent work items, returned in execution order.
  */
-public interface ExecutionPlan extends Describable {
+public interface ExecutionPlan extends Describable, Closeable {
     ExecutionPlan EMPTY = new ExecutionPlan() {
         @Override
         public void useFilter(Spec<? super Task> filter) {
@@ -138,6 +139,10 @@ public interface ExecutionPlan extends Describable {
         public String getDisplayName() {
             return "empty";
         }
+
+        @Override
+        public void close() {
+        }
     };
 
     void useFilter(Spec<? super Task> filter);
@@ -205,4 +210,7 @@ public interface ExecutionPlan extends Describable {
      * Invokes the given action when a task completes (as per {@link Node#isComplete()}). Does nothing for tasks that have already completed.
      */
     void onComplete(Consumer<LocalTaskNode> handler);
+
+    @Override
+    void close();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Represents a graph of dependent work items, returned in execution order.
@@ -114,6 +115,11 @@ public interface ExecutionPlan extends Describable {
         }
 
         @Override
+        public void onComplete(Consumer<LocalTaskNode> handler) {
+            throw new IllegalStateException();
+        }
+
+        @Override
         public boolean allNodesComplete() {
             return true;
         }
@@ -194,4 +200,9 @@ public interface ExecutionPlan extends Describable {
      * Returns the number of work items in the plan.
      */
     int size();
+
+    /**
+     * Invokes the given action when a task completes (as per {@link Node#isComplete()}). Does nothing for tasks that have already completed.
+     */
+    void onComplete(Consumer<LocalTaskNode> handler);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.execution.plan;
 
+import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -27,6 +28,7 @@ public class ExecutionPlanFactory {
     private final NodeValidator nodeValidator;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
+    private final ResourceLockCoordinationService lockCoordinationService;
 
     public ExecutionPlanFactory(
         String displayName,
@@ -34,7 +36,8 @@ public class ExecutionPlanFactory {
         TaskDependencyResolver dependencyResolver,
         NodeValidator nodeValidator,
         ExecutionNodeAccessHierarchy outputHierarchy,
-        ExecutionNodeAccessHierarchy destroyableHierarchy
+        ExecutionNodeAccessHierarchy destroyableHierarchy,
+        ResourceLockCoordinationService lockCoordinationService
     ) {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
@@ -42,9 +45,10 @@ public class ExecutionPlanFactory {
         this.nodeValidator = nodeValidator;
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
+        this.lockCoordinationService = lockCoordinationService;
     }
 
     public ExecutionPlan createPlan() {
-        return new DefaultExecutionPlan(displayName, taskNodeFactory, dependencyResolver, nodeValidator, outputHierarchy, destroyableHierarchy);
+        return new DefaultExecutionPlan(displayName, taskNodeFactory, dependencyResolver, nodeValidator, outputHierarchy, destroyableHierarchy, lockCoordinationService);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -51,8 +51,7 @@ public class LocalTaskNode extends TaskNode {
     private List<? extends ResourceLock> resourceLocks;
     private TaskProperties taskProperties;
 
-    public LocalTaskNode(TaskInternal task, WorkValidationContext workValidationContext, int ordinal) {
-        super(ordinal);
+    public LocalTaskNode(TaskInternal task, WorkValidationContext workValidationContext) {
         this.task = task;
         this.validationContext = workValidationContext;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -99,6 +99,11 @@ public class LocalTaskNode extends TaskNode {
     }
 
     @Override
+    public boolean isPublicNode() {
+        return true;
+    }
+
+    @Override
     public Action<? super Task> getPostAction() {
         return postAction;
     }
@@ -123,7 +128,7 @@ public class LocalTaskNode extends TaskNode {
     }
 
     @Override
-    public void prepareForExecution() {
+    public void prepareForExecution(Action<Node> monitor) {
         ((TaskContainerInternal) task.getProject().getTasks()).prepareForExecution(task);
     }
 
@@ -149,11 +154,6 @@ public class LocalTaskNode extends TaskNode {
         for (Node targetNode : getShouldRunAfter(dependencyResolver)) {
             addShouldSuccessor(targetNode);
         }
-    }
-
-    @Override
-    public boolean requiresMonitoring() {
-        return false;
     }
 
     private void addFinalizerNode(TaskNode finalizerNode) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -88,8 +88,10 @@ public abstract class Node implements Comparable<Node> {
     }
 
     /**
-     * Is it possible for this node to run? Returns {@code true} if this node definitely will not run, {@code false} if it is possible
-     * for the node to run.
+     * Is it possible for this node to run? Returns {@code true} if this node definitely will not run, {@code false} if it is still possible for the node to run.
+     *
+     * <p>A node may be complete for several reasons, for example when its actions have been executed, or when its outputs have been considered up-to-date or loaded from the build cache,
+     * or when it cannot run due to a failure in a dependency.</p>
      */
     public boolean isComplete() {
         return state == ExecutionState.EXECUTED
@@ -277,7 +279,14 @@ public abstract class Node implements Comparable<Node> {
         return getDependencyPredecessors();
     }
 
-    public abstract void prepareForExecution();
+    /**
+     * Called when this node is added to the work graph, prior to resolving its dependencies.
+     *
+     * @param monitor An action that should be called when this node is ready to execute, when the dependencies for this node are executed outside
+     * the work graph that contains this node (for example, when the node represents a task in an included build).
+     */
+    public void prepareForExecution(Action<Node> monitor) {
+    }
 
     public abstract void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor);
 
@@ -325,14 +334,9 @@ public abstract class Node implements Comparable<Node> {
 
     public abstract void resolveMutations();
 
-    public abstract boolean isPublicNode();
-
-    /**
-     * Whether the task needs to be queried if it is completed.
-     *
-     * Everything where the value of {@link #isComplete()} depends on some other state, like another task in an included build.
-     */
-    public abstract boolean requiresMonitoring();
+    public boolean isPublicNode() {
+        return false;
+    }
 
     /**
      * Returns the project state that this node requires mutable access to, if any.

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
@@ -55,9 +55,6 @@ public class OrdinalNode extends Node implements SelfExecutingNode {
     public void rethrowNodeFailure() { }
 
     @Override
-    public void prepareForExecution() { }
-
-    @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) { }
 
     @Override
@@ -67,16 +64,6 @@ public class OrdinalNode extends Node implements SelfExecutingNode {
 
     @Override
     public void resolveMutations() { }
-
-    @Override
-    public boolean isPublicNode() {
-        return false;
-    }
-
-    @Override
-    public boolean requiresMonitoring() {
-        return false;
-    }
 
     @Nullable
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -35,25 +35,23 @@ import java.util.List;
 public class TaskInAnotherBuild extends TaskNode {
     public static TaskInAnotherBuild of(
         TaskInternal task,
-        BuildTreeWorkGraphController taskGraph,
-        int ordinal
+        BuildTreeWorkGraphController taskGraph
     ) {
         BuildIdentifier targetBuild = buildIdentifierOf(task);
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task, ordinal);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task);
         IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
-        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource, ordinal);
+        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource);
     }
 
     public static TaskInAnotherBuild of(
         String taskPath,
         BuildIdentifier targetBuild,
-        BuildTreeWorkGraphController taskGraph,
-        int ordinal
+        BuildTreeWorkGraphController taskGraph
     ) {
-        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, taskPath, ordinal);
+        TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, taskPath);
         IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         Path taskIdentityPath = Path.path(targetBuild.getName()).append(Path.path(taskPath));
-        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource, ordinal);
+        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource);
     }
 
     protected IncludedBuildTaskResource.State state = IncludedBuildTaskResource.State.Waiting;
@@ -62,8 +60,7 @@ public class TaskInAnotherBuild extends TaskNode {
     private final BuildIdentifier targetBuild;
     private final IncludedBuildTaskResource target;
 
-    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild, IncludedBuildTaskResource target, int ordinal) {
-        super(ordinal);
+    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild, IncludedBuildTaskResource target) {
         this.taskIdentityPath = taskIdentityPath;
         this.taskPath = taskPath;
         this.targetBuild = targetBuild;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -21,6 +21,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.BuildIdentifier;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.composite.internal.IncludedBuildTaskResource;
 import org.gradle.composite.internal.TaskIdentifier;
@@ -32,7 +33,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-public class TaskInAnotherBuild extends TaskNode {
+public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     public static TaskInAnotherBuild of(
         TaskInternal task,
         BuildTreeWorkGraphController taskGraph
@@ -82,8 +83,9 @@ public class TaskInAnotherBuild extends TaskNode {
     }
 
     @Override
-    public void prepareForExecution() {
+    public void prepareForExecution(Action<Node> monitor) {
         target.queueForExecution();
+        target.onComplete(() -> monitor.execute(this));
     }
 
     @Nullable
@@ -108,12 +110,11 @@ public class TaskInAnotherBuild extends TaskNode {
 
     @Override
     public Throwable getNodeFailure() {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     @Override
     public void rethrowNodeFailure() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -133,31 +134,19 @@ public class TaskInAnotherBuild extends TaskNode {
     }
 
     @Override
-    public boolean requiresMonitoring() {
-        return true;
-    }
-
-    @Override
-    public boolean isSuccessful() {
+    public boolean allDependenciesSuccessful() {
         return state == IncludedBuildTaskResource.State.Success;
     }
 
     @Override
-    public boolean isVerificationFailure() {
-        return false;
-    }
-
-    @Override
-    public boolean isFailed() {
-        return state == IncludedBuildTaskResource.State.Failed;
-    }
-
-    @Override
-    public boolean isComplete() {
-        if (super.isComplete() || state.isComplete()) {
+    public boolean isReady() {
+        // This node is ready to "execute" when the task in the other build has completed
+        if (!super.isReady()) {
+            return false;
+        }
+        if (state.isComplete()) {
             return true;
         }
-
         state = target.getTaskState();
         return state.isComplete();
     }
@@ -179,6 +168,11 @@ public class TaskInAnotherBuild extends TaskNode {
     @Override
     public void resolveMutations() {
         // Assume for now that no task in the consuming build will destroy the outputs of this task or overlaps with this task
+    }
+
+    @Override
+    public void execute(NodeExecutionContext context) {
+        // This node does not do anything itself
     }
 
     private static BuildIdentifier buildIdentifierOf(TaskInternal task) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -163,11 +163,6 @@ public abstract class TaskNode extends Node {
 
     public abstract TaskInternal getTask();
 
-    @Override
-    public boolean isPublicNode() {
-        return true;
-    }
-
     private void deprecateLifecycleHookReferencingNonLocalTask(String hookName, Node taskNode) {
         if (taskNode instanceof TaskInAnotherBuild) {
             DeprecationLogger.deprecateAction("Using " + hookName + " to reference tasks from another build")

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -37,11 +37,7 @@ public abstract class TaskNode extends Node {
     private final NavigableSet<Node> shouldSuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> finalizers = Sets.newTreeSet();
     private final NavigableSet<Node> finalizingSuccessors = Sets.newTreeSet();
-    private int ordinal;
-
-    public TaskNode(int ordinal) {
-        this.ordinal = ordinal;
-    }
+    private int ordinal = UNKNOWN_ORDINAL;
 
     @Override
     public boolean doCheckDependenciesComplete() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
@@ -34,9 +34,7 @@ public class TaskNodeDependencyResolver implements DependencyResolver {
 
     @Override
     public boolean resolve(Task task, Object node, final Action<? super Node> resolveAction) {
-        TaskNode taskNode = taskNodeFactory.getNode(task);
-        int ordinal = taskNode != null ? taskNode.getOrdinal() : TaskNode.UNKNOWN_ORDINAL;
-        return TASK_AS_TASK.resolve(task, node, resolved -> resolveAction.execute(taskNodeFactory.getOrCreateNode(resolved, ordinal)));
+        return TASK_AS_TASK.resolve(task, node, resolved -> resolveAction.execute(taskNodeFactory.getOrCreateNode(resolved)));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -69,13 +69,13 @@ public class TaskNodeFactory {
         return nodes.get(task);
     }
 
-    public TaskNode getOrCreateNode(Task task, int ordinal) {
+    public TaskNode getOrCreateNode(Task task) {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)), ordinal);
+                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
             } else {
-                node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController, ordinal);
+                node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController);
             }
             nodes.put(task, node);
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -109,6 +109,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
 
     @Override
     public void populate(ExecutionPlan plan) {
+        executionPlan.close();
         executionPlan = plan;
         allTasks = null;
         if (!hasFiredWhenReady) {
@@ -128,6 +129,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
         try (ProjectExecutionServiceRegistry projectExecutionServices = new ProjectExecutionServiceRegistry(globalServices)) {
             executeWithServices(projectExecutionServices, failures);
         } finally {
+            executionPlan.close();
             executionPlan = ExecutionPlan.EMPTY;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildOperationFiringBuildWorkPreparer.java
@@ -25,6 +25,7 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.execution.plan.ExecutionPlan;
+import org.gradle.execution.plan.LocalTaskNode;
 import org.gradle.execution.plan.Node;
 import org.gradle.execution.plan.TaskNode;
 import org.gradle.initialization.DefaultPlannedTask;
@@ -110,12 +111,12 @@ public class BuildOperationFiringBuildWorkPreparer implements BuildWorkPreparer 
 
                 private List<CalculateTaskGraphBuildOperationType.PlannedTask> toPlannedTasks(List<Node> scheduledWork) {
                     return FluentIterable.from(scheduledWork)
-                        .filter(TaskNode.class)
+                        .filter(LocalTaskNode.class)
                         .transform(this::toPlannedTask)
                         .toList();
                 }
 
-                private CalculateTaskGraphBuildOperationType.PlannedTask toPlannedTask(TaskNode taskNode) {
+                private CalculateTaskGraphBuildOperationType.PlannedTask toPlannedTask(LocalTaskNode taskNode) {
                     TaskIdentity<?> taskIdentity = taskNode.getTask().getTaskIdentity();
                     return new DefaultPlannedTask(
                         new PlannedTaskIdentity(taskIdentity),

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraph.java
@@ -16,10 +16,12 @@
 
 package org.gradle.internal.build;
 
+import org.gradle.internal.concurrent.Stoppable;
+
 import java.util.Collection;
 import java.util.function.Consumer;
 
-public interface BuildWorkGraph {
+public interface BuildWorkGraph extends Stoppable {
     /**
      * Schedules the given tasks and all of their dependencies in this work graph.
      */

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -224,6 +224,11 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         }
 
         @Override
+        public void stop() {
+            plan.close();
+        }
+
+        @Override
         public void onComplete(Consumer<LocalTaskNode> handler) {
             handlers.add(handler);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.SettingsInternal;
 import org.gradle.execution.BuildWorkExecutor;
 import org.gradle.execution.plan.BuildWorkPlan;
 import org.gradle.execution.plan.ExecutionPlan;
+import org.gradle.execution.plan.LocalTaskNode;
 import org.gradle.execution.plan.Node;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.initialization.internal.InternalBuildFinishedListener;
@@ -32,6 +33,7 @@ import org.gradle.internal.model.StateTransitionControllerFactory;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
@@ -149,6 +151,9 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
     public void finalizeWorkGraph(BuildWorkPlan plan) {
         DefaultBuildWorkPlan workPlan = unpack(plan);
         state.transition(State.TaskSchedule, State.ReadyToRun, () -> {
+            for (Consumer<LocalTaskNode> handler : workPlan.handlers) {
+                workPlan.plan.onComplete(handler);
+            }
             workPreparer.finalizeWorkGraph(gradle, workPlan.plan);
         });
     }
@@ -211,10 +216,16 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
     private static class DefaultBuildWorkPlan implements BuildWorkPlan {
         private final DefaultBuildLifecycleController owner;
         private final ExecutionPlan plan;
+        private final List<Consumer<LocalTaskNode>> handlers = new ArrayList<>();
 
         public DefaultBuildWorkPlan(DefaultBuildLifecycleController owner, ExecutionPlan plan) {
             this.owner = owner;
             this.plan = plan;
+        }
+
+        @Override
+        public void onComplete(Consumer<LocalTaskNode> handler) {
+            handlers.add(handler);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
@@ -89,6 +89,13 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
         }
 
         @Override
+        public void stop() {
+            if (plan != null) {
+                plan.stop();
+            }
+        }
+
+        @Override
         public boolean schedule(Collection<ExportedTaskNode> taskNodes) {
             assertIsOwner();
             List<Task> tasks = new ArrayList<>();

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
@@ -65,7 +65,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
     }
 
     private DefaultExportedTaskNode doLocate(TaskIdentifier taskIdentifier) {
-        return nodesByPath.computeIfAbsent(taskIdentifier.getTaskPath(), taskPath -> new DefaultExportedTaskNode(taskPath, taskIdentifier.getOrdinal()));
+        return nodesByPath.computeIfAbsent(taskIdentifier.getTaskPath(), DefaultExportedTaskNode::new);
     }
 
     @Nullable
@@ -157,22 +157,15 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
     private class DefaultExportedTaskNode implements ExportedTaskNode {
         final String taskPath;
         TaskNode taskNode;
-        int ordinal;
 
-        DefaultExportedTaskNode(String taskPath, int ordinal) {
+        DefaultExportedTaskNode(String taskPath) {
             this.taskPath = taskPath;
-            this.ordinal = ordinal;
-        }
-
-        @Override
-        public int getOrdinal() {
-            return ordinal;
         }
 
         void maybeBindTask(TaskInternal task) {
             synchronized (lock) {
                 if (taskNode == null) {
-                    taskNode = taskNodeFactory.getOrCreateNode(task, ordinal);
+                    taskNode = taskNodeFactory.getOrCreateNode(task);
                 }
             }
         }
@@ -185,7 +178,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
                     if (task == null) {
                         throw new IllegalStateException("Task '" + taskPath + "' was never scheduled for execution.");
                     }
-                    taskNode = taskNodeFactory.getOrCreateNode(task, ordinal);
+                    taskNode = taskNodeFactory.getOrCreateNode(task);
                 }
                 return taskNode.getTask();
             }
@@ -200,7 +193,7 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
                         // Assume not scheduled yet
                         return IncludedBuildTaskResource.State.Waiting;
                     }
-                    taskNode = taskNodeFactory.getOrCreateNode(task, ordinal);
+                    taskNode = taskNodeFactory.getOrCreateNode(task);
                 }
                 if (taskNode.isExecuted() && taskNode.isSuccessful()) {
                     return IncludedBuildTaskResource.State.Success;

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
@@ -18,6 +18,7 @@ package org.gradle.internal.build;
 
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.composite.internal.IncludedBuildTaskResource;
+import org.gradle.execution.plan.Node;
 
 /**
  * A node in a build's work graph that can be referenced by the work graph of another build.
@@ -26,4 +27,9 @@ public interface ExportedTaskNode {
     TaskInternal getTask();
 
     IncludedBuildTaskResource.State getTaskState();
+
+    /**
+     * Invokes the given action when this task completes (as per {@link Node#isComplete()}). Does nothing if this task has already completed.
+     */
+    void onComplete(Runnable action);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/ExportedTaskNode.java
@@ -26,6 +26,4 @@ public interface ExportedTaskNode {
     TaskInternal getTask();
 
     IncludedBuildTaskResource.State getTaskState();
-
-    int getOrdinal();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -191,6 +191,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.DefaultTextFileResourceLoader;
 import org.gradle.internal.resource.TextFileResourceLoader;
 import org.gradle.internal.resource.local.FileResourceListener;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.scripts.ScriptExecutionListener;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -242,7 +243,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         GradleInternal gradleInternal,
         TaskNodeFactory taskNodeFactory,
         TaskDependencyResolver dependencyResolver,
-        ExecutionNodeAccessHierarchies executionNodeAccessHierarchies
+        ExecutionNodeAccessHierarchies executionNodeAccessHierarchies,
+        ResourceLockCoordinationService lockCoordinationService
     ) {
         return new ExecutionPlanFactory(
             gradleInternal.getIdentityPath().toString(),
@@ -250,7 +252,8 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             dependencyResolver,
             new DefaultNodeValidator(),
             executionNodeAccessHierarchies.getOutputHierarchy(),
-            executionNodeAccessHierarchies.getDestroyableHierarchy()
+            executionNodeAccessHierarchies.getDestroyableHierarchy(),
+            lockCoordinationService
         );
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -77,8 +77,6 @@ import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
 import org.gradle.internal.reflect.DirectInstantiator;
-import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
-import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.service.CachingServiceLocator;
 import org.gradle.internal.service.DefaultServiceLocator;
@@ -135,10 +133,6 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         }
         registration.add(BuildLayoutFactory.class);
         registration.add(DefaultScriptFileResolver.class);
-    }
-
-    ResourceLockCoordinationService createWorkerLeaseCoordinationService() {
-        return new DefaultResourceLockCoordinationService();
     }
 
     CurrentBuildOperationRef createCurrentBuildOperationRef() {

--- a/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/session/CrossBuildSessionState.java
@@ -40,6 +40,7 @@ import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroad
 import org.gradle.internal.operations.notify.BuildOperationNotificationBridge;
 import org.gradle.internal.operations.notify.BuildOperationNotificationValve;
 import org.gradle.internal.operations.trace.BuildOperationTrace;
+import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.ServiceRegistryBuilder;
@@ -93,6 +94,7 @@ public class CrossBuildSessionState implements Closeable {
         }
 
         void configure(ServiceRegistration registration) {
+            registration.add(DefaultResourceLockCoordinationService.class);
             registration.add(DefaultWorkerLeaseService.class);
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -48,7 +48,6 @@ abstract class AbstractExecutionPlanSpec extends Specification {
     private def acquired = new HashSet<MockLock>()
     def thisBuild = backing.gradle
     def project = project()
-    def resourceLockState = new MockResourceLockState(acquired)
     def nodeValidator = Mock(NodeValidator)
 
     protected Set<ProjectInternal> getLockedProjects() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.gradle.util.Path
@@ -52,7 +53,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     def setup() {
         def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new DefaultResourceLockCoordinationService())
     }
 
     TaskInternal task(Map<String, ?> options = [:], String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.execution.plan
 
-
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.CircularReferenceException
 import org.gradle.api.Task
@@ -27,6 +26,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
+import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.util.Path
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
@@ -44,7 +44,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     def setup() {
         def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController))
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new DefaultResourceLockCoordinationService())
     }
 
     def "schedules tasks in dependency order"() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -51,7 +51,7 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'can create a node for a task'() {
         when:
-        def node = graph.getOrCreateNode(a, 0)
+        def node = graph.getOrCreateNode(a)
 
         then:
         !node.inKnownState
@@ -65,16 +65,16 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'caches node for a given task'() {
         when:
-        def node = graph.getOrCreateNode(a, 0)
+        def node = graph.getOrCreateNode(a)
 
         then:
-        graph.getOrCreateNode(a, 0).is(node)
+        graph.getOrCreateNode(a).is(node)
     }
 
     void 'can add multiple nodes'() {
         when:
-        graph.getOrCreateNode(a, 0)
-        graph.getOrCreateNode(b, 0)
+        graph.getOrCreateNode(a)
+        graph.getOrCreateNode(b)
 
         then:
         graph.tasks == [a, b] as Set
@@ -82,9 +82,9 @@ class TaskNodeFactoryTest extends Specification {
 
     void 'clear'() {
         when:
-        graph.getOrCreateNode(a, 0)
-        graph.getOrCreateNode(b, 0)
-        graph.getOrCreateNode(c, 0)
+        graph.getOrCreateNode(a)
+        graph.getOrCreateNode(b)
+        graph.getOrCreateNode(c)
         graph.clear()
 
         then:

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -611,7 +611,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     }
 
     private DefaultExecutionPlan newExecutionPlan() {
-        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)))
+        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, nodeValidator, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new DefaultResourceLockCoordinationService())
     }
 
     def task(String name, Task... dependsOn = []) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -89,11 +89,6 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     }
 
     @Override
-    public boolean requiresMonitoring() {
-        return false;
-    }
-
-    @Override
     public void resolveMutations() {
         // Assume for now that no other node is going to destroy the transform outputs, or overlap with them
     }
@@ -127,10 +122,6 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     @Override
     public Set<Node> getFinalizers() {
         return Collections.emptySet();
-    }
-
-    @Override
-    public void prepareForExecution() {
     }
 
     @Nullable

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 import org.junit.ComparisonFailure
@@ -39,6 +40,7 @@ class EclipseIntegrationTest extends AbstractEclipseIntegrationTest {
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
     @Test
+    @Flaky
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.util.internal.TextUtil
 import org.junit.ComparisonFailure
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import spock.lang.Issue
 
 import java.util.regex.Pattern
@@ -40,7 +41,7 @@ class EclipseIntegrationTest extends AbstractEclipseIntegrationTest {
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
     @Test
-    @Flaky
+    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
+import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.ComparisonFailure
 import org.junit.Rule
@@ -65,6 +66,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
+    @Flaky
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         executer.withTasks('idea').run()
@@ -106,6 +108,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
+    @Flaky
     @ToBeFixedForConfigurationCache
     void overwritesExistingDependencies() {
         executer.withTasks('idea').run()

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.junit.ComparisonFailure
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 import java.util.regex.Pattern
 
@@ -66,7 +67,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
-    @Flaky
+    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         executer.withTasks('idea').run()
@@ -108,7 +109,7 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
-    @Flaky
+    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void overwritesExistingDependencies() {
         executer.withTasks('idea').run()


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Addresses a performance regression in a previous PR. Change `ExecutionPlan` to more precisely track whether nodes are available to be selected, and avoid scanning the list of queued nodes in more cases where there are no nodes available.

Also change node scheduling so that it is somewhat more event driven. Completion of tasks in other execution plans (for included builds) and changes to project and resource locks are now pushed into the plan as events, rather than having the plan poll these things.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
