### PR TITLE
Follow-ups of enabling Test Distribution for performance tests

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -70,13 +70,17 @@ fun Requirements.requiresNoEc2Agent() {
     doesNotContain("teamcity.agent.name", "EC2")
 }
 
-const val failedTestArtifactDestination = ".teamcity/gradle-logs"
+/**
+ * This is an undocumented location that forbids anonymous access.
+ * We put artifacts here to avoid accidentally exposing sensitive information publicly.
+ */
+const val hiddenArtifactDestination = ".teamcity/gradle-logs"
 
 fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, buildJvm: Jvm = BuildToolBuildJvm, timeout: Int = 30) {
     artifactRules = """
-        build/report-* => $failedTestArtifactDestination
-        build/tmp/test files/** => $failedTestArtifactDestination/test-files
-        build/errorLogs/** => $failedTestArtifactDestination/errorLogs
+        build/report-* => $hiddenArtifactDestination
+        build/tmp/test files/** => $hiddenArtifactDestination/test-files
+        build/errorLogs/** => $hiddenArtifactDestination/errorLogs
         subprojects/internal-build-reports/build/reports/incubation/all-incubating.html => incubation-reports
         build/reports/dependency-verification/** => dependency-verification-reports
     """.trimIndent()

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -26,6 +26,8 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, timeout: Int = 30)
     applyDefaultSettings(os = os, timeout = timeout)
     artifactRules = """
         build/report-*-performance-tests.zip => .
+        build/report-*-performance.zip => $hiddenArtifactDestination
+        build/report-*PerformanceTest.zip => $hiddenArtifactDestination
     """.trimIndent()
     detectHangingBuilds = false
     requirements {

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -1,6 +1,6 @@
 package projects
 
-import common.failedTestArtifactDestination
+import common.hiddenArtifactDestination
 import configurations.PerformanceTestsPass
 import configurations.StagePasses
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
@@ -67,7 +67,7 @@ class CheckProject(
                 days = 14,
                 artifactPatterns = """
                 +:**/*
-                +:$failedTestArtifactDestination/**/*"
+                +:$hiddenArtifactDestination/**/*"
                 """.trimIndent()
             )
         }

--- a/.teamcity/src/main/kotlin/projects/StageProject.kt
+++ b/.teamcity/src/main/kotlin/projects/StageProject.kt
@@ -1,7 +1,7 @@
 package projects
 
 import common.VersionedSettingsBranch
-import common.failedTestArtifactDestination
+import common.hiddenArtifactDestination
 import common.toCapitalized
 import configurations.BaseGradleBuildType
 import configurations.FunctionalTest
@@ -49,7 +49,7 @@ class StageProject(
     init {
         features {
             if (stage.specificBuilds.contains(SpecificBuild.SanityCheck)) {
-                buildReportTab("API Compatibility Report", "$failedTestArtifactDestination/report-architecture-test-binary-compatibility-report.html")
+                buildReportTab("API Compatibility Report", "$hiddenArtifactDestination/report-architecture-test-binary-compatibility-report.html")
                 buildReportTab("Incubating APIs Report", "incubation-reports/all-incubating.html")
             }
             if (stage.performanceTests.isNotEmpty()) {

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -338,8 +338,7 @@ fun removeTeamcityTempProperty() {
 
 fun Project.isPerformanceProject() = setOf("build-scan-performance", "performance").contains(name)
 
-fun Project.enableExperimentalTestFiltering() = !setOf("configuration-cache", "kotlin-dsl", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
-
+fun Project.enableExperimentalTestFiltering() = !setOf("build-scan-performance", "configuration-cache", "kotlin-dsl", "performance", "smoke-test", "soak").contains(name) && isExperimentalTestFilteringEnabled
 /**
  * Test lifecycle tasks that correspond to CIBuildModel.TestType (see .teamcity/Gradle_Check/model/CIBuildModel.kt).
  */


### PR DESCRIPTION
- Re-disable Test Selection for performance tests.
- Publish all artifacts in performance tests (esp. for `trace.json`).