### PR TITLE
Avoid creating InstallSamples tasks at configuration phase

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -549,7 +549,7 @@ tasks.named("checkAsciidoctorSampleContents") {
 }
 
 // exclude (unused and non-existing) wrapper of development Gradle version, as well as README, because the timestamp in the Gradle version break the cache
-tasks.withType(InstallSample) {
+tasks.withType(InstallSample).configureEach {
     if (name.contains('ForTest')) {
         excludes.add("gradle/wrapper/**")
         excludes.add("README")


### PR DESCRIPTION
Use `configureEach` instead.

Before:

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/12689835/159233758-76027092-2379-4d66-a883-c66d43caf53d.png">


After:

<img width="976" alt="image" src="https://user-images.githubusercontent.com/12689835/159233720-35b797ba-fadc-4b2c-a45e-3ed9975ecbfa.png">
