### PR TITLE
Capture updated system properties

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
@@ -158,7 +158,9 @@ class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfiguration
 
         then:
         output.count("ON CI") == 1
-        output.contains("because a build logic input of type 'IsSystemPropertySet' has changed")
+        // TODO(mlopatkin) the system property becomes an input itself because it is accessed in the ValueSource implementation.
+        //  This assert should be changed back if ValueSource implementations are allowed to access environment freely.
+        output.contains("because system property 'ci' has changed")
         configurationCache.assertStateStored()
     }
 }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInDynamicGroovyIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInDynamicGroovyIntegrationTest.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.inputs.undeclared
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+
+class SystemPropertyInstrumentationInDynamicGroovyIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "#method is instrumented in dynamic Groovy"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        // Why the separate plugin? The Project.getProperties() is available in the build.gradle as getProperties().
+        // Therefore, it is impossible to call System.getProperties() with static import there, and testing static
+        // import is important because Groovy generates different code in this case.
+        file("buildSrc/src/main/groovy/SomePlugin.groovy") << """
+            import ${Plugin.name}
+            import ${Project.name}
+            import static ${System.name}.clearProperty
+            import static ${System.name}.getProperties
+            import static ${System.name}.getProperty
+            import static ${System.name}.setProperty
+
+            class SomePlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    def returned = $method
+                    println("returned = \$returned")
+                }
+            }
+        """
+
+        buildScript("""
+            apply plugin: SomePlugin
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = some.value")
+        problems.assertResultHasProblems(result) {
+            withInput("Plugin class 'SomePlugin': system property 'some.property'")
+        }
+
+        where:
+        method                                                 | _
+        "System.properties['some.property']"                   | _
+        "System.getProperties().get('some.property')"          | _
+        "getProperties().get('some.property')"                 | _
+        "System.getProperty('some.property')"                  | _
+        "getProperty('some.property')"                         | _
+        "System.getProperty('some.property', 'default.value')" | _
+        "getProperty('some.property', 'default.value')"        | _
+        "System.setProperty('some.property', 'new.value')"     | _
+        "setProperty('some.property', 'new.value')"            | _
+        "System.clearProperty('some.property')"                | _
+        "clearProperty('some.property')"                       | _
+    }
+
+    def "#setProperties is instrumented in dynamic Groovy"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        buildScript("""
+            import static ${System.name}.setProperties
+
+            def newProps = new Properties()
+            System.properties.forEach { k, v -> newProps[k] = v }
+            newProps.replace("some.property", "new.value")
+            ${setProperties}(newProps)
+
+            tasks.register("printProperty") {
+                doLast {
+                    println("returned = \${System.getProperty("some.property")}")
+                }
+            }
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = new.value")
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("returned = new.value")
+
+        where:
+        setProperties          | _
+        "System.setProperties" | _
+        "setProperties"        | _
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInJavaIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInJavaIntegrationTest.groovy
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.inputs.undeclared
+
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+
+class SystemPropertyInstrumentationInJavaIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "#method is instrumented in Java"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        file("buildSrc/src/main/java/SomePlugin.java") << """
+            import ${Plugin.name};
+            import ${Project.name};
+
+            public class SomePlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    Object returned = $method;
+                    System.out.println("returned = " + returned);
+                }
+            }
+        """
+
+        buildScript("""
+            apply plugin: SomePlugin
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = some.value")
+        problems.assertResultHasProblems(result) {
+            withInput("Plugin class 'SomePlugin': system property 'some.property'")
+        }
+
+        where:
+        method                                                     | _
+        "System.getProperties().get(\"some.property\")"            | _
+        "System.getProperty(\"some.property\")"                    | _
+        "System.getProperty(\"some.property\", \"default.value\")" | _
+        "System.setProperty(\"some.property\", \"new.value\")"     | _
+        "System.clearProperty(\"some.property\")"                  | _
+    }
+
+    def "setProperties is instrumented in Java"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        file("buildSrc/src/main/java/SomePlugin.java") << """
+            import ${Plugin.name};
+            import ${Project.name};
+            import ${Properties.name};
+
+            public class SomePlugin implements Plugin<Project> {
+                public void apply(Project project) {
+                    Properties newProps = new Properties();
+                    System.getProperties().forEach(newProps::put);
+                    newProps.replace("some.property", "new.value");
+                    System.setProperties(newProps);
+                }
+            }
+        """
+
+        buildScript("""
+            apply plugin: SomePlugin
+
+             tasks.register("printProperty") {
+                doLast {
+                    println("returned = \${System.getProperty("some.property")}")
+                }
+            }
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = new.value")
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("returned = new.value")
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.inputs.undeclared
+
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+
+class SystemPropertyInstrumentationInKotlinIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "#method is instrumented in Kotlin"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        // Why the separate plugin? The Project.getProperties() is available in the build.gradle.kts as getProperties().
+        file("buildSrc/src/main/kotlin/SomePlugin.kt") << """
+            import ${Plugin.name}
+            import ${Project.name}
+
+            class SomePlugin : Plugin<Project> {
+                override fun apply(project: Project) {
+                    val returned = $method
+                    println("returned = \$returned")
+                }
+            }
+        """
+
+        file("buildSrc/build.gradle.kts") << """
+            plugins {
+                `kotlin-dsl`
+            }
+            repositories {
+                mavenCentral()
+            }
+        """
+
+        buildScript("""
+            apply plugin: SomePlugin
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = some.value")
+        problems.assertResultHasProblems(result) {
+            withInput("Plugin class 'SomePlugin': system property 'some.property'")
+            ignoringUnexpectedInputs()
+        }
+
+        where:
+        method                                                     | _
+        "System.getProperties().get(\"some.property\")"            | _
+        "System.getProperty(\"some.property\")"                    | _
+        "System.getProperty(\"some.property\", \"default.value\")" | _
+        "System.setProperty(\"some.property\", \"new.value\")"     | _
+        "System.clearProperty(\"some.property\")"                  | _
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInStaticGroovyIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInStaticGroovyIntegrationTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.inputs.undeclared
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+
+class SystemPropertyInstrumentationInStaticGroovyIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "#method is instrumented in static Groovy"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        // Why the separate plugin? The Project.getProperties() is available in the build.gradle as getProperties().
+        // Therefore, it is impossible to call System.getProperties() with static import there, and testing static
+        // import is important because Groovy generates different code in this case.
+        file("buildSrc/src/main/groovy/SomePlugin.groovy") << """
+            import ${CompileStatic.name}
+            import ${Plugin.name}
+            import ${Project.name}
+            import static ${System.name}.clearProperty
+            import static ${System.name}.getProperties
+            import static ${System.name}.getProperty
+            import static ${System.name}.setProperty
+
+            @CompileStatic
+            class SomePlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    def returned = $method
+                    println("returned = \$returned")
+                }
+            }
+        """
+
+        buildScript("""
+            apply plugin: SomePlugin
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = some.value")
+        problems.assertResultHasProblems(result) {
+            withInput("Plugin class 'SomePlugin': system property 'some.property'")
+        }
+
+        where:
+        method                                                 | _
+        "System.properties['some.property']"                   | _
+        "System.getProperties().get('some.property')"          | _
+        "getProperties().get('some.property')"                 | _
+        "System.getProperty('some.property')"                  | _
+        "getProperty('some.property')"                         | _
+        "System.getProperty('some.property', 'default.value')" | _
+        "getProperty('some.property', 'default.value')"        | _
+        "System.setProperty('some.property', 'new.value')"     | _
+        "setProperty('some.property', 'new.value')"            | _
+        "System.clearProperty('some.property')"                | _
+        "clearProperty('some.property')"                       | _
+    }
+
+    def "#setProperties is instrumented in static Groovy"() {
+        def configurationCache = newConfigurationCacheFixture()
+
+        given:
+        buildScript("""
+            import ${CompileStatic.name}
+            import static ${System.name}.setProperties
+
+            @CompileStatic
+            class SomePlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    def newProps = new Properties()
+                    System.properties.forEach { k, v -> newProps[k] = v }
+                    newProps.replace("some.property", "new.value")
+                    ${setProperties}(newProps)
+                }
+            }
+
+            apply plugin: SomePlugin
+
+            tasks.register("printProperty") {
+                doLast {
+                    println("returned = \${System.getProperty("some.property")}")
+                }
+            }
+        """)
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("returned = new.value")
+
+        when:
+        configurationCacheRun("-Dsome.property=some.value", "printProperty")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("returned = new.value")
+
+        where:
+        setProperties          | _
+        "System.setProperties" | _
+        "setProperties"        | _
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -320,6 +320,23 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         "1"           | """System.properties["some.property"]=$propertyValue"""
     }
 
