### PR TITLE
Deprecate Project.getBuildDir()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -260,8 +260,12 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * <p>Returns the build directory of this project.  The build directory is the directory which all artifacts are
      * generated into.  The default value for the build directory is <code><i>projectDir</i>/build</code></p>
      *
+     * <p>This method is deprecated and scheduled for removal in Gradle 8. Use {@code getLayout().getBuildDirectory()} instead.</p>
+     *
      * @return The build directory. Never returns null.
+     * @deprecated Use {@link ProjectLayout#getBuildDirectory()} instead.
      */
+    @Deprecated
     File getBuildDir();
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -798,6 +798,8 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
 
     @Override
     public File getBuildDir() {
+        // TODO document deprecation and link it in the error message
+        DeprecationLogger.deprecateMethod(Project.class, "getBuildDir").replaceWith("getLayout().getBuildDirectory()").willBeRemovedInGradle8().undocumented().nagUser();
         return getLayout().getBuildDirectory().getAsFile().get();
     }
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/20210
