### PR TITLE
Use Kotlin 1.6.20-RC2 for build

### DIFF
--- a/build-logic-commons/gradle-plugin/build.gradle.kts
+++ b/build-logic-commons/gradle-plugin/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
     compileOnly("com.gradle:gradle-enterprise-gradle-plugin:3.8")
 
     implementation("org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:2.2.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0-dev-1904")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20-RC2")
     implementation("org.gradle.kotlin:gradle-kotlin-dsl-conventions:0.7.0")
 }

--- a/build-logic-commons/settings.gradle.kts
+++ b/build-logic-commons/settings.gradle.kts
@@ -17,13 +17,6 @@
 dependencyResolutionManagement {
     repositories {
         gradlePluginPortal()
-        maven {
-            name = "Kotlin EAP repository"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-            content {
-                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
-            }
-        }
     }
 }
 

--- a/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.repositories.gradle.kts
@@ -39,12 +39,5 @@ repositories {
             includeGroup("io.usethesource")
         }
     }
-    maven {
-        name = "Kotlin EAP repository"
-        url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        content {
-            includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
-        }
-    }
     mavenCentral()
 }

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractBinaryCompatibilityTest.kt
@@ -190,13 +190,6 @@ abstract class AbstractBinaryCompatibilityTest {
                         apply(plugin = "kotlin")
                         the<ModuleIdentityExtension>().baseName.set("api-module")
                         repositories {
-                            maven {
-                                name = "Kotlin EAP repository"
-                                url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-                                content {
-                                    includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
-                                }
-                            }
                             mavenCentral()
                         }
                         dependencies {

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -10,7 +10,7 @@ val groovyVersion = "3.0.9"
 val asmVersion = "9.2"
 // To try out better kotlin compilation avoidance and incremental compilation
 // with -Pkotlin.incremental.useClasspathSnapshot=true
-val defaultBuildKotlinVersion = "1.7.0-dev-1904"
+val defaultBuildKotlinVersion = "1.6.20-RC2"
 
 val kotlinVersion = providers.gradleProperty("buildKotlinVersion")
     .getOrElse(defaultBuildKotlinVersion)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -17,13 +17,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven {
-            name = "Kotlin EAP repository"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-            content {
-                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
-            }
-        }
     }
 }
 
@@ -44,13 +37,6 @@ dependencyResolutionManagement {
             url = uri("https://repo.gradle.org/gradle/public")
             content {
                 includeModule("classycle", "classycle")
-            }
-        }
-        maven {
-            name = "Kotlin EAP repository"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-            content {
-                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
             }
         }
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,13 +14,6 @@ pluginManagement {
                 includeVersionByRegex("com.gradle.internal.test-selection", "com.gradle.internal.test-selection.gradle.plugin", rcAndMilestonesPattern)
             }
         }
-        maven {
-            name = "Kotlin EAP repository"
-            url = uri("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-            content {
-                includeVersionByRegex("org.jetbrains.kotlin", "kotlin-.*", "1.7.0-dev-1904")
-            }
-        }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
So we don't need to use 1.7.0-dev.

Tested it locally and the compilation avoidance still works.