### PR TITLE
Do not capture whole test instance when provider is enough

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/CleanupTestDirectoryExtension.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/CleanupTestDirectoryExtension.groovy
@@ -42,10 +42,10 @@ class CleanupTestDirectoryExtension implements IAnnotationDrivenExtension<Cleanu
 
         @Override
         void intercept(IMethodInvocation invocation) throws Throwable {
+            TestDirectoryProvider provider = GroovyRuntimeUtil.getProperty(invocation.instance, fieldName) as TestDirectoryProvider
             def noCleanupOnErrorListener = new AbstractRunListener() {
                 @Override
                 void error(ErrorInfo error) {
-                    TestDirectoryProvider provider = GroovyRuntimeUtil.getProperty(invocation.instance, fieldName) as TestDirectoryProvider
                     provider.suppressCleanup()
                 }
             }


### PR DESCRIPTION
The test listeners live for the entire test run duration. Capturing
a test instance in the listener prevents it from being GC'ed, and the
test instance can be quite large. Having hundreds of them can easily
cause OutOfMemoryError.

This commit reduces the retained size of the listener by only capturing
the test directory provider, which is much smaller.
