### PR TITLE
Do not run some UndeclaredBuildInputsIntegrationTest in no-daemon mode

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.configurationcache.inputs.undeclared
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import java.util.function.Supplier
@@ -391,6 +393,9 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         outputContains("some.removed.property = null")
     }
 
+    // Running with --no-daemon causes the test to fail when changing the command line because the
+    // internal property sun.java.command changes.
+    @IgnoreIf({ GradleContextualExecuter.isNoDaemon() })
     def "properties set after clearing system properties with #systemPropsCleaner do not become inputs"() {
         given:
         buildFile("""


### PR DESCRIPTION
The test has to change the Gradle command line to inject a system
property. In the no-daemon mode the change of the command line affects
"sun.java.command" system property that holds this command line. In
all other modes the changes doesn't affect the original command line.
By the nature of the tests all system properties are inputs to the
configuration cache and the no-daemon behavior unexpectedly invalidates
the cache.

This test doesn't test anything particularly specific to no-daemon or
daemon mode and can be safely skipped in the no-daemon configuration.
