### PR TITLE
DirectoryProperty.files should resolve files relative to the base directory

### DIFF
--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFilePropertyFactoryTest.groovy
@@ -195,6 +195,15 @@ class DefaultFilePropertyFactoryTest extends Specification {
         tree.files == [] as Set
     }
 
+    def "Directory.files are relative to the directory"() {
+        def baseDir = tmpDir.createDir("base")
+        def directory = factory.dir(baseDir)
+
+        expect:
+        directory.files("file1", "file2").files ==~ [baseDir.file("file1"), baseDir.file("file2")]
+        directory.dir("sub-dir").files("file1", "file2").files ==~ [baseDir.file("sub-dir/file1"), baseDir.file("sub-dir/file2")]
+    }
+
     def "cannot query the views of a directory property when the property has no value"() {
         def dirVar = factory.newDirectoryProperty()
         def tree = dirVar.asFileTree

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.file
 
 import org.gradle.api.file.Directory
+import org.gradle.api.internal.provider.MissingValueException
 import org.gradle.api.internal.provider.PropertyInternal
 import org.gradle.internal.state.ManagedFactory
 
@@ -81,6 +82,7 @@ class DirectoryPropertyTest extends FileSystemPropertySpec<Directory> {
     def "can view relative paths as a file collection"() {
         given:
         def fileCollection = baseDirectory.files("a/b/c", "d", "e/f")
+        def secondBase = tmpDir.createDir("secondBase")
 
         expect:
         fileCollection.files == [
@@ -88,5 +90,27 @@ class DirectoryPropertyTest extends FileSystemPropertySpec<Directory> {
             baseDir.file("d"),
             baseDir.file("e/f")
         ] as Set
+
+
+        when:
+        baseDirectory.set(secondBase)
+
+        then:
+        fileCollection.files == [
+            secondBase.file("a/b/c"),
+            secondBase.file("d"),
+            secondBase.file("e/f")
+        ] as Set
+    }
+
+    def "cannot resolve file collection when directory property is not set"() {
+        given:
+        baseDirectory.set(null)
+        def fileCollection = baseDirectory.files("a/b/c", "d", "e/f")
+
+        when:
+        fileCollection.files
+        then:
+        thrown(MissingValueException)
     }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DirectoryPropertyTest.groovy
@@ -28,22 +28,22 @@ class DirectoryPropertyTest extends FileSystemPropertySpec<Directory> {
 
     @Override
     Directory someValue() {
-        return baseDir.dir("dir1").get()
+        return baseDirectory.dir("dir1").get()
     }
 
     @Override
     Directory someOtherValue() {
-        return baseDir.dir("other1").get()
+        return baseDirectory.dir("other1").get()
     }
 
     @Override
     Directory someOtherValue2() {
-        return baseDir.dir("other2").get()
+        return baseDirectory.dir("other2").get()
     }
 
     @Override
     Directory someOtherValue3() {
-        return baseDir.dir("other3").get()
+        return baseDirectory.dir("other3").get()
     }
 
     @Override
@@ -63,30 +63,30 @@ class DirectoryPropertyTest extends FileSystemPropertySpec<Directory> {
 
     def "can view directory as a file tree"() {
         given:
-        def dir1 = tmpDir.createDir("dir1")
+        def dir1 = baseDir.createDir("dir1")
         def file1 = dir1.createFile("sub-dir/file1")
         def file2 = dir1.createFile("file2")
-        def dir2 = tmpDir.createDir("dir2")
+        def dir2 = baseDir.createDir("dir2")
         def file3 = dir2.createFile("other/file3")
 
         expect:
-        def tree1 = baseDir.asFileTree
+        def tree1 = baseDirectory.asFileTree
         tree1.files == [file1, file2, file3] as Set
 
         and:
-        def tree2 = baseDir.dir("dir2").get().asFileTree
+        def tree2 = baseDirectory.dir("dir2").get().asFileTree
         tree2.files == [file3] as Set
     }
 
     def "can view relative paths as a file collection"() {
         given:
-        def fileCollection = baseDir.files("a/b/c", "d", "e/f")
+        def fileCollection = baseDirectory.files("a/b/c", "d", "e/f")
 
         expect:
         fileCollection.files == [
-            tmpDir.file("a/b/c"),
-            tmpDir.file("d"),
-            tmpDir.file("e/f")
+            baseDir.file("a/b/c"),
+            baseDir.file("d"),
+            baseDir.file("e/f")
         ] as Set
     }
 }

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FilePropertyTest.groovy
@@ -28,22 +28,22 @@ class FilePropertyTest extends FileSystemPropertySpec<RegularFile> {
 
     @Override
     RegularFile someValue() {
-        return baseDir.file("dir1").get()
+        return baseDirectory.file("dir1").get()
     }
 
     @Override
     RegularFile someOtherValue() {
-        return baseDir.file("other1").get()
+        return baseDirectory.file("other1").get()
     }
 
     @Override
     RegularFile someOtherValue2() {
-        return baseDir.file("other2").get()
+        return baseDirectory.file("other2").get()
     }
 
     @Override
     RegularFile someOtherValue3() {
-        return baseDir.file("other3").get()
+        return baseDirectory.file("other3").get()
     }
 
     @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/FileSystemPropertySpec.groovy
@@ -29,7 +29,9 @@ abstract class FileSystemPropertySpec<T extends FileSystemLocation> extends Prop
     def resolver = TestFiles.resolver(tmpDir.testDirectory)
     def fileCollectionFactory = TestFiles.fileCollectionFactory(tmpDir.testDirectory)
     def factory = new DefaultFilePropertyFactory(host, resolver, fileCollectionFactory)
-    def baseDir = factory.newDirectoryProperty().fileValue(tmpDir.testDirectory)
+    // Make sure that `baseDir` isn't the same as the base for the resolver.
+    def baseDir = tmpDir.testDirectory.createDir("base")
+    def baseDirectory = factory.newDirectoryProperty().fileValue(baseDir)
 
     def "can set value using absolute file"() {
         given:


### PR DESCRIPTION
Currently, `DirectoryProperty.files()` resolves the files relative to the project, instead of relative to the base directory.

Fixes #15128.