### PR TITLE
Allow configuring rich dependency constraints in test suites dependencies block using Kotlin DSL

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
@@ -514,6 +514,42 @@ Artifacts
         succeeds('allIntegrationTests')
     }
 
+    def "JVM Test Suites plugin allows for using exclude in dependencies block"() {
+        given:
+        settingsFile << "rootProject.name = 'Test'"
+
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        useJUnit()
+                        dependencies {
+                            implementation 'org.apache.commons:commons-text:1.9'
+//                            implementation 'org.apache.commons:commons-text:1.9' {
+//                                exclude group: 'org.apache.commons', module: 'commons-lang3:3.11'
+//                            }
+                        }
+                    }
+                }
+            }
+
+            tasks.register('verifyResolve') {
+                doLast {
+                    assert !configurations.testCompileClasspath.resolvedConfiguration.resolvedArtifacts*.file*.name.contains('commons-lang3-3.11.jar')
+                }
+            }
+            """
+
+        expect:
+        succeeds "verifyResolve"
+    }
+
     private String systemFilePath(String path) {
         return path.replace('/', File.separator)
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JvmTestSuitePluginIntegrationTest.groovy
@@ -514,42 +514,6 @@ Artifacts
         succeeds('allIntegrationTests')
     }
 
-    def "JVM Test Suites plugin allows for using exclude in dependencies block"() {
-        given:
-        settingsFile << "rootProject.name = 'Test'"
-
-        buildFile << """
-            plugins {
-                id 'java'
-            }
-
-            ${mavenCentralRepository()}
-
-            testing {
-                suites {
-                    test {
-                        useJUnit()
-                        dependencies {
-                            implementation 'org.apache.commons:commons-text:1.9'
-//                            implementation 'org.apache.commons:commons-text:1.9' {
-//                                exclude group: 'org.apache.commons', module: 'commons-lang3:3.11'
-//                            }
-                        }
-                    }
-                }
-            }
-
-            tasks.register('verifyResolve') {
-                doLast {
-                    assert !configurations.testCompileClasspath.resolvedConfiguration.resolvedArtifacts*.file*.name.contains('commons-lang3-3.11.jar')
-                }
-            }
-            """
-
-        expect:
-        succeeds "verifyResolve"
-    }
-
     private String systemFilePath(String path) {
         return path.replace('/', File.separator)
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
@@ -18,8 +18,7 @@ package org.gradle.api.plugins.jvm;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
+import org.gradle.api.artifacts.ModuleDependency;
 
 /**
  * This DSL element is used to add dependencies to a component, like {@link JvmTestSuite}.
@@ -54,7 +53,7 @@ public interface JvmComponentDependencies {
      * @param configuration additional configuration for the provided dependency
      * @see org.gradle.api.artifacts.dsl.DependencyHandler Valid dependency notations.
      */
-    void implementation(Object dependencyNotation, Action<? super Dependency> configuration);
+    void implementation(Object dependencyNotation, Action<? super ModuleDependency> configuration);
 
     /**
      * Add a dependency to the set of compileOnly dependencies.
@@ -74,7 +73,7 @@ public interface JvmComponentDependencies {
      * @param configuration additional configuration for the provided dependency
      * @see org.gradle.api.artifacts.dsl.DependencyHandler Valid dependency notations.
      */
-    void compileOnly(Object dependencyNotation, Action<? super Dependency> configuration);
+    void compileOnly(Object dependencyNotation, Action<? super ModuleDependency> configuration);
 
     /**
      * Add a dependency to the set of runtimeOnly dependencies.
@@ -94,23 +93,5 @@ public interface JvmComponentDependencies {
      * @param configuration additional configuration for the provided dependency
      * @see org.gradle.api.artifacts.dsl.DependencyHandler Valid dependency notations.
      */
-    void runtimeOnly(Object dependencyNotation, Action<? super Dependency> configuration);
-
-    /**
-     * Returns the dependency constraint handler for this project.
-     *
-     * @return the dependency constraint handler for this project
-     * @since 7.5
-     */
-    DependencyConstraintHandler getConstraints();
-
-    /**
-     * Configures dependency constraint for this project.
-     *
-     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.DependencyConstraintHandler} for this project.</p>
-     *
-     * @param configureAction the action to use to configure module metadata
-     * @since 7.5
-     */
-    void constraints(Action<? super DependencyConstraintHandler> configureAction);
+    void runtimeOnly(Object dependencyNotation, Action<? super ModuleDependency> configuration);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.jvm;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 
 /**
  * This DSL element is used to add dependencies to a component, like {@link JvmTestSuite}.
@@ -94,4 +95,22 @@ public interface JvmComponentDependencies {
      * @see org.gradle.api.artifacts.dsl.DependencyHandler Valid dependency notations.
      */
     void runtimeOnly(Object dependencyNotation, Action<? super Dependency> configuration);
+
+    /**
+     * Returns the dependency constraint handler for this project.
+     *
+     * @return the dependency constraint handler for this project
+     * @since 7.5
+     */
+    DependencyConstraintHandler getConstraints();
+
+    /**
+     * Configures dependency constraint for this project.
+     *
+     * <p>This method executes the given action against the {@link org.gradle.api.artifacts.dsl.DependencyConstraintHandler} for this project.</p>
+     *
+     * @param configureAction the action to use to configure module metadata
+     * @since 7.5
+     */
+    void constraints(Action<? super DependencyConstraintHandler> configureAction);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
@@ -22,6 +22,7 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.internal.catalog.DependencyBundleValueSource;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
@@ -52,6 +53,11 @@ public class DefaultJvmComponentDependencies implements JvmComponentDependencies
 
     @Inject
     protected DependencyHandler getDependencyHandler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected DependencyConstraintHandler getDependencyConstraintHandler() {
         throw new UnsupportedOperationException();
     }
 
@@ -142,5 +148,15 @@ public class DefaultJvmComponentDependencies implements JvmComponentDependencies
             configuration.execute(created);
         }
         return created;
+    }
+
+    @Override
+    public void constraints(Action<? super DependencyConstraintHandler> configureAction) {
+        configureAction.execute(getDependencyConstraintHandler());
+    }
+
+    @Override
+    public DependencyConstraintHandler getConstraints() {
+        return getDependencyConstraintHandler();
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
@@ -496,4 +496,40 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds 'checkConfiguration'
     }
+
+    def "JVM Test Suites plugin allows for using exclude in dependencies block"() {
+        given:
+        settingsFile << "rootProject.name = 'Test'"
+
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        useJUnit()
+                        dependencies {
+                            implementation 'org.apache.commons:commons-text:1.9'
+//                            implementation 'org.apache.commons:commons-text:1.9' {
+//                                exclude group: 'org.apache.commons', module: 'commons-lang3:3.11'
+//                            }
+                        }
+                    }
+                }
+            }
+
+            tasks.register('verifyResolve') {
+                doLast {
+                    assert !configurations.testCompileClasspath.resolvedConfiguration.resolvedArtifacts*.file*.name.contains('commons-lang3-3.11.jar')
+                }
+            }
+            """
+
+        expect:
+        succeeds "verifyResolve"
+    }
 }


### PR DESCRIPTION
Fixes #19673 
