### PR TITLE
Add default toolchains for MacOS.

### DIFF
--- a/subprojects/docs/src/docs/userguide/native/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native/native_software.adoc
@@ -862,10 +862,10 @@ The core Gradle tool chains are able to target the following architectures out o
 | Architectures
 
 | GCC
-| x86, x86_64
+| x86, x86_64, arm64 (macOS Only)
 
 | Clang
-| x86, x86_64
+| x86, x86_64, arm64 (macOS only)
 
 | Visual C++
 | x86, x86_64, ia-64

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -94,6 +94,8 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
 
         target(new Intel32Architecture());
         target(new Intel64Architecture());
+        target(new OsxIntelArchitecture());
+        target(new OsxArmArchitecture());
         configInsertLocation = 0;
     }
 
@@ -298,6 +300,7 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
         @Override
         public boolean supportsPlatform(NativePlatformInternal targetPlatform) {
             return targetPlatform.getOperatingSystem().isCurrent()
+                && !targetPlatform.getOperatingSystem().isMacOsX()
                 && targetPlatform.getArchitecture().isAmd64();
         }
 
@@ -316,6 +319,60 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
             gccToolChain.getObjcppCompiler().withArguments(m64args);
             gccToolChain.getLinker().withArguments(m64args);
             gccToolChain.getAssembler().withArguments(m64args);
+        }
+    }
+
+    private static class OsxIntelArchitecture implements TargetPlatformConfiguration {
+        @Override
+        public boolean supportsPlatform(NativePlatformInternal targetPlatform) {
+            return targetPlatform.getOperatingSystem().isCurrent()
+                && targetPlatform.getOperatingSystem().isMacOsX()
+                && targetPlatform.getArchitecture().isAmd64();
+        }
+
+        @Override
+        public void apply(DefaultGccPlatformToolChain gccToolChain) {
+            gccToolChain.compilerProbeArgs("-arch", "x86_64");
+            Action<List<String>> architectureArgs = new Action<List<String>>() {
+                @Override
+                public void execute(List<String> args) {
+                    args.add("-arch");
+                    args.add("x86_64");
+                }
+            };
+            gccToolChain.getCppCompiler().withArguments(architectureArgs);
+            gccToolChain.getcCompiler().withArguments(architectureArgs);
+            gccToolChain.getObjcCompiler().withArguments(architectureArgs);
+            gccToolChain.getObjcppCompiler().withArguments(architectureArgs);
+            gccToolChain.getLinker().withArguments(architectureArgs);
+            gccToolChain.getAssembler().withArguments(architectureArgs);
+        }
+    }
+
+    private static class OsxArmArchitecture implements TargetPlatformConfiguration {
+        @Override
+        public boolean supportsPlatform(NativePlatformInternal targetPlatform) {
+            return targetPlatform.getOperatingSystem().isCurrent()
+                && targetPlatform.getOperatingSystem().isMacOsX()
+                && targetPlatform.getArchitecture().isArm();
+        }
+
+        @Override
+        public void apply(DefaultGccPlatformToolChain gccToolChain) {
+            gccToolChain.compilerProbeArgs("-arch", "arm64");
+            Action<List<String>> architectureArgs = new Action<List<String>>() {
+                @Override
+                public void execute(List<String> args) {
+                    args.add("-arch");
+                    args.add("arm64");
+                }
+            };
+            gccToolChain.getCppCompiler().withArguments(architectureArgs);
+            gccToolChain.getcCompiler().withArguments(architectureArgs);
+            gccToolChain.getObjcCompiler().withArguments(architectureArgs);
+            gccToolChain.getObjcppCompiler().withArguments(architectureArgs);
+            gccToolChain.getLinker().withArguments(architectureArgs);
+            gccToolChain.getAssembler().withArguments(architectureArgs);
         }
     }
 
@@ -363,5 +420,4 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
             return delegate.getCompilerType();
         }
     }
-
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -46,8 +46,11 @@ import org.gradle.platform.base.internal.toolchain.ToolSearchResult
 import org.gradle.process.internal.ExecActionFactory
 import org.gradle.util.TestUtil
 import org.gradle.util.UsesNativeServices
+import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Specification
 
+import static org.gradle.nativeplatform.platform.internal.ArchitectureInternal.InstructionSet.ARM
 import static org.gradle.nativeplatform.platform.internal.ArchitectureInternal.InstructionSet.X86
 
 @UsesNativeServices
@@ -255,6 +258,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         assert platformActionApplied == 2
     }
 
+    @IgnoreIf(value = {os.macOs}, reason = "Not true on MacOS with multi-arch support")
     def "supplies no additional arguments to target native binary for tool chain default"() {
         def action = Mock(Action)
 
@@ -284,6 +288,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         ["-m64"]  | ["-m64"]
     }
 
+    @IgnoreIf(value = {os.macOs}, reason = "Code under test depends on current platform")
     def "supplies args for supported architecture for non-macOS platforms"() {
         def action = Mock(Action)
 
@@ -314,6 +319,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         "x86_64" | ["-m64"]  | ["-m64"]
     }
 
+    @Requires(value = {os.macOs}, reason = "Code under test depends on current platform")
     def "supplies args for supported architecture for macOS platforms"() {
         def action = Mock(Action)
 
@@ -341,9 +347,10 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         })
 
         where:
-        arch     | instructionSet | registerSize | linkerArg | compilerArg | assemblerArgs
-        "i386"   | X86            | 32           | []        | []          | []
-        "x86_64" | X86            | 64           | []        | []          | []
+        arch      | instructionSet | registerSize | linkerArg | compilerArg | assemblerArgs
+        "i386"    | X86            | 32           | []        | []          | []
+        "x86_64"  | X86            | 64           | []        | []          | []
+        "aarch64" | ARM            | 64           | []        | []          | []
     }
 
     def "uses supplied platform configurations in order to target binary"() {
@@ -430,7 +437,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
     }
 
     def argsFor(GccCommandLineToolConfiguration tool) {
-        assert tool in GccCommandLineToolConfigurationInternal : "Expected argument to be an instance of GccCommandLineToolConfigurationInternal"
+        assert tool instanceof GccCommandLineToolConfigurationInternal : "Expected argument to be an instance of GccCommandLineToolConfigurationInternal"
         def args = []
         tool.getArgAction().execute(args)
         args


### PR DESCRIPTION
Fixes [gradle-native #1096](https://github.com/gradle/gradle-native/issues/1096)

Adds two new default toolchain targets for MacOS x86_64 and
arm64 which use Clang's `-arch` argument to target the correct
architecture.  On MacOS, this is used in preference to the
existing `Intel64Architecture` target which passes `-m64` to the
toolchain.

This is sufficient for `NativeExecutableSpec` to target
`osx_x86-64` and `osx_aarch64` on both Intel and M1 Macs.

I haven't (yet!) located any tests for this functionality, and
so this PR doesn't include any test changes.  Happy to add them
if you can point me in the right direction.

Signed-off-by: Pete Bentley <prb@google.com>

<!--- The issue this PR addresses -->
Fixes [gradle-native #1096](https://github.com/gradle/gradle-native/issues/1096)

### Context
Ease of use on both Intel and ARM based Macs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
