### PR TITLE
Bump commons-io version to 2.11.0

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/util/internal/GFileUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/internal/GFileUtilsTest.groovy
@@ -115,7 +115,8 @@ three
 
         expect:
         readFileQuietly(temp.file("foo.txt")) == "hey"
-        readFileQuietly(new File("missing")) == "Unable to read file 'missing' due to: org.gradle.api.UncheckedIOException: java.io.FileNotFoundException: File 'missing' does not exist"
+        // end of message is platform specific
+        readFileQuietly(new File("missing")).startsWith "Unable to read file 'missing' due to: org.gradle.api.UncheckedIOException: java.io.FileNotFoundException: missing"
         readFileQuietly(temp.createDir("dir")).startsWith "Unable to read file"
     }
 

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -187,7 +187,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
 
             if (path.equals(METADATA_PATH)) {
                 // handle origin metadata
-                originMetadata = readOriginAction.execute(new CloseShieldInputStream(tarInput));
+                originMetadata = readOriginAction.execute(CloseShieldInputStream.wrap(tarInput));
                 tarEntry = tarInput.getNextTarEntry();
             } else {
                 // handle tree

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/SafeStreams.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/SafeStreams.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 public class SafeStreams {
 
     public static OutputStream systemErr() {
-        return new CloseShieldOutputStream(System.err);
+        return CloseShieldOutputStream.wrap(System.err);
     }
 
     public static InputStream emptyInput() {
@@ -33,6 +33,6 @@ public class SafeStreams {
     }
 
     public static OutputStream systemOut() {
-        return new CloseShieldOutputStream(System.out);
+        return CloseShieldOutputStream.wrap(System.out);
     }
 }

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
         api(libs.commonsCodec)          { version { strictly("1.15") }}
         api(libs.commonsCompress)       { version { strictly("1.21") }}
         api(libs.commonsHttpclient)     { version { strictly("4.5.13") }}
-        api(libs.commonsIo)             { version { strictly("2.6") }}
+        api(libs.commonsIo)             { version { strictly("2.11.0") }}
         api(libs.commonsLang)           { version { strictly("2.6") }}
         api(libs.commonsLang3)          { version { strictly("3.12.0") }}
         api(libs.commonsMath)           { version { strictly("3.6.1") }}

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/LineEndingNormalizingInputStreamHasher.java
@@ -69,7 +69,7 @@ public class LineEndingNormalizingInputStreamHasher {
 
         hasher.putHash(SIGNATURE);
 
-        try (BufferedInputStream input = new BufferedInputStream(new CloseShieldInputStream(inputStream), BUFFER_SIZE)) {
+        try (BufferedInputStream input = new BufferedInputStream(CloseShieldInputStream.wrap(inputStream), BUFFER_SIZE)) {
             int peekAhead = -1;
 
             while (true) {


### PR DESCRIPTION
This makes sure existing vulnerabilities in older versions are no longer
present. One example is CVE-2021-29425.

Fixes #20224