### PR TITLE
Unquarantine some integration tests

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -23,13 +23,11 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 import org.junit.ComparisonFailure
 import org.junit.Rule
 import org.junit.Test
-import org.junit.experimental.categories.Category
 import spock.lang.Issue
 
 import java.util.regex.Pattern
@@ -41,7 +39,6 @@ class EclipseIntegrationTest extends AbstractEclipseIntegrationTest {
     public final TestResources testResources = new TestResources(testDirectoryProvider)
 
     @Test
-    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         when:

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -25,12 +25,10 @@ import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.TestResources
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
-import org.gradle.test.fixtures.Flaky
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.ComparisonFailure
 import org.junit.Rule
 import org.junit.Test
-import org.junit.experimental.categories.Category
 
 import java.util.regex.Pattern
 
@@ -67,7 +65,6 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
-    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void canCreateAndDeleteMetaData() {
         executer.withTasks('idea').run()
@@ -109,7 +106,6 @@ class IdeaIntegrationTest extends AbstractIdeIntegrationTest {
     }
 
     @Test
-    @Category(Flaky.class)
     @ToBeFixedForConfigurationCache
     void overwritesExistingDependencies() {
         executer.withTasks('idea').run()


### PR DESCRIPTION
These integration tests were failing due to flakiness in
dependency-management that has been fixed

