### PR TITLE
Fix os predicate on Windows

### DIFF
--- a/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/ZipSlip.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/ZipSlip.java
@@ -47,6 +47,6 @@ public class ZipSlip {
     }
 
     private static boolean isWindows() {
-        return System.getProperty("os.name").contains("windows");
+        return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("b2ad31045aa25f32497631b5ea796fef746d6ee706db4aca922f53aa53a5fbb8")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("07ee5e554dcb15651c8b2c65b694d57a1926768030b8d522d1ef66a31fb14973")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
I found a test was not included on Windows: https://ge.gradle.org/scans/tests?search.relativeStartTime=P7D&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.util.internal.ZipSlipTest&tests.sortField=FAILED&tests.test=identifies%20potentially%20unsafe%20zip%20entry%20names%20%5BunsafePath:%20C:/foo%2C%20safePath:%20foo%2C%20%236%5D&tests.unstableOnly=false

It was due to a wrong predicate on windows.

```
jshell> System.getProperty("os.name")
$1 ==> "Windows 10"
```