### PR TITLE
Use Kotlin 1.7-dev for build-logic

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -14,5 +14,6 @@ dependencies {
     implementation(project(":build-scan"))
 
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.2.0")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0-dev-1904")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.7.0")
 }

--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -17,6 +17,13 @@
 dependencyResolutionManagement {
     repositories {
         gradlePluginPortal()
+        maven {
+            name = "Kotlin EAP repository"
+            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+            content {
+                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+            }
+        }
     }
 }
 

--- a/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
@@ -41,7 +41,7 @@ repositories {
     }
     maven {
         name = "Kotlin EAP repository"
-        url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+        url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
         content {
             includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
         }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -192,7 +192,7 @@ abstract class AbstractBinaryCompatibilityTest {
                         repositories {
                             maven {
                                 name = "Kotlin EAP repository"
-                                url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+                                url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
                                 content {
                                     includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
                                 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -17,6 +17,13 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        maven {
+            name = "Kotlin EAP repository"
+            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+            content {
+                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
+            }
+        }
     }
 }
 
@@ -41,7 +48,7 @@ dependencyResolutionManagement {
         }
         maven {
             name = "Kotlin EAP repository"
-            url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
             content {
                 includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ pluginManagement {
         }
         maven {
             name = "Kotlin EAP repository"
-            url = uri("https://cache-redirector.jetbrains.com/maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
             content {
                 includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
             }


### PR DESCRIPTION
This PR uses kotlin 1.7-dev in build-logic subprojects. After https://github.com/gradle/gradle/pull/20036 we found some problems of mixing different versions of KGP in main build and `build-logic` build: https://ge.gradle.org/s/a5sttxhonyels/timeline?details=xbvsqc6s66be6

To fix this, we use 1.7-dev for compiling `build-logic` as well.