### PR TITLE
Add info about alias normalization to VersionCatalog javadocs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -85,6 +85,9 @@ public interface VersionCatalog extends Named {
 
     /**
      * Returns the list of aliases defined in this version catalog.
+     * <p>
+     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * </p>
      * @return the list of dependency aliases
      *
      * @since 7.1
@@ -95,6 +98,9 @@ public interface VersionCatalog extends Named {
 
     /**
      * Returns the list of aliases defined in this version catalog.
+     * <p>
+     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * </p>
      * @return the list of library aliases
      *
      * @since 7.4
@@ -103,6 +109,9 @@ public interface VersionCatalog extends Named {
 
     /**
      * Returns the list of bundles defined in this version catalog.
+     * <p>
+     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * </p>
      * @return the list of bundle aliases
      *
      * @since 7.1
@@ -111,6 +120,9 @@ public interface VersionCatalog extends Named {
 
     /**
      * Returns the list of version aliases defined in this version catalog.
+     * <p>
+     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * </p>
      * @return the list of version aliases
      *
      * @since 7.1
@@ -119,6 +131,9 @@ public interface VersionCatalog extends Named {
 
     /**
      * Returns the list of plugin aliases defined in this version catalog.
+     * <p>
+     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * </p>
      * @return the list of plugin aliases
      *
      * @since 7.2

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java
@@ -86,7 +86,7 @@ public interface VersionCatalog extends Named {
     /**
      * Returns the list of aliases defined in this version catalog.
      * <p>
-     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * Note: Returned aliases are normalized: '-', '_' and '.' have been replaced with '.'
      * </p>
      * @return the list of dependency aliases
      *
@@ -99,7 +99,7 @@ public interface VersionCatalog extends Named {
     /**
      * Returns the list of aliases defined in this version catalog.
      * <p>
-     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * Note: Returned aliases are normalized: '-', '_' and '.' have been replaced with '.'
      * </p>
      * @return the list of library aliases
      *
@@ -110,7 +110,7 @@ public interface VersionCatalog extends Named {
     /**
      * Returns the list of bundles defined in this version catalog.
      * <p>
-     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * Note: Returned aliases are normalized: '-', '_' and '.' have been replaced with '.'
      * </p>
      * @return the list of bundle aliases
      *
@@ -121,7 +121,7 @@ public interface VersionCatalog extends Named {
     /**
      * Returns the list of version aliases defined in this version catalog.
      * <p>
-     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * Note: Returned aliases are normalized: '-', '_' and '.' have been replaced with '.'
      * </p>
      * @return the list of version aliases
      *
@@ -132,7 +132,7 @@ public interface VersionCatalog extends Named {
     /**
      * Returns the list of plugin aliases defined in this version catalog.
      * <p>
-     * Note: Returned aliases are normalized: '-', '_' and '.'  have been replaced with '.'
+     * Note: Returned aliases are normalized: '-', '_' and '.' have been replaced with '.'
      * </p>
      * @return the list of plugin aliases
      *

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -14,7 +14,8 @@ We would like to thank the following community members for their contributions t
 [Björn Kautler](https://github.com/Vampire),
 [David Burström](https://github.com/davidburstrom),
 [Vladimir Sitnikov](https://github.com/vlsi),
-[Roland Weisleder](https://github.com/rweisleder)
+[Roland Weisleder](https://github.com/rweisleder),
+[Konstantin Gribov](https://github.com/grossws)
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)


### PR DESCRIPTION
### Context
Adds info about alias normalization to `VersionCatalog`'s `getLibraryAliases`, `getPluginAliases` etc.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
