### PR TITLE
Fix ConcurrentModificationException in DefaultSerializerRegistry

### DIFF
--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/DefaultSerializerRegistry.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/DefaultSerializerRegistry.java
@@ -46,7 +46,7 @@ public class DefaultSerializerRegistry implements SerializerRegistry {
     private final Map<Class<?>, Serializer<?>> serializerMap = new ConcurrentSkipListMap<Class<?>, Serializer<?>>(CLASS_COMPARATOR);
 
     // We are using a ConcurrentHashMap here because:
-    //   - We don't want to use a Set with CLASS_COMPARATOR, since that would identity two classes from different classloaders.
+    //   - We don't want to use a Set with CLASS_COMPARATOR, since that would treat two classes with the same name originating from different classloaders as identical, allowing only one in the Set.
     //   - ConcurrentHashMap.newKeySet() isn't available on Java 6, yet, and that is where this code needs to run.
     //   - CopyOnWriteArraySet has slower insert performance, since it is not hash based.
     private final Map<Class<?>, Boolean> javaSerialization = new ConcurrentHashMap<Class<?>, Boolean>();

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerRegistrySpec.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerRegistrySpec.groovy
@@ -50,13 +50,14 @@ class DefaultSerializerRegistrySpec extends Specification {
     def "invoking DefaultSerializerRegistry from multiple threads"() {
         given:
         def conditions = new AsyncConditions(numThreads)
+        def serializer = Stub(Serializer)
         numThreads.times { threadId ->
             Thread.startDaemon("DefaultSerializerRegistry Test #$threadId") {
                 conditions.evaluate {
                     serializableClasses.forEach { theClass ->
                         try {
                             defaultSerializerRegistry.useJavaSerialization(theClass)
-                            defaultSerializerRegistry.register(theClass, Mock(Serializer))
+                            defaultSerializerRegistry.register(theClass, serializer)
                             Thread.sleep(1)
                         } finally {
                             latch.countDown()
@@ -78,7 +79,7 @@ class DefaultSerializerRegistrySpec extends Specification {
         testIteration << (0..9)
     }
 
-    static class SerializableParent {}
+    static class SerializableParent implements Serializable {}
 
     static class Serializable1 extends SerializableParent {}
 


### PR DESCRIPTION
When Gradle encounters a Java type that needs to be serialized using Java's built-in serialization mechanism, then this types is registered in `DefaultSerializerRegistry`. At the same time, Gradle also checks if it can use Java serialization when it tries to serialize an object. This can happen at runtime in parallel. Therefore, `DefaultSerializerRegistry` needs to be thread safe.

This PR makes `DefaultSerializerRegistry` thread safe by using thread safe maps for the bookkeeping.

Fixes https://github.com/JLLeitschuh/ktlint-gradle/issues/518
Replaces #19170

### Context

This is a very naive fix for the `ConcurrentModificationException` in `DefaultSerializerRegistry`.

This is the exception a user of the Ktlint Gradle project was getting:

<details>
  <summary>Stack Trace</summary>
<pre>
* What went wrong:
Execution failed for task ':feedback:loadKtlintReporters'.
> A failure occurred while executing org.jlleitschuh.gradle.ktlint.worker.LoadReportersWorkAction
   > Could not serialize unit of work.
      > java.util.ConcurrentModificationException (no error message)

* Try:
Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':feedback:loadKtlintReporters'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:188)
	at org.gradle.internal.Try$Failure.ifSuccessfulOrElse(Try.java:282)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeIfValid(ExecuteActionsTaskExecuter.java:186)
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:174)
	at org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter.execute(CleanupStaleOutputsExecuter.java:109)
	at org.gradle.api.internal.tasks.execution.FinalizePropertiesTaskExecuter.execute(FinalizePropertiesTaskExecuter.java:46)
	at org.gradle.api.internal.tasks.execution.ResolveTaskExecutionModeExecuter.execute(ResolveTaskExecutionModeExecuter.java:51)
	at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:57)
	at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:56)
	at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:36)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.executeTask(EventFiringTaskExecuter.java:77)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:55)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter$1.call(EventFiringTaskExecuter.java:52)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:200)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:195)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:75)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:68)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:153)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:68)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:62)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.lambda$call$2(DefaultBuildOperationExecutor.java:79)
	at org.gradle.internal.operations.UnmanagedBuildOperationWrapper.callWithUnmanagedSupport(UnmanagedBuildOperationWrapper.java:54)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:79)
	at org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter.execute(EventFiringTaskExecuter.java:52)
	at org.gradle.execution.plan.LocalTaskNodeExecutor.execute(LocalTaskNodeExecutor.java:74)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:402)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$InvokeNodeExecutorsAction.execute(DefaultTaskExecutionGraph.java:389)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:382)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph$BuildOperationAwareExecutionAction.execute(DefaultTaskExecutionGraph.java:368)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.lambda$run$0(DefaultPlanExecutor.java:127)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.execute(DefaultPlanExecutor.java:191)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.executeNextNode(DefaultPlanExecutor.java:182)
	at org.gradle.execution.plan.DefaultPlanExecutor$ExecutorWorker.run(DefaultPlanExecutor.java:124)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:61)