+    def "non-serializable system property is reported"() {
+        given:
+        buildFile("""
+            System.properties["some.property"] = new Thread()
+        """)
+
+        when:
+        configurationCacheFails()
+
+        then:
+        problems.assertFailureHasProblems(failure) {
+            totalProblemsCount = 1
+            withProblem("Build file 'build.gradle': cannot serialize object of type 'java.lang.Thread', a subtype of 'java.lang.Thread', as these are not supported with the configuration cache.")
+            problemsWithStackTraceCount = 0
+        }
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/13155")
     def "plugin can bundle multiple resources with the same name"() {
         file("buildSrc/build.gradle") << """

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -454,6 +454,42 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         EnvVariableRead.getEnvContainsKey("CI")             | "false"    | "defined" | "true"
     }
 
+    def "reports system property reads in dynamic groovy with getProperties"() {
+        def configurationCache = newConfigurationCacheFixture()
+        // Why the separate plugin? The Project.getProperties() is available in the build.gradle as getProperties().
+        // Therefore, it is impossible to call System.getProperties() with static import there, and testing static
+        // import is important because Groovy generates different code in this case.
+        file("buildSrc/src/main/groovy/SomePlugin.groovy") << """
+            import ${Project.name}
+            import ${Plugin.name}
+            import static ${System.name}.getProperties
+
+            class SomePlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    println("read.with.class.name=\${System.getProperties().get("read.with.class.name")}")
+                    println("read.with.static.import=\${getProperties().get("read.with.static.import")}")
+                }
+            }
+        """
+
+        buildFile("""
+            apply plugin: SomePlugin
+        """)
+
+        when:
+        configurationCacheRun("-Dread.with.class.name=ClassName", "-Dread.with.static.import=StaticImport")
+
+        then:
+        outputContains("read.with.class.name=ClassName")
+        outputContains("read.with.static.import=StaticImport")
+        configurationCache.assertStateStored()
+
+        problems.assertResultHasProblems(result) {
+            withInput("Plugin class 'SomePlugin': system property 'read.with.class.name'")
+            withInput("Plugin class 'SomePlugin': system property 'read.with.static.import'")
+        }
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/19710")
     def "modification of allowed properties does not invalidate cache"() {
         buildFile("""

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -286,7 +286,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         ]
     }
 
