### PR TITLE
Move resolution of task mutations to run as a separate node

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/rules/OverlappingOutputsIntegrationTest.groovy
@@ -634,6 +634,9 @@ class OverlappingOutputsIntegrationTest extends AbstractIntegrationSpec implemen
 
         when:
         cleanBuildDir()
+        // When configuration cache is enabled, the task graph for this build will be loaded from the cache and tasks will run in parallel and start in an arbitrary order
+        // Use max-workers=1 to force non-parallel execution and the tasks to run in the specified order (--no-parallel doesn't have an effect with CC)
+        executer.withArgument("--max-workers=1")
         withBuildCache().run(fileTask, localStateDirTask)
         then:
         // Outcome should look the same again

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceParallelExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/services/BuildServiceParallelExecutionIntegrationTest.groovy
@@ -82,13 +82,11 @@ class BuildServiceParallelExecutionIntegrationTest extends AbstractIntegrationSp
         """
 
         expect:
-        blockingServer.expectConcurrent("a")
-        blockingServer.expectConcurrent("b")
+        blockingServer.expectConcurrent(1, "a", "b")
 
         run ":a:ping", ":b:ping"
 
-        blockingServer.expectConcurrent("a")
-        blockingServer.expectConcurrent("b")
+        blockingServer.expectConcurrent(1, "a", "b")
 
         run ":a:ping", ":b:ping"
     }
@@ -132,13 +130,11 @@ class BuildServiceParallelExecutionIntegrationTest extends AbstractIntegrationSp
         """
 
         expect:
-        blockingServer.expectConcurrent("a", "b")
-        blockingServer.expectConcurrent("c")
+        blockingServer.expectConcurrent(2, "a", "b", "c")
 
         run ":a:ping", ":b:ping", ":c:ping"
 
-        blockingServer.expectConcurrent("a", "b")
-        blockingServer.expectConcurrent("c")
+        blockingServer.expectConcurrent(2, "a", "b", "c")
 
         run ":a:ping", ":b:ping", ":c:ping"
     }
@@ -149,10 +145,10 @@ class BuildServiceParallelExecutionIntegrationTest extends AbstractIntegrationSp
 
         buildFile << """
             def service1 = gradle.sharedServices.registerIfAbsent("service1", BuildService) {
-                maxParallelUsages = 1
+                maxParallelUsages = 2
             }
             def service2 = gradle.sharedServices.registerIfAbsent("service2", BuildService) {
-                maxParallelUsages = 1
+                maxParallelUsages = 3
             }
 
             project(':a') {
@@ -161,20 +157,20 @@ class BuildServiceParallelExecutionIntegrationTest extends AbstractIntegrationSp
             }
             project(':b') {
                 ping.usesService(service1)
+                ping.usesService(service2)
             }
             project(':c') {
+                ping.usesService(service1)
                 ping.usesService(service2)
             }
         """
 
         expect:
-        blockingServer.expectConcurrent("a")
-        blockingServer.expectConcurrent("b", "c")
+        blockingServer.expectConcurrent(2, "a", "b", "c")
 
         run ":a:ping", ":b:ping", ":c:ping"
 
-        blockingServer.expectConcurrent("a")
-        blockingServer.expectConcurrent("b", "c")
+        blockingServer.expectConcurrent(2, "a", "b", "c")
 
         run ":a:ping", ":b:ping", ":c:ping"
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -21,8 +21,6 @@ import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
-import org.gradle.util.TestPrecondition
-import org.gradle.util.internal.ToBeImplemented
 import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Issue
@@ -567,9 +565,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
         }
     }
 
