### PR TITLE
Document --show-version option

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -163,6 +163,12 @@ The [`Groovydoc`](dsl/org.gradle.api.tasks.javadoc.Groovydoc.html) task now expo
 
 These defaults are the same as what was previously used, so there should be no changes to the default behavior.
 
+### --show-version (-V) flag
+
+The `-V` flag (long form `--show-version`) instructs Gradle to first print version information and then continue executing any requested tasks.  This is in contrast to the pre-existing `-v` (long form `--version`) flag which prints version information and then immediately exits.
+
+This flag may be useful in CI enviroments to record Gradle version information in the log as part of a single Gradle execution.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -335,7 +335,10 @@ image::gradle-completion-4.0.gif[]
 Shows a help message with all available CLI options.
 
 `-v`, `--version`::
-Prints Gradle, Groovy, Ant, JVM, and operating system version information.
+Prints Gradle, Groovy, Ant, JVM, and operating system version information and exit without executing any tasks.
+
+`-V`, `--show-version`::
+Prints Gradle, Groovy, Ant, JVM, and operating system version information and continue execution of specified tasks.
 
 `-S`, `--full-stacktrace`::
 Print out the full (very verbose) stacktrace for any exceptions. See also <<#sec:command_line_logging, logging options>>.


### PR DESCRIPTION
Related to #20374 - adds release notes and documentation for `--show-version` CLI option.