### PR TITLE
Support compiling against Groovy 4

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -144,6 +144,10 @@ The following are the features that have been promoted in this Gradle release.
 ### Example promoted
 -->
 
+### Support for Groovy 4
+
+Gradle now supports building software using Groovy 4.0.
+
 ## Fixed issues
 
 ## Known issues

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -48,7 +48,7 @@ Gradle is tested with Kotlin 1.3.72 through 1.6.10.
 Gradle plugins written in Kotlin target Kotlin 1.4 for compatibility with Gradle and Kotlin DSL build scripts, even though the embedded Kotlin runtime is Kotlin 1.6.
 
 == Groovy
-Gradle is tested with Groovy 1.5.8 through 3.0.9.
+Gradle is tested with Groovy 1.5.8 through 4.0.0.
 
 Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Gradle and Groovy DSL build scripts.
 

--- a/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -21,6 +21,7 @@ import org.gradle.util.internal.VersionNumber
 
 class GroovyCoverage {
     private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', '2.5.8']
+    private static final String[] FUTURE = ['4.0.0']
 
     static final List<String> SUPPORTED_BY_JDK
 
@@ -48,6 +49,8 @@ class GroovyCoverage {
         if (!GroovySystem.version.endsWith("-SNAPSHOT")) {
             allVersions += GroovySystem.version
         }
+
+        allVersions.addAll(FUTURE)
 
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_16)) {
             return versionsAbove(allVersions, '3.0.0')

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/GroovyRuntime.java
@@ -16,6 +16,7 @@
 package org.gradle.api.tasks;
 
 import com.google.common.collect.Iterables;
+import groovy.lang.GroovySystem;
 import org.gradle.api.Buildable;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -69,7 +70,7 @@ public class GroovyRuntime {
     private static final VersionNumber GROOVY_VERSION_WITH_SEPARATE_ANT = VersionNumber.parse("2.0");
     private static final VersionNumber GROOVY_VERSION_REQUIRING_TEMPLATES = VersionNumber.parse("2.5");
 
-    private static final List<String> GROOVY3_LIBS = Arrays.asList(
+    private static final List<String> GROOVY_LIBS = Arrays.asList(
         "groovy",
         "groovy-ant", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil",
         "groovy-nio", "groovy-sql", "groovy-test",
@@ -127,25 +128,22 @@ public class GroovyRuntime {
 
                 VersionNumber groovyVersion = groovyJar.getVersion();
 
-                // Groovy 3 does not have groovy-all yet we may have the required pieces on classpath via localGroovy()
-                if (groovyVersion.getMajor() == 3) {
-                    return inferGroovy3Classpath(groovyVersion);
+                // We may already have the required pieces on classpath via localGroovy()
+                if (groovyVersion.equals(VersionNumber.parse(GroovySystem.getVersion()))) {
+                    Set<String> groovyJarNames = groovyJarNamesFor(groovyVersion);
+                    List<File> groovyClasspath = collectJarsFromClasspath(classpath, groovyJarNames);
+                    if (groovyClasspath.size() == GROOVY_LIBS.size()) {
+                        return project.getLayout().files(groovyClasspath);
+                    }
                 }
 
-                String notation = groovyJar.getDependencyNotation();
-
-                List<Dependency> dependencies = new ArrayList<>();
-                addDependencyTo(dependencies, notation);
-
-                if (groovyVersion.compareTo(GROOVY_VERSION_WITH_SEPARATE_ANT) >= 0) {
-                    // add groovy-ant to bring in Groovydoc for Groovy 2.0+
-                    addGroovyDependency(notation, dependencies, "groovy-ant");
+                if (groovyVersion.getMajor() <= 2) {
+                    return inferGroovyAllClasspath(groovyJar.getDependencyNotation(), groovyVersion);
+                } else if (groovyVersion.getMajor() == 3) {
+                    return inferGroovyClasspath("org.codehaus.groovy", groovyVersion);
+                } else {
+                    return inferGroovyClasspath("org.apache.groovy", groovyVersion);
                 }
-                if (groovyVersion.compareTo(GROOVY_VERSION_REQUIRING_TEMPLATES) >= 0) {
-                    // add groovy-templates for Groovy 2.5+
-                    addGroovyDependency(notation, dependencies, "groovy-templates");
-                }
-                return detachedRuntimeClasspath(dependencies.toArray(new Dependency[0]));
             }
 
             private void addGroovyDependency(String groovyDependencyNotion, List<Dependency> dependencies, String otherDependency) {
@@ -158,16 +156,26 @@ public class GroovyRuntime {
                 dependencies.add(project.getDependencies().create(notation));
             }
 
-            private FileCollection inferGroovy3Classpath(VersionNumber groovyVersion) {
-                Set<String> groovyJarNames = groovyJarNamesFor(groovyVersion);
-                List<File> groovyClasspath = collectJarsFromClasspath(classpath, groovyJarNames);
-                if (groovyClasspath.size() == GROOVY3_LIBS.size()) {
-                    return project.getLayout().files(groovyClasspath);
+            private FileCollection inferGroovyAllClasspath(String notation, VersionNumber groovyVersion) {
+                List<Dependency> dependencies = new ArrayList<>();
+                addDependencyTo(dependencies, notation);
+
+                if (groovyVersion.compareTo(GROOVY_VERSION_WITH_SEPARATE_ANT) >= 0) {
+                    // add groovy-ant to bring in Groovydoc for Groovy 2.0+
+                    addGroovyDependency(notation, dependencies, "groovy-ant");
+                }
+                if (groovyVersion.compareTo(GROOVY_VERSION_REQUIRING_TEMPLATES) >= 0) {
+                    // add groovy-templates for Groovy 2.5+
+                    addGroovyDependency(notation, dependencies, "groovy-templates");
                 }
 
+                return detachedRuntimeClasspath(dependencies.toArray(new Dependency[0]));
+            }
+
+            private FileCollection inferGroovyClasspath(String groupId, VersionNumber groovyVersion) {
                 return detachedRuntimeClasspath(
-                    GROOVY3_LIBS.stream()
-                        .map(libName -> project.getDependencies().create("org.codehaus.groovy:" + libName + ":" + groovyVersion))
+                    GROOVY_LIBS.stream()
+                        .map(libName -> project.getDependencies().create(groupId + ":" + libName + ":" + groovyVersion))
                         .toArray(Dependency[]::new)
                 );
             }
@@ -195,7 +203,7 @@ public class GroovyRuntime {
     }
 
     private static Set<String> groovyJarNamesFor(VersionNumber groovyVersion) {
-        return GROOVY3_LIBS.stream()
+        return GROOVY_LIBS.stream()
             .map(libName -> libName + "-" + groovyVersion + ".jar")
             .collect(toSet());
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/GroovyRuntimeTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/GroovyRuntimeTest.groovy
@@ -42,8 +42,8 @@ class GroovyRuntimeTest extends AbstractProjectBuilderSpec {
         classifier << ["", "-indy"]
     }
 
-    def "inferred Groovy3 class path uses 'groovy' jars from classpath if all required pieces are found"() {
-        def groovyVersion = "3.0.9"
+    def "inferred Groovy class path uses 'groovy' jars from classpath if all required pieces are found and match the runtime Groovy version"() {
+        def groovyVersion = GroovySystem.version
 
         when:
         def classpath = project.groovyRuntime.inferGroovyClasspath([
@@ -94,19 +94,23 @@ class GroovyRuntimeTest extends AbstractProjectBuilderSpec {
         with(classpath.sourceCollections[0]) {
             it instanceof Configuration
             state == Configuration.State.UNRESOLVED
-            dependencies.size() == expectedJars.size()
-            expectedJars.each { expectedJar ->
-                assert dependencies.any { it.group == "org.codehaus.groovy" && it.name == expectedJar && it.version == groovyVersion } // not sure how to check classifier
+            dependencies.size() == expectedDependencies.size()
+            expectedDependencies.each { expectedJar ->
+                assert dependencies.any {
+                    it.group == expectedGroup && it.name == expectedJar && it.version == groovyVersion
+                } // not sure how to check classifier
             }
         }
 
         where:
-        groovyVersion | classifier | expectedJars
-        "2.1.2"       | ""         | ["groovy", "groovy-ant"]
-        "2.1.2"       | "-indy"    | ["groovy", "groovy-ant"]
-        "2.5.2"       | ""         | ["groovy", "groovy-ant", "groovy-templates"]
-        "2.5.2"       | "-indy"    | ["groovy", "groovy-ant", "groovy-templates"]
-        "3.0.8"       | ""         | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql", "groovy-test"]
+        groovyVersion        | classifier | expectedGroup         | expectedDependencies
+        "2.1.2"              | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant"]
+        "2.1.2"              | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant"]
+        "2.5.2"              | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates"]
+        "2.5.2"              | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates"]
+        GroovySystem.version | ""         | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql", "groovy-test"]
+        GroovySystem.version | "-indy"    | "org.codehaus.groovy" | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql", "groovy-test"]
+        "4.0.0"              | ""         | "org.apache.groovy"   | ["groovy", "groovy-ant", "groovy-templates", "groovy-json", "groovy-xml", "groovy-groovydoc", "groovy-astbuilder", "groovy-console", "groovy-datetime", "groovy-dateutil", "groovy-nio", "groovy-sql", "groovy-test"]
     }
 
     def "useful error message is produced when no groovy runtime could be found on a classpath"() {


### PR DESCRIPTION
This adds the ability to use Gradle to build software based on Groovy 4.0.

* Infer the right Groovy classpath when targeting Groovy 4.
* Compilation is now tested with Groovy 4.0.0.

Note that there is another PR targeted for 8.0 to bump Gradle's own embedded Groovy version to 4.0: #20038.
