### PR TITLE
Offer a more conventional default package name in build-init questionnaire

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/tasks/InitBuild.java
@@ -44,6 +44,7 @@ import org.gradle.work.DisableCachingByDefault;
 import javax.annotation.Nullable;
 import javax.lang.model.SourceVersion;
 import java.util.List;
+import java.util.Locale;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.gradle.buildinit.plugins.internal.PackageNameBuilder.toPackageName;
@@ -283,7 +284,7 @@ public class InitBuild extends DefaultTask {
         String packageName = this.packageName;
         if (initDescriptor.supportsPackage()) {
             if (isNullOrEmpty(packageName)) {
-                packageName = inputHandler.askQuestion("Source package", toPackageName(projectName));
+                packageName = inputHandler.askQuestion("Source package", toPackageName(projectName).toLowerCase(Locale.US));
             }
         } else if (!isNullOrEmpty(packageName)) {
             throw new GradleException("Package name is not supported for '" + initDescriptor.getId() + "' build type.");


### PR DESCRIPTION
When the user runs the init task, the default value for the package name is the name of the project.
The project name, however, has no formatting enforced and can start with an upper-case character.
Upper-case package names are unconventional in Java, and even cause problems with test filtering,
as reported at https://github.com/gradle/gradle/issues/20350.

This change improves the situation by offering the project name lower-cased as the default value for
the package name in the init task command input questionnaire.

Fixes #20350
