### PR TITLE
Properly run Groovydoc tests, disable some

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/MultiVersionIntegrationSpec.groovy
@@ -33,12 +33,18 @@ abstract class MultiVersionIntegrationSpec extends AbstractIntegrationSpec {
     static def version
 
     static VersionNumber getVersionNumber() {
+        if (version == null) {
+            throw new IllegalStateException("No version present")
+        }
         def m = version.toString() =~ CLASSIFIER_PATTERN
         VersionNumber.parse(m[0][1])
     }
 
     @Nullable
     static String getVersionClassifier() {
+        if (version == null) {
+            throw new IllegalStateException("No version present")
+        }
         def m = version.toString() =~ CLASSIFIER_PATTERN
         return m[0][2]
     }

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocOptionsIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocOptionsIntegrationTest.groovy
@@ -20,9 +20,9 @@ import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.GroovyCoverage
 import org.gradle.util.internal.VersionNumber
-import spock.lang.Requires
 
 import static org.gradle.util.internal.GroovyDependencyUtil.groovyModuleDependency
+import static org.junit.Assume.assumeTrue
 
 @TargetCoverage({ GroovyCoverage.SUPPORTS_GROOVYDOC })
 class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
@@ -35,6 +35,11 @@ class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
 
     private static boolean supportsScriptsInGroovydoc() {
         return versionNumber >= VersionNumber.parse("1.7.3")
+    }
+
+    private static boolean supportsDisablingScriptsInGroovydoc() {
+        // Groovy 3 to 4 doesn't support script flags at all. The Parrot parser doesn't check them.
+        return supportsScriptsInGroovydoc() && versionNumber < VersionNumber.parse("3.0.0")
     }
 
     // The flags are available in all versions of Groovydoc, but package/protected only works in 1.7 and above
@@ -71,8 +76,8 @@ class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
         """
     }
 
-    @Requires({ supportsScriptsInGroovydoc() })
     def "scripts are enabled and have main method by default"() {
+        assumeTrue(supportsScriptsInGroovydoc())
         when:
         buildFile << "groovydoc {}"
         run "groovydoc"
@@ -83,8 +88,8 @@ class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
         doc.text =~ GROOVY_DOC_MAIN_PATTERN
     }
 
-    @Requires({ supportsScriptsInGroovydoc() })
     def "scripts can be disabled"() {
+        assumeTrue(supportsDisablingScriptsInGroovydoc())
         when:
         buildFile << "groovydoc { processScripts = false }"
         run "groovydoc"
@@ -94,8 +99,8 @@ class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
         !doc.exists()
     }
 
-    @Requires({ supportsScriptsInGroovydoc() })
     def "main method can be disabled for scripts"() {
+        assumeTrue(supportsDisablingScriptsInGroovydoc())
         when:
         buildFile << "groovydoc { includeMainForScripts = false }"
         run "groovydoc"

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocOptionsIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocOptionsIntegrationTest.groovy
@@ -39,6 +39,7 @@ class GroovyDocOptionsIntegrationTest extends MultiVersionIntegrationSpec {
 
     private static boolean supportsDisablingScriptsInGroovydoc() {
         // Groovy 3 to 4 doesn't support script flags at all. The Parrot parser doesn't check them.
+        // https://issues.apache.org/jira/browse/GROOVY-10578
         return supportsScriptsInGroovydoc() && versionNumber < VersionNumber.parse("3.0.0")
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -408,6 +408,11 @@ public class Groovydoc extends SourceTask {
     /**
      * Whether to process scripts.
      *
+     * <p>
+     * This option has no effect under at least Groovy 3.0.0 to 3.0.10, and Groovy 4.0.0 to 4.0.1, because it is not
+     * currently checked by the new Parrot-based Groovydoc.
+     * </p>
+     *
      * @since 7.5
      */
     @Input
@@ -417,6 +422,11 @@ public class Groovydoc extends SourceTask {
 
     /**
      * Whether to include main method for scripts.
+     *
+     * <p>
+     * This option has no effect under at least Groovy 3.0.0 to 3.0.10, and Groovy 4.0.0 to 4.0.1, because it is not
+     * currently checked by the new Parrot-based Groovydoc.
+     * </p>
      *
      * @since 7.5
      */


### PR DESCRIPTION
Groovydoc 3 & 4 don't check the script flags, so they can't actually be disabled any more.

https://issues.apache.org/jira/browse/GROOVY-10578