### PR TITLE
Fix inputs of GeneratePluginDescriptors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoriesDeclaredInSettingsIntegrationTest.groovy
@@ -573,7 +573,7 @@ class RepositoriesDeclaredInSettingsIntegrationTest extends AbstractModuleDepend
         pluginPortal.start()
         withSettingsPlugin()
         def plugin = new PluginBuilder(file("settings-plugin"))
-            .addPluginId("org.gradle.repo-conventions", "org.gradle.test.RepoConventionPlugin")
+            .addPluginId("org.gradle.repo-conventions", "RepoConventionPlugin")
             .publishAs("g", "a", "1.0", pluginPortal, createExecuter())
 
         // make sure we don't use the default fixture which already adds repositories
@@ -802,20 +802,6 @@ settingsEvaluated {
     }
 
     void withSettingsPlugin() {
-        file("settings-plugin/build.gradle") << """
-            plugins {
-                id 'java-gradle-plugin'
-            }
-
-            gradlePlugin {
-                plugins {
-                    settingsPlugin {
-                        id = 'org.gradle.repo-conventions'
-                        implementationClass = 'org.gradle.test.RepoConventionPlugin'
-                    }
-                }
-            }
-        """
         file("settings-plugin/src/main/java/org/gradle/test/RepoConventionPlugin.java") << """package org.gradle.test;
         import org.gradle.api.Plugin;
         import org.gradle.api.initialization.Settings;

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugin.devel.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.GradleVersion
@@ -901,7 +900,6 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         outputContains('content changed')
     }
 
-    @ToBeFixedForConfigurationCache(because = "groovy precompiled scripts")
     def "a change in project sources invalidates build cache"() {
         given:
         def cacheDir = createDir("cache-dir")

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
@@ -16,11 +16,11 @@
 
 package org.gradle.plugin.devel;
 
-import com.google.common.base.Objects;
 import org.gradle.api.Named;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.Objects;
 
 
 //TODO version - could be different from main artifact's version
@@ -30,7 +30,9 @@ import java.io.Serializable;
  * @see org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
  * @since 2.14
  */
-public class PluginDeclaration implements Named, Serializable {
+public class PluginDeclaration implements Named,
+    // TODO: Shouldn't be serializable, remove the interface in Gradle 8.0.
+    Serializable {
     private final String name;
     private String id;
     private String implementationClass;
@@ -114,17 +116,22 @@ public class PluginDeclaration implements Named, Serializable {
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj instanceof PluginDeclaration) {
             PluginDeclaration other = (PluginDeclaration) obj;
-            return Objects.equal(name, other.name)
-                && Objects.equal(id, other.id)
-                && Objects.equal(implementationClass, other.implementationClass);
+            return Objects.equals(name, other.name)
+                && Objects.equals(id, other.id)
+                && Objects.equals(implementationClass, other.implementationClass)
+                && Objects.equals(displayName, other.displayName)
+                && Objects.equals(description, other.description);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, id, implementationClass);
+        return Objects.hash(name, id, implementationClass);
     }
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -21,7 +21,8 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.tasks.Input;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.file.Deleter;
@@ -32,7 +33,10 @@ import org.gradle.work.DisableCachingByDefault;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Generates plugin descriptors from plugin declarations.
@@ -41,15 +45,20 @@ import java.util.Properties;
 public class GeneratePluginDescriptors extends DefaultTask {
 
     private final ListProperty<PluginDeclaration> declarations;
+    private final Provider<Map<String, String>> implementationClassById;
     private final DirectoryProperty outputDirectory;
 
     public GeneratePluginDescriptors() {
         ObjectFactory objectFactory = getProject().getObjects();
         declarations = objectFactory.listProperty(PluginDeclaration.class);
         outputDirectory = objectFactory.directoryProperty();
+        implementationClassById = getDeclarations().map(declarations -> declarations.stream()
+            .collect(Collectors.toMap(PluginDeclaration::getId, PluginDeclaration::getImplementationClass, (a, b) -> a, LinkedHashMap::new))
+        );
+        getInputs().property("implementationClassById", implementationClassById);
     }
 
-    @Input
+    @Internal("The relevant data is tracked via implementationClassById")
     public ListProperty<PluginDeclaration> getDeclarations() {
         return declarations;
     }
@@ -63,10 +72,12 @@ public class GeneratePluginDescriptors extends DefaultTask {
     public void generatePluginDescriptors() {
         File outputDir = outputDirectory.get().getAsFile();
         clearOutputDirectory(outputDir);
-        for (PluginDeclaration declaration : getDeclarations().get()) {
-            File descriptorFile = new File(outputDir, declaration.getId() + ".properties");
+        for (Map.Entry<String, String> entry : implementationClassById.get().entrySet()) {
+            String id = entry.getKey();
+            String implementationClass = entry.getValue();
+            File descriptorFile = new File(outputDir, id + ".properties");
             Properties properties = new Properties();
-            properties.setProperty("implementation-class", declaration.getImplementationClass());
+            properties.setProperty("implementation-class", implementationClass);
             writePropertiesTo(properties, descriptorFile);
         }
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -55,12 +56,16 @@ public class GeneratePluginDescriptors extends DefaultTask {
         implementationClassById = getDeclarations().map(declarations -> declarations.stream()
             .collect(Collectors.toMap(PluginDeclaration::getId, PluginDeclaration::getImplementationClass, (a, b) -> b, LinkedHashMap::new))
         );
-        getInputs().property("implementationClassById", implementationClassById);
     }
 
     @Internal("The relevant data is tracked via implementationClassById")
     public ListProperty<PluginDeclaration> getDeclarations() {
         return declarations;
+    }
+
+    @Input
+    Provider<Map<String, String>> getImplementationClassById() {
+        return implementationClassById;
     }
 
     @OutputDirectory

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -53,7 +53,7 @@ public class GeneratePluginDescriptors extends DefaultTask {
         declarations = objectFactory.listProperty(PluginDeclaration.class);
         outputDirectory = objectFactory.directoryProperty();
         implementationClassById = getDeclarations().map(declarations -> declarations.stream()
-            .collect(Collectors.toMap(PluginDeclaration::getId, PluginDeclaration::getImplementationClass, (a, b) -> a, LinkedHashMap::new))
+            .collect(Collectors.toMap(PluginDeclaration::getId, PluginDeclaration::getImplementationClass, (a, b) -> b, LinkedHashMap::new))
         );
         getInputs().property("implementationClassById", implementationClassById);
     }


### PR DESCRIPTION
Instead of using the serialized form of `PluginDeclaration` as an input, the task now only considers the relevant parts. The PR also fixes `PluginDeclaration.equals()`, which didn't consider the new fields. This is only necessary for backwards compatibility if other tasks would be using `PluginDeclaration` as an input directly.

`PluginDeclaration` shouldn't be `Serializable` either, though removing the interface would be a breaking change. Maybe we can remove then interface in 8.0.

Fixes #20033 