### PR TITLE
Add details/result to configuration cache load/store build operations

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":core-api"))
     implementation(project(":dependency-management"))
+    implementation(project(":enterprise-operations"))
     implementation(project(":execution"))
     implementation(project(":file-collections"))
     implementation(project(":file-temp"))
@@ -87,7 +88,6 @@ dependencies {
     testImplementation(libs.mockitoKotlin2)
     testImplementation(libs.kotlinCoroutinesDebug)
 
-    integTestImplementation(project(":enterprise-operations"))
     integTestImplementation(project(":jvm-services"))
     integTestImplementation(project(":tooling-api"))
     integTestImplementation(project(":platform-jvm"))

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.configurationcache.ConfigurationCacheLoadBuildOperationType
+import org.gradle.internal.configurationcache.ConfigurationCacheStoreBuildOperationType
+import org.gradle.test.fixtures.file.TestFile
+
+class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "emits no load/store build operations when not used"() {
+        given:
+        withLibBuild()
+        withAppBuild()
+
+        when:
+        inDirectory 'app'
+        run 'assemble'
+
+        then:
+        operations.all(ConfigurationCacheLoadBuildOperationType).empty
+        operations.all(ConfigurationCacheStoreBuildOperationType).empty
+    }
+
+    def "emits load/store build operations when used"() {
+        given:
+        withLibBuild()
+        withAppBuild()
+
+        when:
+        inDirectory 'app'
+        configurationCacheRun 'assemble'
+
+        then:
+        operations.all(ConfigurationCacheLoadBuildOperationType).empty
+        with(operations.all(ConfigurationCacheStoreBuildOperationType)) {
+            size() == 1
+            with(get(0)) {
+                details == [:]
+                it.result == [:]
+            }
+        }
+
+        when:
+        inDirectory 'app'
+        configurationCacheRun 'assemble'
+
+        then:
+        with(operations.all(ConfigurationCacheLoadBuildOperationType)) {
+            size() == 1
+            with(get(0)) {
+                details == [:]
+                it.result == [:]
+            }
+        }
+        operations.all(ConfigurationCacheStoreBuildOperationType).empty
+    }
+
+    private TestFile withLibBuild() {
+        createDir('lib') {
+            file('settings.gradle') << """
+                rootProject.name = 'lib'
+            """
+
+            file('build.gradle') << """
+                plugins { id 'java' }
+                group = 'org.test'
+                version = '1.0'
+            """
+
+            file('src/main/java/Lib.java') << """
+                public class Lib { public static void main() {
+                    System.out.println("Before!");
+                } }
+            """
+        }
+    }
+
+    private TestFile withAppBuild() {
+        createDir('app') {
+            file('settings.gradle') << """
+                includeBuild '../lib'
+            """
+            file('build.gradle') << """
+                plugins {
+                    id 'java'
+                    id 'application'
+                }
+                application {
+                   mainClass = 'Main'
+                }
+                dependencies {
+                    implementation 'org.test:lib:1.0'
+                }
+            """
+            file('src/main/java/Main.java') << """
+                class Main { public static void main(String[] args) {
+                    Lib.main();
+                } }
+            """
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheBuildOperationsIntegrationTest.groovy
@@ -77,7 +77,9 @@ class ConfigurationCacheBuildOperationsIntegrationTest extends AbstractConfigura
         given:
         withLibBuild(true)
         file('settings.gradle') << """
-            includeBuild 'lib'
+            pluginManagement {
+                includeBuild 'lib'
+            }
         """
         buildFile << """
             plugins {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -35,19 +35,19 @@ fun BuildOperationExecutor.withStoreOperation(cacheKey: String, block: () -> Uni
 
 
 private
-val loadDetails = object : ConfigurationCacheLoadBuildOperationType.Details {}
+object loadDetails : ConfigurationCacheLoadBuildOperationType.Details
 
 
 private
-val loadResult = object : ConfigurationCacheLoadBuildOperationType.Result {}
+object loadResult : ConfigurationCacheLoadBuildOperationType.Result
 
 
 private
-val storeDetails = object : ConfigurationCacheStoreBuildOperationType.Details {}
+object storeDetails : ConfigurationCacheStoreBuildOperationType.Details
 
 
 private
-val storeResult = object : ConfigurationCacheStoreBuildOperationType.Result {}
+object storeResult : ConfigurationCacheStoreBuildOperationType.Result
 
 
 private

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache
 
+import org.gradle.internal.configurationcache.ConfigurationCacheLoadBuildOperationType
+import org.gradle.internal.configurationcache.ConfigurationCacheStoreBuildOperationType
 import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationDescriptor
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -24,17 +26,36 @@ import org.gradle.internal.operations.CallableBuildOperation
 
 internal
 fun <T : Any> BuildOperationExecutor.withLoadOperation(block: () -> T) =
-    withOperation("Load configuration cache state", block)
+    withOperation("Load configuration cache state", block, loadDetails, loadResult)
 
 
 internal
 fun BuildOperationExecutor.withStoreOperation(cacheKey: String, block: () -> Unit) =
-    withOperation("Store configuration cache state $cacheKey", block)
+    withOperation("Store configuration cache state $cacheKey", block, storeDetails, storeResult)
 
 
 private
-fun <T : Any> BuildOperationExecutor.withOperation(displayName: String, block: () -> T): T =
+val loadDetails = object : ConfigurationCacheLoadBuildOperationType.Details {}
+
+
+private
+val loadResult = object : ConfigurationCacheLoadBuildOperationType.Result {}
+
+
+private
+val storeDetails = object : ConfigurationCacheStoreBuildOperationType.Details {}
+
+
+private
+val storeResult = object : ConfigurationCacheStoreBuildOperationType.Result {}
+
+
+private
+fun <T : Any, D : Any, R : Any> BuildOperationExecutor.withOperation(displayName: String, block: () -> T, details: D, result: R): T =
     call(object : CallableBuildOperation<T> {
-        override fun description() = BuildOperationDescriptor.displayName(displayName)
-        override fun call(context: BuildOperationContext) = block()
+        override fun description(): BuildOperationDescriptor.Builder =
+            BuildOperationDescriptor.displayName(displayName).details(details)
+
+        override fun call(context: BuildOperationContext): T =
+            block().also { context.setResult(result) }
     })

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildOperations.kt
@@ -26,28 +26,28 @@ import org.gradle.internal.operations.CallableBuildOperation
 
 internal
 fun <T : Any> BuildOperationExecutor.withLoadOperation(block: () -> T) =
-    withOperation("Load configuration cache state", block, loadDetails, loadResult)
+    withOperation("Load configuration cache state", block, LoadDetails, LoadResult)
 
 
 internal
 fun BuildOperationExecutor.withStoreOperation(cacheKey: String, block: () -> Unit) =
-    withOperation("Store configuration cache state $cacheKey", block, storeDetails, storeResult)
+    withOperation("Store configuration cache state $cacheKey", block, StoreDetails, StoreResult)
 
 
 private
-object loadDetails : ConfigurationCacheLoadBuildOperationType.Details
+object LoadDetails : ConfigurationCacheLoadBuildOperationType.Details
 
 
 private
-object loadResult : ConfigurationCacheLoadBuildOperationType.Result
+object LoadResult : ConfigurationCacheLoadBuildOperationType.Result
 
 
 private
-object storeDetails : ConfigurationCacheStoreBuildOperationType.Details
+object StoreDetails : ConfigurationCacheStoreBuildOperationType.Details
 
 
 private
-object storeResult : ConfigurationCacheStoreBuildOperationType.Result
+object StoreResult : ConfigurationCacheStoreBuildOperationType.Result
 
 
 private

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheLoadBuildOperationType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.configurationcache;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * Details about a configuration cache load build operation.
+ *
+ * @since 7.5
+ */
+public class ConfigurationCacheLoadBuildOperationType implements BuildOperationType<ConfigurationCacheLoadBuildOperationType.Details, ConfigurationCacheLoadBuildOperationType.Result> {
+
+    public interface Details {
+    }
+
+    public interface Result {
+    }
+
+}

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/internal/configurationcache/ConfigurationCacheStoreBuildOperationType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.configurationcache;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * Details about a configuration cache store build operation.
+ *
+ * @since 7.5
+ */
+public class ConfigurationCacheStoreBuildOperationType implements BuildOperationType<ConfigurationCacheStoreBuildOperationType.Details, ConfigurationCacheStoreBuildOperationType.Result> {
+
+    public interface Details {
+    }
+
+    public interface Result {
+    }
+
+}


### PR DESCRIPTION
### Context
Gradle Enterprise 2022.2 will contain CC timing information for CC load/store operations, on the "Perf > Config tab" page.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
