### PR TITLE
Make the symmetric nullable check clearer

### DIFF
--- a/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/KotlinCompatibilityTest.java
+++ b/subprojects/architecture-test/src/test/java/org/gradle/architecture/test/KotlinCompatibilityTest.java
@@ -151,12 +151,19 @@ public class KotlinCompatibilityTest {
         }
 
         public boolean nullableIsSymmetric() {
-            Set<Boolean> gettersAreNullable = getters.stream().map(this::getterAnnotatedWithNullable).collect(toSet());
-            Set<Boolean> settersAreNullable = setters.stream().map(this::setterAnnotatedWithNullable).collect(toSet());
-            if (gettersAreNullable.size() > 1 || settersAreNullable.size() > 1) {
+            long nullableGetterCount = getters.stream().filter(this::getterAnnotatedWithNullable).count();
+            long nullableSetterCount = setters.stream().filter(this::setterAnnotatedWithNullable).count();
+
+            boolean gettersArePartiallyNull = 0 < nullableGetterCount && nullableGetterCount < getters.size();
+            boolean settersArePartiallyNull = 0 < nullableSetterCount && nullableSetterCount < setters.size();
+            if (gettersArePartiallyNull || settersArePartiallyNull) {
                 return false;
             }
-            return gettersAreNullable.equals(settersAreNullable);
+
+            boolean nonNullGetters = nullableGetterCount == 0;
+            boolean nonNullSetters = nullableSetterCount == 0;
+            // Either both are non-null, or both are nullable
+            return nonNullGetters == nonNullSetters;
         }
 
         private boolean getterAnnotatedWithNullable(JavaMethod getter) {


### PR DESCRIPTION
This check was extremely opaque, relying on the implicit unique nature of collecting to a set to determine if something was both null and non-null. @big-guy and I had trouble decoding it while debugging another PR. This should be a marked readability improvement, as well as a little bit faster since there's no boxing or set creation.