### PR TITLE
Add configuration option for the size of the execution store

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultExecutionHistoryStore.java
@@ -37,6 +37,7 @@ import static com.google.common.collect.ImmutableSortedMap.copyOfSorted;
 import static com.google.common.collect.Maps.transformValues;
 
 public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
+    public static final String EXECUTION_HISTORY_CACHE_SIZE_SYSTEM_PROPERY = "org.gradle.execution.history.size";
 
     private final PersistentIndexedCache<String, PreviousExecutionState> store;
 
@@ -52,7 +53,7 @@ public class DefaultExecutionHistoryStore implements ExecutionHistoryStore {
             classLoaderHasher
         );
 
-        CacheDecorator inMemoryCacheDecorator = inMemoryCacheDecoratorFactory.decorator(10000, false);
+        CacheDecorator inMemoryCacheDecorator = inMemoryCacheDecoratorFactory.decorator(Integer.getInteger(EXECUTION_HISTORY_CACHE_SIZE_SYSTEM_PROPERY, 10000), false);
         this.store = cache.get().createCache(
             PersistentIndexedCacheParameters.of("executionHistory", String.class, serializer)
             .withCacheDecorator(inMemoryCacheDecorator)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #18255

### Context
<!--- Why do you believe many users will benefit from this change? -->
I do not know how many users are impact by this, but as described in related issue, I encountered much higher memory usage after the upgrade to the newer version of gradle (although I might be wrong, problems are very non-deterministic and sometimes happen even on an older version).

I have tracked the issue to the execution history cache. I believe it keeps some fingerprints for task inputs in memory. Those can get very big. In my case, single entry may be as large as a few MB (hunders/thousands of individual filenames).

I think that sizing of this cache should take into account that some keys might be much heavier that others - but let's leave it for the future. For know, I propose to simply add a property for the size of this cache. My problems disappear when I lower the default value from 10000 to 500 (20x!).

This will allow users with similar issues (kind-of-random GC problems) to check if the source is the same.

I haven't found any documentation for the similar property "org.gradle.cache.reserved.mb", so I also decided to skip documenting this one.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
