### PR TITLE
Turn `BeanCodec` into an object

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/BeanCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/BeanCodec.kt
@@ -28,7 +28,7 @@ import org.gradle.configurationcache.serialization.withBeanTrace
 
 
 internal
-class BeanCodec : Codec<Any> {
+object BeanCodec : Codec<Any> {
 
     override suspend fun WriteContext.encode(value: Any) {
         encodePreservingIdentityOf(value) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ClosureCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ClosureCodec.kt
@@ -23,21 +23,17 @@ import org.gradle.configurationcache.serialization.WriteContext
 
 
 object ClosureCodec : Codec<Closure<*>> {
+
     private
     val defaultOwner = Any()
 
-    private
-    val beanCodec = BeanCodec()
-
     override suspend fun WriteContext.encode(value: Closure<*>) {
         // TODO - should write the owner, delegate and thisObject, replacing project and script references
-        beanCodec.run { encode(value.dehydrate()) }
+        BeanCodec.run { encode(value.dehydrate()) }
     }
 
-    override suspend fun ReadContext.decode(): Closure<*>? {
-        return beanCodec.run {
-            val closure = decode() as Closure<*>
-            closure.rehydrate(null, defaultOwner, defaultOwner)
-        }
+    override suspend fun ReadContext.decode(): Closure<*>? = BeanCodec.run {
+        val closure = decode() as Closure<*>
+        closure.rehydrate(null, defaultOwner, defaultOwner)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -199,7 +199,7 @@ class Codecs(
         // This protects the BeanCodec against StackOverflowErrors but
         // we can still get them for the other codecs, for instance,
         // with deeply nested Lists, deeply nested Maps, etc.
-        bind(reentrant(BeanCodec()))
+        bind(reentrant(BeanCodec))
     }.build()
 
     private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/ProviderCodecs.kt
@@ -64,7 +64,7 @@ class FixedValueReplacingProviderCodec(
     val providerWithChangingValueCodec = Bindings.of {
         bind(ValueSourceProviderCodec(valueSourceProviderFactory))
         bind(BuildServiceProviderCodec(buildStateRegistry))
-        bind(BeanCodec())
+        bind(BeanCodec)
     }.build()
 
     suspend fun WriteContext.encodeProvider(value: ProviderInternal<*>) {


### PR DESCRIPTION
Since it has no state and used in many places.