### PR TITLE
Add threads configuration option to Pmd

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -258,6 +258,66 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         output.contains "\tEnsure you override both equals() and hashCode()"
     }
 
+    void "can configure number of threads on good code"() {
+        goodCode()
+        buildFile << """
+            pmd {
+                threads = 2
+            }
+        """
+
+        expect:
+        succeeds("check")
+        file("build/reports/pmd/main.xml").exists()
+        file("build/reports/pmd/test.xml").exists()
+    }
+
+    def "can configure number of threads on bad code"() {
+        badCode()
+        buildFile << """
+            pmd {
+                threads = 2
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasDescription("Execution failed for task ':pmdTest'.")
+        failure.assertThatCause(containsString("2 PMD rule violations were found. See the report at:"))
+        file("build/reports/pmd/main.xml").assertContents(not(containsClass("org.gradle.Class1")))
+        file("build/reports/pmd/test.xml").assertContents(containsClass("org.gradle.Class1Test"))
+    }
+
+    def "gets reasonable message when number of threads is negative from extension"() {
+        goodCode()
+        buildFile << """
+            pmd {
+                threads = -1
+            }
+        """
+
+        expect:
+        // Use --continue so that when executing in parallel mode a deterministic set of tests run
+        // without --continue, sometimes both pmd tasks are run and sometimes only the only one task is run
+        fails("check", "--continue")
+        failure.assertHasCause("Invalid number of threads '-1'.  Number should not be negative.")
+        // pmdMain and pmdTest
+        failure.assertHasFailures(2)
+    }
+
+    def "gets reasonable message when number of threads is negative from task"() {
+        goodCode()
+        buildFile << """
+            pmdMain {
+                threads = -1
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasCause("Invalid number of threads '-1'.  Number should not be negative.")
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/2326")
     def "check task should not be up-to-date after clean if it only outputs to console"() {
         given:

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -146,7 +146,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      *
      * @param value the number of threads used by PMD
      */
-    public static void validateThreads(int value) {
+    private void validateThreads(int value) {
         if (value < 0) {
             throw new InvalidUserDataException(String.format("Invalid number of threads '%d'.  Number should not be negative.", value));
         }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -72,6 +72,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     private final Property<Integer> rulesMinimumPriority;
     private final Property<Integer> maxFailures;
     private final Property<Boolean> incrementalAnalysis;
+    private final Property<Integer> threads;
 
     public Pmd() {
         ObjectFactory objects = getObjectFactory();
@@ -79,6 +80,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
         this.rulesMinimumPriority = objects.property(Integer.class);
         this.incrementalAnalysis = objects.property(Boolean.class);
         this.maxFailures = objects.property(Integer.class);
+        this.threads = objects.property(Integer.class);
     }
 
     @Inject
@@ -94,6 +96,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     @TaskAction
     public void run() {
         validate(rulesMinimumPriority.get());
+        validateThreads(threads.get());
         PmdInvoker.invoke(this);
     }
 
@@ -135,6 +138,17 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     public static void validate(int value) {
         if (value > 5 || value < 1) {
             throw new InvalidUserDataException(String.format("Invalid rulesMinimumPriority '%d'.  Valid range 1 (highest) to 5 (lowest).", value));
+        }
+    }
+
+    /**
+     * Validates the number of threads used by PMD.
+     *
+     * @param value the number of threads used by PMD
+     */
+    public static void validateThreads(int value) {
+        if (value < 0) {
+            throw new InvalidUserDataException(String.format("Invalid number of threads '%d'.  Number should not be negative.", value));
         }
     }
 
@@ -386,5 +400,15 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     @LocalState
     public File getIncrementalCacheFile() {
         return new File(getTemporaryDir(), "incremental.cache");
+    }
+
+    /**
+     * Specifies the number of threads used by PMD.
+     *
+     * @see PmdExtension#getThreads()
+     */
+    @Input
+    public Property<Integer> getThreads() {
+        return threads;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.quality;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -406,8 +407,10 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * Specifies the number of threads used by PMD.
      *
      * @see PmdExtension#getThreads()
+     * @since 7.5
      */
     @Input
+    @Incubating
     public Property<Integer> getThreads() {
         return threads;
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.plugins.quality;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -236,7 +237,10 @@ public class PmdExtension extends CodeQualityExtension {
 
     /**
      * The number of threads used by PMD.
+     *
+     * @since 7.5
      */
+    @Incubating
     public Property<Integer> getThreads() {
         return threads;
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -42,12 +42,14 @@ public class PmdExtension extends CodeQualityExtension {
     private final Property<Integer> rulesMinimumPriority;
     private final Property<Integer> maxFailures;
     private final Property<Boolean> incrementalAnalysis;
+    private final Property<Integer> threads;
 
     public PmdExtension(Project project) {
         this.project = project;
         this.rulesMinimumPriority = project.getObjects().property(Integer.class).convention(5);
         this.incrementalAnalysis = project.getObjects().property(Boolean.class).convention(true);
         this.maxFailures = project.getObjects().property(Integer.class).convention(0);
+        this.threads = project.getObjects().property(Integer.class).convention(1);
     }
 
     /**
@@ -230,5 +232,12 @@ public class PmdExtension extends CodeQualityExtension {
      */
     public Property<Boolean> getIncrementalAnalysis() {
         return incrementalAnalysis;
+    }
+
+    /**
+     * The number of threads used by PMD.
+     */
+    public Property<Integer> getThreads() {
+        return threads;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -141,6 +141,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         task.getRulesMinimumPriority().convention(extension.getRulesMinimumPriority());
         task.getMaxFailures().convention(extension.getMaxFailures());
         task.getIncrementalAnalysis().convention(extension.getIncrementalAnalysis());
+        task.getThreads().convention(extension.getThreads());
     }
 
     private void configureReportsConventionMapping(Pmd task, final String baseName) {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -112,6 +112,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert maxFailures.get() == 0
             assert rulesMinimumPriority.get() == 5
             assert incrementalAnalysis.get() == true
+            assert threads.get() == 1
         }
     }
 
@@ -131,6 +132,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.maxFailures.get() == 0
         task.rulesMinimumPriority.get() == 5
         task.incrementalAnalysis.get() == true
+        task.threads.get() == 1
     }
 
     def "adds pmd tasks to check lifecycle task"() {
@@ -162,6 +164,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             ignoreFailures = true
             maxFailures = 17
             rulesMinimumPriority = 3
+            threads = 2
         }
 
         expect:
@@ -187,6 +190,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert ignoreFailures == true
             assert maxFailures.get() == 17
             assert rulesMinimumPriority.get() == 3
+            task.threads.get() == 2
         }
     }
 
@@ -200,6 +204,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             ignoreFailures = true
             maxFailures = 5
             rulesMinimumPriority = 3
+            threads = 2
         }
 
         expect:
@@ -215,6 +220,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.ignoreFailures == true
         task.maxFailures.get() == 5
         task.rulesMinimumPriority.get() == 3
+        task.threads.get() == 2
     }
 
     def "configures pmd classpath based on sourcesets"() {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -57,6 +57,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         !extension.ignoreFailures
         extension.maxFailures.get() == 0
         extension.rulesMinimumPriority.get() == 5
+        extension.threads.get() == 1
     }
 
     def "configures pmd task for each source set"() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
@@ -65,6 +65,12 @@
                     <literal>false</literal>
                 </td>
             </tr>
+            <tr>
+                <td>threads</td>
+                <td>
+                    <literal>1</literal>
+                </td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -52,6 +52,10 @@
                 <td>incrementalAnalysis</td>
                 <td><literal>false</literal></td>
             </tr>
+            <tr>
+                <td>threads</td>
+                <td><literal>1</literal></td>
+            </tr>
         </table>
     </section>
     <section>


### PR DESCRIPTION
Fixes #20178

### Context
We see a worse performance when running the PMD task for large sourcesets. The `threads` configuration option is already present in the PMD library.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

### Open questions

- I only added the `threads` option for PMD version `5.0.0` or higher. From the [PMD release notes](https://pmd.github.io/latest/pmd_release_notes_old.html) I concluded that prior versions included a `cpus` option, but I'm not sure if gradle should support this.
- I added integration tests, but would like some feedback about how to test this option properly.
- The  `./gradlew sanityCheck` fails with following errors -> resolved with `--no-configuration-cache` parameter.