### PR TITLE
Update tests for 3rd-party plugins that are important to GE-Solutions

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -84,7 +84,7 @@ abstract class AbstractSmokeTest extends Specification {
         static asciidoctor = Versions.of("3.3.2")
 
         // https://plugins.gradle.org/plugin/com.github.spotbugs
-        static spotbugs = "4.7.6"
+        static spotbugs = "5.0.6"
 
         // https://plugins.gradle.org/plugin/com.bmuschko.docker-java-application
         static docker = "7.1.0"
@@ -135,11 +135,11 @@ abstract class AbstractSmokeTest extends Specification {
         static testRetryPlugin = "1.3.1"
 
         // https://plugins.gradle.org/plugin/com.jfrog.artifactory
-        static artifactoryPlugin = "4.24.20"
+        static artifactoryPlugin = "4.27.1"
         static artifactoryRepoOSSVersion = "6.16.0"
 
         // https://plugins.gradle.org/plugin/io.freefair.aspectj
-        static aspectj = "6.2.0"
+        static aspectj = "6.4.1"
 
         // https://plugins.gradle.org/plugin/de.undercouch.download
         static undercouchDownload = Versions.of("4.1.2")
@@ -157,10 +157,10 @@ abstract class AbstractSmokeTest extends Specification {
         static apt = Versions.of("0.21")
 
         // https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt
-        static detekt = Versions.of("1.18.1")
+        static detekt = Versions.of("1.19.0")
 
         // https://plugins.gradle.org/plugin/com.diffplug.spotless
-        static spotless = Versions.of("6.0.0")
+        static spotless = Versions.of("6.3.0")
 
         // https://plugins.gradle.org/plugin/com.google.cloud.tools.jib
         static jib = Versions.of("3.1.4")

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -185,6 +185,9 @@ abstract class AbstractSmokeTest extends Specification {
 
         // https://github.com/davidmc24/gradle-avro-plugin
         static avro = Versions.of("1.3.0")
+
+        // https://plugins.gradle.org/plugin/io.spring.nohttp
+        static nohttp = Versions.of("0.0.10")
     }
 
     static class Versions implements Iterable<String> {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -188,6 +188,9 @@ abstract class AbstractSmokeTest extends Specification {
 
         // https://plugins.gradle.org/plugin/io.spring.nohttp
         static nohttp = Versions.of("0.0.10")
+
+        // https://plugins.gradle.org/plugin/org.jenkins-ci.jpi
+        static jenkinsJpi = Versions.of("0.43.0")
     }
 
     static class Versions implements Iterable<String> {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -182,6 +182,9 @@ abstract class AbstractSmokeTest extends Specification {
 
         // https://plugins.gradle.org/plugin/com.github.node-gradle.node
         static newNode = Versions.of("3.1.1")
+
+        // https://github.com/davidmc24/gradle-avro-plugin
+        static avro = Versions.of("1.3.0")
     }
 
     static class Versions implements Iterable<String> {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -32,9 +32,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
     private static final String CRASHLYTICS_PLUGIN_ID = 'com.google.firebase.crashlytics'
     private static final String FIREBASE_PERF_PLUGIN_ID = 'com.google.firebase.firebase-perf'
     private static final String SENTRY_PLUGIN_ID = 'io.sentry.android.gradle'
-    // bugsnag is not compatible with AGP 7.0
-    // https://github.com/bugsnag/bugsnag-android-gradle-plugin/issues/399
-//    private static final String BUGSNAG_PLUGIN_ID = 'com.bugsnag.android.gradle'
+    private static final String BUGSNAG_PLUGIN_ID = 'com.bugsnag.android.gradle'
 
     @Override
     Map<String, Versions> getPluginsToValidate() {
@@ -42,7 +40,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
             (GOOGLE_SERVICES_PLUGIN_ID): Versions.of('4.3.5'),
             (CRASHLYTICS_PLUGIN_ID): Versions.of('2.5.1'),
             (FIREBASE_PERF_PLUGIN_ID): Versions.of('1.3.5'),
-//            (BUGSNAG_PLUGIN_ID): Versions.of('5.7.6'),
+            (BUGSNAG_PLUGIN_ID): Versions.of('7.2.0'),
             (FLADLE_PLUGIN_ID): Versions.of('0.14.1'),
             (TRIPLET_PLAY_PLUGIN_ID): Versions.of('3.3.0-agp4.2'),
             (SAFEARGS_PLUGIN_ID): Versions.of('2.3.5'),
@@ -105,6 +103,9 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
                     }
                     if (pluginRequest.id.id == '${SENTRY_PLUGIN_ID}') {
                         useModule("io.sentry:sentry-android-gradle-plugin:\${pluginRequest.version}")
+                    }
+                    if (pluginRequest.id.id == '${BUGSNAG_PLUGIN_ID}') {
+                        useModule("com.bugsnag:bugsnag-android-gradle-plugin:\${pluginRequest.version}")
                     }
                 }
             }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AvroPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AvroPluginSmokeTest.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+class AvroPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
+    @Override
+    Map<String, Versions> getPluginsToValidate() {
+        [
+            'com.github.davidmc24.gradle.plugin.avro': TestedVersions.avro,
+        ]
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FreefairAspectJPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FreefairAspectJPluginSmokeTest.groovy
@@ -36,10 +36,6 @@ class FreefairAspectJPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
             ${mavenCentralRepository()}
 
-            aspectj {
-                version = "1.9.7"
-            }
-
             dependencies {
                 inpath "org.apache.httpcomponents:httpcore-nio:4.4.11"
                 implementation "org.aspectj:aspectjrt:1.9.7"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FreefairAspectJPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/FreefairAspectJPluginSmokeTest.groovy
@@ -86,7 +86,8 @@ class FreefairAspectJPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
     @Override
     Map<String, Versions> getPluginsToValidate() {
         [
-            'io.freefair.aspectj': Versions.of(TestedVersions.aspectj)
+            'io.freefair.aspectj': Versions.of(TestedVersions.aspectj),
+            'io.freefair.aspectj.post-compile-weaving': Versions.of(TestedVersions.aspectj)
         ]
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JenkinsJpiPluginSmokeTest.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+class JenkinsJpiPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
+    @Override
+    Map<String, Versions> getPluginsToValidate() {
+        [
+            'org.jenkins-ci.jpi': TestedVersions.jenkinsJpi,
+        ]
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NohttpPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/NohttpPluginSmokeTest.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+class NohttpPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
+    @Override
+    Map<String, Versions> getPluginsToValidate() {
+        [
+            'io.spring.nohttp': TestedVersions.nohttp,
+        ]
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/SpotBugsPluginSmokeTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
@@ -25,7 +24,6 @@ class SpotBugsPluginSmokeTest extends AbstractPluginValidatingSmokeTest {
 
     @Issue('https://plugins.gradle.org/plugin/com.github.spotbugs')
     @Requires(TestPrecondition.JDK11_OR_EARLIER)
-    @ToBeFixedForConfigurationCache
     def 'spotbugs plugin'() {
         given:
         buildFile << """


### PR DESCRIPTION
These are plugins that the GE-Solutions team has contributed to directly, or are heavily depended-on by our GE customers. As such, we'd like to maintain basic smoke-test coverage for these plugins.