### PR TITLE
Add perf test for large android build configuration time

### DIFF
--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -46,6 +46,12 @@
     "linux" : 1586000
   } ]
 }, {
+  "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run :module21:module02:assembleDebug --dry-run",
+  "durations" : [ {
+    "testProject" : "largeAndroidBuild2",
+    "linux" : 1586000
+  } ]
+}, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
   "durations" : [ {
     "testProject" : "largeAndroidBuild",

--- a/.teamcity/performance-test-durations.json
+++ b/.teamcity/performance-test-durations.json
@@ -49,7 +49,7 @@
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run :module21:module02:assembleDebug --dry-run",
   "durations" : [ {
     "testProject" : "largeAndroidBuild2",
-    "linux" : 1586000
+    "linux" : 2395000
   } ]
 }, {
   "scenario" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",

--- a/.teamcity/performance-tests-ci.json
+++ b/.teamcity/performance-tests-ci.json
@@ -196,6 +196,14 @@
       }
     } ]
   }, {
+    "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run :module21:module02:assembleDebug --dry-run",
+    "groups" : [ {
+      "testProject" : "largeAndroidBuild2",
+      "coverage" : {
+        "per_commit" : [ "linux" ]
+      }
+    } ]
+  }, {
     "testId" : "org.gradle.performance.regression.android.RealLifeAndroidBuildPerformanceTest.run assembleDebug",
     "groups" : [ {
       "testProject" : "largeAndroidBuild",

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -402,7 +402,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
     // Pinned from main branch
-    ref = "e530ae0fe441dfc47a8b4b512ea1f747dc3a9521"
+    ref = "52392af6055d08d432285db7995f6bb7376ddf7a"
 }
 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -399,6 +399,12 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
     ref = "b3964ffea18ef5d280b5b493c5c7b8d8b986056c"
 }
 
+performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
+    remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
+    // Pinned from main branch
+    ref = "52392af6055d08d432285db7995f6bb7376ddf7a"
+}
+
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
     // Pinned from main branch

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -402,7 +402,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
     // Pinned from main branch
-    ref = "52392af6055d08d432285db7995f6bb7376ddf7a"
+    ref = "e530ae0fe441dfc47a8b4b512ea1f747dc3a9521"
 }
 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -402,7 +402,7 @@ performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
     // Pinned from main branch
-    ref = "52392af6055d08d432285db7995f6bb7376ddf7a"
+    ref = "6c03b676971a3f383350b9684cc2aa0b28857c5f"
 }
 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -28,9 +28,13 @@ class AndroidTestProject implements TestProject {
     public static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild'
     )
