### PR TITLE
Ignore "java.awt.headless" in the configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -28,6 +28,8 @@ val allowedProperties = setOf(
     "os.name",
     "os.version",
     "os.arch",
+    // TODO(https://github.com/gradle/gradle/issues/18432) Remove this from the list when a proper support for the modifications is in place.
+    "java.awt.headless", // Some popular plugins modify this property at runtime.
     "java.version",
     "java.version.date",
     "java.vendor",


### PR DESCRIPTION
Some popular plugins modify this property at runtime. This breaks
configuration caching if some other plugin reads the modified value -
the fingerprint check at the next run expects the property to have
the modified value so it fails and invalidates the cache.

This change doesn't fix the issue completely but reverts to the old
behavior: use the default (unmodified) value of the property for the
cached run. It is incorrect but for this particular case seems to be
an acceptable compromise. The proper fix is being tracked at #18432.

Fixes #19710.