### PR TITLE
Fix typo in documentation, use 'file' instead of 'dir'

### DIFF
--- a/subprojects/docs/src/snippets/files/copy/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/copy/groovy/build.gradle
@@ -2,7 +2,7 @@ version = "1.1"
 
 // tag::copy-single-file-example[]
 tasks.register('copyReport', Copy) {
-    from layout.buildDirectory.dir("reports/my-report.pdf")
+    from layout.buildDirectory.file("reports/my-report.pdf")
     into layout.buildDirectory.dir("toArchive")
 }
 // end::copy-single-file-example[]

--- a/subprojects/docs/src/snippets/files/copy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/copy/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ version = "1.1"
 
 // tag::copy-single-file-example[]
 tasks.register<Copy>("copyReport") {
-    from(layout.buildDirectory.dir("reports/my-report.pdf"))
+    from(layout.buildDirectory.file("reports/my-report.pdf"))
     into(layout.buildDirectory.dir("toArchive"))
 }
 // end::copy-single-file-example[]


### PR DESCRIPTION
<!--- The issue this PR addresses -->

The example [here](https://docs.gradle.org/current/userguide/working_with_files.html#sec:copying_single_file_example) should use `file` instead of `dir`

`from(layout.buildDirectory.file("reports/my-report.pdf"))`

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
