### PR TITLE
Upgrade tested AGP versions

### DIFF
--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=4.1.3,4.2.2,7.0.4,7.1.1,7.2.0-beta02,7.3.0-alpha02
+latests=4.1.3,4.2.2,7.0.4,7.1.2,7.2.0-beta04,7.3.0-alpha06

--- a/gradle/dependency-management/agp-versions.properties
+++ b/gradle/dependency-management/agp-versions.properties
@@ -1,2 +1,2 @@
 # Generated - Update by running `./gradlew updateAgpVersions`
-latests=4.1.3,4.2.2,7.0.4,7.1.2,7.2.0-beta04,7.3.0-alpha06
+latests=4.1.3,4.2.2,7.0.4,7.1.2,7.2.0-beta04,7.3.0-alpha07

--- a/subprojects/docs/src/docs/userguide/compatibility.adoc
+++ b/subprojects/docs/src/docs/userguide/compatibility.adoc
@@ -53,4 +53,4 @@ Gradle is tested with Groovy 1.5.8 through 3.0.10.
 Gradle plugins written in Groovy must use Groovy 3.x for compatibility with Gradle and Groovy DSL build scripts.
 
 == Android
-Gradle is tested with Android Gradle Plugin 4.1, 4.2, 7.0 and 7.1. Alpha and beta versions may or may not work.
+Gradle is tested with Android Gradle Plugin 4.1, 4.2, 7.0, 7.1, 7.2 and 7.3. Alpha and beta versions may or may not work.

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerCachingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerCachingSmokeTest.groovy
@@ -1810,6 +1810,7 @@ class AndroidPluginExpectations71 {
         ':rocketsleigh:stripDebugDebugSymbols': NO_SOURCE,
         ':santa-tracker:assembleDebug': SUCCESS,
         ':santa-tracker:bundleDebugClasses': FROM_CACHE,
+        ':santa-tracker:bundleDebugClassesToRuntimeJar': FROM_CACHE,
         ':santa-tracker:checkDebugAarMetadata': FROM_CACHE,
         ':santa-tracker:checkDebugDuplicateClasses': FROM_CACHE,
         ':santa-tracker:checkDebugLibraries': FROM_CACHE,


### PR DESCRIPTION
from 7.1.1 to 7.1.2
from 7.2.0-beta02 to 7.2.0-beta04
from 7.3.0-alpha02 to 7.3.0-alpha06
