### PR TITLE
Move task ordinal inheritance later during graph calculation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
@@ -327,7 +327,6 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         writeAllFiles()
 
         when:
-        executer.startBuildProcessInDebugger(true)
         args '--parallel', '--max-workers=2'
         succeeds(clean.path, generate.path)
 
@@ -356,7 +355,6 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         writeAllFiles()
 
         when:
-        executer.startBuildProcessInDebugger(true)
         args '--parallel', '--max-workers=2'
         succeeds(clean.path, generate.path)
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
+import spock.lang.Issue
 
 class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
     def "destroyer task with a dependency in another project will run before producer tasks when ordered first (type: #type)"() {
@@ -311,6 +312,7 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/20195")
     def "destroyer task that is a finalizer of a producer task will run after the producer even when ordered first (type: #type)"() {
         def foo = subproject(':foo')
         def bar = subproject(':bar')
@@ -330,9 +332,8 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         succeeds(clean.path, generate.path)
 
         then:
-        result.assertTaskOrder(cleanFoo.fullPath, clean.fullPath)
         result.assertTaskOrder(cleanBar.fullPath, clean.fullPath)
-        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
         result.assertTaskOrder(generateFoo.fullPath, generate.fullPath)
         result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
 
@@ -340,6 +341,7 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         type << ProductionType.values()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/20195")
     def "destroyer task that is a finalizer of a producer task and also a dependency will run after the producer even when ordered first (type: #type)"() {
         def foo = subproject(':foo')
         def bar = subproject(':bar')
@@ -359,9 +361,8 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
         succeeds(clean.path, generate.path)
 
         then:
-        result.assertTaskOrder(cleanFoo.fullPath, clean.fullPath)
-        result.assertTaskOrder(cleanBar.fullPath, clean.fullPath)
-        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath)
+        result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
         result.assertTaskOrder(generateFoo.fullPath, generate.fullPath)
         result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api
 import org.gradle.api.internal.artifacts.transform.UnzipTransform
 import org.gradle.integtests.fixtures.executer.TaskOrderSpecs
 import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Issue
 
 class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrderTaskIntegrationTest {
     def "producer task with a dependency in another project will run before destroyer tasks when ordered first (type: #type)"() {
@@ -284,6 +285,64 @@ class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrd
 
         and:
         outputContains("Executing unzip transform...")
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20195")
+    def "producer task that finalizes a destroyer task will run after the destroyer even when ordered first (type: #type)"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateFoo = foo.task('generateFoo').produces('build/foo', type)
+        def generateBar = bar.task('generateBar').produces('build/bar', type)
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+        cleanBar.finalizedBy(generateBar)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generate.path, clean.path)
+
+        then:
+        result.assertTaskOrder(generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, clean.fullPath)
+
+        where:
+        type << ProductionType.values()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20195")
+    def "producer task that finalizes a destroyer task and is also a dependency will run after the destroyer even when ordered first (type: #type)"() {
+        def foo = subproject(':foo')
+        def bar = subproject(':bar')
+
+        def cleanFoo = foo.task('cleanFoo').destroys('build/foo')
+        def cleanBar = bar.task('cleanBar').destroys('build/bar')
+        def clean = rootBuild.task('clean').dependsOn(cleanFoo).dependsOn(cleanBar)
+        def generateBar = bar.task('generateBar').produces('build/bar', type)
+        def generateFoo = foo.task('generateFoo').produces('build/foo', type).dependsOn(generateBar)
+        def generate = rootBuild.task('generate').dependsOn(generateBar).dependsOn(generateFoo)
+        cleanBar.finalizedBy(generateBar)
+
+        writeAllFiles()
+
+        when:
+        args '--parallel', '--max-workers=2'
+        succeeds(generate.path, clean.path)
+
+        then:
+        result.assertTaskOrder(generateBar.fullPath, generateFoo.fullPath, generate.fullPath)
+        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+        result.assertTaskOrder(cleanBar.fullPath, clean.fullPath)
+
+        where:
+        type << ProductionType.values()
     }
 
     static String getArtifactTransformConfiguration() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -203,10 +203,6 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                     if (!visiting.contains(targetNode)) {
                         queue.addFirst(targetNode);
                     }
-                    if (node instanceof TaskNode && targetNode instanceof TaskNode) {
-                        // if the dependency doesn't already have an ordinal assigned, then inherit the ordinal from this node
-                        ((TaskNode) targetNode).maybeSetOrdinal(((TaskNode) node).getOrdinal());
-                    }
                 });
                 if (node.isRequired()) {
                     for (Node successor : node.getDependencySuccessors()) {
@@ -339,6 +335,9 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                         }
                     }
                     nodeQueue.addFirst(new NodeInVisitingSegment(successor, currentSegment));
+                    if (node instanceof TaskNode && successor instanceof TaskNode) {
+                        ((TaskNode) successor).maybeInheritOrdinalAsDependency((TaskNode) node);
+                    }
                 }
                 path.push(node);
             } else {
@@ -366,6 +365,9 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                     if (!visitingNodes.containsKey(finalizer)) {
                         int position = finalizerTaskPosition(finalizer, nodeQueue);
                         nodeQueue.add(position, new NodeInVisitingSegment(finalizer, visitingSegmentCounter++));
+                        if (node instanceof TaskNode && finalizer instanceof TaskNode) {
+                            ((TaskNode) finalizer).maybeInheritOrdinalAsFinalizer((TaskNode) node);
+                        }
                     }
                 }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -185,9 +185,15 @@ public abstract class TaskNode extends Node {
         return ordinal;
     }
 
-    public void maybeSetOrdinal(int ordinal) {
-        if (this.ordinal == UNKNOWN_ORDINAL || this.ordinal > ordinal) {
-            this.ordinal = ordinal;
+    public void maybeInheritOrdinalAsDependency(TaskNode node) {
+        if (this.ordinal == UNKNOWN_ORDINAL || this.ordinal > node.getOrdinal()) {
+            this.ordinal = node.getOrdinal();
+        }
+    }
+
+    public void maybeInheritOrdinalAsFinalizer(TaskNode node) {
+        if (this.ordinal == UNKNOWN_ORDINAL || this.ordinal < node.getOrdinal()) {
+            this.ordinal = node.getOrdinal();
         }
     }
 }


### PR DESCRIPTION
Moves the inheritence of ordinal value later in task graph calculation in order to capture all relationships derived through finalizers.

Fixes #20195

