### PR TITLE
#20132 remove non-actionable 'unsupported kotlin plugin version' warning

### DIFF
--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPluginTest.kt
@@ -234,38 +234,6 @@ class EmbeddedKotlinPluginTest : AbstractPluginTest() {
         result.assertTaskExecuted(":compileKotlin")
     }
 
-    @Test
-    fun `emit a warning if the kotlin plugin version is not the same as embedded`() {
-
-        val logger = mock<Logger>()
-        val template = """
-            WARNING: Unsupported Kotlin plugin version.
-            The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `{}` that might work differently than in the requested version `{}`.
-        """.trimIndent()
-
-
-        logger.warnOnDifferentKotlinVersion(embeddedKotlinVersion)
-
-        inOrder(logger) {
-            verifyNoMoreInteractions()
-        }
-
-
-        logger.warnOnDifferentKotlinVersion("1.3")
-
-        inOrder(logger) {
-            verify(logger).warn(template, embeddedKotlinVersion, "1.3")
-            verifyNoMoreInteractions()
-        }
-
-
-        logger.warnOnDifferentKotlinVersion(null)
-
-        inOrder(logger) {
-            verify(logger).warn(template, embeddedKotlinVersion, null)
-            verifyNoMoreInteractions()
-        }
-    }
 
     private
     fun dependencyDeclarationsFor(configuration: String, modules: List<String>, version: String? = null) =

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/embedded/EmbeddedKotlinPlugin.kt
@@ -17,15 +17,12 @@ package org.gradle.kotlin.dsl.plugins.embedded
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
 
 import org.gradle.api.plugins.JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME
 import org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
 
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
-import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.support.EmbeddedKotlinProvider
 
 import javax.inject.Inject
@@ -46,8 +43,6 @@ class EmbeddedKotlinPlugin @Inject internal constructor(
 
             plugins.apply(KotlinPluginWrapper::class.java)
 
-            logger.warnOnDifferentKotlinVersion(getKotlinPluginVersion())
-
             val embeddedKotlinConfiguration = configurations.create("embeddedKotlin")
             embeddedKotlin.addDependenciesTo(
                 dependencies,
@@ -59,20 +54,6 @@ class EmbeddedKotlinPlugin @Inject internal constructor(
                 configurations.getByName(it).extendsFrom(embeddedKotlinConfiguration)
             }
         }
-    }
-}
-
-
-fun Logger.warnOnDifferentKotlinVersion(kotlinVersion: String?) {
-    if (kotlinVersion != embeddedKotlinVersion) {
-        warn(
-            """
-                WARNING: Unsupported Kotlin plugin version.
-                The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `{}` that might work differently than in the requested version `{}`.
-            """.trimIndent(),
-            embeddedKotlinVersion,
-            kotlinVersion
-        )
     }
 }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #20132

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
