### PR TITLE
Add NoHttpResponseException as a transient error

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories.transport;
 
 import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 
@@ -35,7 +36,7 @@ public class NetworkingIssueVerifier {
      * </ul>
      */
     public static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
-        if (failure instanceof SocketException || failure instanceof SocketTimeoutException) {
+        if (failure instanceof SocketException || failure instanceof SocketTimeoutException || failure instanceof NoHttpResponseException) {
             return true;
         }
         if (failure instanceof DefaultMultiCauseException) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.transport
 
+import org.apache.http.NoHttpResponseException
 import org.apache.http.conn.HttpHostConnectException
 import org.gradle.internal.exceptions.DefaultMultiCauseException
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
@@ -35,6 +36,7 @@ class NetworkingIssueVerifierTest extends Specification {
         description                                                 | failure
         "SocketException"                                           | new SocketException()
         "SocketTimeoutException"                                    | new SocketTimeoutException()
+        "NoHttpResponseException"                                   | new NoHttpResponseException("something went wrong")
         "HttpHostConnectException"                                  | new HttpHostConnectException(new IOException("something went wrong"), null, null)
         "DefaultMultiCauseException"                                | new DefaultMultiCauseException("something went wrong", new SocketTimeoutException())
         "HttpErrorStatusCodeException with server error"            | new HttpErrorStatusCodeException("something", "something", 503, "something")


### PR DESCRIPTION
By handling NoHttpResponseException, when the exception is raised, the repository won't be blocked, instead, the request will be retried after the backoff time.

Fixes https://github.com/gradle/gradle/issues/20334