### PR TITLE
Merging - Split nightly publish build into 2 steps

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -1,6 +1,7 @@
 package common
 
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
+import net.bytebuddy.build.ToStringPlugin.Enhance.Prefix
 
 data class VersionedSettingsBranch(val branchName: String, val enableTriggers: Boolean) {
 
@@ -33,4 +34,13 @@ data class VersionedSettingsBranch(val branchName: String, val enableTriggers: B
         get() = branchName == RELEASE_BRANCH
     val isExperimental: Boolean
         get() = branchName == EXPERIMENTAL_BRANCH
+
+    fun promoteNightlyTaskName() = nightlyTaskName("promote")
+    fun prepNightlyTaskName() = nightlyTaskName("prep")
+
+    private fun nightlyTaskName(prefix: String): String = when {
+        isMaster -> "${prefix}Nightly"
+        isRelease -> "${prefix}ReleaseNightly"
+        else -> "${prefix}PatchReleaseNightly"
+    }
 }

--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -17,20 +17,19 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import common.gradleWrapper
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionMaster
 
-abstract class PublishGradleDistribution(
+abstract class BasePublishGradleDistribution(
     // The branch to be promoted
-    promotedBranch: String,
-    task: String,
+    val promotedBranch: String,
     val triggerName: String,
-    gitUserName: String = "bot-teamcity",
-    gitUserEmail: String = "bot-teamcity@gradle.com",
-    extraParameters: String = "",
-    vcsRootId: String = gradlePromotionMaster
-) : BasePromotionBuildType(vcsRootId) {
+    val gitUserName: String = "bot-teamcity",
+    val gitUserEmail: String = "bot-teamcity@gradle.com",
+    val extraParameters: String = "",
+    vcsRootId: String = gradlePromotionMaster,
+    cleanCheckout: Boolean = true
+) : BasePromotionBuildType(vcsRootId, cleanCheckout) {
 
     init {
         artifactRules = """
@@ -41,23 +40,9 @@ abstract class PublishGradleDistribution(
         **/smoke-tests/build/reports/tests/** => post-smoke-tests
         """.trimIndent()
 
-        steps {
-            gradleWrapper {
-                name = "Promote"
-                tasks = task
-                gradleParams = """-PcommitId=%dep.${RelativeId("Check_Stage_${this@PublishGradleDistribution.triggerName}_Trigger")}.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" """
-            }
-        }
-
         dependencies {
-            snapshot(RelativeId("Check_Stage_${this@PublishGradleDistribution.triggerName}_Trigger")) {
+            snapshot(RelativeId("Check_Stage_${this@BasePublishGradleDistribution.triggerName}_Trigger")) {
             }
         }
     }
-}
-
-fun VersionedSettingsBranch.promoteNightlyTaskName(): String = when {
-    isMaster -> "promoteNightly"
-    isRelease -> "promoteReleaseNightly"
-    else -> "promotePatchReleaseNightly"
 }

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -13,6 +13,8 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     buildType(SanityCheck)
     buildType(PublishNightlySnapshot(branch))
     buildType(PublishNightlySnapshotFromQuickFeedback(branch))
+    buildType(PublishNightlySnapshotFromQuickFeedbackStep1(branch))
+    buildType(PublishNightlySnapshotFromQuickFeedbackStep2(branch))
     buildType(PublishBranchSnapshotFromQuickFeedback)
     buildType(PublishMilestone(branch))
 

--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -20,10 +20,11 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionBranches
 
-object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistribution(
+object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionBothSteps(
     promotedBranch = "%branch.to.promote%",
     triggerName = "QuickFeedback",
-    task = "promoteSnapshot",
+    prepTask = "prepSnapshot",
+    step2TargetTask = "promoteSnapshot",
     extraParameters = "-PpromotedBranch=%branch.qualifier% ",
     vcsRootId = gradlePromotionBranches
 ) {

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionBothSteps.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionBothSteps.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promotion
+
+import common.gradleWrapper
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
+import vcsroots.gradlePromotionMaster
+
+abstract class PublishGradleDistributionBothSteps(
+    // The branch to be promoted
+    promotedBranch: String,
+    prepTask: String,
+    step2TargetTask: String,
+    triggerName: String,
+    gitUserName: String = "bot-teamcity",
+    gitUserEmail: String = "bot-teamcity@gradle.com",
+    extraParameters: String = "",
+    vcsRootId: String = gradlePromotionMaster
+) : BasePublishGradleDistribution(promotedBranch, triggerName, gitUserName, gitUserEmail, extraParameters, vcsRootId) {
+    init {
+        steps {
+            buildStep(extraParameters, gitUserName, gitUserEmail, triggerName, prepTask, "uploadAll")
+            buildStep(extraParameters, gitUserName, gitUserEmail, triggerName, prepTask, step2TargetTask)
+        }
+    }
+}
+
+fun BuildSteps.buildStep(extraParameters: String, gitUserName: String, gitUserEmail: String, triggerName: String, prepTask: String, targetTask: String) {
+    gradleWrapper {
+        name = "Promote"
+        tasks = "$prepTask $targetTask"
+        gradleParams = """-PcommitId=%dep.${RelativeId("Check_Stage_${triggerName}_Trigger")}.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" %additional.gradle.parameters% """
+    }
+}

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -19,11 +19,14 @@ package promotion
 import common.VersionedSettingsBranch
 import configurations.branchFilter
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
+import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistribution(
+class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistributionBothSteps(
     promotedBranch = branch.branchName,
-    task = branch.promoteNightlyTaskName(),
-    triggerName = "ReadyforNightly"
+    prepTask = branch.prepNightlyTaskName(),
+    step2TargetTask = branch.promoteNightlyTaskName(),
+    triggerName = "ReadyforNightly",
+    vcsRootId = gradlePromotionBranches
 ) {
     init {
         id("Promotion_Nightly")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStep1.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStep1.kt
@@ -19,16 +19,25 @@ package promotion
 import common.VersionedSettingsBranch
 import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshotFromQuickFeedback(branch: VersionedSettingsBranch) : PublishGradleDistributionBothSteps(
+class PublishNightlySnapshotFromQuickFeedbackStep1(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
-    prepTask = branch.prepNightlyTaskName(),
-    step2TargetTask = branch.promoteNightlyTaskName(),
     triggerName = "QuickFeedback",
     vcsRootId = gradlePromotionBranches
 ) {
     init {
-        id("Promotion_SnapshotFromQuickFeedback")
-        name = "Nightly Snapshot (from QuickFeedback)"
-        description = "Promotes the latest successful changes on '${branch.branchName}' from Quick Feedback as a new nightly snapshot"
+        id("Promotion_SnapshotFromQuickFeedbackStep1")
+        name = "Nightly Snapshot (from QuickFeedback) - Step 1"
+        description = "Builds and uploads the latest successful changes on '${branch.branchName}' from Quick Feedback as a new distribution"
+
+        steps {
+            buildStep(
+                this@PublishNightlySnapshotFromQuickFeedbackStep1.extraParameters,
+                this@PublishNightlySnapshotFromQuickFeedbackStep1.gitUserName,
+                this@PublishNightlySnapshotFromQuickFeedbackStep1.gitUserEmail,
+                this@PublishNightlySnapshotFromQuickFeedbackStep1.triggerName,
+                branch.prepNightlyTaskName(),
+                "uploadAll"
+            )
+        }
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStep2.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStep2.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package promotion
+
+import common.VersionedSettingsBranch
+import vcsroots.gradlePromotionBranches
+
+class PublishNightlySnapshotFromQuickFeedbackStep2(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
+    promotedBranch = branch.branchName,
+    triggerName = "QuickFeedback",
+    vcsRootId = gradlePromotionBranches,
+    cleanCheckout = false
+) {
+    init {
+        id("Promotion_SnapshotFromQuickFeedbackStep2")
+        name = "Nightly Snapshot (from QuickFeedback) - Step 2"
+        description = "Promotes a previously built distribution on this agent on '${branch.branchName}' from Quick Feedback as a new nightly snapshot"
+
+        steps {
+            buildStep(
+                this@PublishNightlySnapshotFromQuickFeedbackStep2.extraParameters,
+                this@PublishNightlySnapshotFromQuickFeedbackStep2.gitUserName,
+                this@PublishNightlySnapshotFromQuickFeedbackStep2.gitUserEmail,
+                this@PublishNightlySnapshotFromQuickFeedbackStep2.triggerName,
+                branch.prepNightlyTaskName(),
+                branch.promoteNightlyTaskName()
+            )
+        }
+    }
+}

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -20,13 +20,15 @@ import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 
 abstract class PublishRelease(
-    task: String,
+    prepTask: String,
+    step2TargetTask: String,
     requiredConfirmationCode: String,
     promotedBranch: String,
     init: PublishRelease.() -> Unit = {}
-) : PublishGradleDistribution(
+) : PublishGradleDistributionBothSteps(
     promotedBranch = promotedBranch,
-    task = task,
+    prepTask = prepTask,
+    step2TargetTask = step2TargetTask,
     triggerName = "ReadyforRelease",
     gitUserEmail = "%gitUserEmail%",
     gitUserName = "%gitUserName%",
@@ -70,7 +72,8 @@ abstract class PublishRelease(
 
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
-    task = "promoteFinalRelease",
+    prepTask = "prepFinalRelease",
+    step2TargetTask = "promoteFinalRelease",
     requiredConfirmationCode = "final",
     init = {
         id("Promotion_FinalRelease")
@@ -81,7 +84,8 @@ class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
 
 class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
-    task = "promoteRc",
+    prepTask = "prepRc",
+    step2TargetTask = "promoteRc",
     requiredConfirmationCode = "rc",
     init = {
         id("Promotion_ReleaseCandidate")
@@ -92,7 +96,8 @@ class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
 
 class PublishMilestone(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
-    task = "promoteMilestone",
+    prepTask = "prepMilestone",
+    step2TargetTask = "promoteMilestone",
     requiredConfirmationCode = "milestone",
     init = {
         id("Promotion_Milestone")

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common.VersionedSettingsBranch
+import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
+import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
+import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import promotion.PromotionProject
+
+
+class PromotionProjectTests {
+    @Test
+    fun `promotion project has expected build types for master branch`() {
+        val model = setupModelFor("master")
+
+        assertEquals("Promotion", model.name)
+        assertEquals(9, model.buildTypes.size)
+        assertEquals(
+            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Step 1", "Nightly Snapshot (from QuickFeedback) - Step 2", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Start Release Cycle", "Start Release Cycle Test"),
+            model.buildTypes.map { it.name }
+        )
+    }
+
+    @Test
+    fun `promotion project has expected build types for other branches`() {
+        val model = setupModelFor("release")
+
+        assertEquals("Promotion", model.name)
+        assertEquals(9, model.buildTypes.size)
+        assertEquals(
+            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Step 1", "Nightly Snapshot (from QuickFeedback) - Step 2", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Release - Release Candidate", "Release - Final"),
+            model.buildTypes.map { it.name }
+        )
+    }
+
+    @Test
+    fun `promotion sanity check runs 'gradle tasks'`() {
+        val model = setupModelFor("release")
+
+        val sanityCheck = model.findBuildTypeByName("SanityCheck")
+        val steps = sanityCheck.steps.items
+        val gradleBuildStep = gradleStep(steps, 0)
+        gradleBuildStep.assertTasks("tasks")
+    }
+
+    @Test
+    fun `nightly promotion build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepReleaseNightly uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+    }
+
+    @Test
+    fun `start release cycle promotion build type runs one gradle invocation`() {
+        val model = setupModelFor("master")
+        val startReleaseCycle = model.findBuildTypeByName("Start Release Cycle")
+
+        val steps = startReleaseCycle.steps.items
+        assertEquals(1, steps.size)
+
+        val step = gradleStep(steps, 0)
+        step.assertTasks("clean promoteStartReleaseCycle")
+        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" """, step.gradleParams)
+    }
+
+    @Test
+    fun `start release cycle test promotion build type runs one gradle invocation`() {
+        val model = setupModelFor("master")
+        val startReleaseCycle = model.findBuildTypeByName("Start Release Cycle Test")
+
+        val steps = startReleaseCycle.steps.items
+        assertEquals(1, steps.size)
+
+        val step = gradleStep(steps, 0)
+        step.assertTasks("clean promoteStartReleaseCycle")
+        assertTrue(step.gradleParams!!.startsWith("""-PconfirmationCode=startCycle -PtestRun=1"""))
+    }
+
+    @Test
+    fun `nightly promotion from quick feedback build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback)")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepReleaseNightly uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+    }
+
+    @Test
+    fun `publish branch snapshot build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Publish Branch Snapshot (from Quick Feedback)")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepSnapshot uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepSnapshot promoteSnapshot")
+        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+    }
+
+    @Test
+    fun `nightly promotion from quick feedback step 1 build type runs one gradle invocation`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Step 1")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(1, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepReleaseNightly uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+    }
+
+    @Test
+    fun `nightly promotion from quick feedback step 2 build type runs one gradle invocation`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Step 2")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(1, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepReleaseNightly promoteReleaseNightly")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+    }
+
+    @Test
+    fun `publish final release build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Release - Final")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepFinalRelease uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepFinalRelease promoteFinalRelease")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, promote.gradleParams)
+    }
+
+    @Test
+    fun `publish rc build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Release - Release Candidate")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepRc uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepRc promoteRc")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+    }
+
+    @Test
+    fun `publish milestone build type runs two gradle invocations`() {
+        val model = setupModelFor("release")
+        val nightlytSnapshot = model.findBuildTypeByName("Release - Milestone")
+
+        val steps = nightlytSnapshot.steps.items
+        assertEquals(2, steps.size)
+
+        val upload = gradleStep(steps, 0)
+        upload.assertTasks("prepMilestone uploadAll")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+
+        val promote = gradleStep(steps, 1)
+        promote.assertTasks("prepMilestone promoteMilestone")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+    }
+
+    private fun setupModelFor(branchName: String): PromotionProject {
+        // Set the project id here, so we can use methods on the DslContext
+        DslContext.projectId = AbsoluteId("Gradle_${branchName}")
+        DslContext.addParameters("Branch" to branchName)
+        val model = PromotionProject(VersionedSettingsBranch(branchName, true))
+        return model
+    }
+
+    private fun gradleStep(steps: List<BuildStep>, index: Int): GradleBuildStep {
+        assertTrue(steps.size > index)
+        return steps[index] as GradleBuildStep
+    }
+
+    private fun GradleBuildStep.assertTasks(expectedTasks: String) = assertEquals(expectedTasks, this.tasks)
+    private fun PromotionProject.findBuildTypeByName(name: String) = this.buildTypes.find { it.name == name }!!
+}


### PR DESCRIPTION
- Add tests for the promotion project to verify proper build steps are present in projects.
- Slightly deeper class hierarchy to support Half builds which are single steps.
- Allow passing additional arguments to Gradle from TC when running builds.
- Add "prep" tasks which run first during either step (to ensure necessary properties are present).

This supercedes PR #20248 and provides a clean merge with just split work (not JDK 18 or other experimental work).