+    public static final LARGE_ANDROID_BUILD_2 = new AndroidTestProject(
+        templateName: 'largeAndroidBuild2'
+    )
 
     public static final List<AndroidTestProject> ANDROID_TEST_PROJECTS = [
         LARGE_ANDROID_BUILD,
+        LARGE_ANDROID_BUILD_2,
         IncrementalAndroidTestProject.SANTA_TRACKER,
         IncrementalAndroidTestProject.UBER_MOBILE_APP
     ]

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -23,8 +23,8 @@ import javax.annotation.Nullable
 class AndroidTestProject implements TestProject {
 
     private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
-    private static final String AGP_STABLE_TARGET_VERSION = "4.1"
-    private static final String AGP_LATEST_TARGET_VERSION = "4.2"
+    private static final String AGP_STABLE_TARGET_VERSION = "7.0"
+    private static final String AGP_LATEST_TARGET_VERSION = "7.1"
     public static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild'
     )

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -23,8 +23,8 @@ import javax.annotation.Nullable
 class AndroidTestProject implements TestProject {
 
     private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
-    private static final String AGP_STABLE_TARGET_VERSION = "7.0"
-    private static final String AGP_LATEST_TARGET_VERSION = "7.1"
+    private static final String AGP_STABLE_TARGET_VERSION = "4.0"
+    private static final String AGP_LATEST_TARGET_VERSION = "4.1"
     public static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild'
     )

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AndroidTestProject.groovy
@@ -23,8 +23,8 @@ import javax.annotation.Nullable
 class AndroidTestProject implements TestProject {
 
     private static final AndroidGradlePluginVersions AGP_VERSIONS = new AndroidGradlePluginVersions()
-    private static final String AGP_STABLE_TARGET_VERSION = "4.0"
-    private static final String AGP_LATEST_TARGET_VERSION = "4.1"
+    private static final String AGP_STABLE_TARGET_VERSION = "4.1"
+    private static final String AGP_LATEST_TARGET_VERSION = "4.2"
     public static final LARGE_ANDROID_BUILD = new AndroidTestProject(
         templateName: 'largeAndroidBuild'
     )

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -43,7 +43,8 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     @RunFor([
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = "run help"),
         @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = ["largeAndroidBuild", "santaTrackerAndroidBuild"], iterationMatcher = "run assembleDebug"),
-        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = ".*phthalic.*")
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild", iterationMatcher = ".*phthalic.*"),
+        @Scenario(type = PER_COMMIT, operatingSystems = LINUX, testProjects = "largeAndroidBuild2", iterationMatcher = ".*module21.*"),
     ])
     def "run #tasks"() {
         given:
@@ -62,10 +63,11 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        tasks                          | warmUpRuns | runs
-        'help'                         | null       | null
-        'assembleDebug'                | null       | null
-        'clean phthalic:assembleDebug' | 2          | 8
+        tasks                                        | warmUpRuns | runs
+        'help'                                       | null       | null
+        'assembleDebug'                              | null       | null
+        'clean phthalic:assembleDebug'               | 2          | 8
+        ':module21:module02:assembleDebug --dry-run' | null       | null
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -114,6 +114,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     }
 
     private void configureForLargeAndroidBuild2() {
+        runner.targetVersions = ["7.3.3", "7.4"]
         def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.last().javaHome
         runner.addBuildMutator { invocation ->
             new BuildMutator() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -120,7 +120,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
                 @Override
                 void beforeScenario(ScenarioContext context) {
                     def gradleProps = new File(invocation.projectDir, "gradle.properties")
-                    gradleProps << "\norg.gradle.workers.max=16\n"
                     gradleProps << "\norg.gradle.java.home=${buildJavaHome}\n"
                 }
             }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -62,15 +62,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
         and:
         if (testProject.templateName == "largeAndroidBuild2") {
-            def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.last().javaHome
-            runner.addBuildMutator { invocation ->
-                new BuildMutator() {
-                    @Override
-                    void beforeScenario(ScenarioContext context) {
-                        new File(invocation.projectDir, "gradle.properties") << "\norg.gradle.java.home=${buildJavaHome}\n"
-                    }
-                }
-            }
+            runWithJava11()
         }
 
         when:
@@ -84,7 +76,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        ':module21:module02:assembleDebug --dry-run' | 2          | 8
+        ':module21:module02:assembleDebug --dry-run' | 3          | 10
     }
 
     @RunFor([
@@ -118,5 +110,17 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
         where:
         tasks << ['assembleDebug', 'phthalic:assembleDebug']
+    }
+
+    private void runWithJava11() {
+        def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.last().javaHome
+        runner.addBuildMutator { invocation ->
+            new BuildMutator() {
+                @Override
+                void beforeScenario(ScenarioContext context) {
+                    new File(invocation.projectDir, "gradle.properties") << "\norg.gradle.java.home=${buildJavaHome}\n"
+                }
+            }
+        }
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -77,7 +77,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        ':module21:module02:assembleDebug --dry-run' | 2          | 8
+        ':module21:module02:assembleDebug --dry-run' | 4          | 12
     }
 
     @RunFor([
@@ -114,7 +114,6 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     }
 
     private void configureForLargeAndroidBuild2() {
-        runner.targetVersions = ["7.3.3", "7.4"]
         def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.last().javaHome
         runner.addBuildMutator { invocation ->
             new BuildMutator() {

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -84,7 +84,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        ':module21:module02:assembleDebug --dry-run' | null       | null
+        ':module21:module02:assembleDebug --dry-run' | 2          | 8
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -77,7 +77,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        ':module21:module02:assembleDebug --dry-run' | 4          | 12
+        ':module21:module02:assembleDebug --dry-run' | null       | null
     }
 
     @RunFor([

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -114,7 +114,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
     }
 
     private void configureForLargeAndroidBuild2() {
-        def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.last().javaHome
+        def buildJavaHome = AvailableJavaHomes.getAvailableJdks { it.languageVersion == JavaVersion.VERSION_11 }.first().javaHome
         runner.addBuildMutator { invocation ->
             new BuildMutator() {
                 @Override

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -77,7 +77,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        ':module21:module02:assembleDebug --dry-run' | null       | null
+        ':module21:module02:assembleDebug --dry-run' | 8          | 20
     }
 
     @RunFor([


### PR DESCRIPTION
Introduce a new performance test using https://github.com/gradle/perf-android-large-2 that demonstrated configuration time/task graph calculation performance improvement in Gradle 7.4.
