### PR TITLE
Fix NPE and try to find jar location by another way if location from …

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/installation/GradleRuntimeShadedJarDetector.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/installation/GradleRuntimeShadedJarDetector.java
@@ -20,6 +20,7 @@ import org.gradle.internal.UncheckedException;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.CodeSource;
@@ -44,6 +45,17 @@ public class GradleRuntimeShadedJarDetector {
 
         if (codeSource != null) {
             URL location = codeSource.getLocation();
+            if (location == null) {
+                URL resource = clazz.getResource(".");
+                if (resource == null) {
+                    return false;
+                }
+                try {
+                    location = new URL(resource.getFile().split("!")[0]);
+                } catch (MalformedURLException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
 
             if (isJarUrl(location)) {
                 try {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

For memory optimization `ClassLoader` in our project passes null for ProtectionDomain. In this case defaultDomain will be chooses that has null for `CodeSource#location`. And when we try to use gradle-api we get the exception:

```
org.gradle.internal.service.ServiceCreationException: Could not create service of type ClassLoaderRegistry using GlobalScopeServices.createClassLoaderRegistry()
...
Caused by: java.lang.NullPointerException
	at org.gradle.internal.installation.GradleRuntimeShadedJarDetector.isJarUrl(GradleRuntimeShadedJarDetector.java:61)
	at org.gradle.internal.installation.GradleRuntimeShadedJarDetector.isLoadedFrom(GradleRuntimeShadedJarDetector.java:48)
	at org.gradle.internal.service.scopes.GlobalScopeServices.createClassLoaderRegistry(GlobalScopeServices.java:309)
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] `N/A` Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] `N/A` Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] `N/A` Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
