### PR TITLE
Fix dependency verification when Gradle metadata file name doesn't match actual file name

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/validation/GradleMetadataValidationResolveIntegrationTest.groovy
@@ -68,7 +68,7 @@ class GradleMetadataValidationResolveIntegrationTest extends AbstractModuleDepen
         repository {
             'org.test:projectA:1.1' {
                 variant("api") {
-                    artifact("name", null)
+                    artifact("name", null, "name")
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1680,7 +1680,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
     }
 
     @Issue("https://github.com/gradle/gradle/issues/20098")
-    def "doesn't fail validating signature for variant that has file name different than real name"() {
+    def "doesn't fail for a variant that has a file name in the Gradle Module Metadata different to actual artifact"() {
         createMetadataFile {
             keyServer(keyServerFixture.uri)
             verifySignatures()
@@ -1704,17 +1704,11 @@ This can indicate that a dependency has been compromised. Please carefully verif
             }
         }.withModuleMetadata().publish()
         buildFile << """
-            FileCollection customConfiguration = configurations.create("customConfiguration")
             dependencies {
-                add("customConfiguration", "org:foo:1.0") {
+                implementation("org:foo:1.0") {
                     attributes {
                         attribute(Attribute.of(Usage.USAGE_ATTRIBUTE.name, String), "linux64")
                     }
-                }
-            }
-            tasks.register("myTask") {
-                doFirst {
-                    customConfiguration.resolve()
                 }
             }
         """
@@ -1723,7 +1717,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
         serveValidKey()
 
         then:
-        succeeds "myTask"
+        succeeds ":compileJava"
     }
 
     private static void tamperWithFile(File file) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1679,6 +1679,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
 This can indicate that a dependency has been compromised. Please carefully verify the signatures and checksums. Key servers are disabled, this can indicate that you need to update the local keyring with the missing keys."""
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/20098")
     def "doesn't fail validating signature for variant that has file name different than real name"() {
         createMetadataFile {
             keyServer(keyServerFixture.uri)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1686,7 +1686,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
             verifySignatures()
             addTrustedKey("org:foo:1.0", validPublicKeyHexString, "pom", "pom")
             addTrustedKey("org:foo:1.0", validPublicKeyHexString, "module", "module")
-            addTrustedKeyByFileName("org:foo:1.0", "foo-linux64-1.0.klib", validPublicKeyHexString)
+            addTrustedKeyByFileName("org:foo:1.0", "foo.klib", validPublicKeyHexString)
         }
 
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.verification
 
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
@@ -1696,7 +1697,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
             withoutDefaultVariants()
             withVariant("linux64") {
                 attribute(Usage.USAGE_ATTRIBUTE.name, "linux64")
-                attribute("org.gradle.category", "library")
+                attribute(Category.CATEGORY_ATTRIBUTE.name, Category.LIBRARY)
                 useDefaultArtifacts = false
                 artifact("foo.klib", "foo-linux64-1.0.klib")
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -246,11 +246,11 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
 
             public SignatureArtifactMetadata(ModuleComponentArtifactIdentifier artifact, @Nullable IvyArtifactName ivyArtifactName) {
                 this.moduleComponentIdentifier = artifact.getComponentIdentifier();
-                this.artifactIdentifier = getArtifactId(artifact, ivyArtifactName);
+                this.artifactIdentifier = createArtifactId(artifact, ivyArtifactName);
             }
 
-            private ModuleComponentArtifactIdentifier getArtifactId(ModuleComponentArtifactIdentifier artifact, @Nullable IvyArtifactName originalIvyArtifactName) {
-                if (artifact instanceof DefaultModuleComponentArtifactIdentifier || originalIvyArtifactName != null) {
+            private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentArtifactIdentifier artifact, @Nullable IvyArtifactName originalIvyArtifactName) {
+                if (originalIvyArtifactName != null || artifact instanceof DefaultModuleComponentArtifactIdentifier) {
                     IvyArtifactName ivyArtifactName = originalIvyArtifactName != null ? originalIvyArtifactName : ((DefaultModuleComponentArtifactIdentifier) artifact).getName();
                     String extension = ivyArtifactName.getExtension() != null ? ivyArtifactName.getExtension() : ivyArtifactName.getType();
                     ModuleComponentIdentifier moduleComponentIdentifier = artifact.getComponentIdentifier();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
@@ -51,21 +51,6 @@ public class DefaultModuleComponentArtifactIdentifier implements ModuleComponent
     }
 
     @Override
-    public ModuleComponentArtifactIdentifier getSignatureArtifactId() {
-        String extension = name.getExtension();
-        if (extension == null) {
-            extension = name.getType();
-        }
-        return new DefaultModuleComponentArtifactIdentifier(
-            componentIdentifier,
-            name.getName(),
-            "asc",
-            extension + ".asc",
-            name.getClassifier()
-        );
-    }
-
-    @Override
     public String getDisplayName() {
         String name = this.getFileName();
         String componentIdentifier = this.componentIdentifier.toString();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentArtifactIdentifier.java
@@ -34,6 +34,4 @@ public interface ModuleComponentArtifactIdentifier extends ComponentArtifactIden
      */
     String getFileName();
 
-    ModuleComponentArtifactIdentifier getSignatureArtifactId();
-
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentFileArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentFileArtifactIdentifier.java
@@ -28,9 +28,4 @@ public class ModuleComponentFileArtifactIdentifier extends ComponentFileArtifact
     public ModuleComponentIdentifier getComponentIdentifier() {
         return (ModuleComponentIdentifier) super.getComponentIdentifier();
     }
-
-    @Override
-    public ModuleComponentArtifactIdentifier getSignatureArtifactId() {
-        return new ModuleComponentFileArtifactIdentifier(getComponentIdentifier(), getFileName() + ".asc");
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -40,29 +40,17 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
 
     public UrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
         this.componentIdentifier = componentIdentifier;
-        this.fileName = maybeFixFileName(fileName, relativeUrl);
+        this.fileName = fileName;
         this.relativeUrl = relativeUrl;
-        id = createArtifactId(componentIdentifier, relativeUrl);
+        id = createArtifactId(componentIdentifier);
     }
 
-    private String maybeFixFileName(String fileName, String relativeUrl) {
-        if (relativeUrl.isEmpty() || relativeUrl.endsWith(fileName)) {
-            return fileName;
-        }
-        String[] split = relativeUrl.split("/");
-        return split[split.length - 1];
-    }
-
-    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier, String fileName) {
-        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
-            // This special case is for Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
-            // corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
-            return new DefaultModuleComponentArtifactIdentifier(
-                componentIdentifier,
-                getName()
-            );
-        }
-        return new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
+    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier) {
+        // This makes sure that next cases are handled correctly:
+        // 1. Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
+        //    corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
+        // 2. Variants with Gradle Module Metadata when file name doesn't match relative url
+        return new DefaultModuleComponentArtifactIdentifier(componentIdentifier, getName());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -42,10 +42,10 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
         this.componentIdentifier = componentIdentifier;
         this.fileName = fileName;
         this.relativeUrl = relativeUrl;
-        id = createArtifactId(componentIdentifier);
+        id = createArtifactId(componentIdentifier, fileName);
     }
 
-    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier) {
+    private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier, String fileName) {
         if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
             // This special case is for Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
             // corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -40,9 +40,17 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
 
     public UrlBackedArtifactMetadata(ModuleComponentIdentifier componentIdentifier, String fileName, String relativeUrl) {
         this.componentIdentifier = componentIdentifier;
-        this.fileName = fileName;
+        this.fileName = maybeFixFileName(fileName, relativeUrl);
         this.relativeUrl = relativeUrl;
-        id = createArtifactId(componentIdentifier, fileName);
+        id = createArtifactId(componentIdentifier, relativeUrl);
+    }
+
+    private String maybeFixFileName(String fileName, String relativeUrl) {
+        if (relativeUrl.isEmpty() || relativeUrl.endsWith(fileName)) {
+            return fileName;
+        }
+        String[] split = relativeUrl.split("/");
+        return split[split.length - 1];
     }
 
     private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier, String fileName) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -46,7 +46,8 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
     }
 
     private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier) {
-        // This makes sure that next cases are handled correctly:
+        // Using getName() makes sure that file name for ModuleComponentArtifactIdentifier is resolved from the relativeUrl.
+        // This workarounds next cases:
         // 1. Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
         //    corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
         // 2. Variants with Gradle Module Metadata when file name doesn't match relative url

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/UrlBackedArtifactMetadata.java
@@ -46,12 +46,15 @@ public class UrlBackedArtifactMetadata implements ModuleComponentArtifactMetadat
     }
 
     private ModuleComponentArtifactIdentifier createArtifactId(ModuleComponentIdentifier componentIdentifier) {
-        // Using getName() makes sure that file name for ModuleComponentArtifactIdentifier is resolved from the relativeUrl.
-        // This workarounds next cases:
-        // 1. Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
-        //    corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
-        // 2. Variants with Gradle Module Metadata when file name doesn't match relative url
-        return new DefaultModuleComponentArtifactIdentifier(componentIdentifier, getName());
+        if (componentIdentifier instanceof MavenUniqueSnapshotComponentIdentifier) {
+            // This special case is for Maven snapshots with Gradle Module Metadata when we need to remap the file name, which
+            // corresponds to the unique timestamp, to the SNAPSHOT version, for backwards compatibility
+            return new DefaultModuleComponentArtifactIdentifier(
+                componentIdentifier,
+                getName()
+            );
+        }
+        return new ModuleComponentFileArtifactIdentifier(componentIdentifier, fileName);
     }
 
     @Override

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -306,12 +306,12 @@ class ModuleVersionSpec {
                 module.withVariant(variant.name) {
                     attributes = attributes ? attributes + variant.attributes : variant.attributes
                     artifacts = variant.artifacts.collect {
-                        if (it.name && it.name == it.url) {
+                        if (it.name && it.name == it.url && it.name == it.publishUrl) {
                             // publish variant files as "classified". This can be arbitrary in practice, this
                             // just makes it easier for publishing specs
                             new FileSpec("${module.module}-${module.version}-$it.name.${it.ext}")
                         } else {
-                            new FileSpec(it.name, it.url)
+                            new FileSpec(it.name, it.url, it.publishUrl)
                         }
                     }
                     dependencies += variant.dependencies

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/FileSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/FileSpec.groovy
@@ -21,16 +21,24 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class FileSpec {
     String name
+    // Url written in the Gradle Module Metadata
     String url
+    // Url where this file will be published.
+    // Normally publishUrl is the same as url, but it can be set differently for testing some broken behavior.
+    String publishUrl
     String ext = 'jar'
 
     FileSpec(String name) {
-        this.name = name
-        this.url = name
+        this(name, name, name)
     }
 
     FileSpec(String name, String url) {
+        this(name, url, url)
+    }
+
+    FileSpec(String name, String url, String publishUrl) {
         this.name = name
         this.url = url
+        this.publishUrl = publishUrl
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -91,6 +91,10 @@ class VariantMetadataSpec {
         artifacts << new FileSpec(name, url)
     }
 
+    void artifact(String name, String url, String publishUrl) {
+        artifacts << new FileSpec(name, url, publishUrl)
+    }
+
     void capability(String group, String name, String version = '1.0') {
         capabilities << new CapabilitySpec(group, name, version)
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -729,9 +729,9 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
         variants.each {
             it.artifacts.findAll { it.name }.each {
-                def variantArtifact = moduleDir.file(it.name)
+                def variantArtifact = moduleDir.file(it.url)
                 publish(variantArtifact) { Writer writer ->
-                    writer << "${it.name} : Variant artifact $it.name"
+                    writer << "${it.name} : Variant artifact $it.url"
                 }
             }
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -729,9 +729,9 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
 
         variants.each {
             it.artifacts.findAll { it.name }.each {
-                def variantArtifact = moduleDir.file(it.url)
+                def variantArtifact = moduleDir.file(it.publishUrl)
                 publish(variantArtifact) { Writer writer ->
-                    writer << "${it.name} : Variant artifact $it.url"
+                    writer << "${it.name} : Variant artifact $it.publishUrl"
                 }
             }
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -302,7 +302,7 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
-    public MavenModule withVariant(String name, Closure<?> action) {
+    public MavenModule withVariant(String name, @DelegatesTo(value = VariantMetadataSpec.class, strategy = Closure.DELEGATE_FIRST) Closure<?> action) {
         backingModule.withVariant(name, action);
         return this;
     }


### PR DESCRIPTION
The issue in https://github.com/gradle/gradle/issues/20098 is, that `atomicfu-linuxx64-<version>.module` has `files` specified in a way that `name` doesn't match the actual file name. 

This fixes it by always resolving the file name from the relative url in [UrlBackedArtifactMetadata.java](https://github.com/gradle/gradle/compare/asodja/variant-dep-verification?expand=1#diff-12de44ab7d4bee88a8e49d074c2a6d9d2798a1b8b9b709acc00c40e6f944afa2). The same strategy was used only for Maven snapshots before.

Gradle metadata of `atomicfu-linuxx64-<version>.module`:
```
  "formatVersion": "1.1",
  "component": {
    "url": "../../atomicfu/0.17.1/atomicfu-0.17.1.module",
    "group": "org.jetbrains.kotlinx",
    "module": "atomicfu",
    "version": "0.17.1",
    "attributes": {
      "org.gradle.status": "release"
    }
  },
  "variants": [
    {
    ...
      },
      "files": [
        {
          "name": "atomicfu.klib",
          "url": "atomicfu-linuxx64-0.17.1.klib",
        },
        {
          "name": "atomicfu-cinterop-interop.klib",
          "url": "atomicfu-linuxx64-0.17.1-cinterop-interop.klib",
        }
      ]
    }
  ]
}
```

Fixes #20098

@ljacomet what do you think about this? Can this negatively impact any other part of dependency resolution? 
