### PR TITLE
Fix dependency verification when there is an artifact entry without checksum in verification-metadata...

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1303,10 +1303,11 @@ This can indicate that a dependency has been compromised. Please carefully verif
         terse << [true, false]
     }
 
-    def "fallbacks to checksum and fails if artifact has an entry in the verification-metadata but no checksum and .asc file when #description=#enableVerifySignatures"() {
+    def "fallbacks to checksum and fails if artifact has an entry in the verification-metadata but no checksum and .asc file when verify-signatures=#enableVerifySignatures"() {
         createMetadataFile {
             keyServer(keyServerFixture.uri)
             enableVerifySignatures ? verifySignatures() : {}
+            // Add trusted keys just so there is an entry in the verification-metadata
             addTrustedKey("org:foo:1.0", validPublicKeyHexString)
             addTrustedKey("org:foo:1.0", validPublicKeyHexString, "pom", "pom")
         }
@@ -1321,15 +1322,33 @@ This can indicate that a dependency has been compromised. Please carefully verif
         """
 
         when:
+        terseConsoleOutput(false)
         serveValidKey()
 
         then:
         fails ":compileJava"
+        if (enableVerifySignatures) {
+            failure.assertHasCause("""Dependency verification failed for configuration ':compileClasspath':
+  - On artifact foo-1.0.jar (org:foo:1.0) multiple problems reported:
+      - in repository 'maven': artifact wasn't signed
+      - in repository 'maven': checksum is missing from verification metadata.
+  - On artifact foo-1.0.pom (org:foo:1.0) multiple problems reported:
+      - in repository 'maven': artifact wasn't signed
+      - in repository 'maven': checksum is missing from verification metadata.""")
+        } else {
+            failure.assertHasCause("""Dependency verification failed for configuration ':compileClasspath':
+  - On artifact foo-1.0.jar (org:foo:1.0) in repository 'maven': checksum is missing from verification metadata.
+  - On artifact foo-1.0.pom (org:foo:1.0) in repository 'maven': checksum is missing from verification metadata.""")
+        }
+        if (GradleContextualExecuter.isConfigCache()) {
+            failure.assertThatDescription(containsText("""Configuration cache problems found in this build.
+
+1 problem was found storing the configuration cache.
+- Task `:compileJava` of type `org.gradle.api.tasks.compile.JavaCompile`: value 'configuration ':compileClasspath'' failed to visit file collection"""))
+        }
 
         where:
-        description         | enableVerifySignatures
-        "verify-signatures" | true
-        "verify-signatures" | false
+        enableVerifySignatures << [true, false]
     }
 
     def "passes verification if an artifact is signed with multiple keys and one of them is ignored"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureCheckIntegTest.groovy
@@ -1622,8 +1622,11 @@ One artifact failed verification: foo-1.0.jar (org:foo:1.0) from repository mave
         javaLibrary()
         def module = mavenHttpRepo.module("org", "foo", "1.0")
             .withSourceAndJavadoc()
+            .withSignature {
+                signAsciiArmored(it)
+            }
             .publish()
-
+        serveValidKey()
         buildFile << """
             dependencies {
                 implementation "org:foo:1.0"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java
@@ -106,10 +106,17 @@ public class DependencyVerifier {
             for (ArtifactVerificationMetadata verification : verifications) {
                 String verifiedArtifact = verification.getArtifactName();
                 if (verifiedArtifact.equals(foundArtifactFileName)) {
-                    if (signature == null && config.isVerifySignatures()) {
-                        builder.failWith(new MissingSignature(file));
-                    }
-                    if (signature != null) {
+                    if (signature == null) {
+                        // There is no signature file or verify-signature=false
+                        if (config.isVerifySignatures()) {
+                            builder.failWith(new MissingSignature(file));
+                        }
+                        if (verification.getChecksums().isEmpty()) {
+                            builder.failWith(new MissingChecksums(file));
+                            return;
+                        }
+                    } else {
+                        // There is a signature file and verify-signature=true
                         DefaultSignatureVerificationResultBuilder result = new DefaultSignatureVerificationResultBuilder(file, signature);
                         verifySignature(signatureVerificationService, file, signature, allTrustedKeys(foundArtifact, verification.getTrustedPgpKeys()), allIgnoredKeys(verification.getIgnoredPgpKeys()), result);
                         if (result.hasOnlyIgnoredKeys()) {


### PR DESCRIPTION
...but signature verification is disabled or the signature file doesn't exist.

I was double-checking test from https://github.com/gradle/gradle/pull/20360 and I couldn't make it to fail. I noticed that if you have metadata with verify signatures set to `false` and entries have no checksum like:
```
<verification-metadata>
   <configuration>
      <verify-metadata>true</verify-metadata>
      <verify-signatures>false</verify-signatures>
   </configuration>
   <components>
      <component group="org" name="foo" version="1.0">
         <artifact name="foo-1.0.jar">
            <pgp value="d7bf96a169f77b28c934ab1614f53f0824875d73"/>
         </artifact>
         <artifact name="foo-1.0.pom">
            <pgp value="d7bf96a169f77b28c934ab1614f53f0824875d73"/>
         </artifact>
      </component>
   </components>
</verification-metadata>
```
then dependency verification doesn't fail. I would expect that it fails with `checksum is missing from verification metadata`. It doesn't fail also when verify signatures is set to `true`, artifact doesn't have a signature file (`.asc`) and there is no checksum set for the entry.

Fix also makes test from #20360 fail properly if the signature file is missing or if there will be a bug in code that will incorrectly calculate the `.asc` file. 
