### PR TITLE
Remove "execute from Finder" test

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperIntegrationTest.groovy
@@ -16,43 +16,11 @@
 package org.gradle.integtests
 
 import groovy.io.FileType
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import org.gradle.test.fixtures.ConcurrentTestUtil
-import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ GradleContextualExecuter.embedded }) // wrapperExecuter requires a real distribution
 class WrapperIntegrationTest extends AbstractWrapperIntegrationSpec {
-    @Requires(TestPrecondition.MAC_OS_X)
-    @ToBeFixedForConfigurationCache(skip = ToBeFixedForConfigurationCache.Skip.LONG_TIMEOUT)
-    def "can execute from Finder"() {
-        given:
-        file("build.gradle") << """
-task hello {
-    doLast {
-        file('hello.txt').createNewFile()
-    }
-}
-defaultTasks 'hello'
-        """
-        file('settings.gradle') << ''
-        prepareWrapper()
-        def gradlewPath = new File(wrapperExecuter.workingDir as File, 'gradlew').absolutePath
-
-        when:
-        // use the open program since that is what Finder uses
-        // set the cwd to the testDirectory to reproduce where gradle normally is run from
-        new TestFile("/usr/bin/open").execute(["-g", gradlewPath], ['JAVA_OPTS="-Xmx512m"'])
-
-        then:
-        ConcurrentTestUtil.poll(60, 1) {
-            assert file("hello.txt").exists()
-        }
-    }
-
     def "can recover from a broken distribution"() {
         buildFile << "task hello"
         prepareWrapper()


### PR DESCRIPTION
This test is old and has not run for a long time: https://ge.gradle.org/scans/tests?search.relativeStartTime=P90D&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.integtests.WrapperIntegrationTest&tests.sortField=FAILED&tests.test=can%20execute%20from%20Finder&tests.unstableOnly=true

After https://github.com/gradle/gradle/pull/20094 it starts to run and fails. However, on recent macOS, `open` seems not work properly: invoking `open` always runs in HOME directory, not current working directory:

![image](https://user-images.githubusercontent.com/12689835/157383062-54b5bc0f-fbd1-461a-a960-7af3c375ce2d.png)

And because `--args` doesn't work somehow, we can't pass `-p projectDir`: https://stackoverflow.com/questions/29510815/how-to-pass-command-line-arguments-to-a-program-run-with-the-open-command 

Since people rarely run `gradlew` in Finder, let's just remove it.