### PR TITLE
Extract common `maybeRoundLastModified` method

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/FileMetadataTestFixture.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/FileMetadataTestFixture.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures
+
+import org.gradle.api.JavaVersion
+import org.gradle.internal.os.OperatingSystem
+
+class FileMetadataTestFixture {
+    static maybeRoundLastModified(long lastModified) {
+        // Some Java 8 versions on Unix only capture the seconds in lastModified, so we cut off the milliseconds returned from the filesystem as well.
+        // For example, Oracle JDK 1.8.0_181-b13 does not capture milliseconds, while OpenJDK 1.8.0_242-b08 does.
+        return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
+            ? lastModified
+            : lastModified.intdiv(1000) * 1000
+    }
+}

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessorTest.groovy
@@ -18,11 +18,10 @@ package org.gradle.internal.nativeintegration.filesystem.services
 
 import net.rubygrapefruit.platform.Native
 import net.rubygrapefruit.platform.file.Files
-import org.gradle.api.JavaVersion
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.nativeintegration.filesystem.FileMetadataAccessor
-import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.UsesNativeServices
+import static org.gradle.test.fixtures.FileMetadataTestFixture.maybeRoundLastModified
 
 import java.nio.file.LinkOption
 import java.nio.file.attribute.BasicFileAttributeView
@@ -38,14 +37,6 @@ class NativePlatformBackedFileMetadataAccessorTest extends AbstractFileMetadataA
     @Override
     void assertSameLastModified(FileMetadata fileMetadata, File file) {
         assert maybeRoundLastModified(fileMetadata.lastModified) == maybeRoundLastModified(lastModifiedViaJavaNio(file))
-    }
-
-    private static maybeRoundLastModified(long lastModified) {
-        // Some Java 8 versions on Unix only capture the seconds in lastModified, so we cut off the milliseconds returned from the filesystem as well.
-        // For example, Oracle JDK 1.8.0_181-b13 does not capture milliseconds, while OpenJDK 1.8.0_242-b08 does.
-        return (JavaVersion.current().java9Compatible || OperatingSystem.current().windows)
-            ? lastModified
-            : lastModified.intdiv(1000) * 1000
     }
 
     private static long lastModifiedViaJavaNio(File file) {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DirectorySnapshotterAsDirectoryWalkerTest.groovy
@@ -32,6 +32,8 @@ import org.gradle.internal.snapshot.SnapshottingFilter
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
+import static org.gradle.test.fixtures.FileMetadataTestFixture.maybeRoundLastModified
+
 class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerTest<DirectorySnapshotter> {
 
     def "directory snapshotter returns the same details as directory walker"() {
@@ -46,7 +48,7 @@ class DirectorySnapshotterAsDirectoryWalkerTest extends AbstractDirectoryWalkerT
                 def elementFromFileWalker = visitedWithJdk7Walker.find { it.file == element.file }
                 assert elementFromFileWalker != null
                 assert element.directory == elementFromFileWalker.directory
-                assert element.lastModified == elementFromFileWalker.lastModified
+                assert maybeRoundLastModified(element.lastModified) == maybeRoundLastModified(elementFromFileWalker.lastModified)
                 assert element.size == elementFromFileWalker.size
                 assert element.name == elementFromFileWalker.name
                 assert element.path == elementFromFileWalker.path


### PR DESCRIPTION
To be shared by two unit tests.
