### PR TITLE
Rename OutputChangeListener.{beforeOutputChange -> invalidateCachesFor}

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -473,6 +473,8 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
                 abstract RegularFileProperty getZipFile()
 
                 ZipSrc() {
+                    // We need a way to count access times, that is why I ended up with configuring it in the task so it has access to countResolved.
+                    // I didn't find a way to make the test configuration cache compatible without the extra sources property and doing this configuration in the task registration.
                     sourceFiles.from(sources.map {
                         if (countResolved == ${countResolvedBeforeTaskExecution}) {
                             println "resolving input"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
@@ -89,7 +89,7 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
             }
         }
         if (!filesToDelete.isEmpty()) {
-            outputChangeListener.beforeOutputChange(
+            outputChangeListener.invalidateCachesFor(
                 filesToDelete.stream()
                     .map(File::getAbsolutePath)
                     .collect(Collectors.toList())

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
@@ -103,7 +103,7 @@ public class DefaultFileContentCacheFactory implements FileContentCacheFactory, 
         }
 
         @Override
-        public void beforeOutputChange(Iterable<String> affectedOutputPaths) {
+        public void invalidateCachesFor(Iterable<String> affectedOutputPaths) {
             // A very dumb strategy for invalidating cache
             locationCache.clear();
         }

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -185,7 +185,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         0 * _
 
         when:
-        listenerManager.getBroadcaster(OutputChangeListener).beforeOutputChange([])
+        listenerManager.getBroadcaster(OutputChangeListener).invalidateCachesFor([])
         result = cache.get(file)
 
         then:
@@ -214,7 +214,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         0 * _
 
         when:
-        listenerManager.getBroadcaster(OutputChangeListener).beforeOutputChange([])
+        listenerManager.getBroadcaster(OutputChangeListener).invalidateCachesFor([])
         result = cache.get(file)
 
         then:
@@ -244,7 +244,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         0 * _
 
         when:
-        listenerManager.getBroadcaster(OutputChangeListener).beforeOutputChange([])
+        listenerManager.getBroadcaster(OutputChangeListener).invalidateCachesFor([])
         result = cache.get(file)
 
         then:

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/Ear.java
@@ -110,7 +110,7 @@ public class Ear extends Jar {
                 return fileCollectionFactory().generated(
                     getTemporaryDirFactory(),
                     descriptorFileName,
-                    file -> outputChangeListener.beforeOutputChange(singleton(file.getAbsolutePath())),
+                    file -> outputChangeListener.invalidateCachesFor(singleton(file.getAbsolutePath())),
                     outputStream -> {
                         try {
                             outputStream.write(cachedDescriptor.get());

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -107,7 +107,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     def outputChangeListener = new OutputChangeListener() {
 
         @Override
-        void beforeOutputChange(Iterable<String> affectedOutputPaths) {
+        void invalidateCachesFor(Iterable<String> affectedOutputPaths) {
             fileSystemAccess.write(affectedOutputPaths) {}
         }
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
@@ -24,7 +24,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 @ServiceScope(Scopes.Build.class)
 public interface OutputChangeListener {
     /**
-     * Invoked when some locations on disk have been changed or are about to be changed by Gradle.
+     * Invoked when some locations on disk have been changed or are about to be changed.
      * This happens for example just before and after the task actions are executed or the outputs are loaded from the cache.
      *
      * @param affectedOutputPaths The files which are affected by the change.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputChangeListener.java
@@ -24,10 +24,10 @@ import org.gradle.internal.service.scopes.ServiceScope;
 @ServiceScope(Scopes.Build.class)
 public interface OutputChangeListener {
     /**
-     * Invoked when the outputs of a work item are about to change.
-     * This happens for example just before the task actions are executed or the outputs are loaded from the cache.
+     * Invoked when some locations on disk have been changed or are about to be changed by Gradle.
+     * This happens for example just before and after the task actions are executed or the outputs are loaded from the cache.
      *
      * @param affectedOutputPaths The files which are affected by the change.
      */
-    void beforeOutputChange(Iterable<String> affectedOutputPaths);
+    void invalidateCachesFor(Iterable<String> affectedOutputPaths);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildCacheStep.java
@@ -137,7 +137,7 @@ public class BuildCacheStep implements Step<IncrementalChangesContext, AfterExec
             @Override
             public void visitLocalState(File localStateRoot) {
                 try {
-                    outputChangeListener.beforeOutputChange(ImmutableList.of(localStateRoot.getAbsolutePath()));
+                    outputChangeListener.invalidateCachesFor(ImmutableList.of(localStateRoot.getAbsolutePath()));
                     deleter.deleteRecursively(localStateRoot);
                 } catch (IOException ex) {
                     throw new UncheckedIOException(String.format("Failed to clean up local state files for %s: %s", work.getDisplayName(), localStateRoot), ex);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
@@ -119,11 +119,11 @@ public class CaptureStateAfterExecutionStep<C extends InputChangesContext> exten
             }
         });
         ImmutableList<String> outputsToBeChanged = builder.build();
-        outputChangeListener.beforeOutputChange(outputsToBeChanged);
+        outputChangeListener.invalidateCachesFor(outputsToBeChanged);
         try {
             return delegate.execute(work, wrapInChangesOutputsContext(context));
         } finally {
-            outputChangeListener.beforeOutputChange(outputsToBeChanged);
+            outputChangeListener.invalidateCachesFor(outputsToBeChanged);
         }
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemovePreviousOutputsStep.java
@@ -97,7 +97,7 @@ public class RemovePreviousOutputsStep<C extends ChangingOutputsContext, R exten
             for (FileSystemSnapshot snapshot : previousOutputs.getOutputFilesProducedByWork().values()) {
                 try {
                     // Previous outputs can be in a different place than the current outputs
-                    outputChangeListener.beforeOutputChange(SnapshotUtil.rootIndex(snapshot).keySet());
+                    outputChangeListener.invalidateCachesFor(SnapshotUtil.rootIndex(snapshot).keySet());
                     cleaner.cleanupOutputs(snapshot);
                 } catch (IOException e) {
                     throw new UncheckedIOException("Failed to clean up output files for " + work.getDisplayName(), e);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/SkipEmptyWorkStep.java
@@ -264,7 +264,7 @@ public class SkipEmptyWorkStep implements Step<PreviousExecutionContext, Caching
         OutputsCleaner outputsCleaner = outputsCleanerSupplier.get();
         for (FileSystemSnapshot outputFileSnapshot : outputFileSnapshots.values()) {
             try {
-                outputChangeListener.beforeOutputChange(SnapshotUtil.rootIndex(outputFileSnapshot).keySet());
+                outputChangeListener.invalidateCachesFor(SnapshotUtil.rootIndex(outputFileSnapshot).keySet());
                 outputsCleaner.cleanupOutputs(outputFileSnapshot);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -80,7 +80,7 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
         _ * work.visitOutputs(_ as File, _ as UnitOfWork.OutputVisitor) >> { File workspace, UnitOfWork.OutputVisitor visitor ->
             visitor.visitLocalState(localStateFile)
         }
-        1 * outputChangeListener.beforeOutputChange([localStateFile.getAbsolutePath()])
+        1 * outputChangeListener.invalidateCachesFor([localStateFile.getAbsolutePath()])
         1 * deleter.deleteRecursively(_) >> { File root ->
             assert root == localStateFile
             return true

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -66,11 +66,11 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         result.duration == delegateDuration
         assertNoOperation()
 
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegate.execute(work, _) >> delegateResult
         then:
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegateResult.duration >> delegateDuration
         _ * context.beforeExecutionState >> Optional.empty()
@@ -88,11 +88,11 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         result.duration == delegateDuration
         assertOperation()
 
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegate.execute(work, _) >> delegateResult
         then:
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegateResult.duration >> delegateDuration
         _ * context.beforeExecutionState >> Optional.of(Mock(BeforeExecutionState) {
@@ -116,11 +116,11 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         !result.afterExecutionState.get().reused
         assertOperation()
 
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegate.execute(work, _) >> delegateResult
         then:
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegateResult.duration >> delegateDuration
         _ * context.beforeExecutionState >> Optional.of(Mock(BeforeExecutionState) {
@@ -164,11 +164,11 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         result.afterExecutionState.get().originMetadata.executionTime >= result.duration
         !result.afterExecutionState.get().reused
 
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegate.execute(work, _) >> delegateResult
         then:
-        1 * outputChangeListener.beforeOutputChange([])
+        1 * outputChangeListener.invalidateCachesFor([])
         then:
         1 * delegateResult.duration >> delegateDuration
         _ * context.beforeExecutionState >> Optional.of(Stub(BeforeExecutionState) {
@@ -204,12 +204,12 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         }
 
         then:
-        1 * outputChangeListener.beforeOutputChange(changingOutputs)
+        1 * outputChangeListener.invalidateCachesFor(changingOutputs)
 
         then:
         1 * delegate.execute(work, _ as ChangingOutputsContext) >> delegateResult
         then:
-        1 * outputChangeListener.beforeOutputChange(changingOutputs)
+        1 * outputChangeListener.invalidateCachesFor(changingOutputs)
         then:
         1 * delegateResult.duration >> Duration.ofMillis(10)
         _ * context.beforeExecutionState >> Optional.empty()

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -188,8 +188,8 @@ class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext> imp
         }
         _ * context.previousExecutionState >> Optional.of(previousExecutionState)
         1 * previousExecutionState.outputFilesProducedByWork >> ImmutableSortedMap.of("dir", outputs.dirSnapshot, "file", outputs.fileSnapshot)
-        1 * outputChangeListener.beforeOutputChange({ Iterable<String> paths -> paths as List == [outputs.dir.absolutePath] })
-        1 * outputChangeListener.beforeOutputChange({ Iterable<String> paths -> paths as List == [outputs.file.absolutePath] })
+        1 * outputChangeListener.invalidateCachesFor({ Iterable<String> paths -> paths as List == [outputs.dir.absolutePath] })
+        1 * outputChangeListener.invalidateCachesFor({ Iterable<String> paths -> paths as List == [outputs.file.absolutePath] })
     }
 
     void cleanupExclusiveOutputs(WorkOutputs outputs, boolean incrementalExecution = false) {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
@@ -180,7 +180,7 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
         }
 
         and:
-        1 * outputChangeListener.beforeOutputChange(rootPaths(previousOutputFile))
+        1 * outputChangeListener.invalidateCachesFor(rootPaths(previousOutputFile))
 
         and:
         1 * outputsCleaner.cleanupOutputs(outputFileSnapshot)
@@ -215,7 +215,7 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
         }
 
         and:
-        1 * outputChangeListener.beforeOutputChange(rootPaths(previousOutputFile))
+        1 * outputChangeListener.invalidateCachesFor(rootPaths(previousOutputFile))
 
         and:
         1 * outputsCleaner.cleanupOutputs(outputFileSnapshot) >> { throw ioException }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/tasks/Jar.java
@@ -70,7 +70,7 @@ public class Jar extends Zip {
         return fileCollectionFactory().generated(
             getTemporaryDirFactory(),
             "MANIFEST.MF",
-            action(file -> outputChangeListener.beforeOutputChange(ImmutableList.of(file.getAbsolutePath()))),
+            action(file -> outputChangeListener.invalidateCachesFor(ImmutableList.of(file.getAbsolutePath()))),
             action(outputStream -> manifest.get().writeTo(outputStream))
         );
     }


### PR DESCRIPTION
to clarify that this may also happen after the outputs changed. This is a follow up for #20421.