### PR TITLE
Remove Serializable from PluginDeclaration

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -62,6 +62,11 @@ TBD
 
 Previously, `org.gradle.api.AntBuilder` extended the deprecated `groovy.util.AntBuilder` class.  It now extends `groovy.ant.AntBuilder`.
 
+==== PluginDeclaration is not serializable
+
+`org.gradle.plugin.devel.PluginDeclaration` is not serializable anymore.
+If you need to serialize it, you can convert it into your own, serializable class.
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
@@ -20,15 +20,13 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Named;
 import org.gradle.api.provider.SetProperty;
 
-import java.io.Serializable;
-
 /**
  * Describes a Gradle plugin under development.
  *
  * @see org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
  * @since 2.14
  */
-public abstract class PluginDeclaration implements Named, Serializable { // TODO: Shouldn't be serializable, remove the interface in Gradle 8.0.
+public abstract class PluginDeclaration implements Named {
     private final String name;
     private String id;
     private String implementationClass;


### PR DESCRIPTION
There is no need to make PluginDeclaration serializable.

Follow up for #20050.