### PR TITLE
Modify Signature task keying

### DIFF
--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -229,7 +229,15 @@ public class Sign extends DefaultTask implements SignatureSpec {
      * Returns signatures mapped by their key with duplicated and non-existing inputs removed.
      */
     private Map<String, Signature> sanitizedSignatures() {
-        return signatures.matching(signature -> signature.getToSign().exists()).stream().collect(toMap(Signature::toKey, identity(), (signature, duplicate) -> signature));
+        return signatures.matching(signature -> signature.getToSign().exists())
+            .stream()
+            .collect(
+                toMap(
+                    signature -> signature.getToSign().toPath().toAbsolutePath().toString(),
+                    identity(),
+                    (signature, duplicate) -> signature
+                )
+            );
     }
 
     /**

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
@@ -397,10 +397,6 @@ public class Signature extends AbstractPublishArtifact {
         return super.getBuildDependencies();
     }
 
-    String toKey() {
-        return String.join(":", getName(), getType(), getExtension(), getClassifier());
-    }
-
     /**
      * Generates the signature file.
      *

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
@@ -75,8 +75,9 @@ class SigningTasksSpec extends SigningProjectSpec {
         Sign signTask = signing.sign(jar).first()
 
         then:
-        def libsDir = jar.outputs.files.singleFile.parentFile
-        signTask.signaturesByKey == ["test.jar.asc:jar.asc:asc:": signTask.singleSignature]
+        def outputPath = jar.outputs.files.singleFile.toPath().toAbsolutePath().toString()
+        signTask.signaturesByKey.containsKey(outputPath)
+        signTask.signaturesByKey.get(outputPath) == signTask.singleSignature
     }
 
     def "files to sign that do not exist are ignored"() {
@@ -107,7 +108,10 @@ class SigningTasksSpec extends SigningProjectSpec {
         then:
         signTask.signatures.size() == 2
         noExceptionThrown()
-        signTask.signaturesByKey == ["test.jar.asc:jar.asc:asc:": signTask.singleSignature]
+        signTask.signaturesByKey.size() == 1
+        def outputPath = jar.outputs.files.singleFile.toPath().toAbsolutePath().toString()
+        signTask.signaturesByKey.containsKey(outputPath)
+        signTask.signaturesByKey.get(outputPath) == signTask.singleSignature
     }
 
     def "sign task has description"() {


### PR DESCRIPTION
Change the keying of the signatures to only take the filename into account, instead of the Maven coordinates (name, ext, classifier, etc...).
The reason being that previous keying can't differentiate between files that are on a different path but have the same filename.

Fixes #20166