### PR TITLE
Fix support for VerificationException when configuration cache is enabled

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -114,6 +114,7 @@ class WorkNodeCodec(
                 writeSuccessorReferences(node.shouldSuccessors, scheduledNodeIds)
                 writeSuccessorReferences(node.mustSuccessors, scheduledNodeIds)
                 writeSuccessorReferences(node.finalizingSuccessors, scheduledNodeIds)
+                writeSuccessorReferences(node.lifecycleSuccessors, scheduledNodeIds)
             }
         }
     }
@@ -136,6 +137,12 @@ class WorkNodeCodec(
                     require(it is TaskNode)
                     node.addFinalizingSuccessor(it)
                 }
+                val lifecycleSuccessors = mutableSetOf<Node>()
+                readSuccessorReferences(nodesById) {
+                    require(it is TaskNode)
+                    lifecycleSuccessors.add(it)
+                }
+                node.lifecycleSuccessors = lifecycleSuccessors
             }
         }
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/VerificationFailureHandlingIntegraitonTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/VerificationFailureHandlingIntegraitonTest.groovy
@@ -48,8 +48,17 @@ class VerificationFailureHandlingIntegraitonTest extends AbstractIntegrationSpec
     }
 
     def 'consumer task executes when it has a producer task output dependency and producer task has verification failure, with --continue'() {
-        expect:
+        when:
         fails('consumerTask', '--continue')
+
+        then:
+        result.assertTaskExecuted(':producerTask')
+        result.assertTaskExecuted(':consumerTask')
+
+        when:
+        fails('consumerTask', '--continue')
+
+        then:
         result.assertTaskExecuted(':producerTask')
         result.assertTaskExecuted(':consumerTask')
     }
@@ -70,6 +79,8 @@ class VerificationFailureHandlingIntegraitonTest extends AbstractIntegrationSpec
         result.assertTaskNotExecuted(':customTask')
         failure.assertHasCause('ProducerTask threw VerificationException')
         outputDoesNotContain('intentional failure in doLast action')
+
+        fails('consumerTask', '--continue')
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -257,6 +257,16 @@ public class LocalTaskNode extends TaskNode {
         }
     }
 
+    @Override
+    public Set<Node> getLifecycleSuccessors() {
+        return lifecycleSuccessors;
+    }
+
+    @Override
+    public void setLifecycleSuccessors(Set<Node> lifecycleSuccessors) {
+        this.lifecycleSuccessors = lifecycleSuccessors;
+    }
+
     /**
      * Used to determine whether a {@link Node} consumes the <b>outcome</b> of a successor task vs. its output(s).
      *

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -32,6 +32,7 @@ import org.gradle.util.Path;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     public static TaskInAnotherBuild of(
@@ -79,6 +80,18 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     @Override
     public TaskInternal getTask() {
         return target.getTask();
+    }
+
+    @Override
+    public Set<Node> getLifecycleSuccessors() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void setLifecycleSuccessors(Set<Node> successors) {
+        if (!successors.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -66,6 +66,10 @@ public abstract class TaskNode extends Node {
         return mustSuccessors;
     }
 
+    public abstract Set<Node> getLifecycleSuccessors();
+
+    public abstract void setLifecycleSuccessors(Set<Node> successors);
+
     @Override
     public Set<Node> getFinalizers() {
         return finalizers;


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

Ensure the "lifecycle" successors for a task node are persisted to the cache.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
