### PR TITLE
Include subprojects in subprojects.json but not in test-buckets.json

### DIFF
--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -17,7 +17,7 @@ const val MAX_PROJECT_NUMBER_IN_BUCKET = 11
  *
  * Usage: `mvn compile exec:java@update-test-buckets -DinputTestClassDataJson=/path/to/test-class-data.json`.
  */
-fun main(args: Array<String>) {
+fun main() {
     val model = CIBuildModel(
         projectId = "Check",
         branch = VersionedSettingsBranch("master", true),

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketGenerator.kt
@@ -168,7 +168,7 @@ class FunctionalTestBucketGenerator(private val model: CIBuildModel, testTimeDat
         val result = mutableMapOf<TestCoverage, List<BuildTypeBucket>>()
         for (stage in model.stages) {
             for (testCoverage in stage.functionalTests) {
-                if (testCoverage.testType !in listOf(TestType.allVersionsCrossVersion, TestType.quickFeedbackCrossVersion)) {
+                if (testCoverage.testType !in listOf(TestType.allVersionsCrossVersion, TestType.quickFeedbackCrossVersion, TestType.soak)) {
                     result[testCoverage] = splitBucketsByTestClassesForBuildProject(testCoverage, stage, buildProjectClassTimes)
                 }
             }

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -93,13 +93,13 @@ class StatisticBasedFunctionalTestBucketProvider(val model: CIBuildModel, testBu
                 if (it is SmallSubprojectBucket) it.subprojects.map { it.name }
                 else listOf((it as LargeSubprojectSplitBucket).subproject.name)
             }.toSet()
-            val allSubprojectsInModel = model.subprojects.subprojects.filter { it.functionalTests || it.unitTests || it.crossVersionTests }.map { it.name }.toMutableList()
-            allSubprojectsInModel.removeAll(allSubprojectsInBucketJson)
+            val allSubprojectsInModel = model.subprojects.subprojects.filter { it.hasTestsOf(testCoverage.testType) }.map { it.name }
+            val subprojectsInModelButNotInBucketJson = allSubprojectsInModel.toMutableList().apply { removeAll(allSubprojectsInBucketJson) }
 
-            if (buckets.isEmpty() || allSubprojectsInModel.isEmpty()) {
+            if (subprojectsInModelButNotInBucketJson.isEmpty()) {
                 testCoverage to buckets
             } else {
-                testCoverage to mergeUnknownSubprojectsIntoFirstAvailableBucket(buckets, model.subprojects.subprojects.filter { allSubprojectsInModel.contains(it.name) })
+                testCoverage to mergeUnknownSubprojectsIntoFirstAvailableBucket(buckets, model.subprojects.subprojects.filter { subprojectsInModelButNotInBucketJson.contains(it.name) })
             }
         }
     }

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -106,11 +106,10 @@ class StatisticBasedFunctionalTestBucketProvider(val model: CIBuildModel, testBu
 
     private fun mergeUnknownSubprojectsIntoFirstAvailableBucket(buckets: List<BuildTypeBucket>, unknownSubprojects: List<GradleSubproject>): MutableList<BuildTypeBucket> =
         buckets.toMutableList().apply {
-            val firstSmallSubprojectsBucketIndex = indexOfFirst { it is SmallSubprojectBucket }
-            val firstSmallSubprojectsBucket = get(firstSmallSubprojectsBucketIndex) as SmallSubprojectBucket
+            val firstAvailableBucketIndex = indexOfFirst { it is SmallSubprojectBucket }
+            val firstSmallSubprojectsBucket = get(firstAvailableBucketIndex) as SmallSubprojectBucket
 
-            set(firstSmallSubprojectsBucketIndex,
-                SmallSubprojectBucket(firstSmallSubprojectsBucket.subprojects + unknownSubprojects, firstSmallSubprojectsBucket.enableTestDistribution))
+            set(firstAvailableBucketIndex, SmallSubprojectBucket(firstSmallSubprojectsBucket.subprojects + unknownSubprojects, firstSmallSubprojectsBucket.enableTestDistribution))
         }
 
     override fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage): List<FunctionalTest> {

--- a/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
+++ b/.teamcity/src/main/kotlin/model/FunctionalTestBucketProvider.kt
@@ -86,9 +86,32 @@ class StatisticBasedFunctionalTestBucketProvider(val model: CIBuildModel, testBu
             val buckets: List<BuildTypeBucket> = testCoverageAndBucket.getJSONArray("buckets").map {
                 fromJsonObject(it as JSONObject).toBuildTypeBucket(model.subprojects)
             }
-            testCoverage to buckets
+
+            // Sometimes people may add new subproject into `subprojects.json`
+            // in this case we have no historical test running time, so we simply add these subprojects into first available bucket
+            val allSubprojectsInBucketJson = buckets.flatMap {
+                if (it is SmallSubprojectBucket) it.subprojects.map { it.name }
+                else listOf((it as LargeSubprojectSplitBucket).subproject.name)
+            }.toSet()
+            val allSubprojectsInModel = model.subprojects.subprojects.filter { it.functionalTests || it.unitTests || it.crossVersionTests }.map { it.name }.toMutableList()
+            allSubprojectsInModel.removeAll(allSubprojectsInBucketJson)
+
+            if (buckets.isEmpty() || allSubprojectsInModel.isEmpty()) {
+                testCoverage to buckets
+            } else {
+                testCoverage to mergeUnknownSubprojectsIntoFirstAvailableBucket(buckets, model.subprojects.subprojects.filter { allSubprojectsInModel.contains(it.name) })
+            }
         }
     }
+
+    private fun mergeUnknownSubprojectsIntoFirstAvailableBucket(buckets: List<BuildTypeBucket>, unknownSubprojects: List<GradleSubproject>): MutableList<BuildTypeBucket> =
+        buckets.toMutableList().apply {
+            val firstSmallSubprojectsBucketIndex = indexOfFirst { it is SmallSubprojectBucket }
+            val firstSmallSubprojectsBucket = get(firstSmallSubprojectsBucketIndex) as SmallSubprojectBucket
+
+            set(firstSmallSubprojectsBucketIndex,
+                SmallSubprojectBucket(firstSmallSubprojectsBucket.subprojects + unknownSubprojects, firstSmallSubprojectsBucket.enableTestDistribution))
+        }
 
     override fun createFunctionalTestsFor(stage: Stage, testCoverage: TestCoverage): List<FunctionalTest> {
         return buckets.getValue(testCoverage).mapIndexed { bucketIndex: Int, bucket: BuildTypeBucket ->

--- a/.teamcity/test-buckets.json
+++ b/.teamcity/test-buckets.json
@@ -5492,18 +5492,6 @@
 		"testCoverageUuid":7
 	},
 	{
-		"buckets":[],
-		"testCoverageUuid":8
-	},
-	{
-		"buckets":[],
-		"testCoverageUuid":9
-	},
-	{
-		"buckets":[],
-		"testCoverageUuid":35
-	},
-	{
 		"buckets":[
 			{
 				"enableTD":true,


### PR DESCRIPTION
Previously, if a subproject exists in subproject.json but not in
test-buckets.json, it wouldn't be included in generated TeamCity
build configuration.
