### PR TITLE
Use Kotlin 1.7.0-dev-1904 to fix incremental compilation

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
@@ -39,5 +39,12 @@ repositories {
             includeGroup("io.usethesource")
         }
     }
+    maven {
+        name = "Kotlin EAP repository"
+        url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+        content {
+            includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+        }
+    }
     mavenCentral()
 }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -16,22 +16,18 @@
 
 package gradlebuild.binarycompatibility
 
+import org.gradle.kotlin.dsl.*
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-
 import org.hamcrest.CoreMatchers
-
-import org.junit.Assert.assertFalse
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-
 import java.io.File
 import java.nio.file.Files
-
-import org.gradle.kotlin.dsl.*
 
 
 abstract class AbstractBinaryCompatibilityTest {
@@ -194,6 +190,13 @@ abstract class AbstractBinaryCompatibilityTest {
                         apply(plugin = "kotlin")
                         the<ModuleIdentityExtension>().baseName.set("api-module")
                         repositories {
+                            maven {
+                                name = "Kotlin EAP repository"
+                                url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+                                content {
+                                    includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+                                }
+                            }
                             mavenCentral()
                         }
                         dependencies {

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -10,7 +10,7 @@ val groovyVersion = "3.0.9"
 val asmVersion = "9.2"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true
-val defaultBuildKotlinVersion = "1.6.20-M1"
+val defaultBuildKotlinVersion = "1.7.0-dev-1904"
 
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
     .getOrElse(defaultBuildKotlinVersion)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -39,6 +39,13 @@ dependencyResolutionManagement {
                 includeModule("classycle", "classycle")
             }
         }
+        maven {
+            name = "Kotlin EAP repository"
+            url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+            content {
+                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,13 @@ pluginManagement {
                 includeVersionByRegex("com.gradle.internal.test-selection", "com.gradle.internal.test-selection.gradle.plugin", rcAndMilestonesPattern)
             }
         }
+        maven {
+            name = "Kotlin EAP repository"
+            url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+            content {
+                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+            }
+        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
1.6.20 has some bugs with the new incremental compilation related to to build cache hits, which would force us to turn it off.