### PR TITLE
JDK 18 Support

### DIFF
--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -22,7 +22,7 @@ enum class JvmCategory(
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
     MAX_LTS_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java17),
-    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java18),
+    MAX_VERSION(JvmVendor.oracle, JvmVersion.java18),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java11),
     EXPERIMENTAL_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18)
 }

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -21,7 +21,8 @@ enum class JvmCategory(
     override val version: JvmVersion
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18),
+    MAX_LTS_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java17),
+    MAX_VERSION(JvmVendor.openjdk, JvmVersion.java18),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java11),
     EXPERIMENTAL_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18)
 }

--- a/.teamcity/src/main/kotlin/common/JvmCategory.kt
+++ b/.teamcity/src/main/kotlin/common/JvmCategory.kt
@@ -21,7 +21,7 @@ enum class JvmCategory(
     override val version: JvmVersion
 ) : Jvm {
     MIN_VERSION(JvmVendor.oracle, JvmVersion.java8),
-    MAX_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java17),
+    MAX_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18),
     SANTA_TRACKER_SMOKE_TEST_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java11),
     EXPERIMENTAL_VERSION(JvmVendor.adoptiumopenjdk, JvmVersion.java18)
 }

--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -91,7 +91,11 @@ enum class Os(
 
     fun javaInstallationLocations(): String {
         val paths = enumValues<JvmVersion>().joinToString(",") { version ->
-            val vendor = if (version.major >= 11) JvmVendor.adoptiumopenjdk else JvmVendor.oracle
+            val vendor = when {
+                version.major == 18 -> JvmVendor.openjdk
+                version.major >= 11 -> JvmVendor.adoptiumopenjdk
+                else -> JvmVendor.oracle
+            }
             javaHome(DefaultJvm(version, vendor), this)
         }
         return """"-Porg.gradle.java.installations.paths=$paths""""

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -78,7 +78,7 @@ data class CIBuildModel(
             ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
-                TestCoverage(4, TestType.platform, Os.WINDOWS, JvmCategory.MAX_VERSION),
+                TestCoverage(4, TestType.platform, Os.WINDOWS, JvmCategory.MAX_LTS_VERSION),
                 TestCoverage(20, TestType.configCache, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE)
             )
         ),
@@ -104,14 +104,14 @@ data class CIBuildModel(
                 SpecificBuild.FlakyTestQuarantineWindows
             ),
             functionalTests = listOf(
-                TestCoverage(7, TestType.parallel, Os.LINUX, JvmCategory.MAX_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
-                TestCoverage(8, TestType.soak, Os.LINUX, JvmCategory.MAX_VERSION, 1),
+                TestCoverage(7, TestType.parallel, Os.LINUX, JvmCategory.MAX_LTS_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
+                TestCoverage(8, TestType.soak, Os.LINUX, JvmCategory.MAX_LTS_VERSION, 1),
                 TestCoverage(9, TestType.soak, Os.WINDOWS, JvmCategory.MIN_VERSION, 1),
                 TestCoverage(35, TestType.soak, Os.MACOS, JvmCategory.MIN_VERSION, 1),
                 TestCoverage(10, TestType.allVersionsCrossVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(11, TestType.allVersionsCrossVersion, Os.WINDOWS, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
                 TestCoverage(12, TestType.noDaemon, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
-                TestCoverage(13, TestType.noDaemon, Os.WINDOWS, JvmCategory.MAX_VERSION),
+                TestCoverage(13, TestType.noDaemon, Os.WINDOWS, JvmCategory.MAX_LTS_VERSION),
                 TestCoverage(14, TestType.platform, Os.MACOS, JvmCategory.MIN_VERSION, expectedBucketNumber = 20),
                 TestCoverage(15, TestType.forceRealizeDependencyManagement, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
                 TestCoverage(33, TestType.allVersionsIntegMultiVersion, Os.LINUX, JvmCategory.MIN_VERSION, ALL_CROSS_VERSION_BUCKETS.size),
@@ -377,7 +377,7 @@ enum class SpecificBuild {
     },
     SmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return SmokeTests(model, stage, JvmCategory.MAX_VERSION)
+            return SmokeTests(model, stage, JvmCategory.MAX_LTS_VERSION)
         }
     },
     SantaTrackerSmokeTests {
@@ -392,7 +392,7 @@ enum class SpecificBuild {
     },
     GradleBuildSmokeTests {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, GRADLE_BUILD_SMOKE_TEST_NAME)
+            return SmokeTests(model, stage, JvmCategory.MAX_LTS_VERSION, GRADLE_BUILD_SMOKE_TEST_NAME)
         }
     },
     ConfigCacheSmokeTestsMinJavaVersion {
@@ -402,7 +402,7 @@ enum class SpecificBuild {
     },
     ConfigCacheSmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return SmokeTests(model, stage, JvmCategory.MAX_VERSION, "configCacheSmokeTest")
+            return SmokeTests(model, stage, JvmCategory.MAX_LTS_VERSION, "configCacheSmokeTest")
         }
     },
     FlakyTestQuarantineLinux {

--- a/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
+++ b/.teamcity/src/test/kotlin/ApplyDefaultConfigurationTest.kt
@@ -143,8 +143,8 @@ class ApplyDefaultConfigurationTest {
 
     private
     fun expectedRunnerParam(daemon: String = "--daemon", extraParameters: String = "", os: Os = Os.LINUX): String {
-        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.adoptiumopenjdk.64bit%"
-        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.adoptiumopenjdk.64bit%,%windows.java17.adoptiumopenjdk.64bit%,%windows.java18.adoptiumopenjdk.64bit%"
+        val linuxPaths = "-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.openjdk.64bit%"
+        val windowsPaths = "-Porg.gradle.java.installations.paths=%windows.java8.oracle.64bit%,%windows.java11.adoptiumopenjdk.64bit%,%windows.java17.adoptiumopenjdk.64bit%,%windows.java18.openjdk.64bit%"
         val expectedInstallationPaths = if (os == Os.WINDOWS) windowsPaths else linuxPaths
         return "-Dorg.gradle.workers.max=%maxParallelForks% -PmaxParallelForks=%maxParallelForks% -Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url% -s --no-configuration-cache %additional.gradle.parameters% $daemon --continue $extraParameters \"-Dscan.tag.Check\" \"-Dscan.tag.\" -PteamCityBuildId=%teamcity.build.id% \"$expectedInstallationPaths\" -Porg.gradle.java.installations.auto-download=false"
     }

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -93,7 +93,7 @@ class PerformanceTestBuildTypeTest {
             "-PautoDownloadAndroidStudio=true",
             "-PrunAndroidStudioInHeadlessMode=true",
             "-Porg.gradle.java.installations.auto-download=false",
-            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.adoptiumopenjdk.64bit%\"",
+            "\"-Porg.gradle.java.installations.paths=%linux.java8.oracle.64bit%,%linux.java11.adoptiumopenjdk.64bit%,%linux.java17.adoptiumopenjdk.64bit%,%linux.java18.openjdk.64bit%\"",
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -6,7 +6,7 @@ description = "Provides a platform that constrains versions of external dependen
 
 // Here you should declare versions which should be shared by the different modules of buildSrc itself
 val javaParserVersion = "3.18.0"
-val groovyVersion = "3.0.9"
+val groovyVersion = "3.0.10"
 val asmVersion = "9.2"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -214,7 +214,7 @@ fun Test.configureJvmForTest() {
         project.testJavaVendor.map {
             when (it.toLowerCase()) {
                 "oracle" -> vendor.set(JvmVendorSpec.ORACLE)
-                "openjdk" -> vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+                "openjdk" -> vendor.set(JvmVendorSpec.ADOPTIUM)
             }
         }.getOrNull()
     }

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -16,9 +16,11 @@
 
 package org.gradle.buildinit.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
+import spock.lang.IgnoreIf
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
 import static org.hamcrest.CoreMatchers.allOf
@@ -206,6 +208,8 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         ].combinations()
     }
 
+    // Spock pulls an old version of Groovy that doesn't work with Java 18
+    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
     def "creates sample source with package and spock and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'spock', '--package', 'my.lib', '--dsl', scriptDsl.id)
@@ -227,6 +231,8 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         scriptDsl << ScriptDslFixture.SCRIPT_DSLS
     }
 
+    // Spock pulls an old version of Groovy that doesn't work with Java 18
+    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
     def "creates sample source with package and spock and #scriptDsl build scripts with --incubating"() {
         def dslFixture = dslFixtureFor(scriptDsl)
 

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/JavaLibraryInitIntegrationTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.buildinit.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitTestFramework
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
 import static org.hamcrest.CoreMatchers.allOf
@@ -209,7 +210,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     // Spock pulls an old version of Groovy that doesn't work with Java 18
-    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+    @Requires(TestPrecondition.JDK17_OR_EARLIER)
     def "creates sample source with package and spock and #scriptDsl build scripts"() {
         when:
         run('init', '--type', 'java-library', '--test-framework', 'spock', '--package', 'my.lib', '--dsl', scriptDsl.id)
@@ -232,7 +233,7 @@ class JavaLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
     }
 
     // Spock pulls an old version of Groovy that doesn't work with Java 18
-    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+    @Requires(TestPrecondition.JDK17_OR_EARLIER)
     def "creates sample source with package and spock and #scriptDsl build scripts with --incubating"() {
         def dslFixture = dslFixtureFor(scriptDsl)
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -16,12 +16,11 @@
 
 package org.gradle.api.reporting.model
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-import org.gradle.internal.os.OperatingSystem
-
-import static org.junit.Assume.assumeFalse
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ModelReportIntegrationTest extends AbstractIntegrationSpec {
@@ -223,11 +222,8 @@ model {
 
     // nb: specifically doesn't use the parsing fixture, so that the output is visualised
     //If you're changing this you will also need to change: src/snippets/modelRules/basicRuleSourcePlugin/basicRuleSourcePlugin-model-task.out
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "displays a report in the correct format"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         given:
         settingsFile << "rootProject.name = 'test'"
         buildFile << """
@@ -415,11 +411,8 @@ model {
 ''')
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "method rule sources have simple type names and correct order"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         given:
         buildFile << """
 ${managedNumbers()}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/model/ModelReportIntegrationTest.groovy
@@ -16,8 +16,12 @@
 
 package org.gradle.api.reporting.model
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.internal.os.OperatingSystem
+
+import static org.junit.Assume.assumeFalse
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ModelReportIntegrationTest extends AbstractIntegrationSpec {
@@ -220,6 +224,10 @@ model {
     // nb: specifically doesn't use the parsing fixture, so that the output is visualised
     //If you're changing this you will also need to change: src/snippets/modelRules/basicRuleSourcePlugin/basicRuleSourcePlugin-model-task.out
     def "displays a report in the correct format"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         given:
         settingsFile << "rootProject.name = 'test'"
         buildFile << """
@@ -408,6 +416,10 @@ model {
     }
 
     def "method rule sources have simple type names and correct order"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         given:
         buildFile << """
 ${managedNumbers()}

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -603,11 +603,16 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching 'org.gradle.docs.samples.*.snippet-java-library-module*.sample'
         }
 
-        // Disable tests that use JaCoCo under JDK 18 until JaCoCo 0.8.8 is released.
         if (javaVersion.isCompatibleWith(JavaVersion.VERSION_18)) {
+            // Disable tests that use JaCoCo under JDK 18 until JaCoCo 0.8.8 is released.
             excludeTestsMatching "org.gradle.docs.samples.SamplesTest.structuring-software-projects_*_aggregate-reports.sample"
             excludeTestsMatching "org.gradle.docs.samples.SamplesTest.structuring-software-projects_*_umbrella-build.sample"
             excludeTestsMatching "org.gradle.docs.samples.SamplesTest.jvm-multi-project-with-code-coverage-*.sample"
+            excludeTestsMatching "org.gradle.docs.samples.*.snippet-testing-jacoco-application*.sample"
+
+            // Disable tests that suffer from charset issues under JDK 18 for now
+            excludeTestsMatching "org.gradle.docs.samples.*.snippet-custom-model-internal-views_*_softwareModelExtend-iv.sample"
+            excludeTestsMatching "org.gradle.docs.samples.*.snippet-model-rules-basic-rule-source-plugin_*_basicRuleSourcePlugin-model-task.sample"
         }
     }
 }

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -602,6 +602,13 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching "org.gradle.docs.samples.*.incubating-java-modules-*.sample"
             excludeTestsMatching 'org.gradle.docs.samples.*.snippet-java-library-module*.sample'
         }
+
+        // Disable tests that use JaCoCo under JDK 18 until JaCoCo 0.8.8 is released.
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_18)) {
+            excludeTestsMatching "org.gradle.docs.samples.SamplesTest.structuring-software-projects_*_aggregate-reports.sample"
+            excludeTestsMatching "org.gradle.docs.samples.SamplesTest.structuring-software-projects_*_umbrella-build.sample"
+            excludeTestsMatching "org.gradle.docs.samples.SamplesTest.jvm-multi-project-with-code-coverage-*.sample"
+        }
     }
 }
 

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -119,6 +119,12 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
     JDK16_OR_EARLIER({
         JavaVersion.current() <= JavaVersion.VERSION_16
     }),
+    JDK17_OR_EARLIER({
+        JavaVersion.current() <= JavaVersion.VERSION_17
+    }),
+    JDK18_OR_LATER({
+        JavaVersion.current() >= JavaVersion.VERSION_18
+    }),
     JDK_ORACLE({
         System.getProperty('java.vm.vendor') == 'Oracle Corporation'
     }),
@@ -146,6 +152,9 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         WINDOWS.fulfilled && "embedded" != System.getProperty("org.gradle.integtest.executer")
     }),
     SUPPORTS_TARGETING_JAVA6({ !JDK12_OR_LATER.fulfilled }),
