### PR TITLE
Verify change to a project's GAV is permitted

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -472,16 +472,18 @@ public abstract class DefaultProject extends AbstractPluginAware implements Proj
     // Fixes root cause of issue 20377
     private void verifyChangeToGAVPermitted(String changeComponentName) {
         getRootProject().getAllprojects().forEach(p -> {
-            p.getConfigurations().forEach(c -> {
-                c.getDependencies().forEach(d -> {
-                    if (d instanceof ProjectDependency) {
-                        if (((ProjectDependency) d).getDependencyProject().equals(this)) {
-                            throw new RuntimeException("Cannot set " + changeComponentName + " on " + this + " because it is already a dependency of " + p + ".  " +
-                                    "A project's GAV coordinates cannot change after a it becomes a dependency of another project.");
-                        }
-                    }
-                });
-            });
+                if (!p.equals(this)) {
+                    p.getConfigurations().forEach(c -> {
+                        c.getDependencies().forEach(d -> {
+                            if (d instanceof ProjectDependency) {
+                                if (((ProjectDependency) d).getDependencyProject().equals(this)) {
+                                    throw new RuntimeException("Cannot set " + changeComponentName + " on " + this + " because it is already a dependency of " + p + ".  " +
+                                            "A project's GAV coordinates cannot change after a it becomes a dependency of another project.");
+                                }
+                            }
+                        });
+                    });
+                }
         });
     }
 


### PR DESCRIPTION
- Change is not allowed after the project has already been added as a project dependency, as this may make the project unresolvable.
- Only check after project group is already set to a non-null value, to permit the initial naming.

Fixes #20377
