### PR TITLE
Fetch missing keys for dependency verification every 24h

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildCachingKeyService.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildCachingKeyService.java
@@ -115,7 +115,7 @@ public class CrossBuildCachingKeyService implements PublicKeyService, Closeable 
             // if a key was found in the cache, it's permanent
             return false;
         }
-        long elapsed = key.timestamp - timeProvider.getCurrentTime();
+        long elapsed = timeProvider.getCurrentTime() - key.timestamp;
         return refreshKeys || elapsed > MISSING_KEY_TIMEOUT;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/signatures/CrossBuildSignatureVerificationService.java
@@ -97,7 +97,7 @@ public class CrossBuildSignatureVerificationService implements SignatureVerifica
         if (missingKeys == null || missingKeys.isEmpty()) {
             return false;
         }
-        long elapsed = entry.timestamp - timeProvider.getCurrentTime();
+        long elapsed = timeProvider.getCurrentTime() - entry.timestamp;
         return refreshKeys || elapsed > MISSING_KEY_TIMEOUT;
     }
 


### PR DESCRIPTION
For dependency verification, we cache if some key is missing. The cache entry is invalidated if you use `--refresh-keys` or `24 hours` have passed.  

But it seems that the second condition is never true. The reason for that is that elapsed time was incorrectly calculated. This fixes it.

I noticed that when I was investigating https://github.com/gradle/gradle/pull/20360.