+    // Currently JDK 18 has a bug that prevents UTF-8 standard output on Windows.
+    // https://bugs.openjdk.java.net/browse/JDK-8283620
+    SUPPORTS_UTF8_STDOUT({ !(JDK18_OR_LATER.fulfilled && WINDOWS.fulfilled) }),
     // Currently mac agents are not that strong so we avoid running high-concurrency tests on them
     HIGH_PERFORMANCE(NOT_MAC_OS_X),
     NOT_EC2_AGENT({

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishValidationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishValidationIntegTest.groovy
@@ -16,15 +16,23 @@
 
 package org.gradle.api.publish.ivy
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.encoding.Identifier
 
 import javax.xml.namespace.QName
+
+import static org.junit.Assume.assumeFalse
 
 class IvyPublishValidationIntegTest extends AbstractIvyPublishIntegTest {
 
     @ToBeFixedForConfigurationCache
     def "can publish with metadata containing #identifier characters"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18) && identifier.displayName == "non-ascii"
+        )
         given:
         file("content-file") << "some content"
         def organisation = identifier.safeForFileName().decorate("org")

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishValidationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishValidationIntegTest.groovy
@@ -16,23 +16,19 @@
 
 package org.gradle.api.publish.ivy
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.encoding.Identifier
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import javax.xml.namespace.QName
-
-import static org.junit.Assume.assumeFalse
 
 class IvyPublishValidationIntegTest extends AbstractIvyPublishIntegTest {
 
     @ToBeFixedForConfigurationCache
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "can publish with metadata containing #identifier characters"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18) && identifier.displayName == "non-ascii"
-        )
         given:
         file("content-file") << "some content"
         def organisation = identifier.safeForFileName().decorate("org")

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -16,11 +16,15 @@
 
 package org.gradle.testing.jacoco.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