-    // Stopping the hanging Gradle process fails on Windows
-    @org.gradle.util.Requires(TestPrecondition.LINUX)
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/17013")
+    @Issue("https://github.com/gradle/gradle/issues/17013")
     def "does not deadlock when resolving outputs requires resolving multiple artifacts"() {
         buildFile("""
             import org.gradle.util.internal.GFileUtils
@@ -616,19 +612,8 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
             withArgument("--parallel")
         }
 
-        when:
-        def daemon = executer.withArgument("outputDeadlock").start()
-        if (!GradleContextualExecuter.configCache) {
-            Thread.sleep(10_000)
-        }
-        then:
-        if (GradleContextualExecuter.configCache) {
-            // There is no deadlock with configuration caching, since the resolution already happened.
-            daemon.waitForFinish()
-        } else {
-            // TODO: The build should finish normally
-            assert daemon.isRunning()
-        }
+        expect:
+        succeeds("outputDeadlock")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/17905")

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -26,7 +26,6 @@ import org.gradle.internal.resources.ResourceLock;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public class ActionNode extends Node implements SelfExecutingNode {
     private final WorkNodeAction action;
@@ -60,16 +59,6 @@ public class ActionNode extends Node implements SelfExecutingNode {
             addDependencySuccessor(node);
             processHardSuccessor.execute(node);
         }
-    }
-
-    @Override
-    public Set<Node> getFinalizers() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public void resolveMutations() {
-        // Assume has no outputs that can be destroyed or that overlap with another node
     }
 
     public WorkNodeAction getAction() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -31,39 +31,34 @@ import static org.gradle.internal.reflect.validation.TypeValidationProblemRender
 
 public class DefaultNodeValidator implements NodeValidator {
     @Override
-    public boolean hasValidationProblems(Node node) {
-        if (node instanceof LocalTaskNode) {
-            LocalTaskNode taskNode = (LocalTaskNode) node;
-            WorkValidationContext validationContext = taskNode.getValidationContext();
-            Class<?> taskType = GeneratedSubclasses.unpackType(taskNode.getTask());
-            // We don't know whether the task is cacheable or not, so we ignore cacheability problems for scheduling
-            TypeValidationContext taskValidationContext = validationContext.forType(taskType, false);
-            taskNode.getTaskProperties().validateType(taskValidationContext);
-            List<TypeValidationProblem> problems = validationContext.getProblems();
-            problems.stream()
-                .filter(problem -> problem.getSeverity().isWarning())
-                .forEach(problem -> {
-                    Optional<UserManualReference> userManualReference = problem.getUserManualReference();
-                    String docId = "more_about_tasks";
-                    String section = "sec:up_to_date_checks";
-                    if (userManualReference.isPresent()) {
-                        UserManualReference docref = userManualReference.get();
-                        docId = docref.getId();
-                        section = docref.getSection();
-                    }
-                    // Because our deprecation warning system doesn't support multiline strings (bummer!) both in rendering
-                    // **and** testing (no way to capture multiline deprecation warnings), we have to resort to removing details
-                    // and rendering
-                    String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
-                    DeprecationLogger.deprecateBehaviour(warning)
-                        .withContext("Execution optimizations are disabled to ensure correctness.")
-                        .willBeRemovedInGradle8()
-                        .withUserManual(docId, section)
-                        .nagUser();
-                });
-            return !problems.isEmpty();
-        } else {
-            return false;
-        }
+    public boolean hasValidationProblems(LocalTaskNode node) {
+        WorkValidationContext validationContext = node.getValidationContext();
+        Class<?> taskType = GeneratedSubclasses.unpackType(node.getTask());
+        // We don't know whether the task is cacheable or not, so we ignore cacheability problems for scheduling
+        TypeValidationContext taskValidationContext = validationContext.forType(taskType, false);
+        node.getTaskProperties().validateType(taskValidationContext);
+        List<TypeValidationProblem> problems = validationContext.getProblems();
+        problems.stream()
+            .filter(problem -> problem.getSeverity().isWarning())
+            .forEach(problem -> {
+                Optional<UserManualReference> userManualReference = problem.getUserManualReference();
+                String docId = "more_about_tasks";
+                String section = "sec:up_to_date_checks";
+                if (userManualReference.isPresent()) {
+                    UserManualReference docref = userManualReference.get();
+                    docId = docref.getId();
+                    section = docref.getSection();
+                }
+                // Because our deprecation warning system doesn't support multiline strings (bummer!) both in rendering
+                // **and** testing (no way to capture multiline deprecation warnings), we have to resort to removing details
+                // and rendering
+                String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
+                DeprecationLogger.deprecateBehaviour(warning)
+                    .withContext("Execution optimizations are disabled to ensure correctness.")
+                    .willBeRemovedInGradle8()
+                    .withUserManual(docId, section)
+                    .nagUser();
+            });
+        return !problems.isEmpty();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
@@ -242,7 +242,11 @@ public class DefaultPlanExecutor implements PlanExecutor {
                 }
             } finally {
                 coordinationService.withStateLock(state -> {
-                    executionPlan.finishedExecuting(selected);
+                    try {
+                        executionPlan.finishedExecuting(selected);
+                    } catch (Throwable t) {
+                        executionPlan.abortAllAndFail(t);
+                    }
                     // Notify other threads that the node is finished as this may unblock further work
                     // or this might be the last node in the graph
                     coordinationService.notifyStateChange();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
@@ -25,7 +25,6 @@ public class ExecutionPlanFactory {
     private final String displayName;
     private final TaskNodeFactory taskNodeFactory;
     private final TaskDependencyResolver dependencyResolver;
-    private final NodeValidator nodeValidator;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
     private final ResourceLockCoordinationService lockCoordinationService;
@@ -34,7 +33,6 @@ public class ExecutionPlanFactory {
         String displayName,
         TaskNodeFactory taskNodeFactory,
         TaskDependencyResolver dependencyResolver,
-        NodeValidator nodeValidator,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy,
         ResourceLockCoordinationService lockCoordinationService
@@ -42,13 +40,12 @@ public class ExecutionPlanFactory {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
         this.dependencyResolver = dependencyResolver;
-        this.nodeValidator = nodeValidator;
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
         this.lockCoordinationService = lockCoordinationService;
     }
 
     public ExecutionPlan createPlan() {
-        return new DefaultExecutionPlan(displayName, taskNodeFactory, dependencyResolver, nodeValidator, outputHierarchy, destroyableHierarchy, lockCoordinationService);
+        return new DefaultExecutionPlan(displayName, taskNodeFactory, dependencyResolver, outputHierarchy, destroyableHierarchy, lockCoordinationService);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/NodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/NodeValidator.java
@@ -17,5 +17,5 @@
 package org.gradle.execution.plan;
 
 public interface NodeValidator {
-    boolean hasValidationProblems(Node node);
+    boolean hasValidationProblems(LocalTaskNode node);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNode.java
@@ -24,7 +24,6 @@ import org.gradle.internal.resources.ResourceLock;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Represents a node in the graph that controls ordinality of destroyers and producers as they are
@@ -56,14 +55,6 @@ public class OrdinalNode extends Node implements SelfExecutingNode {
 
     @Override
     public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) { }
-
-    @Override
-    public Set<Node> getFinalizers() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public void resolveMutations() { }
 
     @Nullable
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import org.gradle.api.Action;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.NodeExecutionContext;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.resources.ResourceLock;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+public class ResolveMutationsNode extends Node implements SelfExecutingNode {
+    private final LocalTaskNode node;
+    private final NodeValidator nodeValidator;
+    private Exception failure;
+
+    public ResolveMutationsNode(LocalTaskNode node, NodeValidator nodeValidator) {
+        this.node = node;
+        this.nodeValidator = nodeValidator;
+    }
+
+    public Node getNode() {
+        return node;
+    }
+
+    @Override
+    public String toString() {
+        return "Resolve mutations for " + node;
+    }
+
+    @Override
+    public int compareTo(Node o) {
+        return -1;
+    }
+
+    @Nullable
+    @Override
+    public Throwable getNodeFailure() {
+        return failure;
+    }
+
+    @Override
+    public void rethrowNodeFailure() {
+        throw UncheckedException.throwAsUncheckedException(failure);
+    }
+
+    @Override
+    public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
+    }
+
+    @Nullable
+    @Override
+    public ResourceLock getProjectToLock() {
+        return node.getProjectToLock();
+    }
+
+    @Nullable
+    @Override
+    public ProjectInternal getOwningProject() {
+        return node.getOwningProject();
+    }
+
+    @Override
+    public List<? extends ResourceLock> getResourcesToLock() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void execute(NodeExecutionContext context) {
+        try {
+            MutationInfo mutations = node.getMutationInfo();
+            node.resolveMutations();
+            mutations.hasValidationProblem = nodeValidator.hasValidationProblems(node);
+        } catch (Exception e) {
+            failure = e;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -165,11 +165,6 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     }
 
     @Override
-    public void resolveMutations() {
-        // Assume for now that no task in the consuming build will destroy the outputs of this task or overlaps with this task
-    }
-
-    @Override
     public void execute(NodeExecutionContext context) {
         // This node does not do anything itself
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -49,14 +49,21 @@ import java.util.Set;
 public class TaskNodeFactory {
     private final Map<Task, TaskNode> nodes = new HashMap<>();
     private final BuildTreeWorkGraphController workGraphController;
+    private final NodeValidator nodeValidator;
     private final GradleInternal thisBuild;
     private final DocumentationRegistry documentationRegistry;
     private final DefaultTypeOriginInspectorFactory typeOriginInspectorFactory;
 
-    public TaskNodeFactory(GradleInternal thisBuild, DocumentationRegistry documentationRegistry, BuildTreeWorkGraphController workGraphController) {
+    public TaskNodeFactory(
+        GradleInternal thisBuild,
+        DocumentationRegistry documentationRegistry,
+        BuildTreeWorkGraphController workGraphController,
+        NodeValidator nodeValidator
+    ) {
         this.thisBuild = thisBuild;
         this.documentationRegistry = documentationRegistry;
         this.workGraphController = workGraphController;
+        this.nodeValidator = nodeValidator;
         this.typeOriginInspectorFactory = new DefaultTypeOriginInspectorFactory();
     }
 
@@ -73,7 +80,7 @@ public class TaskNodeFactory {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
+                node = new LocalTaskNode((TaskInternal) task, nodeValidator, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
             } else {
                 node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController);
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -226,6 +226,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             registration.add(ProjectFactory.class);
             registration.add(DefaultSettingsLoaderFactory.class);
             registration.add(ResolvedBuildLayout.class);
+            registration.add(DefaultNodeValidator.class);
             registration.add(TaskNodeFactory.class);
             registration.add(TaskNodeDependencyResolver.class);
             registration.add(WorkNodeDependencyResolver.class);
@@ -250,7 +251,6 @@ public class BuildScopeServices extends DefaultServiceRegistry {
             gradleInternal.getIdentityPath().toString(),
             taskNodeFactory,
             dependencyResolver,
-            new DefaultNodeValidator(),
             executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getDestroyableHierarchy(),
             lockCoordinationService

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -38,7 +38,7 @@ class TaskNodeFactoryTest extends Specification {
         project.gradle >> gradle
         project.pluginManager >> Stub(PluginManagerInternal)
 
-        graph = new TaskNodeFactory(gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController))
+        graph = new TaskNodeFactory(gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator))
     }
 
     private TaskInternal task(String name) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -89,11 +89,6 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     }
 
     @Override
-    public void resolveMutations() {
-        // Assume for now that no other node is going to destroy the transform outputs, or overlap with them
-    }
-
-    @Override
     public String toString() {
         return transformationStep.getDisplayName();
     }
@@ -118,11 +113,6 @@ public abstract class TransformationNode extends Node implements SelfExecutingNo
     }
 
     protected abstract CalculatedValueContainer<TransformationSubject, ?> getTransformedArtifacts();
-
-    @Override
-    public Set<Node> getFinalizers() {
-        return Collections.emptySet();
-    }
 
     @Nullable
     @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultWorkValidationContext.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class DefaultWorkValidationContext implements WorkValidationContext {
     private final Set<Class<?>> types = new HashSet<>();
@@ -45,8 +46,8 @@ public class DefaultWorkValidationContext implements WorkValidationContext {
     @Override
     public TypeValidationContext forType(Class<?> type, boolean cacheable) {
         types.add(type);
-        Optional<PluginId> pluginId = typeOriginInspector.findPluginDefining(type);
-        return new ProblemRecordingTypeValidationContext(documentationRegistry, type, pluginId.orElse(null)) {
+        Supplier<Optional<PluginId>> pluginId = () -> typeOriginInspector.findPluginDefining(type);
+        return new ProblemRecordingTypeValidationContext(documentationRegistry, type, pluginId) {
 
             @Override
             protected void recordProblem(TypeValidationProblem problem) {

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFile.java
@@ -624,6 +624,7 @@ public class TestFile extends File {
     }
 
     private void visit(Set<String> names, String prefix, File file, boolean ignoreDirs) {
+        assert file.isDirectory();
         for (File child : file.listFiles()) {
             if (child.isFile() || !ignoreDirs && child.isDirectory() && child.list().length == 0) {
                 names.add(prefix + child.getName());

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/DefaultTypeValidationContext.java
@@ -23,6 +23,7 @@ import org.gradle.internal.reflect.validation.TypeValidationProblem;
 import org.gradle.internal.reflect.validation.TypeValidationProblemRenderer;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
 
 public class DefaultTypeValidationContext extends ProblemRecordingTypeValidationContext {
     private final boolean reportCacheabilityProblems;
@@ -37,7 +38,7 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
     }
 
     private DefaultTypeValidationContext(DocumentationRegistry documentationRegistry, @Nullable Class<?> rootType, boolean reportCacheabilityProblems) {
-        super(documentationRegistry, rootType, null);
+        super(documentationRegistry, rootType, Optional::empty);
         this.reportCacheabilityProblems = reportCacheabilityProblems;
     }
 
@@ -53,6 +54,4 @@ public class DefaultTypeValidationContext extends ProblemRecordingTypeValidation
     public ImmutableMap<String, Severity> getProblems() {
         return problems.build();
     }
-
-
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ProblemRecordingTypeValidationContext.java
@@ -27,15 +27,19 @@ import org.gradle.internal.reflect.validation.TypeValidationProblem;
 import org.gradle.plugin.use.PluginId;
 
 import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 abstract public class ProblemRecordingTypeValidationContext implements TypeValidationContext {
     private final DocumentationRegistry documentationRegistry;
     private final Class<?> rootType;
-    private final PluginId pluginId;
+    private final Supplier<Optional<PluginId>> pluginId;
 
-    public ProblemRecordingTypeValidationContext(DocumentationRegistry documentationRegistry,
-                                                 @Nullable Class<?> rootType,
-                                                 @Nullable PluginId pluginId) {
+    public ProblemRecordingTypeValidationContext(
+        DocumentationRegistry documentationRegistry,
+        @Nullable Class<?> rootType,
+        Supplier<Optional<PluginId>> pluginId
+    ) {
         this.documentationRegistry = documentationRegistry;
         this.rootType = rootType;
         this.pluginId = pluginId;
@@ -43,14 +47,19 @@ abstract public class ProblemRecordingTypeValidationContext implements TypeValid
 
     @Override
     public void visitTypeProblem(Action<? super TypeProblemBuilder> problemSpec) {
-        DefaultTypeValidationProblemBuilder builder = new DefaultTypeValidationProblemBuilder(documentationRegistry, pluginId);
+        DefaultTypeValidationProblemBuilder builder = new DefaultTypeValidationProblemBuilder(documentationRegistry, pluginId());
         problemSpec.execute(builder);
         recordProblem(builder.build());
     }
 
+    @Nullable
+    private PluginId pluginId() {
+        return pluginId.get().orElse(null);
+    }
+
     @Override
     public void visitPropertyProblem(Action<? super PropertyProblemBuilder> problemSpec) {
-        DefaultPropertyValidationProblemBuilder builder = new DefaultPropertyValidationProblemBuilder(documentationRegistry, pluginId);
+        DefaultPropertyValidationProblemBuilder builder = new DefaultPropertyValidationProblemBuilder(documentationRegistry, pluginId());
         problemSpec.execute(builder);
         builder.forType(rootType);
         recordProblem(builder.build());


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

Move resolution of task mutations out of `ExecutionPlan.selectNext()` and into worker threads. This work is potentially expensive and can execute user code. Running it in `selectNext()` would block all other threads from starting or finishing nodes, locking or unlocking resources or acquiring or releasing worker leases. Given that dependency resolution can do these things, this also would cause a deadlock when resolving the mutations.

Moving the resolution out addresses these issues, but also has a couple of other important advantages:
- these nodes are dynamically added to the plan, so are a step towards taking coarse grained nodes and exploding them into finer-grained nodes (task nodes are "exploded" into a resolve node and an execute node).
- these nodes run at the correct time to provide a home for other work that "prepares" a task for execution, such as finalizing properties or doing dependency resolution.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