Caused by: org.gradle.workers.internal.DefaultWorkerExecutor$WorkExecutionException: A failure occurred while executing org.jlleitschuh.gradle.ktlint.worker.LoadReportersWorkAction
	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$2(DefaultWorkerExecutor.java:208)
	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runExecution(DefaultConditionalExecutionQueue.java:214)
	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.runBatch(DefaultConditionalExecutionQueue.java:164)
	at org.gradle.internal.work.DefaultConditionalExecutionQueue$ExecutionRunner.run(DefaultConditionalExecutionQueue.java:131)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:61)
Caused by: org.gradle.workers.internal.WorkSerializationException: Could not serialize unit of work.
	at org.gradle.workers.internal.DefaultActionExecutionSpecFactory.serialize(DefaultActionExecutionSpecFactory.java:79)
	at org.gradle.workers.internal.DefaultActionExecutionSpecFactory.newTransportableSpec(DefaultActionExecutionSpecFactory.java:42)
	at org.gradle.workers.internal.IsolatedClassloaderWorkerFactory$1.lambda$execute$0(IsolatedClassloaderWorkerFactory.java:51)
	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:44)
	at org.gradle.workers.internal.AbstractWorker$1.call(AbstractWorker.java:41)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:200)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:195)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:75)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$3.execute(DefaultBuildOperationRunner.java:68)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:153)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:68)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:62)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.lambda$call$2(DefaultBuildOperationExecutor.java:79)
	at org.gradle.internal.operations.UnmanagedBuildOperationWrapper.callWithUnmanagedSupport(UnmanagedBuildOperationWrapper.java:54)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:79)
	at org.gradle.workers.internal.AbstractWorker.executeWrappedInBuildOperation(AbstractWorker.java:41)
	at org.gradle.workers.internal.IsolatedClassloaderWorkerFactory$1.execute(IsolatedClassloaderWorkerFactory.java:49)
	at org.gradle.workers.internal.DefaultWorkerExecutor.lambda$submitWork$2(DefaultWorkerExecutor.java:206)
	... 6 more
Caused by: java.util.ConcurrentModificationException
	at org.gradle.internal.serialize.DefaultSerializerRegistry.build(DefaultSerializerRegistry.java:84)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.writeIsolatable(IsolatableSerializerRegistry.java:129)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedManagedValueSerializer.write(IsolatableSerializerRegistry.java:345)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedManagedValueSerializer.write(IsolatableSerializerRegistry.java:338)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.writeIsolatable(IsolatableSerializerRegistry.java:129)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.writeIsolatableSequence(IsolatableSerializerRegistry.java:142)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.access$2200(IsolatableSerializerRegistry.java:62)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedArraySerializer.write(IsolatableSerializerRegistry.java:515)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedArraySerializer.write(IsolatableSerializerRegistry.java:510)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.writeIsolatable(IsolatableSerializerRegistry.java:129)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedManagedValueSerializer.write(IsolatableSerializerRegistry.java:345)
	at org.gradle.workers.internal.IsolatableSerializerRegistry$IsolatedManagedValueSerializer.write(IsolatableSerializerRegistry.java:338)
	at org.gradle.workers.internal.IsolatableSerializerRegistry.writeIsolatable(IsolatableSerializerRegistry.java:129)
	at org.gradle.workers.internal.DefaultActionExecutionSpecFactory.serialize(DefaultActionExecutionSpecFactory.java:76)
	... 23 more
</pre>
</details>
