### PR TITLE
Fix issue with deadlocking between test task and dependency resolution

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/TestMainAction.java
@@ -24,10 +24,7 @@ import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.TestStartEvent;
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor;
 import org.gradle.internal.time.Clock;
-import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
-
-import java.util.Collections;
 
 public class TestMainAction implements Runnable {
     private final Runnable detector;
@@ -58,9 +55,7 @@ public class TestMainAction implements Runnable {
                 detector.run();
             } finally {
                 // Release worker lease while waiting for tests to complete
-                // Do not release any other locks, so that other test tasks from the same project do not start running
-                WorkerLeaseRegistry.WorkerLease currentWorkerLease = workerLeaseService.getCurrentWorkerLease();
-                workerLeaseService.withoutLocks(Collections.singletonList(currentWorkerLease), new Runnable() {
+                workerLeaseService.blocking(new Runnable() {
                     @Override
                     public void run() {
                         processor.stop();

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/TestMainActionTest.groovy
@@ -43,8 +43,7 @@ class TestMainActionTest extends Specification {
         then:
         1* detector.run()
         then:
-        1 * workerLeaseService.currentWorkerLease >> lease
-        1 * workerLeaseService.withoutLocks([lease], _) >> { l, Runnable runnable -> runnable.run() }
+        1 * workerLeaseService.blocking(_) >> { Runnable runnable -> runnable.run() }
         1 * processor.stop()
         then:
         1 * timeProvider.getCurrentTime() >> 200L
@@ -68,8 +67,7 @@ class TestMainActionTest extends Specification {
         then:
         1 * detector.run() >> { throw failure }
         then:
-        1 * workerLeaseService.currentWorkerLease >> lease
-        1 * workerLeaseService.withoutLocks([lease], _) >> { l, Runnable runnable -> runnable.run() }
+        1 * workerLeaseService.blocking(_) >> { Runnable runnable -> runnable.run() }
         1 * processor.stop()
         then:
         1 * resultProcessor.completed(!null, !null)
@@ -119,8 +117,7 @@ class TestMainActionTest extends Specification {
         then:
         1 * detector.run()
         then:
-        1 * workerLeaseService.currentWorkerLease >> lease
-        1 * workerLeaseService.withoutLocks([lease], _) >> { l, Runnable runnable -> runnable.run() }
+        1 * workerLeaseService.blocking(_) >> { Runnable runnable -> runnable.run() }
         1 * processor.stop() >> { throw failure }
         then:
         1 * resultProcessor.completed(!null, !null)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #20269 

This reverts the change in 7.4 where we release only the worker lease, so that we now release both the project lock and worker lease while waiting for tests to complete.  Since the project lock has been split and there is an additional task execution lock, we can release the project lock without releasing the task execution lock, so that other things can reach over into the project, but we can still block other tasks from the same project from starting execution.