### PR TITLE
Do not track configuration inputs when inside the ValueSource

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheValueSourceIntegrationTest.groovy
@@ -90,8 +90,7 @@ class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfiguration
 
         then:
         output.count("ON CI") == 1
-        // TODO(mlopatkin) maybe revisit this decision if we decide that ValueSources are free to read whatever files they want
-        configurationCache.assertStateStored()
+        configurationCache.assertStateLoaded()
 
         when: "running after changing the property value"
         file("local.properties").text = "ci=false"
@@ -158,9 +157,98 @@ class ConfigurationCacheValueSourceIntegrationTest extends AbstractConfiguration
 
         then:
         output.count("ON CI") == 1
-        // TODO(mlopatkin) the system property becomes an input itself because it is accessed in the ValueSource implementation.
-        //  This assert should be changed back if ValueSource implementations are allowed to access environment freely.
-        output.contains("because system property 'ci' has changed")
+        output.contains("because a build logic input of type 'IsSystemPropertySet' has changed")
         configurationCache.assertStateStored()
+    }
+
+    def "ValueSource can use #accessor without making it an input"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile.text = """
+
+            import org.gradle.api.provider.*
+
+            abstract class IsInputSet implements ValueSource<Boolean, Parameters> {
+                interface Parameters extends ValueSourceParameters {
+                    Property<String> getPropertyName()
+                }
+                @Override Boolean obtain() {
+                    return ${accessor}(parameters.propertyName.get()) != null
+                }
+            }
+
+            def isCi = providers.of(IsInputSet) {
+                parameters {
+                    propertyName = "ci"
+                }
+            }
+            if (isCi.get()) {
+                tasks.register("build") {
+                    doLast { println("ON CI") }
+                }
+            } else {
+                tasks.register("build") {
+                    doLast { println("NOT CI") }
+                }
+            }
+        """
+
+        when:
+        executer.withEnvironmentVars(ci: "1")
+        configurationCacheRun("-Dci=1", "build")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("ON CI")
+
+        when: "changing the value of the input doesn't invalidate cache"
+        executer.withEnvironmentVars(ci: "2")
+        configurationCacheRun("-Dci=2", "build")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("ON CI")
+
+        when: "removing the input invalidates cache"
+        configurationCacheRun("build")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("NOT CI")
+
+        where:
+        accessor             | _
+        "System.getProperty" | _
+        "System.getenv"      | _
+    }
+
+    def "other build inputs are still tracked after computing ValueSource"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile.text = """
+
+            import org.gradle.api.provider.*
+
+            abstract class ConstantSource implements ValueSource<Integer, ValueSourceParameters.None> {
+                @Override Integer obtain() {
+                    return 42
+                }
+            }
+
+            def vsResult = providers.of(ConstantSource) {}
+            println("ValueSource result = \${vsResult.get()}")
+            println("some.property = \${System.getProperty("some.property")}")
+        """
+
+        when:
+        configurationCacheRun("-Dsome.property=1")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("some.property = 1")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': system property 'some.property'")
+            ignoringUnexpectedInputs()
+        }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
@@ -111,4 +111,4 @@ sealed class ConfigurationCacheFingerprint {
 
 
 internal
-typealias ObtainedValue = ValueSourceProviderFactory.Listener.ObtainedValue<Any, ValueSourceParameters>
+typealias ObtainedValue = ValueSourceProviderFactory.ValueListener.ObtainedValue<Any, ValueSourceParameters>

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt.orig
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt.orig
@@ -81,9 +81,13 @@ class ConfigurationCacheFingerprintWriter(
     private val fileCollectionFactory: FileCollectionFactory,
     private val directoryFileTreeFactory: DirectoryFileTreeFactory,
     private val taskExecutionTracker: TaskExecutionTracker,
+<<<<<<< HEAD
     private val environmentChangeTracker: EnvironmentChangeTracker,
+) : ValueSourceProviderFactory.Listener,
+=======
 ) : ValueSourceProviderFactory.ValueListener,
     ValueSourceProviderFactory.ComputationListener,
+>>>>>>> cd7c1c9b530 (Do not track configuration inputs when inside the ValueSource)
     WorkInputListener,
     ScriptExecutionListener,
     UndeclaredBuildInputListener,
@@ -205,7 +209,11 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun systemPropertyRead(key: String, value: Any?, consumer: String?) {
-        if (inputTrackingDisabledForThread || isSystemPropertyMutated(key)) {
+<<<<<<< HEAD
+        if (isSystemPropertyMutated(key)) {
+=======
+        if (inputTrackingDisabledForThread) {
+>>>>>>> cd7c1c9b530 (Do not track configuration inputs when inside the ValueSource)
             return
         }
         sink().systemPropertyRead(key, value)
@@ -239,9 +247,7 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun systemPropertiesPrefixedBy(prefix: String, snapshot: Map<String, String?>) {
-        if (inputTrackingDisabledForThread) {
-            return
-        }
+<<<<<<< HEAD
         val filteredSnapshot = snapshot.mapValues { e ->
             if (isSystemPropertyMutated(e.key)) {
                 ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy.IGNORED
@@ -250,6 +256,12 @@ class ConfigurationCacheFingerprintWriter(
             }
         }
         buildScopedSink.write(ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy(prefix, filteredSnapshot))
+=======
+        if (inputTrackingDisabledForThread) {
+            return
+        }
+        buildScopedSink.write(ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy(prefix, snapshot))
+>>>>>>> cd7c1c9b530 (Do not track configuration inputs when inside the ValueSource)
     }
 
     override fun envVariablesPrefixedBy(prefix: String, snapshot: Map<String, String?>) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSourceProviderFactory.java
@@ -43,9 +43,13 @@ public interface ValueSourceProviderFactory {
         Action<? super ValueSourceSpec<P>> configureAction
     );
 
-    void addListener(Listener listener);
+    void addValueListener(ValueListener listener);
 
-    void removeListener(Listener listener);
+    void removeValueListener(ValueListener listener);
+
+    void addComputationListener(ComputationListener listener);
+
+    void removeComputationListener(ComputationListener listener);
 
     <T, P extends ValueSourceParameters> Provider<T> instantiateValueSourceProvider(
         Class<? extends ValueSource<T, P>> valueSourceType,
@@ -53,9 +57,19 @@ public interface ValueSourceProviderFactory {
         @Nullable P parameters
     );
 
+    /**
+     * The listener that is notified when the value of the {@code ValueSource} is computed. There is no ordering guarantees with the
+     * {@link ValueListener#valueObtained(ValueListener.ObtainedValue, ValueSource)}.
+     */
     @EventScope(Scopes.Build.class)
-    interface Listener {
+    interface ComputationListener {
+        void beforeValueObtained();
 
+        void afterValueObtained();
+    }
+
+    @EventScope(Scopes.Build.class)
+    interface ValueListener {
         <T, P extends ValueSourceParameters> void valueObtained(
             ObtainedValue<T, P> obtainedValue,
             ValueSource<T, P> source


### PR DESCRIPTION
The ValueSource's value is a part of the configuration cache fingerprint
and it is recomputed each time the build runs, even when it runs from
cache. There is no need to additionally track inputs as only the value
of the ValueSource matters in the end.

For example, this allows users to implement complex filtering of the
available system properties without making every property an input to
the configuration phase.

Fixes https://github.com/gradle/configuration-cache/issues/569.

Another option would be to introduce a BuildOperation to compute ValueSource and use BuildOperationDetails to filter it out, similar to the TaskExecutionTracking, but this isn't as straightforward. It might be beneficial to make ValueSources visible to the build scan in the future, though.