### PR TITLE
Fix mapping a ValueProvider with configuration caching

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -25,6 +25,8 @@ import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
 public class Collectors {
     public interface ProvidedCollector<T> extends Collector<T> {
         boolean isProvidedBy(Provider<?> provider);
@@ -116,7 +118,9 @@ public class Collectors {
             } else if (value.isFixedValue()) {
                 visitor.execute(ExecutionTimeValue.fixedValue(ImmutableList.of(value.getFixedValue())));
             } else {
-                visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue().map(e -> ImmutableList.of(e))));
+                visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue()
+                    .map(transformer(e -> ImmutableList.of(e)))
+                ));
             }
         }
 


### PR DESCRIPTION
When using a mapped value source in a `ListProperty`, then the build failed on a configuration cache hit with:
```
Could not load the value of field `transformer` of `org.gradle.api.internal.provider.TransformBackedProvider` bean found in field `providers` of `org.gradle.api.internal.provider.AbstractCollectionProperty$CollectingProvider` bean found in field `...` of task ...
```

This PR fixes this by converting the lambda used in `Collectors` to a serializable lambda.