### PR TITLE
Fallback to x64 for jvm8 in toolchain on aarch64 for Windows and macOS

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -126,7 +126,8 @@ public class AdoptOpenJdkRemoteBinary {
 
     public String toFilename(JavaToolchainSpec spec) {
         JavaLanguageVersion javaLanguageVersion = determineLanguageVersion(spec);
-        return String.format("%s-%s-%s-%s-%s.%s", determineVendor(spec), javaLanguageVersion, determineArch(javaLanguageVersion), determineImplementation(spec), determineOs(), determineFileExtension());
+        String osString = determineOs();
+        return String.format("%s-%s-%s-%s-%s.%s", determineVendor(spec), javaLanguageVersion, determineArch(javaLanguageVersion, osString), determineImplementation(spec), osString, determineFileExtension());
     }
 
     private String determineFileExtension() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -71,7 +71,7 @@ public class AdoptOpenJdkRemoteBinary {
 
         if (vendorSpec.test(JvmVendor.KnownJvmVendor.ADOPTOPENJDK.asJvmVendor())) {
             DeprecationLogger.deprecateBehaviour("Due to changes in AdoptOpenJDK download endpoint, downloading a JDK with an explicit vendor of AdoptOpenJDK should be replaced with a spec without a vendor or using Eclipse Temurin / IBM Semeru.")
-                .willBeRemovedInGradle8().withUpgradeGuideSection(7, "adoptopenjdk_download").nagUser();
+                    .willBeRemovedInGradle8().withUpgradeGuideSection(7, "adoptopenjdk_download").nagUser();
             return true;
         }
 
@@ -88,17 +88,18 @@ public class AdoptOpenJdkRemoteBinary {
 
     private URI constructUri(JavaToolchainSpec spec) {
         JavaLanguageVersion javaLanguageVersion = determineLanguageVersion(spec);
+        String osString = determineOs();
         return URI.create(getServerBaseUri() +
-            "v3/binary/latest/" + javaLanguageVersion.toString() +
-            "/" +
-            determineReleaseState() +
-            "/" +
-            determineOs() +
-            "/" +
-            determineArch(javaLanguageVersion) +
-            "/jdk/" +
-            determineImplementation(spec) +
-            "/normal/adoptopenjdk");
+                "v3/binary/latest/" + javaLanguageVersion +
+                "/" +
+                determineReleaseState() +
+                "/" +
+                osString +
+                "/" +
+                determineArch(javaLanguageVersion, osString) +
+                "/jdk/" +
+                determineImplementation(spec) +
+                "/normal/adoptopenjdk");
     }
 
     private String determineImplementation(JavaToolchainSpec spec) {
@@ -139,14 +140,14 @@ public class AdoptOpenJdkRemoteBinary {
         return spec.getLanguageVersion().get();
     }
 
-    private String determineArch(JavaLanguageVersion javaLanguageVersion) {
+    private String determineArch(JavaLanguageVersion javaLanguageVersion, String osString) {
         switch (systemInfo.getArchitecture()) {
             case i386:
                 return "x32";
             case amd64:
                 return "x64";
             case aarch64:
-                if(javaLanguageVersion.asInt() <= 8) {
+                if (javaLanguageVersion.asInt() <= 8 && (osString.equalsIgnoreCase("mac") || osString.equals("windows"))) {
                     return "x64";
                 } else {
                     return "aarch64";

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -148,7 +148,7 @@ public class AdoptOpenJdkRemoteBinary {
             case amd64:
                 return "x64";
             case aarch64:
-                if (javaLanguageVersion.asInt() <= 8 && (osString.equalsIgnoreCase("mac") || osString.equals("windows"))) {
+                if (javaLanguageVersion.asInt() <= 8 && (osString.equalsIgnoreCase("mac") || osString.equalsIgnoreCase("windows"))) {
                     return "x64";
                 } else {
                     return "aarch64";

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -87,14 +87,15 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     private URI constructUri(JavaToolchainSpec spec) {
+        JavaLanguageVersion javaLanguageVersion = determineLanguageVersion(spec);
         return URI.create(getServerBaseUri() +
-            "v3/binary/latest/" + determineLanguageVersion(spec).toString() +
+            "v3/binary/latest/" + javaLanguageVersion.toString() +
             "/" +
             determineReleaseState() +
             "/" +
             determineOs() +
             "/" +
-            determineArch() +
+            determineArch(javaLanguageVersion) +
             "/jdk/" +
             determineImplementation(spec) +
             "/normal/adoptopenjdk");
@@ -137,14 +138,18 @@ public class AdoptOpenJdkRemoteBinary {
         return spec.getLanguageVersion().get();
     }
 
-    private String determineArch() {
+    private String determineArch(JavaLanguageVersion javaLanguageVersion) {
         switch (systemInfo.getArchitecture()) {
             case i386:
                 return "x32";
             case amd64:
                 return "x64";
             case aarch64:
-                return "aarch64";
+                if(!javaLanguageVersion.canCompileOrRun(9)) {
+                    return "x64";
+                } else {
+                    return "aarch64";
+                }
         }
         return systemInfo.getArchitectureName();
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java
@@ -124,7 +124,8 @@ public class AdoptOpenJdkRemoteBinary {
     }
 
     public String toFilename(JavaToolchainSpec spec) {
-        return String.format("%s-%s-%s-%s-%s.%s", determineVendor(spec), determineLanguageVersion(spec), determineArch(), determineImplementation(spec), determineOs(), determineFileExtension());
+        JavaLanguageVersion javaLanguageVersion = determineLanguageVersion(spec);
+        return String.format("%s-%s-%s-%s-%s.%s", determineVendor(spec), javaLanguageVersion, determineArch(javaLanguageVersion), determineImplementation(spec), determineOs(), determineFileExtension());
     }
 
     private String determineFileExtension() {
@@ -145,7 +146,7 @@ public class AdoptOpenJdkRemoteBinary {
             case amd64:
                 return "x64";
             case aarch64:
-                if(!javaLanguageVersion.canCompileOrRun(9)) {
+                if(javaLanguageVersion.asInt() <= 8) {
                     return "x64";
                 } else {
                     return "aarch64";

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -58,7 +58,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         13         | "Linux"             | SystemInfo.Architecture.aarch64 | "/13/ga/linux/aarch64/jdk/hotspot/normal/adoptopenjdk"
         11         | "Mac OS X"          | SystemInfo.Architecture.amd64   | "/11/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
         12         | "Darwin"            | SystemInfo.Architecture.i386    | "/12/ga/mac/x32/jdk/hotspot/normal/adoptopenjdk"
-        8          | "OSX"               | SystemInfo.Architecture.aarch64 | "/11/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
+        8          | "OSX"               | SystemInfo.Architecture.aarch64 | "/8/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
         13         | "OSX"               | SystemInfo.Architecture.aarch64 | "/13/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk"
         13         | "Solaris"           | SystemInfo.Architecture.i386    | "/13/ga/solaris/x32/jdk/hotspot/normal/adoptopenjdk"
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -58,6 +58,7 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
         13         | "Linux"             | SystemInfo.Architecture.aarch64 | "/13/ga/linux/aarch64/jdk/hotspot/normal/adoptopenjdk"
         11         | "Mac OS X"          | SystemInfo.Architecture.amd64   | "/11/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
         12         | "Darwin"            | SystemInfo.Architecture.i386    | "/12/ga/mac/x32/jdk/hotspot/normal/adoptopenjdk"
+        8          | "OSX"               | SystemInfo.Architecture.aarch64 | "/11/ga/mac/x64/jdk/hotspot/normal/adoptopenjdk"
         13         | "OSX"               | SystemInfo.Architecture.aarch64 | "/13/ga/mac/aarch64/jdk/hotspot/normal/adoptopenjdk"
         13         | "Solaris"           | SystemInfo.Architecture.i386    | "/13/ga/solaris/x32/jdk/hotspot/normal/adoptopenjdk"
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinaryTest.groovy
@@ -50,9 +50,11 @@ class AdoptOpenJdkRemoteBinaryTest extends Specification {
 
         where:
         jdkVersion | operatingSystemName | architecture                    | expectedPath
+        8          | "Windows"           | SystemInfo.Architecture.aarch64 | "/8/ga/windows/x64/jdk/hotspot/normal/adoptopenjdk"
         11         | "Windows"           | SystemInfo.Architecture.amd64   | "/11/ga/windows/x64/jdk/hotspot/normal/adoptopenjdk"
         12         | "Windows"           | SystemInfo.Architecture.i386    | "/12/ga/windows/x32/jdk/hotspot/normal/adoptopenjdk"
         13         | "Windows"           | SystemInfo.Architecture.aarch64 | "/13/ga/windows/aarch64/jdk/hotspot/normal/adoptopenjdk"
+        8          | "Linux"             | SystemInfo.Architecture.aarch64 | "/8/ga/linux/aarch64/jdk/hotspot/normal/adoptopenjdk"
         11         | "Linux"             | SystemInfo.Architecture.amd64   | "/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk"
         12         | "Linux"             | SystemInfo.Architecture.i386    | "/12/ga/linux/x32/jdk/hotspot/normal/adoptopenjdk"
         13         | "Linux"             | SystemInfo.Architecture.aarch64 | "/13/ga/linux/aarch64/jdk/hotspot/normal/adoptopenjdk"


### PR DESCRIPTION
### Context
This will fix the fact, that on aarch64 processors it is not possible to build software that targets the toolchain version 8. Mainly it fixes it for m1 processors. 
Nevertheless for other system the aarch64 package for adoptopenjdk8 is not existent, so it cannot be downloaded.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
