### PR TITLE
Disable incremental Kotlin compilation after cache hit

### DIFF
--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -10,6 +10,7 @@ val groovyVersion = "3.0.9"
 val asmVersion = "9.2"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true
+// When we update to kotlin 1.7.x remove the workaround in gradlebuild.kotlin-library.gradle.kts
 val defaultBuildKotlinVersion = "1.6.20-M1"
 
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.kotlin-library.gradle.kts
@@ -39,6 +39,16 @@ tasks {
             // Make sure the classes dir is used for test compilation (required by tests accessing internal methods) - https://github.com/gradle/gradle/issues/11501
             classpath = sourceSets.main.get().output.classesDirs + classpath - files(tasks.jar)
         }
+
+        // Workaround for https://youtrack.jetbrains.com/issue/KT-34862
+        // Remove when we use Kotlin 1.7
+        val incrementalStateDirectory = layout.buildDirectory.dir("kotlin/$name")
+        doFirst {
+            val localStateDir = incrementalStateDirectory.get().asFile
+            if (!localStateDir.exists()) {
+                incremental = false
+            }
+        }
     }
 
     codeQuality {


### PR DESCRIPTION
To workaround https://youtrack.jetbrains.com/issue/KT-34862. The bug should be fixed in 1.7.