### PR TITLE
Fix DirectorySnapshotterAsDirectoryWalkerTest

### DIFF
--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -49,7 +49,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
                 def elementFromFileWalker = visitedWithJdk7Walker.find { it.file == element.file }
                 assert elementFromFileWalker != null
                 assert element.directory == elementFromFileWalker.directory
-                assert element.lastModified == elementFromFileWalker.lastModified
+                assert (element.lastModified / 1000).toLong() == (elementFromFileWalker.lastModified / 1000).toLong()
                 assert element.size == elementFromFileWalker.size
                 assert element.name == elementFromFileWalker.name
                 assert element.path == elementFromFileWalker.path


### PR DESCRIPTION
After upgrading to latest Oracle JDK, the test started failing with:

```
assert element.lastModified == elementFromFileWalker.lastModified
       |       |            |  |                     |
       |       1648771753663|  |                     1648771753000
```

We simply normalize it to unblock master.