### PR TITLE
Add an alias for aarch64 to supported list of arm-v8/arm64 architectures

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/Architecture.java
@@ -21,7 +21,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
- * A cpu architecture.
+ * A CPU architecture.
  *
  * <table>
  *     <tr>
@@ -52,7 +52,7 @@ import org.gradle.internal.HasInternalProtocol;
  *     <tr>
  *         <td>ARM</td>
  *         <td>"arm", "arm-v7", "armv7", "arm32"</td>
- *         <td>"arm64", "arm-v8"</td>
+ *         <td>"aarch64", "arm64", "arm-v8"</td>
  *     </tr>
  * </table>
  */

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/Architectures.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/Architectures.java
@@ -26,13 +26,14 @@ public class Architectures {
     public static final KnownArchitecture X86_64 = new KnownArchitecture("x86-64", "x86_64", "amd64", "x64");
     public static final KnownArchitecture IA_64 = new KnownArchitecture("ia-64", "ia64");
     public static final KnownArchitecture ARM_V7 = new KnownArchitecture("arm-v7", "armv7", "arm", "arm32");
+    public static final KnownArchitecture AARCH64 = new KnownArchitecture("aarch64", "arm-v8", "arm64");
 
     private static final List<KnownArchitecture> KNOWN_ARCHITECTURES = asList(
             X86,
             X86_64,
             IA_64,
             ARM_V7,
-            new KnownArchitecture("arm-v8", "arm64"),
+            AARCH64,
             new KnownArchitecture("ppc"),
             new KnownArchitecture("ppc64"),
             new KnownArchitecture("sparc-v8", "sparc", "sparc32"),

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/DefaultArchitecture.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/DefaultArchitecture.java
@@ -54,7 +54,7 @@ public class DefaultArchitecture implements ArchitectureInternal {
 
     @Override
     public boolean isArm() {
-        return Architectures.ARM_V7.isAlias(name);
+        return Architectures.ARM_V7.isAlias(name) || Architectures.AARCH64.isAlias(name);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/NativePlatforms.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/NativePlatforms.java
@@ -41,7 +41,7 @@ public class NativePlatforms {
         ArchitectureInternal x64 = Architectures.forInput("x86_64");
         ArchitectureInternal ia64 = Architectures.forInput("ia64");
         ArchitectureInternal armv7 = Architectures.forInput("armv7");
-        ArchitectureInternal armv8 = Architectures.forInput("armv8");
+        ArchitectureInternal aarch64 = Architectures.forInput("aarch64");
         ArchitectureInternal sparc = Architectures.forInput("sparc");
         ArchitectureInternal ultrasparc = Architectures.forInput("ultrasparc");
         ArchitectureInternal ppc = Architectures.forInput("ppc");
@@ -55,24 +55,25 @@ public class NativePlatforms {
         platforms.add(createPlatform(freebsd, x86));
         platforms.add(createPlatform(freebsd, x64));
         platforms.add(createPlatform(freebsd, armv7));
-        platforms.add(createPlatform(freebsd, armv8));
+        platforms.add(createPlatform(freebsd, aarch64));
         platforms.add(createPlatform(freebsd, ppc));
         platforms.add(createPlatform(freebsd, ppc64));
 
         platforms.add(createPlatform(unix, x86));
         platforms.add(createPlatform(unix, x64));
         platforms.add(createPlatform(unix, armv7));
-        platforms.add(createPlatform(unix, armv8));
+        platforms.add(createPlatform(unix, aarch64));
         platforms.add(createPlatform(unix, ppc));
         platforms.add(createPlatform(unix, ppc64));
 
         platforms.add(createPlatform(linux, x64));
         platforms.add(createPlatform(linux, x86));
         platforms.add(createPlatform(linux, armv7));
-        platforms.add(createPlatform(linux, armv8));
+        platforms.add(createPlatform(linux, aarch64));
 
         platforms.add(createPlatform(osx, x86));
         platforms.add(createPlatform(osx, x64));
+        platforms.add(createPlatform(osx, aarch64));
 
         platforms.add(createPlatform(solaris, x64));
         platforms.add(createPlatform(solaris, x86));

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/platform/internal/ArchitecturesTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/platform/internal/ArchitecturesTest.groovy
@@ -33,4 +33,11 @@ class ArchitecturesTest extends Specification {
         where:
         architecture << [ "x86-64", "x86_64", "amd64", "x64" ]
     }
+
+    def "test ARM aliases"() {
+        expect:
+        Architectures.forInput(architecture).isArm()
+        where:
+        architecture << [ "aarch64", "arm-v8", "arm", "armv7" ]
+    }
 }


### PR DESCRIPTION
This is the name reported by uname and used more widely than arm-v8

