### PR TITLE
Add providers to look up env vars and system properties by prefix

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/EnvVariableInjection.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/EnvVariableInjection.groovy
@@ -20,6 +20,10 @@ import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
 
 abstract class EnvVariableInjection extends BuildInputInjection {
     static EnvVariableInjection environmentVariable(String key, String value) {
+        return environmentVariables((key): value)
+    }
+
+    static EnvVariableInjection environmentVariables(Map<String, String> variables) {
         return new EnvVariableInjection() {
             @Override
             String getDescription() {
@@ -29,11 +33,13 @@ abstract class EnvVariableInjection extends BuildInputInjection {
             @Override
             void setup(AbstractConfigurationCacheIntegrationTest test) {
                 HashMap<String, String> environment = new HashMap<>(System.getenv())
-                if (value != null) {
-                    environment.put(key, value)
-                } else {
-                    environment.remove(key)
-                }
+                variables.forEach((k, v) -> {
+                    if (v != null) {
+                        environment.put(k, v)
+                    } else {
+                        environment.remove(k)
+                    }
+                })
                 test.executer.withEnvironmentVars(environment)
             }
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -709,6 +709,10 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         then:
         configurationCache.assertStateStored()
         outputContains("Configuration: CI1 = 1")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': environment variables prefixed by 'CI'")
+        }
+
 
         when:
         EnvVariableInjection.environmentVariable("CI1", "1").setup(this)
@@ -726,6 +730,9 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         configurationCache.assertStateStored()
         outputContains("Configuration: CI1 = 1")
         outputContains("Configuration: CI2 = 2")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': environment variables prefixed by 'CI'")
+        }
     }
 
     def "build logic can read system properties with prefix"() {
@@ -751,6 +758,9 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         then:
         configurationCache.assertStateStored()
         outputContains("Configuration: some.property.1 = 1")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': system properties prefixed by 'some.property.'")
+        }
 
         when:
         configurationCacheRun("-Dsome.property.1=1", "print")
@@ -766,6 +776,9 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         configurationCache.assertStateStored()
         outputContains("Configuration: some.property.1 = 1")
         outputContains("Configuration: some.property.2 = 2")
+        problems.assertResultHasProblems(result) {
+            withInput("Build file 'build.gradle': system properties prefixed by 'some.property.'")
+        }
     }
 
     def "system properties overwritten in build logic are not inputs to prefixed system properties"() {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -78,7 +78,7 @@ class InstrumentedInputAccessListener(
     val externalProcessListener = configurationCacheProblemsListener
 
     override fun systemPropertyQueried(key: String, value: Any?, consumer: String) {
-        if (allowedProperties.contains(key) || environmentChangeTracker.isSystemPropertyMutated(key) || Workarounds.canReadSystemProperty(consumer)) {
+        if (allowedProperties.contains(key) || Workarounds.canReadSystemProperty(consumer)) {
             return
         }
         undeclaredInputBroadcast.systemPropertyRead(key, value, consumer)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprint.kt
@@ -85,8 +85,23 @@ sealed class ConfigurationCacheFingerprint {
 
     class SystemPropertiesPrefixedBy(
         val prefix: String,
-        val snapshot: Map<String, String?>
-    ) : ConfigurationCacheFingerprint()
+        val snapshot: Map<String, Any?>
+    ) : ConfigurationCacheFingerprint() {
+        companion object {
+            /**
+             * The placeholder for system properties modified by the build logic at the time of
+             * reading. Such properties shouldn't be taken into account when comparing snapshots.
+             */
+            val IGNORED: Any = Ignored.INSTANCE
+
+            // Enum ensures that only one instance of INSTANCE exists and even deserialization
+            // doesn't create a new one. The `object` has no such guarantee.
+            private
+            enum class Ignored {
+                INSTANCE
+            }
+        }
+    }
 
     class EnvironmentVariablesPrefixedBy(
         val prefix: String,

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintChecker.kt
@@ -193,8 +193,16 @@ class ConfigurationCacheFingerprintChecker(private val host: Host) {
                 }
             }
             is ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy -> input.run {
-                val current = System.getProperties().uncheckedCast<Map<String, Any>>().filterKeysByPrefix(prefix)
-                if (current != snapshot) {
+                val currentWithoutIgnored = System.getProperties().uncheckedCast<Map<String, Any>>().filterKeysByPrefix(prefix).filterKeys {
+                    // remove properties that are known to be modified by the build logic at the moment of obtaining this, as their initial
+                    // values doesn't matter.
+                    snapshot[it] != ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy.IGNORED
+                }
+                val snapshotWithoutIgnored = snapshot.filterValues {
+                    // remove placeholders of modified properties to only compare relevant values.
+                    it != ConfigurationCacheFingerprint.SystemPropertiesPrefixedBy.IGNORED
+                }
+                if (currentWithoutIgnored != snapshotWithoutIgnored) {
                     return "the set of system properties prefixed by '$prefix' has changed"
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintController.kt
@@ -33,6 +33,7 @@ import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.location
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.serialization.ReadContext
+import org.gradle.configurationcache.services.EnvironmentChangeTracker
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.concurrent.Stoppable
 import org.gradle.internal.event.ListenerManager
@@ -74,6 +75,7 @@ class ConfigurationCacheFingerprintController internal constructor(
     private val report: ConfigurationCacheReport,
     private val userCodeApplicationContext: UserCodeApplicationContext,
     private val taskExecutionTracker: TaskExecutionTracker,
+    private val environmentChangeTracker: EnvironmentChangeTracker,
 ) : Stoppable {
 
     interface Host {
@@ -121,7 +123,8 @@ class ConfigurationCacheFingerprintController internal constructor(
                 writeContextForOutputStream(projectScopedOutputStream),
                 fileCollectionFactory,
                 directoryFileTreeFactory,
-                taskExecutionTracker
+                taskExecutionTracker,
+                environmentChangeTracker
             )
             addListener(fingerprintWriter)
             return Writing(fingerprintWriter, buildScopedSpoolFile, projectScopedSpoolFile)

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -31,6 +31,7 @@ import org.gradle.process.ExecOutput;
 import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 
@@ -76,6 +77,28 @@ public interface ProviderFactory {
     Provider<String> environmentVariable(Provider<String> variableName);
 
     /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the environment variables with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the environment variable names
+     * @return The provider. Never returns null.
+     * @since 7.5
+     */
+    @Incubating
+    Provider<Map<String, String>> environmentVariablesPrefixedBy(String variableNamePrefix);
+
+    /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the environment variables with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the environment variable names
+     * @return The provider. Never returns null.
+     * @since 7.5
+     */
+    @Incubating
+    Provider<Map<String, String>> environmentVariablesPrefixedBy(Provider<String> variableNamePrefix);
+
+    /**
      * Creates a {@link Provider} whose value is fetched from system properties using the given property name.
      *
      * @param propertyName the name of the system property
@@ -92,6 +115,28 @@ public interface ProviderFactory {
      * @since 6.1
      */
     Provider<String> systemProperty(Provider<String> propertyName);
+
+    /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the system properties with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the system property names
+     * @return The provider. Never returns null.
+     * @since 7.5
+     */
+    @Incubating
+    Provider<Map<String, String>> systemPropertiesPrefixedBy(String variableNamePrefix);
+
+    /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the system properties with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the system property names
+     * @return The provider. Never returns null.
+     * @since 7.5
+     */
+    @Incubating
+    Provider<Map<String, String>> systemPropertiesPrefixedBy(Provider<String> variableNamePrefix);
 
     /**
      * Creates a {@link Provider} whose value is fetched from the Gradle property of the given name.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -22,9 +22,11 @@ import org.gradle.api.file.FileContents;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource;
+import org.gradle.api.internal.provider.sources.EnvironmentVariablesPrefixedByValueSource;
 import org.gradle.api.internal.provider.sources.FileBytesValueSource;
 import org.gradle.api.internal.provider.sources.FileTextValueSource;
 import org.gradle.api.internal.provider.sources.GradlePropertyValueSource;
+import org.gradle.api.internal.provider.sources.SystemPropertiesPrefixedByValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
 import org.gradle.api.internal.provider.sources.process.DefaultExecOutput;
 import org.gradle.api.internal.provider.sources.process.ProcessOutputProviderFactory;
@@ -40,6 +42,7 @@ import org.gradle.process.ExecSpec;
 import org.gradle.process.JavaExecSpec;
 
 import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 
@@ -90,6 +93,19 @@ public class DefaultProviderFactory implements ProviderFactory {
     }
 
     @Override
+    public Provider<Map<String, String>> environmentVariablesPrefixedBy(String variableNamePrefix) {
+        return environmentVariablesPrefixedBy(Providers.of(variableNamePrefix));
+    }
+
+    @Override
+    public Provider<Map<String, String>> environmentVariablesPrefixedBy(Provider<String> variableNamePrefix) {
+        return of(
+            EnvironmentVariablesPrefixedByValueSource.class,
+            spec -> spec.getParameters().getPrefix().set(variableNamePrefix)
+        );
+    }
+
+    @Override
     public Provider<String> systemProperty(String propertyName) {
         return systemProperty(Providers.of(propertyName));
     }
@@ -99,6 +115,19 @@ public class DefaultProviderFactory implements ProviderFactory {
         return of(
             SystemPropertyValueSource.class,
             spec -> spec.getParameters().getPropertyName().set(propertyName)
+        );
+    }
+
+    @Override
+    public Provider<Map<String, String>> systemPropertiesPrefixedBy(String variableNamePrefix) {
+        return systemPropertiesPrefixedBy(Providers.of(variableNamePrefix));
+    }
+
+    @Override
+    public Provider<Map<String, String>> systemPropertiesPrefixedBy(Provider<String> variableNamePrefix) {
+        return of(
+            SystemPropertiesPrefixedByValueSource.class,
+            spec -> spec.getParameters().getPrefix().set(variableNamePrefix)
         );
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariablesPrefixedByValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/EnvironmentVariablesPrefixedByValueSource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class EnvironmentVariablesPrefixedByValueSource extends MapWithPrefixedKeysValueSource<EnvironmentVariablesPrefixedByValueSource.Parameters> {
+    public interface Parameters extends MapWithPrefixedKeysValueSource.Parameters {
+    }
+
+    @Override
+    protected Stream<Map.Entry<String, String>> itemsToFilter() {
+        return System.getenv().entrySet().stream();
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/MapWithPrefixedKeysValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/MapWithPrefixedKeysValueSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import com.google.common.collect.ImmutableMap;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class MapWithPrefixedKeysValueSource<P extends MapWithPrefixedKeysValueSource.Parameters> implements ValueSource<Map<String, String>, P> {
+    public interface Parameters extends ValueSourceParameters {
+        Property<String> getPrefix();
+    }
+
+    @Nullable
+    @Override
+    public Map<String, String> obtain() {
+        String prefix = getParameters().getPrefix().getOrElse("");
+
+        return itemsToFilter()
+            .filter(e -> e.getKey().startsWith(prefix))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    protected abstract Stream<Map.Entry<String, String>> itemsToFilter();
+}

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertiesPrefixedByValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/SystemPropertiesPrefixedByValueSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class SystemPropertiesPrefixedByValueSource extends MapWithPrefixedKeysValueSource<SystemPropertiesPrefixedByValueSource.Parameters> {
+    public interface Parameters extends MapWithPrefixedKeysValueSource.Parameters {
+    }
+
+    @Override
+    protected Stream<Map.Entry<String, String>> itemsToFilter() {
+        return System.getProperties().entrySet().stream()
+            .filter(e -> e.getKey() instanceof String && e.getValue() instanceof String)
+            .map(e -> {
+                Map.Entry<?, ?> untypedEntry = e;
+                @SuppressWarnings("unchecked")
+                Map.Entry<String, String> stringEntry = (Map.Entry<String, String>) untypedEntry;
+                return stringEntry;
+            });
+    }
+}


### PR DESCRIPTION
There are many user requests to be able to look up a subset of the
environment variables or system properties in configuration-cache
compatible way. Filtering the variables in the build logic makes all
of them, even the unrelated ones, inputs to the configuration cache,
reducing cache hits. The configuration cache machinery is unable to
understand the meaning of the filtering code in the build logic and
,therefore, cannot reduce the number of inputs.
    
This commit adds a specific API to address the most common use case
of selecting a subset of variables with names sharing a common prefix.
When the provider returned by the new API is resolved at the
configuration time, all variables with the prefix become an input.
No other variables affect the cache fingerprint.

Fixes #13819
