### PR TITLE
Rewrites comment to correct typo: word "loose"

### DIFF
--- a/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/model/GradleDistribution.kt
+++ b/build-logic/integration-testing/src/main/kotlin/gradlebuild/integrationtests/model/GradleDistribution.kt
@@ -27,7 +27,7 @@ import java.util.SortedSet
 open class GradleDistribution(private val gradleHomeDir: FileCollection) {
 
     /**
-     * Make sure this stays type FileCollection (lazy) to not loose dependency information.
+     * Make sure this stays type FileCollection (lazy) to avoid losing dependency information.
      */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Rewrites comment to read better
Rewrites comment to correct typo: word "loose"

Signed-off-by: T-A-B <78736596+T-A-B@users.noreply.github.com>

<!--- The issue this PR addresses -->
Fixes #?  Comment language is ineffective.

### Context
<!--- Why do you believe many users will benefit from this change? -->
Readability is increased which will allow for faster comprehension of the edited file.

<!--- Link to relevant issues or forum discussions here -->
N/A

### Contributor Checklist
- [ x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
