### PR TITLE
Fix comment in PerformanceTestDirectoryProvider

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestDirectoryProvider.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestDirectoryProvider.groovy
@@ -23,7 +23,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 @CompileStatic
 class PerformanceTestDirectoryProvider extends TestNameTestDirectoryProvider {
     PerformanceTestDirectoryProvider(Class<?> klass) {
-        // NOTE: the space in the directory name is intentional
+        // Java does not support spaces in GC logging location
         super(new TestFile(new File("build/tmp/performance-test-files")), klass)
     }
 }


### PR DESCRIPTION
The comment was lost in https://github.com/gradle/gradle/commit/1af03ab6925aca7ed3d05831c6d0223408a83b67.

Kudos to @lacasseio for finding this.