### PR TITLE
core-api: remove extraneous word in doc

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DuplicatesStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DuplicatesStrategy.java
@@ -17,7 +17,7 @@
 package org.gradle.api.file;
 
 /**
- * Strategies for dealing with the potential creation of duplicate files for or archive entries.
+ * Strategies for dealing with the potential creation of duplicate files or archive entries.
  */
 public enum DuplicatesStrategy {
 


### PR DESCRIPTION
Removes the word "for" from documentation for DuplicatesStrategy

<!--- The issue this PR addresses -->
Fixes none. PR trivial enough that it would make an issue overkill.

### Context
<!--- Why do you believe many users will benefit from this change? -->
Reading documentation will be easier as the wording is a bit confusing with the extra word.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