-    def "build logic can set up property at configuration phase"() {
+    def "system property set at the configuration phase is restored when running from cache"() {
         given:
         buildFile("""
             $propertySetter
@@ -320,7 +320,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         "1"           | """System.properties["some.property"]=$propertyValue"""
     }
 
-    def "build logic can remove property at configuration phase"() {
+    def "system property removed at the configuration phase is removed when running from cache"() {
         given:
         buildFile("""
             $propertyRemover
@@ -431,7 +431,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         'System.setProperties(new Properties())' | _
     }
 
-    def "updated system property can be removed"() {
+    def "system property removed after update at the configuration phase is removed when running from cache"() {
         given:
         buildFile("""
             System.setProperty("some.property", "some.value")
@@ -460,7 +460,7 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         outputContains("some.property present = false")
     }
 
-    def "system property with a string key is removed even if it is set externally"() {
+    def "system property added and removed at the configuration phase is removed when running from cache even if set externally"() {
         given:
         buildFile("""
             System.properties.putAll(someProperty: "some.value")  // Use putAll to avoid recording property as an input

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultBuildTreeModelControllerServices.kt
@@ -26,6 +26,7 @@ import org.gradle.configurationcache.problems.ConfigurationCacheProblems
 import org.gradle.configurationcache.serialization.beans.BeanStateReaderLookup
 import org.gradle.configurationcache.serialization.beans.BeanStateWriterLookup
 import org.gradle.configurationcache.serialization.codecs.jos.JavaSerializationEncodingLookup
+import org.gradle.configurationcache.services.EnvironmentChangeTracker
 import org.gradle.internal.buildtree.BuildActionModelRequirements
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeModelControllerServices
@@ -94,6 +95,7 @@ class DefaultBuildTreeModelControllerServices : BuildTreeModelControllerServices
         registration.add(BuildModelParameters::class.java, modelParameters)
         registration.add(BuildActionModelRequirements::class.java, requirements)
         if (modelParameters.isConfigurationCache) {
+            registration.add(EnvironmentChangeTracker::class.java)
             registration.add(ConfigurationCacheBuildTreeLifecycleControllerFactory::class.java)
             registration.add(ConfigurationCacheStartParameter::class.java)
             registration.add(ConfigurationCacheClassLoaderScopeRegistryListener::class.java)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -92,6 +92,10 @@ class InstrumentedInputAccessListener(
         environmentChangeTracker.systemPropertyRemoved(key)
     }
 
+    override fun systemPropertiesCleared(consumer: String) {
+        environmentChangeTracker.systemPropertiesCleared()
+    }
+
     override fun envVariableQueried(key: String, value: String?, consumer: String) {
         if (Workarounds.canReadEnvironmentVariable(consumer)) {
             return

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -88,6 +88,10 @@ class InstrumentedInputAccessListener(
         environmentChangeTracker.systemPropertyChanged(key, value, consumer)
     }
 
+    override fun systemPropertyRemoved(key: Any, consumer: String) {
+        environmentChangeTracker.systemPropertyRemoved(key)
+    }
+
     override fun envVariableQueried(key: String, value: String?, consumer: String) {
         if (Workarounds.canReadEnvironmentVariable(consumer)) {
             return

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache
 import org.gradle.api.file.FileCollection
 import org.gradle.configurationcache.initialization.ConfigurationCacheProblemsListener
 import org.gradle.configurationcache.serialization.Workarounds
+import org.gradle.configurationcache.services.EnvironmentChangeTracker
 import org.gradle.internal.classpath.Instrumented
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.service.scopes.Scopes
@@ -67,26 +68,31 @@ val allowedProperties = setOf(
 class InstrumentedInputAccessListener(
     listenerManager: ListenerManager,
     configurationCacheProblemsListener: ConfigurationCacheProblemsListener,
+    private val environmentChangeTracker: EnvironmentChangeTracker,
 ) : Instrumented.Listener {
 
     private
-    val broadcast = listenerManager.getBroadcaster(UndeclaredBuildInputListener::class.java)
+    val undeclaredInputBroadcast = listenerManager.getBroadcaster(UndeclaredBuildInputListener::class.java)
 
     private
     val externalProcessListener = configurationCacheProblemsListener
 
     override fun systemPropertyQueried(key: String, value: Any?, consumer: String) {
-        if (allowedProperties.contains(key) || Workarounds.canReadSystemProperty(consumer)) {
+        if (allowedProperties.contains(key) || environmentChangeTracker.isSystemPropertyMutated(key) || Workarounds.canReadSystemProperty(consumer)) {
             return
         }
-        broadcast.systemPropertyRead(key, value, consumer)
+        undeclaredInputBroadcast.systemPropertyRead(key, value, consumer)
+    }
+
+    override fun systemPropertyChanged(key: Any, value: Any?, consumer: String) {
+        environmentChangeTracker.systemPropertyChanged(key, value, consumer)
     }
 
     override fun envVariableQueried(key: String, value: String?, consumer: String) {
         if (Workarounds.canReadEnvironmentVariable(consumer)) {
             return
         }
-        broadcast.envVariableRead(key, value, consumer)
+        undeclaredInputBroadcast.envVariableRead(key, value, consumer)
     }
 
     override fun externalProcessStarted(command: String, consumer: String) {
@@ -100,10 +106,10 @@ class InstrumentedInputAccessListener(
         if (Workarounds.canReadFiles(consumer)) {
             return
         }
-        broadcast.fileOpened(file, consumer)
+        undeclaredInputBroadcast.fileOpened(file, consumer)
     }
 
     override fun fileCollectionObserved(fileCollection: FileCollection, consumer: String) {
-        broadcast.fileCollectionObserved(fileCollection, consumer)
+        undeclaredInputBroadcast.fileCollectionObserved(fileCollection, consumer)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/JsonModelWriter.kt
@@ -121,6 +121,11 @@ class JsonModelWriter(val writer: Writer) {
                     }
                 }
             }
+            is PropertyTrace.SystemProperty -> {
+                property("kind", "SystemProperty")
+                comma()
+                property("name", trace.name)
+            }
             is PropertyTrace.Task -> {
                 property("kind", "Task")
                 comma()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/PropertyProblem.kt
@@ -132,6 +132,14 @@ sealed class PropertyTrace {
             get() = trace.containingUserCode
     }
 
+    class SystemProperty(
+        val name: String,
+        val trace: PropertyTrace
+    ) : PropertyTrace() {
+        override val containingUserCode: String
+            get() = trace.containingUserCode
+    }
+
     override fun toString(): String =
         StringBuilder().apply {
             sequence.forEach {
@@ -158,6 +166,11 @@ sealed class PropertyTrace {
                 append(" ")
                 quoted(trace.name)
                 append(" of ")
+            }
+            is SystemProperty -> {
+                append("system property ")
+                quoted(trace.name)
+                append(" set at ")
             }
             is Bean -> {
                 quoted(trace.type.name)
@@ -203,6 +216,7 @@ sealed class PropertyTrace {
         get() = when (this) {
             is Bean -> trace
             is Property -> trace
+            is SystemProperty -> trace
             else -> null
         }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
@@ -51,6 +51,10 @@ object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnviro
                 }
             }
         }
+
+        writeCollection(value.removals) { removal ->
+            writeString(removal.key)
+        }
     }
 
     override suspend fun ReadContext.decode(): EnvironmentChangeTracker.CachedEnvironmentState {
@@ -60,6 +64,11 @@ object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnviro
             EnvironmentChangeTracker.SystemPropertySet(key, value, null)
         }
 
-        return EnvironmentChangeTracker.CachedEnvironmentState(updates)
+        val removals = readList {
+            val key = readString()
+            EnvironmentChangeTracker.SystemPropertyRemove(key)
+        }
+
+        return EnvironmentChangeTracker.CachedEnvironmentState(updates, removals)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.serialization.codecs
+
+import org.gradle.configurationcache.serialization.Codec
+import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.serialization.WriteContext
+import org.gradle.configurationcache.serialization.readList
+import org.gradle.configurationcache.serialization.writeCollection
+import org.gradle.configurationcache.services.EnvironmentChangeTracker
+
+
+internal
+object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnvironmentState> {
+    override suspend fun WriteContext.encode(value: EnvironmentChangeTracker.CachedEnvironmentState) {
+        writeCollection(value.updates) { update ->
+            write(update.key)
+            write(update.value)
+        }
+    }
+
+    override suspend fun ReadContext.decode(): EnvironmentChangeTracker.CachedEnvironmentState {
+        val updates = readList {
+            val key = read() as Any
+            val value = read()
+            EnvironmentChangeTracker.SystemPropertySet(key, value)
+        }
+
+        return EnvironmentChangeTracker.CachedEnvironmentState(updates)
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
@@ -34,6 +34,8 @@ import java.io.IOException
 internal
 object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnvironmentState> {
     override suspend fun WriteContext.encode(value: EnvironmentChangeTracker.CachedEnvironmentState) {
+        writeBoolean(value.cleared)
+
         writeCollection(value.updates) { update ->
             withPropertyTrace(PropertyTrace.SystemProperty(update.key.toString(), update.location ?: PropertyTrace.Unknown)) {
                 try {
@@ -58,6 +60,7 @@ object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnviro
     }
 
     override suspend fun ReadContext.decode(): EnvironmentChangeTracker.CachedEnvironmentState {
+        val cleared = readBoolean()
         val updates = readList {
             val key = read() as Any
             val value = read()
@@ -69,6 +72,6 @@ object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnviro
             EnvironmentChangeTracker.SystemPropertyRemove(key)
         }
 
-        return EnvironmentChangeTracker.CachedEnvironmentState(updates, removals)
+        return EnvironmentChangeTracker.CachedEnvironmentState(cleared, updates, removals)
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -170,6 +170,8 @@ class Codecs(
 
         bind(TaskReferenceCodec)
 
+        bind(CachedEnvironmentStateCodec)
+
         bind(IsolatedManagedValueCodec(managedFactoryRegistry))
         bind(IsolatedImmutableManagedValueCodec(managedFactoryRegistry))
         bind(IsolatedJavaSerializedValueSnapshotCodec)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTracker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTracker.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.services
+
+import org.gradle.internal.service.scopes.Scopes
+import org.gradle.internal.service.scopes.ServiceScope
+import java.util.concurrent.ConcurrentHashMap
+
+
+/**
+ * The environment state that was mutated at the configuration phase and has to be restored before running a build from the cache.
+ */
+@ServiceScope(Scopes.BuildTree::class)
+class EnvironmentChangeTracker {
+    private
+    val mutatedSystemProperties = ConcurrentHashMap<Any, SystemPropertyChange>()
+
+    fun isSystemPropertyMutated(key: String): Boolean = mutatedSystemProperties.containsKey(key)
+
+    fun loadFrom(storedState: CachedEnvironmentState) {
+        storedState.updates.forEach { update ->
+            mutatedSystemProperties[update.key] = update
+            System.getProperties()[update.key] = update.value
+        }
+    }
+
+    fun getCachedState(): CachedEnvironmentState {
+        return CachedEnvironmentState(mutatedSystemProperties.values.filterIsInstance<SystemPropertySet>())
+    }
+
+    fun systemPropertyChanged(key: Any, value: Any?, consumer: String) {
+        mutatedSystemProperties[key] = SystemPropertySet(key, value)
+    }
+
+    class CachedEnvironmentState(val updates: List<SystemPropertySet>)
+
+    sealed class SystemPropertyChange(val key: Any)
+
+    class SystemPropertySet(key: Any, val value: Any?) : SystemPropertyChange(key)
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTracker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTracker.kt
@@ -26,66 +26,144 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * The environment state that was mutated at the configuration phase and has to be restored before running a build from the cache.
+ *
+ * The class can operate in two modes. First is the tracking mode when all environment-modifying operations are stored
+ * and the list of the operations can be retrieved as the CachedEnvironmentState object. This mode is intended for the
+ * builds with the configuration phase. The second mode applies the restored state to the environment and doesn't
+ * track anything. This mode is used when the configuration is restored from the configuration cache.
+ * Mode selection happens upon the first use of the class. Calling an operation that isn't supported in the current
+ * mode results in the IllegalStateException.
  */
 @ServiceScope(Scopes.BuildTree::class)
 class EnvironmentChangeTracker(private val userCodeApplicationContext: UserCodeApplicationContext) {
     private
-    val mutatedSystemProperties = ConcurrentHashMap<Any, SystemPropertyChange>()
+    val mode = ModeHolder()
 
-    @Volatile
+    fun isSystemPropertyMutated(key: String) = mode.toTrackingMode().isSystemPropertyMutated(key)
+
+    fun loadFrom(storedState: CachedEnvironmentState) = mode.toRestoringMode().loadFrom(storedState)
+
+    fun getCachedState() = mode.toTrackingMode().getCachedState()
+
+    fun systemPropertyChanged(key: Any, value: Any?, consumer: String) = mode.toTrackingMode().systemPropertyChanged(key, value, consumer)
+
+    fun systemPropertyRemoved(key: Any) = mode.toTrackingMode().systemPropertyRemoved(key)
+
+    fun systemPropertiesCleared() = mode.toTrackingMode().systemPropertiesCleared()
+
     private
-    var systemPropertiesCleared = false
+    inner class ModeHolder {
+        // ModeHolder encapsulates concurrent mode updates.
+        private
+        var mode: TrackerMode = Initial()
 
-    fun isSystemPropertyMutated(key: String): Boolean {
-        return systemPropertiesCleared || mutatedSystemProperties.containsKey(key)
+        private
+        inline fun <T : TrackerMode> setMode(transition: (TrackerMode) -> T): T {
+            synchronized(this) {
+                val newMode = transition(mode)
+                mode = newMode
+                return newMode
+            }
+        }
+
+        fun toTrackingMode(): Tracking = setMode(TrackerMode::toTracking)
+
+        fun toRestoringMode(): Restoring = setMode(TrackerMode::toRestoring)
     }
 
-    fun loadFrom(storedState: CachedEnvironmentState) {
-        if (storedState.cleared) {
+    private
+    sealed interface TrackerMode {
+        fun toTracking(): Tracking
+        fun toRestoring(): Restoring
+    }
+
+    private
+    inner class Initial : TrackerMode {
+        override fun toTracking(): Tracking {
+            return Tracking()
+        }
+
+        override fun toRestoring(): Restoring {
+            return Restoring()
+        }
+    }
+
+    private
+    inner class Tracking : TrackerMode {
+        private
+        val mutatedSystemProperties = ConcurrentHashMap<Any, SystemPropertyChange>()
+
+        @Volatile
+        private
+        var systemPropertiesCleared = false
+
+        override fun toTracking(): Tracking {
+            return this
+        }
+
+        override fun toRestoring(): Restoring {
+            throw IllegalStateException("Cannot restore state because change tracking is already in progress")
+        }
+
+        fun isSystemPropertyMutated(key: String): Boolean {
+            return systemPropertiesCleared || mutatedSystemProperties.containsKey(key)
+        }
+
+        fun getCachedState(): CachedEnvironmentState {
+            return CachedEnvironmentState(
+                cleared = systemPropertiesCleared,
+                updates = mutatedSystemProperties.values.filterIsInstance<SystemPropertySet>(),
+                removals = mutatedSystemProperties.values.filterIsInstance<SystemPropertyRemove>()
+            )
+        }
+
+        fun systemPropertyChanged(key: Any, value: Any?, consumer: String) {
+            mutatedSystemProperties[key] = SystemPropertySet(key, value, userCodeApplicationContext.location(consumer))
+        }
+
+        fun systemPropertyRemoved(key: Any) {
+            if (key is String) {
+                // Externally set system properties can only use Strings as keys. If the removal argument is a string
+                // then it can affect externally set property and has to be persisted. Then removal will be applied on
+                // the next run from cache.
+                mutatedSystemProperties[key] = SystemPropertyRemove(key)
+            } else {
+                // If the key is not a string, it can only affect properties that were set by the build logic. There is
+                // no need to persist the removal, but the set value should not be persisted too. A placeholder value
+                // will keep the key mutated to avoid recording it as an input.
+                mutatedSystemProperties[key] = SystemPropertyIgnored
+            }
+        }
+
+        fun systemPropertiesCleared() {
             systemPropertiesCleared = true
-            System.getProperties().clear()
-        }
-
-        storedState.updates.forEach { update ->
-            mutatedSystemProperties[update.key] = update
-            System.getProperties()[update.key] = update.value
-        }
-
-        storedState.removals.forEach { removal ->
-            mutatedSystemProperties[removal.key] = removal
-            System.clearProperty(removal.key)
+            mutatedSystemProperties.clear()
         }
     }
 
-    fun getCachedState(): CachedEnvironmentState {
-        return CachedEnvironmentState(
-            cleared = systemPropertiesCleared,
-            updates = mutatedSystemProperties.values.filterIsInstance<SystemPropertySet>(),
-            removals = mutatedSystemProperties.values.filterIsInstance<SystemPropertyRemove>()
-        )
-    }
-
-    fun systemPropertyChanged(key: Any, value: Any?, consumer: String) {
-        mutatedSystemProperties[key] = SystemPropertySet(key, value, userCodeApplicationContext.location(consumer))
-    }
-
-    fun systemPropertyRemoved(key: Any) {
-        if (key is String) {
-            // Externally set system properties can only use Strings as keys. If the removal argument is a string
-            // then it can affect externally set property and has to be persisted. Then removal will be applied on
-            // the next run from cache.
-            mutatedSystemProperties[key] = SystemPropertyRemove(key)
-        } else {
-            // If the key is not a string, it can only affect properties that were set by the build logic. There is
-            // no need to persist the removal, but the set value should not be persisted too. A placeholder value
-            // will keep the key mutated to avoid recording it as an input.
-            mutatedSystemProperties[key] = SystemPropertyIgnored
+    private
+    class Restoring : TrackerMode {
+        override fun toTracking(): Tracking {
+            throw IllegalStateException("Cannot track state because it was restored")
         }
-    }
 
-    fun systemPropertiesCleared() {
-        systemPropertiesCleared = true
-        mutatedSystemProperties.clear()
+        override fun toRestoring(): Restoring {
+            throw IllegalStateException("Cannot restore state because it was already restored")
+        }
+
+        fun loadFrom(storedState: CachedEnvironmentState) {
+            if (storedState.cleared) {
+                System.getProperties().clear()
+            }
+
+            storedState.updates.forEach { update ->
+                System.getProperties()[update.key] = update.value
+            }
+
+            storedState.removals.forEach { removal ->
+                System.clearProperty(removal.key)
+            }
+        }
     }
 
     class CachedEnvironmentState(val cleared: Boolean, val updates: List<SystemPropertySet>, val removals: List<SystemPropertyRemove>)

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTrackerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/services/EnvironmentChangeTrackerTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache.services
+
+import org.gradle.configuration.internal.DefaultUserCodeApplicationContext
+import org.junit.Test
+
+
+class EnvironmentChangeTrackerTest {
+    @Test(expected = IllegalStateException::class)
+    fun `loading state after first update throws`() {
+        val tracker = EnvironmentChangeTracker(DefaultUserCodeApplicationContext())
+
+        tracker.systemPropertyRemoved("some.property")
+
+        tracker.loadFrom(emptyEnvironmentState())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `updating state after loading throws`() {
+        val tracker = EnvironmentChangeTracker(DefaultUserCodeApplicationContext())
+
+        tracker.loadFrom(emptyEnvironmentState())
+
+        tracker.systemPropertyRemoved("some.property")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `loading twice throws`() {
+        val tracker = EnvironmentChangeTracker(DefaultUserCodeApplicationContext())
+
+        tracker.loadFrom(emptyEnvironmentState())
+        tracker.loadFrom(emptyEnvironmentState())
+    }
+
+    private
+    fun emptyEnvironmentState() = EnvironmentChangeTracker.CachedEnvironmentState(cleared = false, updates = listOf(), removals = listOf())
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
@@ -141,6 +141,11 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
             public void onRemove(Object object) {
                 // Environment variables are immutable.
             }
+
+            @Override
+            public void onClear() {
+                // Environment variables are immutable.
+            }
         };
     }
 
@@ -158,6 +163,11 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
 
             @Override
             public void onRemove(Object object) {
+                // Environment variables are immutable.
+            }
+
+            @Override
+            public void onClear() {
                 // Environment variables are immutable.
             }
         };

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
@@ -62,7 +62,7 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
 
     @Override
     public Set<String> keySet() {
-        return new AccessTrackingSet<>(super.keySet(), this::getAndReport, this::reportAggregatingAccess);
+        return new AccessTrackingSet<>(super.keySet(), trackingListener());
     }
 
     private String getAndReport(@Nullable Object key) {
@@ -74,7 +74,7 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
 
     @Override
     public Set<Entry<String, String>> entrySet() {
-        return new AccessTrackingSet<>(delegate.entrySet(), this::onAccessEntrySetElement, this::reportAggregatingAccess);
+        return new AccessTrackingSet<>(delegate.entrySet(), entrySetTrackingListener());
     }
 
     private void onAccessEntrySetElement(@Nullable Object potentialEntry) {
@@ -123,6 +123,34 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
     private void reportAggregatingAccess() {
         // Mark all map contents as inputs if some aggregating access is used.
         delegate.forEach(onAccess);
+    }
+
+    private AccessTrackingSet.Listener trackingListener() {
+        return new AccessTrackingSet.Listener() {
+            @Override
+            public void onAccess(Object o) {
+                getAndReport(o);
+            }
+
+            @Override
+            public void onAggregatingAccess() {
+                reportAggregatingAccess();
+            }
+        };
+    }
+
+    private AccessTrackingSet.Listener entrySetTrackingListener() {
+        return new AccessTrackingSet.Listener() {
+            @Override
+            public void onAccess(Object o) {
+                onAccessEntrySetElement(o);
+            }
+
+            @Override
+            public void onAggregatingAccess() {
+                reportAggregatingAccess();
+            }
+        };
     }
 }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingEnvMap.java
@@ -136,6 +136,11 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
             public void onAggregatingAccess() {
                 reportAggregatingAccess();
             }
+
+            @Override
+            public void onRemove(Object object) {
+                // Environment variables are immutable.
+            }
         };
     }
 
@@ -149,6 +154,11 @@ class AccessTrackingEnvMap extends ForwardingMap<String, String> {
             @Override
             public void onAggregatingAccess() {
                 reportAggregatingAccess();
+            }
+
+            @Override
+            public void onRemove(Object object) {
+                // Environment variables are immutable.
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
@@ -44,6 +44,8 @@ class AccessTrackingProperties extends Properties {
         void onChange(Object key, Object newValue);
 
         void onRemove(Object key);
+
+        void onClear();
     }
 
     // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of method is tracked currently.
@@ -280,6 +282,7 @@ class AccessTrackingProperties extends Properties {
 
     @Override
     public void clear() {
+        listener.onClear();
         delegate.clear();
     }
 
@@ -414,6 +417,11 @@ class AccessTrackingProperties extends Properties {
             public void onRemove(Object object) {
                 listener.onRemove(object);
             }
+
+            @Override
+            public void onClear() {
+                listener.onClear();
+            }
         };
     }
 
@@ -435,6 +443,11 @@ class AccessTrackingProperties extends Properties {
                 if (entry != null) {
                     listener.onRemove(entry.getKey());
                 }
+            }
+
+            @Override
+            public void onClear() {
+                listener.onClear();
             }
         };
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
@@ -35,14 +35,13 @@ import java.util.function.Function;
 
 /**
  * A wrapper for {@link Properties} that notifies a listener about accesses.
- * interface.
  */
 class AccessTrackingProperties extends Properties {
     // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of method is tracked currently.
     private final Properties delegate;
-    private final BiConsumer<? super String, ? super String> onAccess;
+    private final BiConsumer<Object, Object> onAccess;
 
-    public AccessTrackingProperties(Properties delegate, BiConsumer<? super String, ? super String> onAccess) {
+    public AccessTrackingProperties(Properties delegate, BiConsumer<Object, Object> onAccess) {
         this.delegate = delegate;
         this.onAccess = onAccess;
     }
@@ -98,7 +97,7 @@ class AccessTrackingProperties extends Properties {
     }
 
     private void onAccessEntrySetElement(@Nullable Object potentialEntry) {
-        Map.Entry<String, String> entry = AccessTrackingUtils.tryConvertingToTrackableEntry(potentialEntry);
+        Map.Entry<?, ?> entry = AccessTrackingUtils.tryConvertingToEntry(potentialEntry);
         if (entry != null) {
             getAndReport(entry.getKey());
         }
@@ -305,9 +304,7 @@ class AccessTrackingProperties extends Properties {
     }
 
     private void reportKeyAndValue(Object key, Object value) {
-        if (key instanceof String && (value == null || value instanceof String)) {
-            onAccess.accept((String) key, (String) value);
-        }
+        onAccess.accept(key, value);
     }
 
     private void reportAggregatingAccess() {

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingProperties.java
@@ -40,13 +40,57 @@ import java.util.function.Function;
  * A wrapper for {@link Properties} that notifies a listener about accesses.
  */
 class AccessTrackingProperties extends Properties {
+    /**
+     * A listener that is notified about reads and modifications of the Properties instance.
+     * Note that there's no guarantee about the state of the Properties object when the
+     * listener's method is called because of modifying operation: it may happen before or after modification.
+     */
     public interface Listener {
+        /**
+         * Called when the property with the name {@code key} is read. The {@code value} is the value of the property observed by the caller.
+         * The Properties object may not contain the property with this name, the value is {@code null} then. Note that most modifying methods
+         * like {@link Properties#setProperty(String, String)} provide information about the previous value and trigger this method.
+         * All modifying operations call this method prior to {@link #onChange(Object, Object)}, {@link #onRemove(Object)} or {@link #onClear()}.
+         * <p>
+         * When this method is called because of the modifying operation, the state of the observed Properties object is undefined for the duration of the
+         * call: it may be already completely or partially modified to reflect the result of the operation.
+         *
+         * @param key the key used by the caller to access the property
+         * @param value the value observed by the caller or {@code null} if there is no value for the given key
+         */
         void onAccess(Object key, @Nullable Object value);
 
+        /**
+         * Called when the property with the name {@code key} is updated or added. The {@code newValue} is the new value of the property provided by
+         * the caller. If the modifying method provides a way for the caller to observe a previous value of the key then
+         * {@link #onAccess(Object, Object)} method is called prior to this method.
+         * <p>
+         * The state of the observed Properties object is undefined for the duration of the call: it may be already completely or partially
+         * modified to reflect the result of the operation.
+         *
+         * @param key the key used by the caller to access the property
+         * @param newValue the value provided by the caller
+         */
         void onChange(Object key, Object newValue);
 
+        /**
+         * Called when the property with the name {@code key} is removed. The Properties object may not contain the property prior to the modification.
+         * If the modifying method provides a way for the caller to observe a previous value of the key then {@link #onAccess(Object, Object)} method is
+         * called prior to this method.
+         * <p>
+         * The state of the observed Properties object is undefined for the duration of the call: it may be already completely or partially
+         * modified to reflect the result of the operation.
+         *
+         * @param key the key used by the caller to access the property
+         */
         void onRemove(Object key);
 
+        /**
+         * Called when the caller unconditionally removes all properties in this Properties object, for example by calling {@link Properties#clear()}.
+         * <p>
+         * The state of the observed Properties object is undefined for the duration of the call: it may be already completely or partially
+         * modified to reflect the result of the operation.
+         */
         void onClear();
     }
 
@@ -328,19 +372,19 @@ class AccessTrackingProperties extends Properties {
 
     @Override
     public void putAll(Map<?, ?> t) {
-        // putAll has no return value so keys do not become inputs.
-        t.forEach(listener::onChange);
         synchronized (delegate) {
             delegate.putAll(t);
         }
+        // putAll has no return value so keys do not become inputs.
+        t.forEach(listener::onChange);
     }
 
     @Override
     public void clear() {
-        listener.onClear();
         synchronized (delegate) {
             delegate.clear();
         }
+        listener.onClear();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
@@ -38,6 +38,8 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
         void onAggregatingAccess();
 
         void onRemove(Object object);
+
+        void onClear();
     }
 
     // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of entrySet/keySet methods are currently tracked.
@@ -87,6 +89,12 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
             listener.onRemove(o);
         }
         return delegate.removeAll(collection);
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+        listener.onClear();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
@@ -33,6 +33,8 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
         void onAccess(Object o);
 
         void onAggregatingAccess();
+
+        void onRemove(Object object);
     }
 
     // TODO(https://github.com/gradle/configuration-cache/issues/337) Only a limited subset of entrySet/keySet methods are currently tracked.
@@ -65,6 +67,7 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
     public boolean remove(Object o) {
         // We cannot perform modification before notifying because the listener may want to query the state of the delegate prior to that.
         listener.onAccess(o);
+        listener.onRemove(o);
         return delegate.remove(o);
     }
 
@@ -73,6 +76,7 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
         // We cannot perform modification before notifying because the listener may want to query the state of the delegate prior to that.
         for (Object o : collection) {
             listener.onAccess(o);
+            listener.onRemove(o);
         }
         return delegate.removeAll(collection);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingSet.java
@@ -131,7 +131,7 @@ class AccessTrackingSet<E> extends ForwardingSet<E> {
     public Object[] toArray() {
         // this is basically a reimplementation of the standardToArray that doesn't call this.size()
         // and avoids double-reporting of the aggregating access.
-        return toArray(new Object[delegate.size()]);
+        return toArray(new Object[0]);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/AccessTrackingUtils.java
@@ -44,10 +44,10 @@ class AccessTrackingUtils {
      */
     @Nullable
     public static Map.Entry<String, String> tryConvertingToTrackableEntry(Object o) {
-        if (!(o instanceof Map.Entry)) {
+        Map.Entry<?, ?> entry = tryConvertingToEntry(o);
+        if (entry == null) {
             return null;
         }
-        Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
         // Return a copy to make sure that the results of getKey() and getValue() do not change.
         Object key = entry.getKey();
         Object value = entry.getValue();
@@ -57,4 +57,11 @@ class AccessTrackingUtils {
         return null;
     }
 
+    @Nullable
+    public static Map.Entry<?, ?> tryConvertingToEntry(Object o) {
+        if (!(o instanceof Map.Entry)) {
+            return null;
+        }
+        return (Map.Entry<?, ?>) o;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -567,11 +567,29 @@ public class Instrumented {
         }
 
         @Override
+        public Object callStatic(Class receiver, Object arg1) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperty(arg1.toString(), array.owner.getName());
+            } else {
+                return super.callStatic(receiver, arg1);
+            }
+        }
+
+        @Override
         public Object call(Object receiver, Object arg1, Object arg2) throws Throwable {
             if (receiver.equals(System.class)) {
                 return systemProperty(arg1.toString(), convertToString(arg2), array.owner.getName());
             } else {
                 return super.call(receiver, arg1, arg2);
+            }
+        }
+
+        @Override
+        public Object callStatic(Class receiver, Object arg1, Object arg2) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperty(arg1.toString(), convertToString(arg2), array.owner.getName());
+            } else {
+                return super.callStatic(receiver, arg1, arg2);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -85,6 +85,7 @@ public class Instrumented {
                     array.array[callSite.getIndex()] = new SetSystemPropertyCallSite(callSite);
                     break;
                 case "properties":
+                case "getProperties":
                     array.array[callSite.getIndex()] = new SystemPropertiesCallSite(callSite);
                     break;
                 case "getInteger":
@@ -557,6 +558,24 @@ public class Instrumented {
                 return systemProperties(array.owner.getName());
             } else {
                 return super.callGetProperty(receiver);
+            }
+        }
+
+        @Override
+        public Object call(Object receiver) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperties(array.owner.getName());
+            } else {
+                return super.call(receiver);
+            }
+        }
+
+        @Override
+        public Object callStatic(Class receiver) throws Throwable {
+            if (receiver.equals(System.class)) {
+                return systemProperties(array.owner.getName());
+            } else {
+                return super.callStatic(receiver);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -126,7 +126,10 @@ public class Instrumented {
     // Called by generated code.
     public static Properties systemProperties(String consumer) {
         return new AccessTrackingProperties(System.getProperties(), (k, v) -> {
-            systemPropertyQueried(convertToString(k), convertToString(v), consumer);
+            // Do not track accesses to non-String properties. Only String properties can be set externally, so they cannot affect the cached configuration.
+            if (k instanceof String && (v == null || v instanceof String)) {
+                systemPropertyQueried(convertToString(k), convertToString(v), consumer);
+            }
         });
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -51,6 +51,10 @@ public class Instrumented {
         }
 
         @Override
+        public void systemPropertiesCleared(String consumer) {
+        }
+
+        @Override
         public void envVariableQueried(String key, @Nullable String value, String consumer) {
         }
 
@@ -87,6 +91,9 @@ public class Instrumented {
                     break;
                 case "setProperty":
                     array.array[callSite.getIndex()] = new SetSystemPropertyCallSite(callSite);
+                    break;
+                case "setProperties":
+                    array.array[callSite.getIndex()] = new SetSystemPropertiesCallSite(callSite);
                     break;
                 case "clearProperty":
                     array.array[callSite.getIndex()] = new ClearSystemPropertyCallSite(callSite);
@@ -158,6 +165,11 @@ public class Instrumented {
             public void onRemove(Object key) {
                 listener().systemPropertyRemoved(key, consumer);
             }
+
+            @Override
+            public void onClear() {
+                listener().systemPropertiesCleared(consumer);
+            }
         });
     }
 
@@ -175,6 +187,12 @@ public class Instrumented {
         systemPropertyQueried(key, oldValue, consumer);
         listener().systemPropertyRemoved(key, consumer);
         return oldValue;
+    }
+
+    public static void setSystemProperties(Properties properties, String consumer) {
+        listener().systemPropertiesCleared(consumer);
+        properties.forEach((k, v) -> listener().systemPropertyChanged(k, v, consumer));
+        System.setProperties(properties);
     }
 
     // Called by generated code.
@@ -433,6 +451,13 @@ public class Instrumented {
         void systemPropertyRemoved(Object key, String consumer);
 
         /**
+         * Invoked when all system properties are removed.
+         *
+         * @param consumer the name of the class that is removing the system properties
+         */
+        void systemPropertiesCleared(String consumer);
+
+        /**
          * Invoked when the code reads the environment variable.
          *
          * @param key the name of the variable
@@ -571,6 +596,32 @@ public class Instrumented {
                 return setSystemProperty(convertToString(arg1), convertToString(arg2), array.owner.getName());
             } else {
                 return super.callStatic(receiver, arg1, arg2);
+            }
+        }
+    }
+
+    private static class SetSystemPropertiesCallSite extends AbstractCallSite {
+        public SetSystemPropertiesCallSite(CallSite callSite) {
+            super(callSite);
+        }
+
+        @Override
+        public Object call(Object receiver, Object arg1) throws Throwable {
+            if (receiver.equals(System.class) && arg1 instanceof Properties) {
+                setSystemProperties((Properties) arg1, array.owner.getName());
+                return null;
+            } else {
+                return super.call(receiver, arg1);
+            }
+        }
+
+        @Override
+        public Object callStatic(Class receiver, Object arg1) throws Throwable {
+            if (receiver.equals(System.class) && arg1 instanceof Properties) {
+                setSystemProperties((Properties) arg1, array.owner.getName());
+                return null;
+            } else {
+                return super.callStatic(receiver, arg1);
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -334,6 +334,10 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
                     _LDC(binaryClassNameOf(className));
                     _INVOKESTATIC(INSTRUMENTED_TYPE, "setSystemProperty", RETURN_STRING_FROM_STRING_STRING_STRING);
                     return true;
+                } else if (name.equals("clearProperty") && descriptor.equals(RETURN_STRING_FROM_STRING)) {
+                    _LDC(binaryClassNameOf(className));
+                    _INVOKESTATIC(INSTRUMENTED_TYPE, "clearSystemProperty", RETURN_STRING_FROM_STRING_STRING);
+                    return true;
                 } else if (name.equals("getenv")) {
                     if (descriptor.equals(RETURN_STRING_FROM_STRING)) {
                         // System.getenv(String) -> String

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -330,6 +330,10 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
                     _LDC(binaryClassNameOf(className));
                     _INVOKESTATIC(INSTRUMENTED_TYPE, "systemProperties", RETURN_PROPERTIES_FROM_STRING);
                     return true;
+                } else if (name.equals("setProperty") && descriptor.equals(RETURN_STRING_FROM_STRING_STRING)) {
+                    _LDC(binaryClassNameOf(className));
+                    _INVOKESTATIC(INSTRUMENTED_TYPE, "setSystemProperty", RETURN_STRING_FROM_STRING_STRING_STRING);
+                    return true;
                 } else if (name.equals("getenv")) {
                     if (descriptor.equals(RETURN_STRING_FROM_STRING)) {
                         // System.getenv(String) -> String

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -62,7 +62,7 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
     /**
      * Decoration format. Increment this when making changes.
      */
-    private static final int DECORATION_FORMAT = 18;
+    private static final int DECORATION_FORMAT = 19;
 
     private static final Type SYSTEM_TYPE = getType(System.class);
     private static final Type STRING_TYPE = getType(String.class);

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingTransformer.java
@@ -72,6 +72,7 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
     private static final Type SERIALIZED_LAMBDA_TYPE = getType(SerializedLambda.class);
     private static final Type LONG_TYPE = getType(Long.class);
     private static final Type BOOLEAN_TYPE = getType(Boolean.class);
+    public static final Type PROPERTIES_TYPE = getType(Properties.class);
 
     private static final String RETURN_STRING = getMethodDescriptor(STRING_TYPE);
     private static final String RETURN_STRING_FROM_STRING = getMethodDescriptor(STRING_TYPE, STRING_TYPE);
@@ -93,8 +94,10 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
     private static final String RETURN_PRIMITIVE_BOOLEAN_FROM_STRING_STRING = getMethodDescriptor(Type.BOOLEAN_TYPE, STRING_TYPE, STRING_TYPE);
     private static final String RETURN_OBJECT_FROM_INT = getMethodDescriptor(OBJECT_TYPE, Type.INT_TYPE);
     private static final String RETURN_BOOLEAN_FROM_OBJECT = getMethodDescriptor(Type.BOOLEAN_TYPE, OBJECT_TYPE);
-    private static final String RETURN_PROPERTIES = getMethodDescriptor(getType(Properties.class));
-    private static final String RETURN_PROPERTIES_FROM_STRING = getMethodDescriptor(getType(Properties.class), STRING_TYPE);
+    private static final String RETURN_PROPERTIES = getMethodDescriptor(PROPERTIES_TYPE);
+    private static final String RETURN_PROPERTIES_FROM_STRING = getMethodDescriptor(PROPERTIES_TYPE, STRING_TYPE);
+    private static final String RETURN_VOID_FROM_PROPERTIES = getMethodDescriptor(Type.VOID_TYPE, PROPERTIES_TYPE);
+    private static final String RETURN_VOID_FROM_PROPERTIES_STRING = getMethodDescriptor(Type.VOID_TYPE, PROPERTIES_TYPE, STRING_TYPE);
     private static final String RETURN_CALL_SITE_ARRAY = getMethodDescriptor(getType(CallSiteArray.class));
     private static final String RETURN_VOID_FROM_CALL_SITE_ARRAY = getMethodDescriptor(Type.VOID_TYPE, getType(CallSiteArray.class));
     private static final String RETURN_OBJECT_FROM_SERIALIZED_LAMBDA = getMethodDescriptor(OBJECT_TYPE, SERIALIZED_LAMBDA_TYPE);
@@ -329,6 +332,10 @@ class InstrumentingTransformer implements CachedClasspathTransformer.Transform {
                 } else if (name.equals("getProperties") && descriptor.equals(RETURN_PROPERTIES)) {
                     _LDC(binaryClassNameOf(className));
                     _INVOKESTATIC(INSTRUMENTED_TYPE, "systemProperties", RETURN_PROPERTIES_FROM_STRING);
+                    return true;
+                } else if (name.equals("setProperties") && descriptor.equals(RETURN_VOID_FROM_PROPERTIES)) {
+                    _LDC(binaryClassNameOf(className));
+                    _INVOKESTATIC(INSTRUMENTED_TYPE, "setSystemProperties", RETURN_VOID_FROM_PROPERTIES_STRING);
                     return true;
                 } else if (name.equals("setProperty") && descriptor.equals(RETURN_STRING_FROM_STRING_STRING)) {
                     _LDC(binaryClassNameOf(className));

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AbstractAccessTrackingMapTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AbstractAccessTrackingMapTest.groovy
@@ -24,7 +24,7 @@ import java.util.function.Consumer
 
 abstract class AbstractAccessTrackingMapTest extends Specification {
     protected final Map<String, String> innerMap = ['existing': 'existingValue', 'other': 'otherValue']
-    protected final BiConsumer<Object, Object> consumer = Mock()
+    protected final BiConsumer<Object, Object> onAccess = Mock()
 
     protected abstract Map<? super String, ? super String> getMapUnderTestToRead()
 
@@ -34,8 +34,8 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         result == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         where:
         key        | expectedResult  | reportedValue
@@ -49,8 +49,8 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         result == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         where:
         key        | expectedResult  | reportedValue
@@ -65,8 +65,8 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         result == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         where:
         key        | expectedResult | reportedValue
@@ -80,8 +80,8 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing', null)
-        0 * consumer._
+        1 * onAccess.accept('missing', null)
+        0 * onAccess._
     }
 
     def "aggregating method #methodName reports all map contents as inputs"() {
@@ -89,9 +89,9 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
         operation.accept(getMapUnderTestToRead())
 
         then:
-        (1.._) * consumer.accept('existing', 'existingValue')
-        (1.._) * consumer.accept('other', 'otherValue')
-        0 * consumer._
+        (1.._) * onAccess.accept('existing', 'existingValue')
+        (1.._) * onAccess.accept('other', 'otherValue')
+        0 * onAccess._
 
         where:
         methodName              | operation
@@ -111,7 +111,7 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
         getMapUnderTestToRead().toString()
 
         then:
-        0 * consumer._
+        0 * onAccess._
     }
 
     def "entrySet() contains(entry(#key, #requestedValue)) and containsAll(entry(#key, #requestedValue)) are tracked"() {
@@ -120,16 +120,16 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         containsResult == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         when:
         def containsAllResult = getMapUnderTestToRead().entrySet().containsAll(Collections.singleton(entry(key, requestedValue)))
 
         then:
         containsAllResult == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         where:
         key        | requestedValue  | reportedValue   | expectedResult
@@ -145,9 +145,9 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         result == expectedResult
-        1 * consumer.accept(key1, reportedValue1)
-        1 * consumer.accept(key2, reportedValue2)
-        0 * consumer._
+        1 * onAccess.accept(key1, reportedValue1)
+        1 * onAccess.accept(key2, reportedValue2)
+        0 * onAccess._
 
         where:
         key1       | requestedValue1    | reportedValue1  | key2          | requestedValue2    | reportedValue2 | expectedResult
@@ -163,16 +163,16 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         containsResult == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         when:
         def containsAllResult = getMapUnderTestToRead().keySet().containsAll(Collections.singleton(key))
 
         then:
         containsAllResult == expectedResult
-        1 * consumer.accept(key, reportedValue)
-        0 * consumer._
+        1 * onAccess.accept(key, reportedValue)
+        0 * onAccess._
 
         where:
         key        | expectedResult | reportedValue
@@ -186,9 +186,9 @@ abstract class AbstractAccessTrackingMapTest extends Specification {
 
         then:
         result == expectedResult
-        1 * consumer.accept(key1, reportedValue1)
-        1 * consumer.accept(key2, reportedValue2)
-        0 * consumer._
+        1 * onAccess.accept(key1, reportedValue1)
+        1 * onAccess.accept(key2, reportedValue2)
+        0 * onAccess._
 
         where:
         key1       | reportedValue1  | key2           | reportedValue2 | expectedResult

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingEnvMapTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingEnvMapTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.classpath
 class AccessTrackingEnvMapTest extends AbstractAccessTrackingMapTest {
     @Override
     protected Map<String, String> getMapUnderTestToRead() {
-        return new AccessTrackingEnvMap(innerMap, consumer)
+        return new AccessTrackingEnvMap(innerMap, onAccess)
     }
 
     def "access to non-string element with containsKey throws"() {
@@ -28,6 +28,6 @@ class AccessTrackingEnvMapTest extends AbstractAccessTrackingMapTest {
 
         then:
         thrown(RuntimeException)
-        0 * consumer._
+        0 * onAccess._
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesNonStringTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesNonStringTest.groovy
@@ -261,6 +261,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         result == expectedResult
         1 * listener.onAccess(key, expectedResult)
+        1 * listener.onRemove(key)
+        0 * listener._
+
         where:
         key                     | expectedResult
         EXISTING_KEY            | EXISTING_VALUE
@@ -275,6 +278,8 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        1 * listener.onRemove(key)
+        0 * listener._
 
         when:
         def removeAllResult = getMapUnderTestToWrite().keySet().removeAll(Collections.<Object> singleton(key))
@@ -282,6 +287,8 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeAllResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        1 * listener.onRemove(key)
+        0 * listener._
 
         where:
         key                     | expectedValue    | expectedResult
@@ -298,6 +305,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         1 * listener.onAccess(EXISTING_KEY, EXISTING_VALUE)
         1 * listener.onAccess('existing', 'existingStringValue')
         1 * listener.onAccess('keyWithNonStringValue', NON_STRING_VALUE)
+        1 * listener.onRemove(EXISTING_KEY)
+        1 * listener.onRemove('existing')
+        1 * listener.onRemove('keyWithNonStringValue')
         0 * listener._
     }
 
@@ -308,6 +318,8 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        1 * listener.onRemove(key)
+        0 * listener._
 
         when:
         def removeAllResult = getMapUnderTestToWrite().entrySet().removeAll(Collections.singleton(entry(key, requestedValue)))
@@ -315,6 +327,8 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeAllResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        1 * listener.onRemove(key)
+        0 * listener._
 
         where:
         key                     | expectedValue         | requestedValue   | expectedResult

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesNonStringTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesNonStringTest.groovy
@@ -265,7 +265,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         result == expectedResult
         1 * listener.onAccess(key, expectedResult)
+        then:
         1 * listener.onRemove(key)
+        then:
         0 * listener._
 
         where:
@@ -282,7 +284,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        then:
         1 * listener.onRemove(key)
+        then:
         0 * listener._
 
         when:
@@ -291,7 +295,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeAllResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        then:
         1 * listener.onRemove(key)
+        then:
         0 * listener._
 
         where:
@@ -303,7 +309,7 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
 
     def "keySet() removeAll() is tracked for non-strings"() {
         when:
-        def result = getMapUnderTestToRead().keySet().removeAll(Arrays.asList(EXISTING_KEY, 'keyWithNonStringValue', 'existing'))
+        def result = getMapUnderTestToWrite().keySet().removeAll(Arrays.asList(EXISTING_KEY, 'keyWithNonStringValue', 'existing'))
         then:
         result
         1 * listener.onAccess(EXISTING_KEY, EXISTING_VALUE)
@@ -331,7 +337,9 @@ class AccessTrackingPropertiesNonStringTest extends Specification {
         then:
         removeAllResult == expectedResult
         1 * listener.onAccess(key, expectedValue)
+        then:
         1 * listener.onRemove(key)
+        then:
         0 * listener._
 
         where:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
@@ -545,6 +545,29 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
         changeCount = changed != null ? 1 : 0
     }
 
+    def "entry method setValue changes map"() {
+        when:
+        def map = getMapUnderTestToWrite()
+        def entry = map.entrySet().find { entry -> entry.getKey() == 'existing'}
+
+        def result = entry.setValue('newValue')
+
+        then:
+        result == 'existingValue'
+        map['existing'] == 'newValue'
+    }
+
+    def "entry method setValue reports change"() {
+        when:
+        def entry = getMapUnderTestToWrite().entrySet().find { entry -> entry.getKey() == 'existing'}
+
+        entry.setValue('newValue')
+
+        then:
+        1 * onChange.accept('existing', 'newValue')
+        0 * onChange._
+    }
+
     private static Properties propertiesWithContent(Map<String, String> contents) {
         Properties props = new Properties()
         props.putAll(contents)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
@@ -27,6 +27,7 @@ import java.util.function.Consumer
 class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
     private BiConsumer<Object, Object> onChange = Mock()
     private Consumer<Object> onRemove = Mock()
+    private Runnable onClear = Mock()
 
     private AccessTrackingProperties.Listener listener = new AccessTrackingProperties.Listener() {
         @Override
@@ -42,6 +43,11 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
         @Override
         void onRemove(Object key) {
             onRemove.accept(key)
+        }
+
+        @Override
+        void onClear() {
+            onClear.run()
         }
     }
 
@@ -246,7 +252,7 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
 
     def "method #methodName does not report properties as inputs"() {
         when:
-        operation.accept(getMapUnderTestToRead())
+        operation.accept(getMapUnderTestToWrite())
 
         then:
         0 * onAccess._
@@ -565,6 +571,19 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
 
         then:
         1 * onChange.accept('existing', 'newValue')
+        0 * onChange._
+    }
+
+    def "method clear() notifies listener and changes map"() {
+        def map = getMapUnderTestToWrite()
+        when:
+        map.clear()
+
+        then:
+        map.isEmpty()
+        1 * onClear.run()
+        0 * onAccess._
+        0 * onRemove._
         0 * onChange._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingPropertiesTest.groovy
@@ -433,13 +433,11 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
         0 * onAccess._
 
         where:
-        key        | newValue   | oldValue
-        'existing' | 'newValue' | 'existingValue'
-        'existing' | null       | 'existingValue'
-        'missing'  | 'newValue' | null
-        'missing'  | null       | null
-
-        changeCount = oldValue == null ? 1 : 0
+        key        | newValue   | oldValue        | changeCount
+        'existing' | 'newValue' | 'existingValue' | 0
+        'existing' | null       | 'existingValue' | 0
+        'missing'  | 'newValue' | null            | 1
+        'missing'  | null       | null            | 0
     }
 
     def "method computeIfPresent(#key, #newValue) changes map"() {
@@ -554,7 +552,7 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
     def "entry method setValue changes map"() {
         when:
         def map = getMapUnderTestToWrite()
-        def entry = map.entrySet().find { entry -> entry.getKey() == 'existing'}
+        def entry = map.entrySet().find { entry -> entry.getKey() == 'existing' }
 
         def result = entry.setValue('newValue')
 
@@ -565,7 +563,7 @@ class AccessTrackingPropertiesTest extends AbstractAccessTrackingMapTest {
 
     def "entry method setValue reports change"() {
         when:
-        def entry = getMapUnderTestToWrite().entrySet().find { entry -> entry.getKey() == 'existing'}
+        def entry = getMapUnderTestToWrite().entrySet().find { entry -> entry.getKey() == 'existing' }
 
         entry.setValue('newValue')
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
@@ -105,6 +105,7 @@ class AccessTrackingSetTest extends Specification {
         then:
         result
         1 * listener.onAccess('existing')
+        1 * listener.onRemove('existing')
         0 * listener._
     }
 
@@ -115,6 +116,7 @@ class AccessTrackingSetTest extends Specification {
         then:
         !result
         1 * listener.onAccess('missing')
+        1 * listener.onRemove('missing')
         0 * listener._
     }
 
@@ -126,6 +128,8 @@ class AccessTrackingSetTest extends Specification {
         result
         1 * listener.onAccess('existing')
         1 * listener.onAccess('other')
+        1 * listener.onRemove('existing')
+        1 * listener.onRemove('other')
         0 * listener._
     }
 
@@ -137,6 +141,8 @@ class AccessTrackingSetTest extends Specification {
         !result
         1 * listener.onAccess('missing')
         1 * listener.onAccess('alsoMissing')
+        1 * listener.onRemove('missing')
+        1 * listener.onRemove('alsoMissing')
         0 * listener._
     }
 
@@ -148,6 +154,8 @@ class AccessTrackingSetTest extends Specification {
         result
         1 * listener.onAccess('existing')
         1 * listener.onAccess('missing')
+        1 * listener.onRemove('existing')
+        1 * listener.onRemove('missing')
         0 * listener._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
@@ -181,6 +181,16 @@ class AccessTrackingSetTest extends Specification {
         "removeIf(Predicate)" | call(s -> s.removeIf(e -> false))
     }
 
+    def "method clear is reported"() {
+        when:
+        set.clear()
+
+        then:
+        inner.isEmpty()
+        1 * listener.onClear()
+        0 * listener._
+    }
+
     def "method #methodName is not reported as aggregating"() {
         when:
         operation.accept(set)
@@ -191,7 +201,6 @@ class AccessTrackingSetTest extends Specification {
         where:
         methodName    | operation
         "retainAll()" | call(s -> s.retainAll(Collections.emptySet()))
-        "clear()"     | call(s -> s.clear())
         "toString()"  | call(s -> s.toString())
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
@@ -21,10 +21,9 @@ import spock.lang.Specification
 import java.util.function.Consumer
 
 class AccessTrackingSetTest extends Specification {
-    private final Consumer<Object> consumer = Mock()
-    private final Runnable aggregatingAccess = Mock()
+    private final AccessTrackingSet.Listener listener = Mock()
     private final Set<String> inner = new HashSet<>(Arrays.asList('existing', 'other'))
-    private final AccessTrackingSet<String> set = new AccessTrackingSet<>(inner, consumer, aggregatingAccess)
+    private final AccessTrackingSet<String> set = new AccessTrackingSet<>(inner, listener)
 
     def "contains of existing element is tracked"() {
         when:
@@ -32,9 +31,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         result
-        1 * consumer.accept('existing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('existing')
+        0 * listener._
     }
 
     def "contains of null is tracked"() {
@@ -43,9 +41,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept(null)
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess(null)
+        0 * listener._
     }
 
     def "contains of missing element is tracked"() {
@@ -54,9 +51,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('missing')
+        0 * listener._
     }
 
     def "contains of inconvertible element is tracked"() {
@@ -65,9 +61,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept(123)
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess(123)
+        0 * listener._
     }
 
     def "containsAll of existing elements is tracked"() {
@@ -76,10 +71,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         result
-        1 * consumer.accept('existing')
-        1 * consumer.accept('other')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('existing')
+        1 * listener.onAccess('other')
+        0 * listener._
     }
 
     def "containsAll of missing elements is tracked"() {
@@ -88,10 +82,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing')
-        1 * consumer.accept('alsoMissing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('missing')
+        1 * listener.onAccess('alsoMissing')
+        0 * listener._
     }
 
     def "containsAll of missing and existing elements is tracked"() {
@@ -100,10 +93,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing')
-        1 * consumer.accept('existing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('missing')
+        1 * listener.onAccess('existing')
+        0 * listener._
     }
 
     def "remove of existing element is tracked"() {
@@ -112,9 +104,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         result
-        1 * consumer.accept('existing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('existing')
+        0 * listener._
     }
 
     def "remove of missing element is tracked"() {
@@ -123,9 +114,8 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('missing')
+        0 * listener._
     }
 
     def "removeAll of existing elements is tracked"() {
@@ -134,10 +124,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         result
-        1 * consumer.accept('existing')
-        1 * consumer.accept('other')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('existing')
+        1 * listener.onAccess('other')
+        0 * listener._
     }
 
     def "removeAll of missing elements is tracked"() {
@@ -146,10 +135,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         !result
-        1 * consumer.accept('missing')
-        1 * consumer.accept('alsoMissing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('missing')
+        1 * listener.onAccess('alsoMissing')
+        0 * listener._
     }
 
     def "removeAll of existing and missing elements is tracked"() {
@@ -158,10 +146,9 @@ class AccessTrackingSetTest extends Specification {
 
         then:
         result
-        1 * consumer.accept('existing')
-        1 * consumer.accept('missing')
-        0 * consumer._
-        0 * aggregatingAccess._
+        1 * listener.onAccess('existing')
+        1 * listener.onAccess('missing')
+        0 * listener._
     }
 
     def "method #methodName is reported as aggregating"() {
@@ -169,8 +156,8 @@ class AccessTrackingSetTest extends Specification {
         operation.accept(set)
 
         then:
-        0 * consumer._
-        (1.._) * aggregatingAccess.run()
+        (1.._) * listener.onAggregatingAccess()
+        0 * listener._
 
         where:
         methodName            | operation
@@ -191,8 +178,7 @@ class AccessTrackingSetTest extends Specification {
         operation.accept(set)
 
         then:
-        0 * consumer._
-        0 * aggregatingAccess.run()
+        0 * listener._
 
         where:
         methodName    | operation

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/AccessTrackingSetTest.groovy
@@ -116,46 +116,60 @@ class AccessTrackingSetTest extends Specification {
         then:
         !result
         1 * listener.onAccess('missing')
+        then:
         1 * listener.onRemove('missing')
+        then:
         0 * listener._
     }
 
     def "removeAll of existing elements is tracked"() {
         when:
-        def result = set.removeAll('existing', 'other')
+        def result = set.removeAll(['existing', 'other'])
 
         then:
         result
         1 * listener.onAccess('existing')
-        1 * listener.onAccess('other')
+        then:
         1 * listener.onRemove('existing')
+        then:
+        1 * listener.onAccess('other')
+        then:
         1 * listener.onRemove('other')
+        then:
         0 * listener._
     }
 
     def "removeAll of missing elements is tracked"() {
         when:
-        def result = set.removeAll('missing', 'alsoMissing')
+        def result = set.removeAll(['missing', 'alsoMissing'])
 
         then:
         !result
         1 * listener.onAccess('missing')
-        1 * listener.onAccess('alsoMissing')
+        then:
         1 * listener.onRemove('missing')
+        then:
+        1 * listener.onAccess('alsoMissing')
+        then:
         1 * listener.onRemove('alsoMissing')
+        then:
         0 * listener._
     }
 
     def "removeAll of existing and missing elements is tracked"() {
         when:
-        def result = set.removeAll('existing', 'missing')
+        def result = set.removeAll(['existing', 'missing'])
 
         then:
         result
         1 * listener.onAccess('existing')
-        1 * listener.onAccess('missing')
+        then:
         1 * listener.onRemove('existing')
+        then:
+        1 * listener.onAccess('missing')
+        then:
         1 * listener.onRemove('missing')
+        then:
         0 * listener._
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -235,7 +235,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/edd5a925756f9e184e86c343f144191a/thing.jar")
+        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -263,7 +263,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/a4cdf563229efdb0dd6757a7e5469f9b/thing.dir.jar")
+        def cachedFile = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -293,8 +293,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/a4cdf563229efdb0dd6757a7e5469f9b/thing.dir.jar")
-        def cachedFile = testDir.file("cached/edd5a925756f9e184e86c343f144191a/thing.jar")
+        def cachedDir = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
+        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -351,8 +351,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/a4cdf563229efdb0dd6757a7e5469f9b/thing.dir.jar")
-        def cachedFile = testDir.file("cached/edd5a925756f9e184e86c343f144191a/thing.jar")
+        def cachedDir = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
+        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -372,7 +372,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/2b088b2faf4c2cbf2d23a43d06e2dea2/thing.jar")
+        def cachedFile = testDir.file("cached/f5f441108338e7d1bebb5460a1fce0d9/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)


### PR DESCRIPTION
This is a complete fix to the problem of system properties updated at the configuration time.

The overall idea is simple: let's intercept all ways to update system properties and store updated values in the cache. Stored values are reapplied on the next run. The list of the properties removed at the configuration time is also stored in cache. If the user clears all system properties at once (by resetting them to something else or by clearing) then this fact is also stored. The order of mutations matter - if the build script sets some properties and removes them afterwards, then only removals are stored.
The ultimate goal is to have identical system properties at the execution phase regardless of running with the configuration phase or from the cache.

The core is the `EnvironmentChangeTracker` that receives all updates and maintains the actual list. The state is in the separate class `CachedEnvironmentState` with its own codec. The codec helps to provide a useful report (with property names) when some values are not serializable.

I tried to make the commits isolated without much back-and-forth. There are some drive-by fixes of the existing instrumentation of the dynamic Groovy code, but in separate commits.

Fixes #18432 
