### PR TITLE
Rebaseline TaskOutputCachingJavaPerformanceTest

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/buildcache/TaskOutputCachingJavaPerformanceTest.groovy
@@ -37,7 +37,7 @@ class TaskOutputCachingJavaPerformanceTest extends AbstractTaskOutputCachingPerf
         runner.warmUpRuns = 11
         runner.runs = 21
         runner.minimumBaseVersion = "3.5"
-        runner.targetVersions = ["7.5-20211227231450+0000"]
+        runner.targetVersions = ["7.5-20220312232108+0000"]
     }
 
     def "clean assemble with remote http cache"() {


### PR DESCRIPTION
To accept a <2% accumulated regression.