+import spock.lang.IgnoreIf
 
 import static org.hamcrest.CoreMatchers.startsWith
 
+// JaCoCo does not support Java 18 yet
+@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
 class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         multiProjectBuild("root", ["application", "direct", "transitive"]) {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -16,15 +16,16 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.hamcrest.CoreMatchers.startsWith
 
 // JaCoCo does not support Java 18 yet
-@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+@Requires(TestPrecondition.JDK17_OR_EARLIER)
 class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         multiProjectBuild("root", ["application", "direct", "transitive"]) {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
@@ -16,11 +16,15 @@
 
 package org.gradle.testing.jacoco.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import spock.lang.IgnoreIf
 
+// JaCoCo does not support Java 18 yet
+@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
 class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoCachingIntegrationTest.groovy
@@ -16,15 +16,16 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 // JaCoCo does not support Java 18 yet
-@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+@Requires(TestPrecondition.JDK17_OR_EARLIER)
 class JacocoCachingIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.testing.jacoco.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -24,7 +25,10 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportFixture
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import spock.lang.IgnoreIf
 
+// JaCoCo does not support Java 18 yet
+@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
 class JacocoPluginIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoPluginIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.api.Project
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -25,10 +25,11 @@ import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportFixture
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 // JaCoCo does not support Java 18 yet
-@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+@Requires(TestPrecondition.JDK17_OR_EARLIER)
 class JacocoPluginIntegrationTest extends AbstractIntegrationSpec implements InspectsConfigurationReport {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoReportRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoReportRelocationIntegrationTest.groovy
@@ -16,9 +16,13 @@
 
 package org.gradle.testing.jacoco.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import spock.lang.IgnoreIf
 
+// JaCoCo does not support Java 18 yet
+@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
 class JacocoReportRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoReportRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoReportRelocationIntegrationTest.groovy
@@ -16,13 +16,14 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractTaskRelocationIntegrationTest
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 // JaCoCo does not support Java 18 yet
-@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+@Requires(TestPrecondition.JDK17_OR_EARLIER)
 class JacocoReportRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
 
     private final JavaProjectUnderTest javaProjectUnderTest = new JavaProjectUnderTest(testDirectory)

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
@@ -16,13 +16,17 @@
 
 package org.gradle.testing.jacoco.plugins
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
+import spock.lang.IgnoreIf
 
 import static org.gradle.util.BinaryDiffUtils.levenshteinDistance
 import static org.gradle.util.BinaryDiffUtils.toHexStrings
 
+// JaCoCo does not support Java 18 yet
+@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
 class JacocoTestRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTestRelocationIntegrationTest.groovy
@@ -16,17 +16,18 @@
 
 package org.gradle.testing.jacoco.plugins
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.jacoco.plugins.fixtures.JavaProjectUnderTest
-import spock.lang.IgnoreIf
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.util.BinaryDiffUtils.levenshteinDistance
 import static org.gradle.util.BinaryDiffUtils.toHexStrings
 
 // JaCoCo does not support Java 18 yet
-@IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+@Requires(TestPrecondition.JDK17_OR_EARLIER)
 class JacocoTestRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override

--- a/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
+++ b/subprojects/jacoco/src/testFixtures/groovy/org/gradle/testing/jacoco/plugins/fixtures/JacocoCoverage.groovy
@@ -27,7 +27,9 @@ final class JacocoCoverage {
 
     // Release notes: https://www.jacoco.org/jacoco/trunk/doc/changes.html
     static List<String> getSupportedVersionsByJdk() {
-        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+        if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)) {
+            return filter(JacocoVersion.SUPPORTS_JDK_18)
+        } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
             return filter(JacocoVersion.SUPPORTS_JDK_17)
         } else if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
             return filter(JacocoVersion.SUPPORTS_JDK_16)
@@ -52,6 +54,7 @@ final class JacocoCoverage {
         static final SUPPORTS_JDK_15 = new JacocoVersion(0, 8, 6)
         static final SUPPORTS_JDK_16 = new JacocoVersion(0, 8, 6)
         static final SUPPORTS_JDK_17 = new JacocoVersion(0, 8, 7)
+        static final SUPPORTS_JDK_18 = new JacocoVersion(0, 8, 8)
 
         private final int major
         private final int minor

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/JacocoIntegrationTest.kt
@@ -3,6 +3,8 @@ package org.gradle.kotlin.dsl.integration
 import org.gradle.integtests.fixtures.RepoScriptBlockUtil
 import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.LeaksFileHandles
+import org.gradle.util.TestPrecondition
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 
@@ -11,6 +13,7 @@ class JacocoIntegrationTest : AbstractPluginIntegrationTest() {
 
     @Test
     fun `jacoco ignore codegen`() {
+        assumeTrue("JaCoCo does not support JDK 18 yet", TestPrecondition.JDK17_OR_EARLIER.isFulfilled)
         withBuildScript(
             """
             plugins {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
@@ -16,10 +16,13 @@
 
 package org.gradle.model.dsl.internal.transform
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.internal.os.OperatingSystem
 
 import static org.hamcrest.CoreMatchers.containsString
+import static org.junit.Assume.assumeFalse
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
@@ -141,6 +144,10 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
     }
 
     def "only closure literals can be used as rules"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         when:
         buildScript """
             class MyPlugin extends RuleSource {

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/internal/transform/ModelDslRuleDetectionIntegrationSpec.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.model.dsl.internal.transform
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-import org.gradle.internal.os.OperatingSystem
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.hamcrest.CoreMatchers.containsString
-import static org.junit.Assume.assumeFalse
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
@@ -143,11 +143,8 @@ class ModelDslRuleDetectionIntegrationSpec extends AbstractIntegrationSpec {
         ]
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "only closure literals can be used as rules"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         when:
         buildScript """
             class MyPlugin extends RuleSource {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -16,21 +16,17 @@
 
 package org.gradle.language.base
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-import org.gradle.internal.os.OperatingSystem
-
-import static org.junit.Assume.assumeFalse
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "model report for unmanaged software components shows them all"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         given:
         buildFile << """
             ${registerAllTypes()}
@@ -96,11 +92,8 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
             """.stripIndent().trim()
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "model report for managed software components show them all with their managed properties"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         given:
         buildFile << """
             ${registerAllTypes()}

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/ComponentModelReportIntegrationTest.groovy
@@ -16,13 +16,21 @@
 
 package org.gradle.language.base
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.internal.os.OperatingSystem
+
+import static org.junit.Assume.assumeFalse
 
 @UnsupportedWithConfigurationCache(because = "software model")
 class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
 
     def "model report for unmanaged software components shows them all"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         given:
         buildFile << """
             ${registerAllTypes()}
@@ -89,6 +97,10 @@ class ComponentModelReportIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "model report for managed software components show them all with their managed properties"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         given:
         buildFile << """
             ${registerAllTypes()}

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -16,12 +16,16 @@
 
 package org.gradle.language.base
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
+
+import static org.junit.Assume.assumeFalse
 
 @Requires(TestPrecondition.ONLINE)
 @UnsupportedWithConfigurationCache(because = "software model")
@@ -31,6 +35,10 @@ class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
 
     // NOTE If you change this, you'll also need to change docs/src/doc/snippets/customModel/languageType/groovy/softwareModelExtend-iv-model.out
     def "show mutated public view data but no internal view data in model report"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         given:
         sample internalViewsSample
         when:

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/InternalViewsSampleIntegrationTest.groovy
@@ -16,16 +16,13 @@
 
 package org.gradle.language.base
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
-
-import static org.junit.Assume.assumeFalse
 
 @Requires(TestPrecondition.ONLINE)
 @UnsupportedWithConfigurationCache(because = "software model")
@@ -34,11 +31,8 @@ class InternalViewsSampleIntegrationTest extends AbstractIntegrationSpec {
     Sample internalViewsSample = new Sample(temporaryFolder, "customModel/internalViews/groovy")
 
     // NOTE If you change this, you'll also need to change docs/src/doc/snippets/customModel/languageType/groovy/softwareModelExtend-iv-model.out
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "show mutated public view data but no internal view data in model report"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         given:
         sample internalViewsSample
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/InvokeDynamicGroovyCompilerSpec.groovy
@@ -18,7 +18,7 @@ package org.gradle.groovy.compile
 
 import org.gradle.integtests.fixtures.TargetVersions
 
-@TargetVersions(['3.0.9:indy'])
+@TargetVersions(['3.0.10:indy'])
 class InvokeDynamicGroovyCompilerSpec extends ApiGroovyCompilerIntegrationSpec {
     def canEnableAndDisableInvokeDynamicOptimization() {
         when:

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.test.fixtures.file.TestFile
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import spock.lang.IgnoreIf
 
 class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -353,6 +354,8 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
     }
 
     @ToBeFixedForConfigurationCache(because = ":buildDashboard")
+    // JaCoCo does not support Java 18 yet
+    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
     void 'dashboard includes JaCoCo reports'() {
         given:
         goodCode()

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/plugins/BuildDashboardPluginIntegrationTest.groovy
@@ -20,9 +20,10 @@ import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import spock.lang.IgnoreIf
 
 class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
@@ -355,7 +356,7 @@ class BuildDashboardPluginIntegrationTest extends WellBehavedPluginTest {
 
     @ToBeFixedForConfigurationCache(because = ":buildDashboard")
     // JaCoCo does not support Java 18 yet
-    @IgnoreIf({ JavaVersion.current() >= JavaVersion.VERSION_18 })
+    @Requires(TestPrecondition.JDK17_OR_EARLIER)
     void 'dashboard includes JaCoCo reports'() {
         given:
         goodCode()

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
@@ -15,13 +15,16 @@
  */
 package org.gradle.testing
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
+import org.gradle.internal.os.OperatingSystem
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
+import static org.junit.Assume.assumeFalse
 
 @TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE_JUPITER })
 class DefaultTestOrderingIntegrationTest extends MultiVersionIntegrationSpec {
@@ -43,6 +46,10 @@ public class ${testName} {
     }
 
     def "test classes are scanned and run in deterministic order by default"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         addEmptyTestClass("AdTest")
         addEmptyTestClass("AATest")
         addEmptyTestClass("AyTest")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/DefaultTestOrderingIntegrationTest.groovy
@@ -15,16 +15,16 @@
  */
 package org.gradle.testing
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestResources
-import org.gradle.internal.os.OperatingSystem
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE_JUPITER
-import static org.junit.Assume.assumeFalse
 
 @TargetCoverage({ JUNIT_4_LATEST + JUNIT_VINTAGE_JUPITER })
 class DefaultTestOrderingIntegrationTest extends MultiVersionIntegrationSpec {
@@ -45,11 +45,8 @@ public class ${testName} {
 """
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "test classes are scanned and run in deterministic order by default"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         addEmptyTestClass("AdTest")
         addEmptyTestClass("AATest")
         addEmptyTestClass("AyTest")

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -62,7 +62,7 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         type           | jdk
-        'differentJdk' | AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+        'differentJdk' | AvailableJavaHomes.differentJdk
         'current'      | Jvm.current()
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing
 
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -16,9 +16,11 @@
 
 package org.gradle.testing.junit
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
@@ -26,6 +28,7 @@ import static org.gradle.testing.fixture.JUnitCoverage.JUPITER
 import static org.gradle.testing.fixture.JUnitCoverage.VINTAGE
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.is
+import static org.junit.Assume.assumeFalse
 
 // https://github.com/junit-team/junit5/issues/1285
 @TargetCoverage({ JUNIT_4_LATEST + [JUPITER, VINTAGE] })
@@ -46,6 +49,10 @@ class JUnitLoggingOutputCaptureIntegrationTest extends JUnitMultiVersionIntegrat
     }
 
     def "captures logging output events"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         file("src/test/java/OkTest.java") << """
 public class OkTest {
     static {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -16,19 +16,19 @@
 
 package org.gradle.testing.junit
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.TargetCoverage
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_4_LATEST
 import static org.gradle.testing.fixture.JUnitCoverage.JUPITER
 import static org.gradle.testing.fixture.JUnitCoverage.VINTAGE
 import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.CoreMatchers.is
-import static org.junit.Assume.assumeFalse
 
 // https://github.com/junit-team/junit5/issues/1285
 @TargetCoverage({ JUNIT_4_LATEST + [JUPITER, VINTAGE] })
@@ -48,11 +48,8 @@ class JUnitLoggingOutputCaptureIntegrationTest extends JUnitMultiVersionIntegrat
         """
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "captures logging output events"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         file("src/test/java/OkTest.java") << """
 public class OkTest {
     static {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformOnJdk7IntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformOnJdk7IntegrationTest.groovy
@@ -18,12 +18,15 @@ package org.gradle.testing.junitplatform
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
+
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
+import static org.junit.Assume.assumeNotNull
 
 class JUnitPlatformOnJdk7IntegrationTest extends AbstractIntegrationSpec {
 
     def setup() {
         def jdk7 = AvailableJavaHomes.getJdk7()
+        assumeNotNull(jdk7)
         file("gradle.properties").writeProperties("org.gradle.java.installations.paths": jdk7.javaHome.canonicalPath)
         buildFile << """
             apply plugin: 'java'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -16,21 +16,28 @@
 
 package org.gradle.testing.testng
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestClassExecutionResult
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.GradleVersion
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER
 import static org.gradle.testing.fixture.TestNGCoverage.STANDARD_COVERAGE
 import static org.hamcrest.CoreMatchers.is
+import static org.junit.Assume.assumeFalse
 
 @TargetCoverage({STANDARD_COVERAGE})
 class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationSpec {
 
     def setup() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         buildFile << """
             apply plugin: "java"
             ${mavenCentralRepository()}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGLoggingOutputCaptureIntegrationTest.groovy
@@ -16,28 +16,25 @@
 
 package org.gradle.testing.testng
 
-import org.gradle.api.JavaVersion
+
 import org.gradle.integtests.fixtures.HtmlTestExecutionResult
 import org.gradle.integtests.fixtures.JUnitXmlTestExecutionResult
 import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.integtests.fixtures.TestClassExecutionResult
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.GradleVersion
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.testing.fixture.TestNGCoverage.FIXED_ICLASS_LISTENER
 import static org.gradle.testing.fixture.TestNGCoverage.STANDARD_COVERAGE
 import static org.hamcrest.CoreMatchers.is
-import static org.junit.Assume.assumeFalse
 
 @TargetCoverage({STANDARD_COVERAGE})
+@Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
 class TestNGLoggingOutputCaptureIntegrationTest extends MultiVersionIntegrationSpec {
 
     def setup() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         buildFile << """
             apply plugin: "java"
             ${mavenCentralRepository()}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -17,11 +17,15 @@
 package org.gradle.integtests.tooling.m8
 
 import org.apache.commons.io.output.TeeOutputStream
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApiLoggingSpecification
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
+
+import static org.junit.Assume.assumeFalse
 
 @LeaksFileHandles
 class ToolingApiLoggingCrossVersionSpec extends ToolingApiLoggingSpecification {
@@ -89,6 +93,10 @@ project.logger.debug("debug logging yyy");
     }
 
     def "client receives same standard output and standard error as if running from the command-line"() {
+        assumeFalse(
+            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
+            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
+        )
         toolingApi.verboseLogging = false
 
         file("build.gradle") << """

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -17,15 +17,13 @@
 package org.gradle.integtests.tooling.m8
 
 import org.apache.commons.io.output.TeeOutputStream
-import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.tooling.fixture.TestOutputStream
 import org.gradle.integtests.tooling.fixture.ToolingApiLoggingSpecification
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.GradleVersion
-
-import static org.junit.Assume.assumeFalse
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 @LeaksFileHandles
 class ToolingApiLoggingCrossVersionSpec extends ToolingApiLoggingSpecification {
@@ -92,11 +90,8 @@ project.logger.debug("debug logging yyy");
         shouldNotContainProviderLogging(err)
     }
 
+    @Requires(TestPrecondition.SUPPORTS_UTF8_STDOUT)
     def "client receives same standard output and standard error as if running from the command-line"() {
-        assumeFalse(
-            "Java 18 currently creates issues with System.out charset resulting in these tests failing",
-            OperatingSystem.current().isWindows() && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_18)
-        )
         toolingApi.verboseLogging = false
 
         file("build.gradle") << """


### PR DESCRIPTION
Fixes #19283 

JaCoCo needs to be updated to 0.8.8 (not released yet) for some tests.
Spock needs to be updated to 2.2 (not released yet) for some tests.
Many tests involving Unicode and System.out capture are disabled due to #20267.

In my opinion, none of the above are blockers on this being merged.

@blindpirate I added you as reviewer, I wanted to make sure it was okay to merge the change I made to make this run Java 18 instead of Java 17 on CI. Perhaps we wish to test both 17 and 18? Not sure.