### PR TITLE
Fix windows script return code

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.launchable-jar.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.launchable-jar.gradle.kts
@@ -46,6 +46,9 @@ tasks.jar.configure {
 val startScripts = tasks.register<GradleStartScriptGenerator>("startScripts") {
     startScriptsDir.set(layout.buildDirectory.dir("startScripts"))
     launcherJar.from(tasks.jar)
+    // The trick below is to use the templates from the current code instead of the wrapper. It does not cover the case where the generation logic is updated though.
+    unixScriptTemplate.from(layout.projectDirectory.file("../plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt"))
+    windowsScriptTemplate.from(layout.projectDirectory.file("../plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt"))
 }
 
 configurations {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild/startscript/tasks/GradleStartScriptGenerator.kt
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild/startscript/tasks/GradleStartScriptGenerator.kt
@@ -18,14 +18,24 @@ package gradlebuild.startscript.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.internal.plugins.StartScriptGenerator
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.internal.file.temp.TemporaryFileProvider
+import org.gradle.api.internal.plugins.DefaultTemplateBasedStartScriptGenerator
+import org.gradle.api.internal.plugins.StartScriptGenerator
+import org.gradle.api.internal.plugins.StartScriptTemplateBindingFactory
+import org.gradle.api.internal.resources.FileCollectionBackedTextResource
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.util.internal.TextUtil
+import java.nio.charset.StandardCharsets
+import javax.inject.Inject
 
 
 @CacheableTask
@@ -38,13 +48,25 @@ abstract class GradleStartScriptGenerator : DefaultTask() {
     val launcherJarName: String
         get() = launcherJar.singleFile.name
 
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val unixScriptTemplate: ConfigurableFileCollection
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val windowsScriptTemplate: ConfigurableFileCollection
+
     @get:OutputDirectory
     abstract val startScriptsDir: DirectoryProperty
+
+    @get:Inject
+    internal
+    abstract val temporaryFileProvider: TemporaryFileProvider
 
     @TaskAction
     fun generate() {
         logging.captureStandardOutput(LogLevel.INFO)
-        val generator = StartScriptGenerator()
+        val generator = StartScriptGenerator(createUnixStartScriptGenerator(), createWindowsStartScriptGenerator())
         generator.setApplicationName("Gradle")
         generator.setOptsEnvironmentVar("GRADLE_OPTS")
         generator.setExitEnvironmentVar("GRADLE_EXIT_CONSOLE")
@@ -56,4 +78,18 @@ abstract class GradleStartScriptGenerator : DefaultTask() {
         generator.generateUnixScript(startScriptsDir.file("gradle").get().asFile)
         generator.generateWindowsScript(startScriptsDir.file("gradle.bat").get().asFile)
     }
+
+    private
+    fun createUnixStartScriptGenerator() = DefaultTemplateBasedStartScriptGenerator(
+        TextUtil.getUnixLineSeparator(),
+        StartScriptTemplateBindingFactory.unix(),
+        FileCollectionBackedTextResource(temporaryFileProvider, unixScriptTemplate, StandardCharsets.UTF_8)
+    )
+
+    private
+    fun createWindowsStartScriptGenerator() = DefaultTemplateBasedStartScriptGenerator(
+        TextUtil.getWindowsLineSeparator(),
+        StartScriptTemplateBindingFactory.windows(),
+        FileCollectionBackedTextResource(temporaryFileProvider, windowsScriptTemplate, StandardCharsets.UTF_8)
+    )
 }

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -81,8 +81,10 @@ if %ERRORLEVEL% equ 0 goto mainEnd
 :fail
 rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if not ""=="%${exitEnvironmentVar}%" exit %ERRORLEVEL%
-exit /b %ERRORLEVEL%
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%${exitEnvironmentVar}%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 89
+        destination.toString().split(TextUtil.windowsLineSeparator).length == 91
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {


### PR DESCRIPTION
There was a path where ERRORLEVEL was not set but the script failed.
This change makes sure that we return a non zero code in that case.