### PR TITLE
Add ability to stream FileSystemSnapshot depth-first

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/OutputsCleaner.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/OutputsCleaner.java
@@ -21,7 +21,6 @@ import org.gradle.internal.file.Deleter;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
-import org.gradle.internal.snapshot.SnapshotUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +28,9 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Cleans outputs, removing empty directories.
@@ -64,9 +63,9 @@ public class OutputsCleaner {
      * After cleaning up the files, the empty directories are removed as well.
      */
     public void cleanupOutputs(FileSystemSnapshot snapshot) throws IOException {
-        // TODO We could make this faster by visiting the snapshot
-        for (Map.Entry<String, FileSystemLocationSnapshot> entry : SnapshotUtil.index(snapshot).entrySet()) {
-            cleanupOutput(new File(entry.getKey()), entry.getValue().getType());
+        // TODO This could be even faster if we processed the stream directly, but that complicates exception handling
+        for (FileSystemLocationSnapshot entry : snapshot.stream().collect(Collectors.toList())) {
+            cleanupOutput(new File(entry.getAbsolutePath()), entry.getType());
         }
         cleanupDirectories();
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/OutputSnapshotUtil.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSortedMap.copyOfSorted;
 import static com.google.common.collect.Maps.transformEntries;
@@ -79,10 +80,12 @@ public class OutputSnapshotUtil {
 
     @VisibleForTesting
     static FileSystemSnapshot findOutputPropertyStillPresentSincePreviousExecution(FileSystemSnapshot previous, FileSystemSnapshot current) {
-        Map<String, FileSystemLocationSnapshot> previousIndex = index(previous);
+        Set<String> previousAbsolutePaths = previous.stream()
+            .map(FileSystemLocationSnapshot::getAbsolutePath)
+            .collect(Collectors.toSet());
         return filterSnapshot(current, (currentSnapshot, isRoot) ->
             // Include only outputs that we already considered outputs after the previous execution
-            previousIndex.containsKey(currentSnapshot.getAbsolutePath())
+            previousAbsolutePaths.contains(currentSnapshot.getAbsolutePath())
         );
     }
 

--- a/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultFileSystemWatchingStatistics.java
+++ b/subprojects/file-watching/src/main/java/org/gradle/internal/watch/vfs/impl/DefaultFileSystemWatchingStatistics.java
@@ -19,11 +19,11 @@ package org.gradle.internal.watch.vfs.impl;
 import com.google.common.collect.EnumMultiset;
 import com.google.common.collect.Multiset;
 import org.gradle.internal.file.FileType;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
+import org.gradle.internal.snapshot.MetadataSnapshot;
 import org.gradle.internal.snapshot.SnapshotHierarchy;
 import org.gradle.internal.watch.registry.FileWatcherRegistry;
 import org.gradle.internal.watch.vfs.FileSystemWatchingStatistics;
-
-import static org.gradle.internal.snapshot.SnapshotVisitResult.CONTINUE;
 
 public class DefaultFileSystemWatchingStatistics implements FileSystemWatchingStatistics {
     private final FileWatcherRegistry.FileWatchingStatistics fileWatchingStatistics;
@@ -65,10 +65,9 @@ public class DefaultFileSystemWatchingStatistics implements FileSystemWatchingSt
     private static VirtualFileSystemStatistics getStatistics(SnapshotHierarchy root) {
         EnumMultiset<FileType> retained = EnumMultiset.create(FileType.class);
         root.rootSnapshots()
-            .forEach(snapshot -> snapshot.accept(entrySnapshot -> {
-                retained.add(entrySnapshot.getType());
-                return CONTINUE;
-            }));
+            .flatMap(FileSystemSnapshot::stream)
+            .map(MetadataSnapshot::getType)
+            .forEach(retained::add);
         return new VirtualFileSystemStatistics(retained);
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompositeFileSystemSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/CompositeFileSystemSnapshot.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class CompositeFileSystemSnapshot implements FileSystemSnapshot {
     private final ImmutableList<FileSystemSnapshot> snapshots;
@@ -59,6 +60,12 @@ public class CompositeFileSystemSnapshot implements FileSystemSnapshot {
             }
         }
         return SnapshotVisitResult.CONTINUE;
+    }
+
+    @Override
+    public Stream<FileSystemSnapshot> stream() {
+        return snapshots.stream()
+            .flatMap(FileSystemSnapshot::stream);
     }
 
     public boolean equals(Object o) {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/DirectorySnapshot.java
@@ -25,6 +25,7 @@ import org.gradle.internal.hash.HashCode;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.gradle.internal.snapshot.ChildMapFactory.childMapFromSorted;
 import static org.gradle.internal.snapshot.SnapshotVisitResult.CONTINUE;
@@ -39,7 +40,11 @@ public class DirectorySnapshot extends AbstractFileSystemLocationSnapshot {
     private final HashCode contentHash;
 
     public DirectorySnapshot(String absolutePath, String name, AccessType accessType, HashCode contentHash, List<FileSystemLocationSnapshot> children) {
-        this(absolutePath, name, accessType, contentHash, childMapFromSorted(children.stream()
+        this(absolutePath, name, accessType, contentHash, children.stream());
+    }
+
+    public DirectorySnapshot(String absolutePath, String name, AccessType accessType, HashCode contentHash, Stream<FileSystemLocationSnapshot> children) {
+        this(absolutePath, name, accessType, contentHash, childMapFromSorted(children
             .map(it -> new ChildMap.Entry<>(it.getName(), it))
             .collect(Collectors.toList())));
     }
@@ -125,10 +130,16 @@ public class DirectorySnapshot extends AbstractFileSystemLocationSnapshot {
         return transformer.visitDirectory(this);
     }
 
+    @Override
+    public Stream<FileSystemLocationSnapshot> stream() {
+        return children.stream()
+            .map(ChildMap.Entry::getValue);
+    }
+
+    // TODO Move this to tests
     @VisibleForTesting
     public ImmutableList<FileSystemLocationSnapshot> getChildren() {
-        return children.stream()
-            .map(ChildMap.Entry::getValue)
+        return stream()
             .collect(ImmutableList.toImmutableList());
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemLeafSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemLeafSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.snapshot;
 
+import java.util.stream.Stream;
+
 /**
  * The snapshot of a leaf element in the file system that can have no children of its own.
  */
@@ -33,5 +35,10 @@ public interface FileSystemLeafSnapshot extends FileSystemLocationSnapshot {
         } finally {
             pathTracker.leave();
         }
+    }
+
+    @Override
+    default Stream<FileSystemLocationSnapshot> stream() {
+        return Stream.of(this);
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshot.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.snapshot;
 
+import java.util.stream.Stream;
+
 /**
  * A snapshot of a part of the file system.
  */
@@ -33,6 +35,11 @@ public interface FileSystemSnapshot {
         public SnapshotVisitResult accept(RelativePathTracker pathTracker, RelativePathTrackingFileSystemSnapshotHierarchyVisitor visitor) {
             return SnapshotVisitResult.CONTINUE;
         }
+
+        @Override
+        public Stream<FileSystemLocationSnapshot> stream() {
+            return Stream.empty();
+        }
     };
 
     /**
@@ -48,4 +55,11 @@ public interface FileSystemSnapshot {
      * The walk is depth first.
      */
     SnapshotVisitResult accept(RelativePathTracker pathTracker, RelativePathTrackingFileSystemSnapshotHierarchyVisitor visitor);
+
+    /**
+     * Walks the whole hierarchy represented by this snapshot.
+     *
+     * The walk is depth first.
+     */
+    Stream<? extends FileSystemLocationSnapshot> stream();
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotUtil.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/SnapshotUtil.java
@@ -29,10 +29,8 @@ public class SnapshotUtil {
 
     public static Map<String, FileSystemLocationSnapshot> index(FileSystemSnapshot snapshot) {
         HashMap<String, FileSystemLocationSnapshot> index = new HashMap<>();
-        snapshot.accept(entrySnapshot -> {
-            index.put(entrySnapshot.getAbsolutePath(), entrySnapshot);
-            return SnapshotVisitResult.CONTINUE;
-        });
+        snapshot.stream()
+                .forEach(entrySnapshot -> index.put(entrySnapshot.getAbsolutePath(), entrySnapshot));
         return index;
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -332,7 +332,7 @@ public class DirectorySnapshotter {
                                 internedFileName,
                                 AccessType.VIA_SYMLINK,
                                 targetSnapshot.getHash(),
-                                targetSnapshot.getChildren()
+                                targetSnapshot.stream()
                             );
                             builder.visitDirectory(directorySnapshotAccessedViaSymlink);
                             boolean symlinkFiltered = symlinkHasBeenFiltered.get();

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -27,9 +27,7 @@ import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.snapshot.DirectorySnapshot
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
-import org.gradle.internal.snapshot.FileSystemSnapshotHierarchyVisitor
 import org.gradle.internal.snapshot.RegularFileSnapshot
-import org.gradle.internal.snapshot.SnapshotVisitResult
 import org.gradle.internal.snapshot.SnapshottingFilter
 import org.gradle.internal.vfs.FileSystemAccess
 import org.gradle.test.fixtures.file.CleanupTestDirectory
@@ -37,7 +35,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
-import static org.gradle.internal.snapshot.SnapshotVisitResult.CONTINUE
+import java.util.stream.Collectors
 
 @CleanupTestDirectory
 class FileSystemSnapshotFilterTest extends Specification {
@@ -110,15 +108,10 @@ class FileSystemSnapshotFilterTest extends Specification {
     }
 
     private Set<File> filteredPaths(FileSystemSnapshot unfiltered, PatternSet patterns) {
-        def result = [] as Set
-        def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns).asSnapshotPredicate, unfiltered)
-        filtered.accept(new FileSystemSnapshotHierarchyVisitor() {
-            SnapshotVisitResult visitEntry(FileSystemLocationSnapshot snapshot) {
-                result << new File(snapshot.absolutePath)
-                return CONTINUE
-            }
-        })
-        return result
+        FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(patterns).asSnapshotPredicate, unfiltered).stream()
+            .map(FileSystemLocationSnapshot::getAbsolutePath)
+            .map(File::new)
+            .collect(Collectors.toSet())
     }
 
     private static PatternSet include(String pattern) {


### PR DESCRIPTION
Allow visiting `FileSystemSnasphot` hierarchies using the Java streams API. In places this allows for simpler functional code chaining. In other places it also leads to more efficient code.