### PR TITLE
Report @Input annotation misapplied to File/Directory-based properties with useful error message

### DIFF
--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/fingerprint/impl/DefaultInputFingerprinter.java
@@ -19,6 +19,7 @@ package org.gradle.internal.execution.fingerprint.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.api.file.RegularFile;
 import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.execution.fingerprint.FileCollectionFingerprinterRegistry;
@@ -112,10 +113,14 @@ public class DefaultInputFingerprinter implements InputFingerprinter {
                     valueSnapshotsBuilder.put(propertyName, valueSnapshotter.snapshot(actualValue, previousSnapshot));
                 }
             } catch (Exception e) {
+                String msg = "value '%s' cannot be serialized";
+                if (actualValue instanceof RegularFile) {
+                    msg += ".  This property might have to use @InputFile, or a related file-based input annotation, instead of @Input";
+                }
+
                 throw new InputFingerprintingException(
                     propertyName,
-                    String.format("value '%s' cannot be serialized",
-                    value.getValue()),
+                    String.format(msg, value.getValue()),
                     e);
             }
         }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestInputAnnotationFailures.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestInputAnnotationFailures.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class TestInputAnnotationFailures extends AbstractIntegrationSpec {
+    def "misconfigured @Input annotation fails with outputs.upToDateWhen() with helpful error message"() {
+        given:
+        buildFile << """
+            import groovy.transform.CompileStatic
+
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            @CacheableTask
+            @CompileStatic
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract RegularFileProperty getMyFile()
+
+                @TaskAction
+                void action() {
+                    logger.warn("Input file: {}", myFile.getAsFile().get().absolutePath)
+                }
+            }
+
+            tasks.register('myTask', MyTask) {
+                outputs.upToDateWhen { false }
+                myFile = project.layout.projectDirectory.file('myFile.txt')
+            }
+        """
+
+        expect:
+        fails 'myTask'
+        result.assertHasErrorOutput("Cannot fingerprint input property 'myFile'")
+        result.assertHasErrorOutput("This property might have to use @InputFile, or a related file-based input annotation, instead of @Input")
+    }
+
+    def "misconfigured @Input annotation succeeds if no upToDate check done"() {
+        given:
+        buildFile << """
+            import groovy.transform.CompileStatic
+
+            plugins {
+                id 'java'
+            }
+
+            ${mavenCentralRepository()}
+
+            @CacheableTask
+            @CompileStatic
+            abstract class MyTask extends DefaultTask {
+                @Input
+                abstract RegularFileProperty getMyFile()
+
+                @TaskAction
+                void action() {
+                    logger.warn("Input file: {}", myFile.getAsFile().get().absolutePath)
+                }
+            }
+
+            tasks.register('myTask', MyTask) {
+                myFile = project.layout.projectDirectory.file('myFile.txt')
+            }
+        """
+
+        expect:
+        succeeds 'myTask'
+    }
+}


### PR DESCRIPTION
@big-guy - This is the bug(?) that bit me.  Looks like it only happens when you add `upToDateWhen` into the mix.  Works fine if you switch to `@InputFile` from `@Input`.

@wolfs, from @lptr - Sterling thought the execution team might be interested in seeing this one.  This isn't meant to merge, just to demonstrate the problem and a potential improvement to the error message which would have saved me some time.