### PR TITLE
Fall back to hashing the zip entry when ABI extraction fails during fingerprinting

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultCompileClasspathFingerprinter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/DefaultCompileClasspathFingerprinter.java
@@ -29,7 +29,7 @@ import org.gradle.internal.fingerprint.impl.AbstractFileCollectionFingerprinter;
 public class DefaultCompileClasspathFingerprinter extends AbstractFileCollectionFingerprinter implements CompileClasspathFingerprinter {
     public DefaultCompileClasspathFingerprinter(ResourceSnapshotterCacheService cacheService, FileCollectionSnapshotter fileCollectionSnapshotter, StringInterner stringInterner) {
         super(ClasspathFingerprintingStrategy.compileClasspath(
-            new CachingResourceHasher(new AbiExtractingClasspathResourceHasher(), cacheService),
+            new CachingResourceHasher(AbiExtractingClasspathResourceHasher.DEFAULT, cacheService),
             cacheService,
             stringInterner
         ), fileCollectionSnapshotter);

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinCompileClasspathFingerprinter.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/normalization/KotlinCompileClasspathFingerprinter.kt
@@ -37,7 +37,7 @@ class KotlinCompileClasspathFingerprinter(
     stringInterner: StringInterner
 ) : AbstractFileCollectionFingerprinter(
     ClasspathFingerprintingStrategy.compileClasspath(
-        CachingResourceHasher(AbiExtractingClasspathResourceHasher(KotlinApiClassExtractor()), cacheService),
+        CachingResourceHasher(AbiExtractingClasspathResourceHasher.withoutFallback(KotlinApiClassExtractor()), cacheService),
         cacheService,
         stringInterner,
         CompileAvoidanceExceptionReporter()

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -585,7 +585,8 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         executedAndNotSkipped ':fooJar', ':compileJava'
-        outputContains "Malformed archive 'foo.jar'"
+        outputContains "Could not analyze foo.class for incremental compilation"
+        outputContains "Unsupported class file major version"
     }
 
     @Issue("gradle/gradle#1358")

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -38,21 +38,22 @@ import java.util.Collections;
 
 public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbiExtractingClasspathResourceHasher.class);
+    public static final AbiExtractingClasspathResourceHasher DEFAULT = withFallback(new ApiClassExtractor(Collections.emptySet()));
 
     private final ApiClassExtractor extractor;
     private final FallbackStrategy fallbackStrategy;
 
-    public AbiExtractingClasspathResourceHasher() {
-        this(new ApiClassExtractor(Collections.emptySet()), FallbackStrategy.FULL_HASH);
-    }
-
-    public AbiExtractingClasspathResourceHasher(ApiClassExtractor extractor) {
-        this(extractor, FallbackStrategy.NONE);
-    }
-
     private AbiExtractingClasspathResourceHasher(ApiClassExtractor extractor, FallbackStrategy fallbackStrategy) {
         this.extractor = extractor;
         this.fallbackStrategy = fallbackStrategy;
+    }
+
+    public static AbiExtractingClasspathResourceHasher withFallback(ApiClassExtractor extractor) {
+        return new AbiExtractingClasspathResourceHasher(extractor, FallbackStrategy.FULL_HASH);
+    }
+
+    public static AbiExtractingClasspathResourceHasher withoutFallback(ApiClassExtractor extractor) {
+        return new AbiExtractingClasspathResourceHasher(extractor, FallbackStrategy.NONE);
     }
 
     @Nullable


### PR DESCRIPTION
Fixes #20398 

