### PR TITLE
Remove ineffective JVM version tracking

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
@@ -22,6 +22,7 @@ import org.gradle.internal.classloader.ConfigurableClassLoaderHierarchyHasher;
 import org.gradle.internal.classloader.HashingClassLoaderFactory;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLoaderHierarchyHasher {
@@ -33,6 +34,7 @@ public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLo
         Map<ClassLoader, String> knownClassLoaders = Maps.newHashMap();
 
         String gradleVersion = GradleVersion.current().getVersion();
+        addClassLoader(knownClassLoaders, null, "bootstrap");
         addClassLoader(knownClassLoaders, registry.getRuntimeClassLoader(), "runtime:" + gradleVersion);
         addClassLoader(knownClassLoaders, registry.getGradleApiClassLoader(), "gradle-api:" + gradleVersion);
         addClassLoader(knownClassLoaders, registry.getGradleCoreApiClassLoader(), "gradle-core-api:" + gradleVersion);
@@ -41,9 +43,7 @@ public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLo
         return knownClassLoaders;
     }
 
-    private static void addClassLoader(Map<ClassLoader, String> knownClassLoaders, ClassLoader classLoader, String id) {
-        if (classLoader != null) {
-            knownClassLoaders.put(classLoader, id);
-        }
+    private static void addClassLoader(Map<ClassLoader, String> knownClassLoaders, @Nullable ClassLoader classLoader, String id) {
+        knownClassLoaders.put(classLoader, id);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
@@ -34,6 +34,9 @@ public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLo
         Map<ClassLoader, String> knownClassLoaders = Maps.newHashMap();
 
         String gradleVersion = GradleVersion.current().getVersion();
+
+        // Some implementations may use null to represent the bootstrap class loader and in such cases
+        // Class.getClassLoader() will return null when the class was loaded by the bootstrap class loader.
         addClassLoader(knownClassLoaders, null, "bootstrap");
         addClassLoader(knownClassLoaders, registry.getRuntimeClassLoader(), "runtime:" + gradleVersion);
         addClassLoader(knownClassLoaders, registry.getGradleApiClassLoader(), "gradle-api:" + gradleVersion);

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/RegistryAwareClassLoaderHierarchyHasher.java
@@ -32,13 +32,6 @@ public class RegistryAwareClassLoaderHierarchyHasher extends ConfigurableClassLo
     private static Map<ClassLoader, String> collectKnownClassLoaders(ClassLoaderRegistry registry) {
         Map<ClassLoader, String> knownClassLoaders = Maps.newHashMap();
 
-        String javaVmVersion = String.format("%s|%s", System.getProperty("java.vm.name"), System.getProperty("java.vm.vendor"));
-        ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
-        if (systemClassLoader != null) {
-            addClassLoader(knownClassLoaders, systemClassLoader, "system-app" + javaVmVersion);
-            addClassLoader(knownClassLoaders, systemClassLoader.getParent(), "system-ext" + javaVmVersion);
-        }
-
         String gradleVersion = GradleVersion.current().getVersion();
         addClassLoader(knownClassLoaders, registry.getRuntimeClassLoader(), "runtime:" + gradleVersion);
         addClassLoader(knownClassLoaders, registry.getGradleApiClassLoader(), "gradle-api:" + gradleVersion);

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -484,7 +484,7 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Only files and directories can be registered as outputs (was: TAR 'readable resource')")
     }
 
-    def "Task with duration input should be skipped"() {
+    def "task with base Java type input property can be up-to-date"() {
         buildFile << """
             class MyTask extends DefaultTask {
                 @Input Duration duration

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -483,4 +483,35 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         fails("taskWithInvalidOutput")
         failure.assertHasCause("Only files and directories can be registered as outputs (was: TAR 'readable resource')")
     }
+
+    def "Task with duration input should be skipped"() {
+        buildFile << """
+            class MyTask extends DefaultTask {
+                @Input Duration duration
+                @OutputFile File output
+
+                @TaskAction def exec() {
+                    output.text = duration.toString()
+                }
+            }
+
+            task myTask(type: MyTask) {
+                duration = Duration.ofMinutes(1)
+                output = project.file("build/output.txt")
+            }
+        """
+
+        when:
+        run ':myTask'
+
+        then:
+        executedAndNotSkipped ':myTask'
+
+        when:
+        run ':myTask'
+
+        then:
+        skipped ':myTask'
+    }
+
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Most (or all?) types that we track are loaded via one of our classloaders, and thus we never hit the system classloader. We only use the JVM version when tracking a task, transform or nested type that was loaded directly through the system classloader.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
