### PR TITLE
Add test for convention properties + mapping to `null`

### DIFF
--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyTest.groovy
@@ -356,4 +356,15 @@ class DefaultPropertyTest extends PropertySpec<String> {
         1 * transformer.transform("abc") >> "cba"
         0 * _
     }
+
+    def "provider from property with convention can be absent"() {
+        def property = propertyWithDefaultValue(String)
+        property.convention("convention")
+
+        when:
+        def provider = property.map { value -> null }
+
+        then:
+        !provider.isPresent()
+    }
 }


### PR DESCRIPTION
Adds a small test for a behaviour regarding properties, conventions and mapping I wasn't sure about.