### PR TITLE
Fix branch name extraction when channel is adhoc

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -312,7 +312,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
     }
 
     private String mapVcsBranch(String channelPattern, String vcsBranch) {
-        if (channelPattern.startsWith("commits-")) {
+        if (!channelPattern.startsWith("commits-")) {
             return vcsBranch;
         }
         String currentBranch = channelPattern.substring("commits-".length());

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionResultsStore.java
@@ -221,7 +221,6 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
         return withConnection("load results", connection -> {
             String buildIdQuery = teamcityBuildIdQueryFor(teamcityBuildIds);
             String channelPatternQuery = channelPatternQueryFor(channelPatterns);
-            String currentBranch = channelPatterns.get(0).substring("commits-".length());
             try (
                 PreparedStatement executionsForName = connection.prepareStatement("select id, startTime, endTime, targetVersion, tasks, args, gradleOpts, daemon, operatingSystem, jvm, vcsBranch, vcsCommit, channel, host, cleanTasks, teamCityBuildId from testExecution where testClass = ? and testId = ? and testProject = ? and startTime >= ? and (" + channelPatternQuery + buildIdQuery + ") order by startTime desc limit ?");
                 PreparedStatement operationsForExecution = connection.prepareStatement("select version, testExecution, totalTime from testOperation "
@@ -262,7 +261,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                         performanceResults.setDaemon((Boolean) testExecutions.getObject(8));
                         performanceResults.setOperatingSystem(testExecutions.getString(9));
                         performanceResults.setJvm(testExecutions.getString(10));
-                        performanceResults.setVcsBranch(mapVcsBranch(currentBranch, testExecutions.getString(11).trim()));
+                        performanceResults.setVcsBranch(mapVcsBranch(channelPatterns.get(0), testExecutions.getString(11).trim()));
                         performanceResults.setVcsCommits(ResultsStoreHelper.split(testExecutions.getString(12)));
                         performanceResults.setChannel(testExecutions.getString(13));
                         performanceResults.setHost(testExecutions.getString(14));
@@ -288,7 +287,7 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
                 }
                 operationsForExecution.setInt(++idx, mostRecentN);
 
-                try (ResultSet operations = operationsForExecution.executeQuery()){
+                try (ResultSet operations = operationsForExecution.executeQuery()) {
                     while (operations.next()) {
                         CrossVersionPerformanceResults result = results.get(operations.getLong(2));
                         if (result == null) {
@@ -312,7 +311,11 @@ public class CrossVersionResultsStore extends AbstractWritableResultsStore<Cross
         });
     }
 
-    private String mapVcsBranch(String currentBranch, String vcsBranch) {
+    private String mapVcsBranch(String channelPattern, String vcsBranch) {
+        if (channelPattern.startsWith("commits-")) {
+            return vcsBranch;
+        }
+        String currentBranch = channelPattern.substring("commits-".length());
         if (currentBranch.equals(vcsBranch)) {
             return currentBranch;
         }


### PR DESCRIPTION
When channel is not 'commits-X', the current code fails with:

java.lang.StringIndexOutOfBoundsException: String index out of range: -3
    at java.base/java.lang.String.substring(String.java:1841)
    at CrossVersionResultsStore.lambda$getTestResults$2(CrossVersionResultsStore.java:224)
