### PR TITLE
Support running configuration-cache-report as included build

### DIFF
--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -11,6 +11,8 @@ val configurationCacheReportPath by configurations.creating {
     attributes { attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named("configuration-cache-report")) }
 }
 
+// You can have a faster feedback loop by running `configuration-cache-report` as an included build
+// See https://github.com/gradle/configuration-cache-report#development-with-gradlegradle-and-composite-build
 dependencies {
     configurationCacheReportPath(libs.configurationCacheReport)
 }


### PR DESCRIPTION
So we can have a faster feedback loop.

It's documented here: https://github.com/gradle/configuration-cache-report#development-with-gradlegradle-and-composite-build

```
./gradlew <TheTaskToBeRunInGradleBuild> --include-build ../configuration-cache-report -Porg.gradle.dependency.verification=lenient
```

I made a change and verified it works.