### PR TITLE
Always capture the file name for artifact transforms

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -23,7 +23,6 @@ import org.gradle.internal.execution.fingerprint.FileCollectionSnapshotter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FingerprintingStrategy;
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import javax.annotation.Nullable;
@@ -51,11 +50,6 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileSystemSnapshot snapshot, @Nullable FileCollectionFingerprint previousFingerprint) {
         return DefaultCurrentFileCollectionFingerprint.from(snapshot, fingerprintingStrategy, previousFingerprint);
-    }
-
-    @Override
-    public String normalizePath(FileSystemLocationSnapshot root) {
-        return fingerprintingStrategy.normalizePath(root);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -32,14 +32,13 @@ import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory;
-import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.FileValueSupplier;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.InputVisitor;
-import org.gradle.internal.execution.fingerprint.impl.DefaultFileNormalizationSpec;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.execution.workspace.WorkspaceProvider;
+import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
@@ -71,7 +70,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
     private static final CachingDisabledReason NOT_CACHEABLE = new CachingDisabledReason(CachingDisabledReasonCategory.NOT_CACHEABLE, "Caching not enabled.");
     private static final String INPUT_ARTIFACT_PROPERTY_NAME = "inputArtifact";
     private static final String INPUT_ARTIFACT_PATH_PROPERTY_NAME = "inputArtifactPath";
-    private static final String INPUT_ARTIFACT_NAME_PROPERTY_NAME = "inputArtifactName";
     private static final String INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME = "inputArtifactSnapshot";
     private static final String DEPENDENCIES_PROPERTY_NAME = "inputArtifactDependencies";
     private static final String SECONDARY_INPUTS_HASH_PROPERTY_NAME = "inputPropertiesHash";
@@ -212,18 +210,12 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             // This is a performance hack. We could use the regular fingerprint of the input artifact, but that takes longer than
             // capturing the normalized path and the snapshot of the raw contents, so we are using these to determine the identity
             FileSystemLocationSnapshot inputArtifactSnapshot = fileSystemAccess.read(inputArtifact.getAbsolutePath(), Function.identity());
-            visitor.visitInputProperty(INPUT_ARTIFACT_PATH_PROPERTY_NAME, () -> {
-                FileCollectionFingerprinter inputArtifactFingerprinter = inputFingerprinter.getFingerprinterRegistry().getFingerprinter(
-                    DefaultFileNormalizationSpec.from(transformer.getInputArtifactNormalizer(), transformer.getInputArtifactDirectorySensitivity(), transformer.getInputArtifactLineEndingNormalization()));
-                return inputArtifactFingerprinter.normalizePath(inputArtifactSnapshot);
-            });
             visitor.visitInputProperty(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME, inputArtifactSnapshot::getHash);
         }
 
         @Override
         public Identity identify(Map<String, ValueSnapshot> identityInputs, Map<String, CurrentFileCollectionFingerprint> identityFileInputs) {
             return new ImmutableTransformationWorkspaceIdentity(
-                identityInputs.get(INPUT_ARTIFACT_NAME_PROPERTY_NAME),
                 identityInputs.get(INPUT_ARTIFACT_PATH_PROPERTY_NAME),
                 identityInputs.get(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME),
                 identityInputs.get(SECONDARY_INPUTS_HASH_PROPERTY_NAME),
@@ -365,7 +357,14 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         public void visitIdentityInputs(InputVisitor visitor) {
             // Emulate secondary inputs as a single property for now
             visitor.visitInputProperty(SECONDARY_INPUTS_HASH_PROPERTY_NAME, transformer::getSecondaryInputHash);
-            visitor.visitInputProperty(INPUT_ARTIFACT_NAME_PROPERTY_NAME, inputArtifact::getName);
+            visitor.visitInputProperty(INPUT_ARTIFACT_PATH_PROPERTY_NAME, () ->
+                // We always need the name as an input to the artifact transform,
+                // since it is part of the ComponentArtifactIdentifier returned by the transform.
+                // For absolute paths, the name is already part of the normalized path,
+                // and for all the other normalization strategies we use the name directly.
+                transformer.getInputArtifactNormalizer().equals(AbsolutePathInputNormalizer.class)
+                    ? inputArtifact.getAbsolutePath()
+                    : inputArtifact.getName());
             visitor.visitInputFileProperty(DEPENDENCIES_PROPERTY_NAME, NON_INCREMENTAL,
                 new FileValueSupplier(
                     dependencies,
@@ -414,14 +413,12 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
     }
 
     private static class ImmutableTransformationWorkspaceIdentity implements UnitOfWork.Identity {
-        private final ValueSnapshot inputArtifactName;
         private final ValueSnapshot inputArtifactPath;
         private final ValueSnapshot inputArtifactSnapshot;
         private final ValueSnapshot secondaryInputSnapshot;
         private final HashCode dependenciesHash;
 
-        public ImmutableTransformationWorkspaceIdentity(ValueSnapshot inputArtifactName, ValueSnapshot inputArtifactPath, ValueSnapshot inputArtifactSnapshot, ValueSnapshot secondaryInputSnapshot, HashCode dependenciesHash) {
-            this.inputArtifactName = inputArtifactName;
+        public ImmutableTransformationWorkspaceIdentity(ValueSnapshot inputArtifactPath, ValueSnapshot inputArtifactSnapshot, ValueSnapshot secondaryInputSnapshot, HashCode dependenciesHash) {
             this.inputArtifactPath = inputArtifactPath;
             this.inputArtifactSnapshot = inputArtifactSnapshot;
             this.secondaryInputSnapshot = secondaryInputSnapshot;
@@ -431,7 +428,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         @Override
         public String getUniqueId() {
             Hasher hasher = Hashing.newHasher();
-            inputArtifactName.appendToHasher(hasher);
             inputArtifactPath.appendToHasher(hasher);
             inputArtifactSnapshot.appendToHasher(hasher);
             secondaryInputSnapshot.appendToHasher(hasher);
@@ -450,9 +446,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
 
             ImmutableTransformationWorkspaceIdentity that = (ImmutableTransformationWorkspaceIdentity) o;
 
-            if (!inputArtifactName.equals(that.inputArtifactName)) {
-                return false;
-            }
             if (!inputArtifactPath.equals(that.inputArtifactPath)) {
                 return false;
             }
@@ -468,7 +461,6 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         @Override
         public int hashCode() {
             int result = inputArtifactPath.hashCode();
-            result = 31 * result + inputArtifactName.hashCode();
             result = 31 * result + inputArtifactSnapshot.hashCode();
             result = 31 * result + secondaryInputSnapshot.hashCode();
             result = 31 * result + dependenciesHash.hashCode();

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/FileCollectionFingerprinter.java
@@ -19,7 +19,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
 import javax.annotation.Nullable;
@@ -44,9 +43,4 @@ public interface FileCollectionFingerprinter {
      * Returns an empty fingerprint.
      */
     CurrentFileCollectionFingerprint empty();
-
-    /**
-     * Returns the normalized path to use for the given root
-     */
-    String normalizePath(FileSystemLocationSnapshot root);
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -140,11 +140,6 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
     }
 
     @Override
-    public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        return "";
-    }
-
-    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -45,7 +45,5 @@ public interface FingerprintingStrategy {
 
     CurrentFileCollectionFingerprint getEmptyFingerprint();
 
-    String normalizePath(FileSystemLocationSnapshot snapshot);
-
     HashCode getConfigurationHash();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -52,11 +52,6 @@ public class AbsolutePathFingerprintingStrategy extends AbstractDirectorySensiti
     }
 
     @Override
-    public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        return snapshot.getAbsolutePath();
-    }
-
-    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -53,11 +53,6 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     }
 
     @Override
-    public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        return IGNORED_PATH;
-    }
-
-    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -52,11 +52,6 @@ public class NameOnlyFingerprintingStrategy extends AbstractDirectorySensitiveFi
     }
 
     @Override
-    public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        return snapshot.getName();
-    }
-
-    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -55,15 +55,6 @@ public class RelativePathFingerprintingStrategy extends AbstractDirectorySensiti
     }
 
     @Override
-    public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        if (snapshot.getType() == FileType.Directory) {
-            return "";
-        } else {
-            return snapshot.getName();
-        }
-    }
-
-    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(FileSystemSnapshot roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<>();


### PR DESCRIPTION
as an input. See #19408 for the reasons why we want to make this change.

This is a follow up to #19988.