### PR TITLE
Suppress ignorable shellcheck warnings

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -115,6 +115,7 @@ done
 
 APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
 
+# shellcheck disable=SC2034 # May not be used but available in case it's useful
 APP_NAME="${applicationName}"
 APP_BASE_NAME=\${0##*/}
 
@@ -178,12 +179,14 @@ fi
 if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
     case \$MAX_FD in #(
       max*)
+        # shellcheck disable=SC3045 # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
         MAX_FD=\$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case \$MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # shellcheck disable=SC3045 # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
         ulimit -n "\$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to \$MAX_FD"
     esac


### PR DESCRIPTION
* APP_NAME may not be used but available in case it's useful
* ulimit -H might not work since it's not POSIX, which is why there's a test for it
* ulimit -n might not work since it's not POSIX, which is why there's a test for it

### Context
It would be nice for the generated `gradlew` to pass shellcheck without any warnings.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
