### PR TITLE
Fix failing JavaExecDebugIntegrationTest

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -64,7 +64,7 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         def failure = executer.withTasks(taskName).withStackTraceChecksDisabled().runWithFailure()
-        failure.assertHasErrorOutput('ERROR: transport error 202: connect failed:')
+        failure.error.contains('ERROR: transport error 202: connect failed:') || failure.error.contains('ERROR: transport error 202: handshake failed')
 
         where:
         taskName << ['runJavaExec', 'runProjectJavaExec', 'runExecOperationsJavaExec', 'test']


### PR DESCRIPTION
The error output was slightly different on Test Distribution agent.
