### PR TITLE
Cherry-pick two non-production changes to `release`

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -52,6 +52,7 @@ import gradlebuild.basics.BuildParams.TEST_JAVA_VERSION
 import gradlebuild.basics.BuildParams.TEST_SPLIT_EXCLUDE_TEST_CLASSES
 import gradlebuild.basics.BuildParams.TEST_SPLIT_INCLUDE_TEST_CLASSES
 import gradlebuild.basics.BuildParams.TEST_SPLIT_ONLY_TEST_GRADLE_VERSION
+import gradlebuild.basics.BuildParams.YARNPKG_MIRROR_URL
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
@@ -110,6 +111,7 @@ object BuildParams {
     const val TEST_SPLIT_ONLY_TEST_GRADLE_VERSION = "onlyTestGradleVersion"
     const val TEST_JAVA_VENDOR = "testJavaVendor"
     const val TEST_JAVA_VERSION = "testJavaVersion"
+    const val YARNPKG_MIRROR_URL = "YARNPKG_MIRROR_URL"
 }
 
 
@@ -307,3 +309,7 @@ val Project.maxTestDistributionPartitionSecond: Long?
 val Project.maxParallelForks: Int
     get() = gradleProperty(MAX_PARALLEL_FORKS).getOrElse("4").toInt() *
         environmentVariable("BUILD_AGENT_VARIANT").getOrElse("").let { if (it == "AX41") 2 else 1 }
+
+
+val Project.yarnpkgMirrorUrl: Provider<String>
+    get() = environmentVariable(YARNPKG_MIRROR_URL)

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/propagated-env-variables.kt
@@ -46,6 +46,7 @@ val propagatedEnvironmentVariables = listOf(
 
     // Used by Gradle test infrastructure
     "REPO_MIRROR_URLS",
+    "YARNPKG_MIRROR_URL",
 
     // Used to find local java installations
     "SDKMAN_CANDIDATES_DIR",

--- a/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
+++ b/build-logic/uber-plugins/src/main/kotlin/gradlebuild.internal.kotlin-js.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import gradlebuild.basics.yarnpkgMirrorUrl
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 
@@ -36,6 +37,14 @@ kotlin {
             }
         }
         binaries.executable()
+    }
+}
+
+rootProject.run {
+    yarnpkgMirrorUrl.orNull?.let { mirrorUrl ->
+        tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {
+            args += listOf("--registry", mirrorUrl)
+        }
     }
 }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
@@ -393,11 +393,11 @@ class SwiftIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInt
         return result
     }
 
-    def swiftsourceinfoFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
+    def swiftmoduleFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
         return intermediateFileFor(sourceFile, intermediateFilesDir, "~partial.swiftmodule")
     }
 
-    def swiftmoduleFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
+    def swiftsourceinfoFileFor(File sourceFile, String intermediateFilesDir = "build/obj/main/debug") {
         return intermediateFileFor(sourceFile, intermediateFilesDir, "~partial.swiftsourceinfo")
     }
 


### PR DESCRIPTION
Cherry-picked from https://github.com/gradle/gradle/pull/19638 and https://github.com/gradle/gradle/pull/19885  because I saw at least two failures on `release`.