### PR TITLE
Add deprecation warning for serializing PluginDeclaration

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/PluginDeclaration.java
@@ -17,8 +17,10 @@
 package org.gradle.plugin.devel;
 
 import org.gradle.api.Named;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -133,5 +135,14 @@ public class PluginDeclaration implements Named,
     @Override
     public int hashCode() {
         return Objects.hash(name, id, implementationClass);
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        DeprecationLogger.deprecateIndirectUsage("Declaring PluginDeclaration as an input or serializing PluginDeclaration")
+            .withAdvice("Use your own object and copy the necessary data from PluginDeclaration.")
+            .willBecomeAnErrorInGradle8()
+            .undocumented()
+            .nagUser();
+        out.defaultWriteObject();
     }
 }


### PR DESCRIPTION
This PR tries to emit a deprecation warning when somebody tries to serialize `PluginDeclaration`. This happens for example when you declare `PluginDeclaration` as an input.

**Note that this doesn't work right now, since configuration caching tries to serialize `Serializable` types when storing to the configuration cache, and that also would emit the deprecation warning. Though when removing `Serializable` from the interface, configuration caching still works.**

Preparation for #20097.