### PR TITLE
Allow compilation of build scripts against a different Gradle API version

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -384,7 +384,7 @@ public interface DependencyHandler extends ExtensionAware {
     Dependency gradleApi();
 
     /**
-     * Creates a dependency on the API of the current version of Gradle.
+     * Creates a dependency on the API of the specified version of Gradle.
      *
      * @return The dependency.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -384,6 +384,13 @@ public interface DependencyHandler extends ExtensionAware {
     Dependency gradleApi();
 
     /**
+     * Creates a dependency on the API of the current version of Gradle.
+     *
+     * @return The dependency.
+     */
+    Dependency gradleApi(String version);
+
+    /**
      * Creates a dependency on the <a href="https://docs.gradle.org/current/userguide/test_kit.html" target="_top">Gradle test-kit</a> API.
      *
      * @return The dependency.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -17,6 +17,7 @@ package org.gradle.api.artifacts.dsl;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
@@ -387,7 +388,9 @@ public interface DependencyHandler extends ExtensionAware {
      * Creates a dependency on the API of the specified version of Gradle.
      *
      * @return The dependency.
+     * @since 7.5
      */
+    @Incubating
     Dependency gradleApi(String version);
 
     /**

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.groovy.scripts
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.IgnoreRest
 
 class GroovyImportsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -38,21 +37,5 @@ import org.apache.commons.math3.util.FastMath
         expect:
         args("--init-script", initScript.toString())
         succeeds("help")
-    }
-
-    @IgnoreRest
-    def "can compile basic script"() {
-        buildScript """
-           println 'hello'
-           @groovy.transform.CompileStatic
-def myMethod(Task task) {
-    task.doNotTrackState("dont")
-}
-        """
-
-        expect:
-        succeeds("help"
-            , "-Dorg.gradle.api.version=6.9.1", "-Dgradle.api.repository.url=file:///Users/wolfs/projects/gradle/provider-api-migration-testbed/gradle-repository/build/repo"
-        )
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyImportsIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.groovy.scripts
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.IgnoreRest
 
 class GroovyImportsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -39,4 +40,19 @@ import org.apache.commons.math3.util.FastMath
         succeeds("help")
     }
 
+    @IgnoreRest
+    def "can compile basic script"() {
+        buildScript """
+           println 'hello'
+           @groovy.transform.CompileStatic
+def myMethod(Task task) {
+    task.doNotTrackState("dont")
+}
+        """
+
+        expect:
+        succeeds("help"
+            , "-Dorg.gradle.api.version=6.9.1", "-Dgradle.api.repository.url=file:///Users/wolfs/projects/gradle/provider-api-migration-testbed/gradle-repository/build/repo"
+        )
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
@@ -28,8 +28,11 @@ import java.util.Optional;
 import java.util.Set;
 
 public class GradleApiVersionProvider {
+
+    public static final String GRADLE_API_SOURCE_VERSION_PROPERTY = "org.gradle.api.source-version";
+
     public static Optional<String> getGradleApiSourceVersion() {
-        return Optional.ofNullable(System.getProperty("org.gradle.api.source-version"));
+        return Optional.ofNullable(System.getProperty(GRADLE_API_SOURCE_VERSION_PROPERTY));
     }
 
     public static void addGradleSourceApiRepository(RepositoryHandler repositoryHandler) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
@@ -28,26 +28,26 @@ import java.util.Optional;
 import java.util.Set;
 
 public class GradleApiVersionProvider {
-    public static Optional<String> getSourceApiGradleVersion() {
-        return Optional.ofNullable(System.getProperty("org.gradle.api.version"));
+    public static Optional<String> getGradleApiSourceVersion() {
+        return Optional.ofNullable(System.getProperty("org.gradle.api.source-version"));
     }
 
     public static void addGradleSourceApiRepository(RepositoryHandler repositoryHandler) {
-        getSourceApiGradleVersion().ifPresent(version -> {
+        getGradleApiSourceVersion().ifPresent(version -> {
             String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
             repositoryHandler.maven(repo -> repo.setUrl(repositoryUrl));
         });
     }
 
     public static void addToConfiguration(Configuration configuration, DependencyHandler repositoryHandler) {
-        Dependency gradleApiDependency = getSourceApiGradleVersion()
+        Dependency gradleApiDependency = getGradleApiSourceVersion()
             .map(repositoryHandler::gradleApi)
             .orElseGet(repositoryHandler::gradleApi);
         configuration.getDependencies().add(gradleApiDependency);
     }
 
     public static Collection<File> resolveGradleSourceApi(DependencyResolutionServices dependencyResolutionServices) {
-        return getSourceApiGradleVersion()
+        return getGradleApiSourceVersion()
             .map(version -> gradleApisFromRepository(dependencyResolutionServices, version))
             .orElseGet(() -> gradleApisFromCurrentGradle(dependencyResolutionServices.getDependencyHandler()));
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/GradleApiVersionProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.SelfResolvingDependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+public class GradleApiVersionProvider {
+    public static Optional<String> getSourceApiGradleVersion() {
+        return Optional.ofNullable(System.getProperty("org.gradle.api.version"));
+    }
+
+    public static void addGradleSourceApiRepository(RepositoryHandler repositoryHandler) {
+        getSourceApiGradleVersion().ifPresent(version -> {
+            String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
+            repositoryHandler.maven(repo -> repo.setUrl(repositoryUrl));
+        });
+    }
+
+    public static void addToConfiguration(Configuration configuration, DependencyHandler repositoryHandler) {
+        Dependency gradleApiDependency = getSourceApiGradleVersion()
+            .map(repositoryHandler::gradleApi)
+            .orElseGet(repositoryHandler::gradleApi);
+        configuration.getDependencies().add(gradleApiDependency);
+    }
+
+    public static Collection<File> resolveGradleSourceApi(DependencyResolutionServices dependencyResolutionServices) {
+        return getSourceApiGradleVersion()
+            .map(version -> gradleApisFromRepository(dependencyResolutionServices, version))
+            .orElseGet(() -> gradleApisFromCurrentGradle(dependencyResolutionServices.getDependencyHandler()));
+    }
+
+    private static Set<File> gradleApisFromCurrentGradle(DependencyHandler dependencyHandler) {
+        SelfResolvingDependency gradleApiDependency = (SelfResolvingDependency) dependencyHandler.gradleApi();
+        return gradleApiDependency.resolve();
+
+    }
+    private static Set<File> gradleApisFromRepository(DependencyResolutionServices dependencyResolutionServices, String version) {
+        addGradleSourceApiRepository(dependencyResolutionServices.getResolveRepositoryHandler());
+        Configuration detachedConfiguration = dependencyResolutionServices.getConfigurationContainer().detachedConfiguration(dependencyResolutionServices.getDependencyHandler().gradleApi(version));
+        return detachedConfiguration.resolve();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClasspathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GroovyScriptClasspathProvider.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.groovy.scripts.internal;
+
+import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.internal.classloader.ClassLoaderVisitor;
+import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.classpath.DefaultClassPath;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+public class GroovyScriptClasspathProvider {
+    private final ConcurrentMap<ClassLoaderScope, ClassPath> cachedScopeCompilationClasspath = new ConcurrentHashMap<>();
+    private final Map<ClassLoader, Set<File>> cachedClasspaths = new HashMap<>();
+    private final Set<File> gradleImplementationClasspath = new LinkedHashSet<>();
+    private ClassPath gradleApi;
+    private ClassPath groovyJars;
+    private final Supplier<Collection<File>> gradleApiJarsProvider;
+    private final Supplier<Set<File>> groovyJarsProvider;
+
+    public GroovyScriptClasspathProvider(
+        ClassLoaderScope coreAndPluginsScope,
+        Supplier<Collection<File>> gradleApiJarsProvider,
+        Supplier<Set<File>> groovyJarsProvider
+    ) {
+        this.gradleApiJarsProvider = gradleApiJarsProvider;
+        this.groovyJarsProvider = groovyJarsProvider;
+        this.gradleImplementationClasspath.addAll(classpathOf(coreAndPluginsScope.getExportClassLoader()));
+        this.gradleImplementationClasspath.removeIf(file -> !file.getName().startsWith("gradle-"));
+    }
+
+    public ClassPath compilationClassPathOf(ClassLoaderScope scope) {
+        return getGradleApi().plus(exportClassPathFromHierarchyOf(scope));
+    }
+
+    private ClassPath getGradleApi() {
+        if (gradleApi == null) {
+            gradleApi = DefaultClassPath.of(gradleApiJarsProvider.get());
+        }
+        return gradleApi;
+    }
+
+    private ClassPath getGroovy() {
+        if (groovyJars == null) {
+            groovyJars = DefaultClassPath.of(groovyJarsProvider.get());
+        }
+        return groovyJars;
+    }
+
+    private ClassPath exportClassPathFromHierarchyOf(ClassLoaderScope scope) {
+        Set<File> exportedClasspath = new LinkedHashSet<>(classpathOf(scope.getExportClassLoader()));
+        exportedClasspath.removeAll(gradleImplementationClasspath);
+        return DefaultClassPath.of(exportedClasspath);
+    }
+
+    private Set<File> classpathOf(ClassLoader classLoader) {
+        Set<File> classpath = cachedClasspaths.get(classLoader);
+        if (classpath == null) {
+            Set<File> classpathFiles = new LinkedHashSet<>();
+            new ClassLoaderVisitor() {
+                @Override
+                public void visitClassPath(URL[] classPath) {
+                    for (URL url : classPath) {
+                        if (url.getProtocol().equals("file")) {
+                            classpathFiles.add(new File(toUri(url)));
+                        }
+                    }
+                }
+
+                @Override
+                public void visitParent(ClassLoader parent) {
+                    classpathFiles.addAll(classpathOf(parent));
+                }
+
+                private URI toUri(URL url) {
+                    try {
+                        return url.toURI();
+                    } catch (URISyntaxException e) {
+                        try {
+                            return new URL(
+                                url.getProtocol(),
+                                url.getHost(),
+                                url.getPort(),
+                                url.getFile().replace(" ", "%20")
+                            ).toURI();
+                        } catch (URISyntaxException | MalformedURLException ex) {
+                            throw new RuntimeException(ex);
+                        }
+                    }
+                }
+            }.visit(classLoader);
+            cachedClasspaths.put(classLoader, classpathFiles);
+            classpath = classpathFiles;
+        }
+        return classpath;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -267,6 +267,11 @@ public abstract class DefaultDependencyHandler implements DependencyHandler, Met
     }
 
     @Override
+    public Dependency gradleApi(String version) {
+        return dependencyFactory.createDependency("org.gradle:gradle-api:" + version);
+    }
+
+    @Override
     public Dependency gradleTestKit() {
         return dependencyFactory.createDependency(DependencyFactory.ClassPathNotation.GRADLE_TEST_KIT);
     }

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPlugins.kt
@@ -19,6 +19,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskProvider
@@ -44,8 +45,9 @@ class PrecompiledScriptPlugins : Plugin<Project> {
 
             dependencies {
                 "kotlinCompilerPluginClasspath"(gradleKotlinDslJarsOf(project))
-                "kotlinCompilerPluginClasspath"(gradleApi())
             }
+            GradleApiVersionProvider.addToConfiguration(configurations.getByName("kotlinCompilerPluginClasspath"), dependencies)
+            GradleApiVersionProvider.addGradleSourceApiRepository(repositories)
         }
     }
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -246,6 +246,9 @@ fun Project.enableScriptCompilationOf(
                         .map(java.lang.Boolean::parseBoolean)
                         .orElse(false)
                 )
+                gradleApiVersion.set(providers
+                    .systemProperty(GradleApiVersionProvider.GRADLE_API_SOURCE_VERSION_PROPERTY)
+                    .orElse(GradleVersion.current().version))
                 plugins = scriptPlugins
             }
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -23,6 +23,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.initialization.Settings
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider
 import org.gradle.api.internal.plugins.DefaultPluginManager
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.model.ObjectFactory
@@ -55,6 +56,7 @@ import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 import org.gradle.tooling.model.kotlin.dsl.KotlinDslModelsParameters
+import org.gradle.util.GradleVersion
 import java.io.File
 import java.util.function.Consumer
 import javax.inject.Inject
@@ -230,7 +232,7 @@ fun Project.enableScriptCompilationOf(
 
         val (generatePrecompiledScriptPluginAccessors, _) =
             codeGenerationTask<GeneratePrecompiledScriptPluginAccessors>(
-                "accessors",
+                "accessors${GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().baseVersion.version)}",
                 "generatePrecompiledScriptPluginAccessors",
                 kotlinSourceDirectorySet
             ) {

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/GeneratePrecompiledScriptPluginAccessors.kt
@@ -122,6 +122,9 @@ abstract class GeneratePrecompiledScriptPluginAccessors @Inject internal constru
     @get:Input
     abstract val strict: Property<Boolean>
 
+    @get:Input
+    abstract val gradleApiVersion: Property<String>
+
     init {
         outputs.doNotCacheIf(
             "Generated accessors can only be cached in strict mode."

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -119,7 +119,6 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
             }
 
             task("test") {
-                doNotTrackState("no state")
                 doLast {
                     // Capturing when
                     when (val value = coroutine.first()) {

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/KotlinBuildScriptIntegrationTest.kt
@@ -119,6 +119,7 @@ class KotlinBuildScriptIntegrationTest : AbstractKotlinIntegrationTest() {
             }
 
             task("test") {
+                doNotTrackState("no state")
                 doLast {
                     // Capturing when
                     when (val value = coroutine.first()) {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragment.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragment.kt
@@ -20,6 +20,7 @@ import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassMetadata
 
 import org.gradle.internal.classanalysis.AsmConstants.ASM_LEVEL
+import org.gradle.util.GradleVersion
 
 import org.jetbrains.org.objectweb.asm.ClassVisitor
 import org.jetbrains.org.objectweb.asm.ClassWriter
@@ -30,7 +31,8 @@ data class AccessorFragment(
     val source: String,
     val bytecode: BytecodeWriter,
     val metadata: MetadataWriter,
-    val signature: JvmMethodSignature
+    val signature: JvmMethodSignature,
+    val supportedSince: GradleVersion? = null
 )
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -49,6 +49,7 @@ import org.gradle.kotlin.dsl.support.bytecode.visitSignature
 import org.gradle.kotlin.dsl.support.bytecode.with
 import org.gradle.kotlin.dsl.support.bytecode.writeFunctionOf
 import org.gradle.kotlin.dsl.support.bytecode.writePropertyOf
+import org.gradle.util.GradleVersion
 import org.jetbrains.org.objectweb.asm.MethodVisitor
 
 
@@ -71,6 +72,7 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
     val (functionFlags, deprecationBlock) =
         if (config.hasDeclarationDeprecations()) publicFunctionWithAnnotationsFlags to config.getDeclarationDeprecationBlock()
         else publicFunctionFlags to ""
+    val compileAgainstGradleVersion = GradleVersion.version(System.getProperty("org.gradle.api.version", GradleVersion.current().version)).baseVersion
 
     className to sequenceOf(
         AccessorFragment(
@@ -265,7 +267,8 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
             signature = JvmMethodSignature(
                 propertyName,
                 "(Lorg/gradle/api/artifacts/dsl/DependencyHandler;Lorg/gradle/api/provider/ProviderConvertible;Lorg/gradle/api/Action;)V"
-            )
+            ),
+            supportedSince = GradleVersion.version("7.4")
         ),
         AccessorFragment(
             source = name.run {
@@ -598,7 +601,7 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                 ""
             )
         )
-    )
+    ).filter { it.supportedSince?.let { it <= compileAgainstGradleVersion } ?: true }
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -19,6 +19,7 @@ package org.gradle.kotlin.dsl.accessors
 import kotlinx.metadata.KmVariance
 import kotlinx.metadata.jvm.JvmMethodSignature
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider
 import org.gradle.api.reflect.TypeOf
 import org.gradle.internal.deprecation.ConfigurationDeprecationType
 import org.gradle.internal.hash.Hashing.hashString
@@ -72,7 +73,9 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
     val (functionFlags, deprecationBlock) =
         if (config.hasDeclarationDeprecations()) publicFunctionWithAnnotationsFlags to config.getDeclarationDeprecationBlock()
         else publicFunctionFlags to ""
-    val compileAgainstGradleVersion = GradleVersion.version(System.getProperty("org.gradle.api.version", GradleVersion.current().version)).baseVersion
+    val sourceApiGradleVersion = GradleVersion.version(
+        GradleApiVersionProvider.getSourceApiGradleVersion().orElse(GradleVersion.current().version)
+    ).baseVersion
 
     className to sequenceOf(
         AccessorFragment(
@@ -601,7 +604,7 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
                 ""
             )
         )
-    ).filter { it.supportedSince?.let { it <= compileAgainstGradleVersion } ?: true }
+    ).filter { it.supportedSince?.let { it <= sourceApiGradleVersion } ?: true }
 }
 
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorFragments.kt
@@ -74,7 +74,7 @@ fun fragmentsForConfiguration(accessor: Accessor.ForConfiguration): Fragments = 
         if (config.hasDeclarationDeprecations()) publicFunctionWithAnnotationsFlags to config.getDeclarationDeprecationBlock()
         else publicFunctionFlags to ""
     val sourceApiGradleVersion = GradleVersion.version(
-        GradleApiVersionProvider.getSourceApiGradleVersion().orElse(GradleVersion.current().version)
+        GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version)
     ).baseVersion
 
     className to sequenceOf(

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -603,7 +603,7 @@ fun IO.writeAccessorsTo(
     }
 }
 
-val sourceGradleApiVersion = GradleApiVersionProvider.getSourceApiGradleVersion().orElse(GradleVersion.current().version).apply {
+val sourceGradleApiVersion = GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version).apply {
     println("Gradle API version: $this")
 }
 val supportsProviderConvertible = GradleVersion.version(sourceGradleApiVersion).baseVersion >= GradleVersion.version("7.4")

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -45,6 +45,7 @@ import org.gradle.kotlin.dsl.concurrent.withAsynchronousIO
 import org.gradle.kotlin.dsl.support.ClassBytesRepository
 import org.gradle.kotlin.dsl.support.appendReproducibleNewLine
 import org.gradle.kotlin.dsl.support.useToRun
+import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.metadata.ProtoBuf
 import org.jetbrains.kotlin.metadata.ProtoBuf.Visibility
 import org.jetbrains.kotlin.metadata.deserialization.Flags
@@ -601,6 +602,10 @@ fun IO.writeAccessorsTo(
     }
 }
 
+val gradleApiVersion = System.getProperty("org.gradle.api.version", GradleVersion.current().version).apply {
+    println("Gradle API version: $this")
+}
+val supportsProviderConvertible = GradleVersion.version(gradleApiVersion).baseVersion >= GradleVersion.version("7.4")
 
 internal
 fun fileHeaderWithImportsFor(accessorsPackage: String = kotlinDslPackageName) = """
@@ -623,7 +628,7 @@ import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderConvertible
+${if (supportsProviderConvertible) "import org.gradle.api.provider.ProviderConvertible" else ""}
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -120,6 +120,7 @@ class GenerateProjectAccessors(
         const val CLASSPATH_INPUT_PROPERTY = "classpath"
         const val SOURCES_OUTPUT_PROPERTY = "sources"
         const val CLASSES_OUTPUT_PROPERTY = "classes"
+        const val SOURCE_GRADLE_API_VERSION = "sourceGradleApiVersion"
     }
 
     override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput {
@@ -147,6 +148,7 @@ class GenerateProjectAccessors(
     override fun identify(identityInputs: Map<String, ValueSnapshot>, identityFileInputs: Map<String, CurrentFileCollectionFingerprint>): UnitOfWork.Identity {
         val hasher = Hashing.newHasher()
         requireNotNull(identityInputs[PROJECT_SCHEMA_INPUT_PROPERTY]).appendToHasher(hasher)
+        requireNotNull(identityInputs[SOURCE_GRADLE_API_VERSION]).appendToHasher(hasher)
         hasher.putHash(requireNotNull(identityFileInputs[CLASSPATH_INPUT_PROPERTY]).hash)
         val identityHash = hasher.hash().toString()
         return UnitOfWork.Identity { identityHash }
@@ -160,6 +162,7 @@ class GenerateProjectAccessors(
 
     override fun visitIdentityInputs(visitor: InputVisitor) {
         visitor.visitInputProperty(PROJECT_SCHEMA_INPUT_PROPERTY) { hashCodeFor(projectSchema) }
+        visitor.visitInputProperty(SOURCE_GRADLE_API_VERSION) { GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version) }
         visitor.visitInputFileProperty(
             CLASSPATH_INPUT_PROPERTY,
             NON_INCREMENTAL,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -17,6 +17,7 @@
 package org.gradle.kotlin.dsl.accessors
 
 import org.gradle.api.Project
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.ClasspathNormalizer
@@ -602,10 +603,10 @@ fun IO.writeAccessorsTo(
     }
 }
 
-val gradleApiVersion = System.getProperty("org.gradle.api.version", GradleVersion.current().version).apply {
+val sourceGradleApiVersion = GradleApiVersionProvider.getSourceApiGradleVersion().orElse(GradleVersion.current().version).apply {
     println("Gradle API version: $this")
 }
-val supportsProviderConvertible = GradleVersion.version(gradleApiVersion).baseVersion >= GradleVersion.version("7.4")
+val supportsProviderConvertible = GradleVersion.version(sourceGradleApiVersion).baseVersion >= GradleVersion.version("7.4")
 
 internal
 fun fileHeaderWithImportsFor(accessorsPackage: String = kotlinDslPackageName) = """

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -606,10 +606,12 @@ fun IO.writeAccessorsTo(
     }
 }
 
-val sourceGradleApiVersion = GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version).apply {
-    println("Gradle API version: $this")
-}
-val supportsProviderConvertible = GradleVersion.version(sourceGradleApiVersion).baseVersion >= GradleVersion.version("7.4")
+val sourceGradleApiVersion
+    get() = GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version).apply {
+        println("Gradle API version: $this")
+    }
+val supportsProviderConvertible
+    get() = GradleVersion.version(sourceGradleApiVersion).baseVersion >= GradleVersion.version("7.4")
 
 internal
 fun fileHeaderWithImportsFor(accessorsPackage: String = kotlinDslPackageName) = """

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -607,9 +607,7 @@ fun IO.writeAccessorsTo(
 }
 
 val sourceGradleApiVersion
-    get() = GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version).apply {
-        println("Gradle API version: $this")
-    }
+    get() = GradleApiVersionProvider.getGradleApiSourceVersion().orElse(GradleVersion.current().version)
 val supportsProviderConvertible
     get() = GradleVersion.version(sourceGradleApiVersion).baseVersion >= GradleVersion.version("7.4")
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/tasks/PrintAccessors.kt
@@ -18,6 +18,10 @@ package org.gradle.kotlin.dsl.accessors.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.serialization.Cached
 
@@ -42,6 +46,14 @@ abstract class PrintAccessors : DefaultTask() {
     @get:Inject
     protected
     abstract val projectSchemaProvider: ProjectSchemaProvider
+
+    @get:Input
+    @get:Optional
+    abstract val sourceGradleApiVersion: Property<String>
+
+    init {
+        sourceGradleApiVersion.set(GradleApiVersionProvider.getGradleApiSourceVersion().orElse(null))
+    }
 
     private
     val schema = Cached.of { schemaOf(project) }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -17,12 +17,17 @@
 package org.gradle.kotlin.dsl.provider
 
 import org.gradle.api.internal.ClassPathRegistry
+import org.gradle.api.internal.artifacts.DependencyManagementServices
+import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory
+import org.gradle.api.internal.artifacts.dsl.dependencies.UnknownProjectFinder
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.internal.file.FileCollectionFactory
+import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.temp.TemporaryFileProvider
+import org.gradle.api.internal.initialization.RootScriptDomainObjectContext
 import org.gradle.api.internal.initialization.loadercache.DefaultClasspathHasher
 import org.gradle.cache.internal.GeneratedGradleJarCache
 import org.gradle.groovy.scripts.internal.ScriptSourceHasher
@@ -57,6 +62,10 @@ object BuildServices {
         classPathRegistry: ClassPathRegistry,
         classLoaderScopeRegistry: ClassLoaderScopeRegistry,
         dependencyFactory: DependencyFactory,
+        dependencyManagementServices: DependencyManagementServices,
+        fileResolver: FileResolver,
+        fileCollectionFactory: FileCollectionFactory,
+        dependencyMetaDataProvider: DependencyMetaDataProvider,
         jarCache: GeneratedGradleJarCache,
         temporaryFileProvider: TemporaryFileProvider,
         progressLoggerFactory: ProgressLoggerFactory
@@ -66,7 +75,13 @@ object BuildServices {
             moduleRegistry,
             classPathRegistry,
             classLoaderScopeRegistry.coreAndPluginsScope,
-            gradleApiJarsProviderFor(dependencyFactory),
+            gradleApiJarsProviderFor(dependencyFactory, dependencyManagementServices.create(
+                fileResolver,
+                fileCollectionFactory,
+                dependencyMetaDataProvider,
+                UnknownProjectFinder("Some unknown project"),
+                RootScriptDomainObjectContext.PLUGINS
+            )),
             versionedJarCacheFor(jarCache),
             temporaryFileProvider,
             StandardJarGenerationProgressMonitorProvider(progressLoggerFactory)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/BuildServices.kt
@@ -75,7 +75,7 @@ object BuildServices {
             moduleRegistry,
             classPathRegistry,
             classLoaderScopeRegistry.coreAndPluginsScope,
-            gradleApiJarsProviderFor(dependencyFactory, dependencyManagementServices.create(
+            gradleApiJarsProviderFor(dependencyManagementServices.create(
                 fileResolver,
                 fileCollectionFactory,
                 dependencyMetaDataProvider,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -208,16 +208,17 @@ class KotlinScriptClassPathProvider(
 internal
 fun gradleApiJarsProviderFor(dependencyFactory: DependencyFactory, dependencyResolutionServices: DependencyResolutionServices): JarsProvider =
     {
-        gradleApisFromRepository(dependencyResolutionServices, dependencyFactory)
-//        gradleApisFromCurrentGradle(dependencyFactory)
+        System.getProperty("org.gradle.api.version")?.let { version ->
+            gradleApisFromRepository(dependencyResolutionServices, dependencyFactory, version)
+        } ?: gradleApisFromCurrentGradle(dependencyFactory)
     }
 
 private
-fun gradleApisFromRepository(dependencyResolutionServices: DependencyResolutionServices, dependencyFactory: DependencyFactory): Set<File> {
+fun gradleApisFromRepository(dependencyResolutionServices: DependencyResolutionServices, dependencyFactory: DependencyFactory, version: String): Set<File> {
     dependencyResolutionServices.resolveRepositoryHandler.maven("https://repo.gradle.org/gradle/libs-releases")
     val gradleModules = listOf("core", "core-api", "tooling-api", "kotlin-dsl")
     val detachedConfiguration = dependencyResolutionServices.configurationContainer.detachedConfiguration(
-        *gradleModules.map { dependencyFactory.gradleDependency(it) }.toTypedArray()
+        *gradleModules.map { dependencyFactory.gradleDependency(it, version) }.toTypedArray()
     )
 
     return detachedConfiguration.resolve()

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -215,8 +215,9 @@ fun gradleApiJarsProviderFor(dependencyFactory: DependencyFactory, dependencyRes
 
 private
 fun gradleApisFromRepository(dependencyResolutionServices: DependencyResolutionServices, dependencyFactory: DependencyFactory, version: String): Set<File> {
-    dependencyResolutionServices.resolveRepositoryHandler.maven("https://repo.gradle.org/gradle/libs-releases")
-    val gradleModules = listOf("core", "core-api", "tooling-api", "kotlin-dsl")
+    val repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases")
+    dependencyResolutionServices.resolveRepositoryHandler.maven(repositoryUrl)
+    val gradleModules = listOf("api")
     val detachedConfiguration = dependencyResolutionServices.configurationContainer.detachedConfiguration(
         *gradleModules.map { dependencyFactory.gradleDependency(it, version) }.toTypedArray()
     )

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/DependencyHandlerDelegate.kt
@@ -87,6 +87,9 @@ abstract class DependencyHandlerDelegate : DependencyHandler {
     override fun gradleApi(): Dependency =
         delegate.gradleApi()
 
+    override fun gradleApi(version: String): Dependency =
+        delegate.gradleApi(version)
+
     override fun gradleTestKit(): Dependency =
         delegate.gradleTestKit()
 

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -156,6 +156,11 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
         if (apiVersion == null || apiVersion.isEmpty()) {
             dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
         } else {
+            String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
+            project.getRepositories().maven(repository -> {
+                repository.setName("gradleApiRepository");
+                repository.setUrl(repositoryUrl);
+            });
             dependencies.add(API_CONFIGURATION, dependencies.gradleApi(apiVersion));
         }
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -152,7 +152,12 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
     private void applyDependencies(Project project) {
         DependencyHandler dependencies = project.getDependencies();
-//        dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
+        String apiVersion = System.getProperty("org.gradle.api.version");
+        if (apiVersion == null || apiVersion.isEmpty()) {
+            dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
+        } else {
+            dependencies.add(API_CONFIGURATION, dependencies.gradleApi(apiVersion));
+        }
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -152,7 +152,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
     private void applyDependencies(Project project) {
         DependencyHandler dependencies = project.getDependencies();
-        dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
+//        dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileCopyDetails;
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry;
 import org.gradle.api.internal.plugins.PluginDescriptor;
@@ -152,17 +153,8 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
     private void applyDependencies(Project project) {
         DependencyHandler dependencies = project.getDependencies();
-        String apiVersion = System.getProperty("org.gradle.api.version");
-        if (apiVersion == null || apiVersion.isEmpty()) {
-            dependencies.add(API_CONFIGURATION, dependencies.gradleApi());
-        } else {
-            String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
-            project.getRepositories().maven(repository -> {
-                repository.setName("gradleApiRepository");
-                repository.setUrl(repositoryUrl);
-            });
-            dependencies.add(API_CONFIGURATION, dependencies.gradleApi(apiVersion));
-        }
+        GradleApiVersionProvider.addToConfiguration(project.getConfigurations().getByName(API_CONFIGURATION), dependencies);
+        GradleApiVersionProvider.addGradleSourceApiRepository(project.getRepositories());
     }
 
     private void configureJarTask(Project project, GradlePluginDevelopmentExtension extension) {

--- a/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
+++ b/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
@@ -17,6 +17,7 @@
 package org.gradle.initialization.buildsrc;
 
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.artifacts.GradleApiVersionProvider;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.GroovyPlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
@@ -30,17 +31,8 @@ public class GroovyBuildSrcProjectConfigurationAction implements BuildSrcProject
         project.getPluginManager().apply(GroovyPlugin.class);
 
         DependencyHandler dependencies = project.getDependencies();
-        String apiVersion = System.getProperty("org.gradle.api.version");
-        if (apiVersion == null || apiVersion.isEmpty()) {
-            dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.gradleApi());
-        } else {
-            String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
-            project.getRepositories().maven(repository -> {
-                repository.setName("gradleApiRepository");
-                repository.setUrl(repositoryUrl);
-            });
-            dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.gradleApi(apiVersion));
-        }
+        GradleApiVersionProvider.addToConfiguration(project.getConfigurations().getByName(JavaPlugin.API_CONFIGURATION_NAME), dependencies);
+        GradleApiVersionProvider.addGradleSourceApiRepository(project.getRepositories());
         dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.localGroovy());
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
+++ b/subprojects/plugins/src/main/java/org/gradle/initialization/buildsrc/GroovyBuildSrcProjectConfigurationAction.java
@@ -30,7 +30,17 @@ public class GroovyBuildSrcProjectConfigurationAction implements BuildSrcProject
         project.getPluginManager().apply(GroovyPlugin.class);
 
         DependencyHandler dependencies = project.getDependencies();
-        dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.gradleApi());
+        String apiVersion = System.getProperty("org.gradle.api.version");
+        if (apiVersion == null || apiVersion.isEmpty()) {
+            dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.gradleApi());
+        } else {
+            String repositoryUrl = System.getProperty("gradle.api.repository.url", "https://repo.gradle.org/gradle/libs-releases");
+            project.getRepositories().maven(repository -> {
+                repository.setName("gradleApiRepository");
+                repository.setUrl(repositoryUrl);
+            });
+            dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.gradleApi(apiVersion));
+        }
         dependencies.add(JavaPlugin.API_CONFIGURATION_NAME, dependencies.localGroovy());
     }
 }


### PR DESCRIPTION
This PRs explores what would be necessary to compile build scripts against a different Gradle API. It allows passing  the Gradle API version via `-Dorg.gradle.api.version=6.9` to the Gradle installation. Note that you also need a repository which contains an artifact for the Gradle API of this version with the coordinates `org.gradle:gradle-api:<version>`. You can specify the URL of the repository via `-Dgradle.api.repository.url=...`.

Currently this works for Kotlin and Groovy build scripts. It also should work for Kotlin pre-compiled scripts and Kotlin and Groovy build logic. Though it doesn't work for Groovy pre-compiled build scripts. I suppose we should be able to make this work with Groovy pre-compiled build scripts as well, though I did run into some classloader problems there.

You can also declare a dependency in your build script on the Gradle API with a version by using `gradleApi(<version>)` instead of `gradleApi()`.

Exploration doc: https://docs.google.com/document/d/1JB75X_Lt5BlubszqD0l10rHPqL89B2yd-yD39qizyDA/edit