### PR TITLE
Enable Test Distribution for performance tests

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -80,7 +80,7 @@ class PerformanceTest(
                                 "%performance.baselines%",
                                 extraParameters,
                                 os
-                            ) +
+                            ) + "-DenableTestDistribution=%enableTestDistribution%" +
                                 buildToolGradleParameters() +
                                 buildScanTag("PerformanceTest")
                             ).joinToString(separator = " ")

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -97,6 +97,7 @@ class PerformanceTestBuildTypeTest {
             "\"-Porg.gradle.performance.branchName=%teamcity.build.branch%\"",
             "\"-Porg.gradle.performance.db.url=%performance.db.url%\"",
             "\"-Porg.gradle.performance.db.username=%performance.db.username%\"",
+            "-DenableTestDistribution=%enableTestDistribution%",
             "-Dorg.gradle.workers.max=%maxParallelForks%",
             "-PmaxParallelForks=%maxParallelForks%",
             "-Dorg.gradle.internal.plugins.portal.url.override=%gradle.plugins.portal.url%",

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -309,7 +309,7 @@ fun configureTests() {
                     preferredMaxDuration.set(Duration.ofSeconds(this))
                 }
                 // No limit; use all available executors
-                distribution.maxRemoteExecutors.set(null)
+                distribution.maxRemoteExecutors.set(if (project.isPerformanceProject()) 0 else null)
                 // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
                 server.set(uri("https://ge-td-dogfooding.grdev.net"))
 
@@ -336,7 +336,9 @@ fun removeTeamcityTempProperty() {
     }
 }
 
-fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
+fun Project.isPerformanceProject() = setOf("build-scan-performance", "performance").contains(name)
+
+fun Project.enableExperimentalTestFiltering() = !setOf("configuration-cache", "kotlin-dsl", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
 
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).


### PR DESCRIPTION
So that we can use Test Selection for it.
It's only enabled on local executors.
