### PR TITLE
Use serializable lambda for rename in CopySpecWrapper

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -99,6 +99,24 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
         "jar.get().archiveFile"          | _
     }
 
+    @Issue("gradle/gradle#20390")
+    def "can deserialize copy task with rename"() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile """
+            tasks.register('copyAndRename', Copy) {
+                from('foo') { rename { 'bar' } }
+            }
+        """
+
+        when:
+        configurationCacheRun "copyAndRename"
+        configurationCacheRun "copyAndRename"
+
+        then:
+        configurationCache.assertStateLoaded()
+    }
+
     def "configuration cache for help on empty project"() {
         given:
         settingsFile.createFile()

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/CopySpecWrapper.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static org.gradle.api.internal.lambdas.SerializableLambdas.transformer;
+
 /**
  * Wraps another CopySpec impl, only exposing the CopySpec API.
  *
@@ -207,11 +209,11 @@ public class CopySpecWrapper implements CopySpec {
 
     @Override
     public CopySpec rename(final Closure closure) {
-        delegate.rename(s -> {
+        delegate.rename(transformer(s -> {
             Object res = closure.call(s);
             //noinspection ConstantConditions
             return res == null ? null : res.toString();
-        });
+        }));
         return this;
     }
 


### PR DESCRIPTION
Signed-off-by: Filip Daca <filip.hubert.daca@gmail.com>

<!--- The issue this PR addresses -->
Fixes #20390

### Context

This PR fixes configuration cache for Copy tasks with `rename` action by using a serializable lambda wrapper.

It would make build configuration cache work for below example:
```
tasks.register('foo', Copy) {
  from('bar') { rename { 'biz' } }
}
```

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] ~~Provide unit tests (under `<subproject>/src/test`) to verify logic~~
- [ ] ~~Update User Guide, DSL Reference, and Javadoc for public-facing changes~~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
