### PR TITLE
Report circular references in hash sets as problems

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
+++ b/build-logic/basics/src/main/kotlin/gradlebuild.minify.gradle.kts
@@ -41,6 +41,8 @@ val keepPatterns = mapOf(
         "it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet",
         "it.unimi.dsi.fastutil.objects.ObjectOpenHashSet",
         "it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap",
+        // For the configuration cache module
+        "it.unimi.dsi.fastutil.objects.ReferenceArrayList",
         "it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet",
     )
 )

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -142,7 +142,7 @@ public class DefaultClassPath implements ClassPath, Serializable {
 
     @Override
     public ClassPath plus(ClassPath other) {
-        if (files.isEmpty()) {
+        if (isEmpty()) {
             return other;
         }
         if (other.isEmpty()) {

--- a/subprojects/configuration-cache/build.gradle.kts
+++ b/subprojects/configuration-cache/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation(project(":build-option"))
 
     implementation(libs.capsule)
+    implementation(libs.fastutil)
     implementation(libs.groovy)
     implementation(libs.groovyJson)
     implementation(libs.slf4jApi)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCircularReferenceIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCircularReferenceIntegrationTest.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+
+class ConfigurationCacheCircularReferenceIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def 'circular reference without hashCode override is no problem'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile '''
+
+            class Circular {
+                private final String a
+                def direct = new HashSet<Object>()
+                def indirect = new Indirect()
+                private final String z
+
+                Circular(String a, String z) {
+                    this.a = a
+                    this.z = z
+                }
+
+                String toString() {
+                    "$a:$z"
+                }
+            }
+
+            class Indirect {
+                def references = new HashSet<Object>()
+            }
+
+            def circular = new Circular('foo', 'bar')
+            circular.direct.add(circular)
+            circular.indirect.references.add(circular)
+
+            tasks.register('circular') {
+                doLast {
+                    def direct = circular.direct
+                    def indirect = circular.indirect.references
+                    println('toString() => ' + circular)
+                    println('circular in direct => ' + (circular in direct))
+                    println('circular in indirect => ' + (circular in indirect))
+                    println('Circular(foo, bar) in direct => ' + (new Circular('foo', 'bar') in direct))
+                    println('Circular(foo, bar) in indirect => ' + (new Circular('foo', 'bar') in indirect))
+                    println('circular === direct.first() => ' + (circular === direct.first()))
+                    println('circular === indirect.first() => ' + (circular === indirect.first()))
+                }
+            }
+        '''
+
+        when:
+        configurationCacheRun 'circular'
+
+        then:
+        configurationCache.assertStateStored()
+        problems.assertResultHasProblems(result) {
+            withTotalProblemsCount(0)
+        }
+
+        when:
+        configurationCacheRun 'circular'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        outputContains 'toString() => foo:bar'
+        outputContains 'circular in direct => true'
+        outputContains 'circular in indirect => true'
+        outputContains 'Circular(foo, bar) in direct => false'
+        outputContains 'Circular(foo, bar) in indirect => false'
+        outputContains 'circular === direct.first() => true'
+        outputContains 'circular === indirect.first() => true'
+    }
+
+    def 'circular reference in HashSet is fully initialized prior to insertion but problems are reported'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile '''
+
+            class Circular {
+                private final String a
+                def direct = new HashSet<Object>()
+                def indirect = new Indirect()
+                private final String z
+
+                Circular(String a, String z) {
+                    this.a = a
+                    this.z = z
+                }
+
+                int hashCode() {
+                    assert a != null && z != null
+                    a.hashCode() ^ z.hashCode()
+                }
+
+                boolean equals(Object other) {
+                    assert a != null && z != null
+                    (other instanceof Circular) && a == other.a && z == other.z
+                }
+
+                String toString() {
+                    "$a:$z"
+                }
+            }
+
+            class Indirect {
+                def references = new HashSet<Object>()
+            }
+
+            def circular = new Circular('foo', 'bar')
+            circular.direct.add(circular)
+            circular.indirect.references.add(circular)
+
+            tasks.register('circular') {
+                doLast {
+                    def direct = circular.direct
+                    def indirect = circular.indirect.references
+                    println('toString() => ' + circular)
+                    println('circular in direct => ' + (circular in direct))
+                    println('circular in indirect => ' + (circular in indirect))
+                    println('Circular(foo, bar) in direct => ' + (new Circular('foo', 'bar') in direct))
+                    println('Circular(foo, bar) in indirect => ' + (new Circular('foo', 'bar') in indirect))
+                    println('circular === direct.first() => ' + (circular === direct.first()))
+                    println('circular === indirect.first() => ' + (circular === indirect.first()))
+                }
+            }
+        '''
+
+        when:
+        configurationCacheRunLenient 'circular'
+
+        then:
+        configurationCache.assertStateStored()
+        problems.assertResultHasProblems(result) {
+            withUniqueProblems("Task `:circular` of type `org.gradle.api.DefaultTask`: Circular references can lead to undefined behavior upon deserialization.")
+            withTotalProblemsCount(2)
+            withProblemsWithStackTraceCount(0)
+        }
+
+        when:
+        configurationCacheRunLenient 'circular'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        outputContains 'toString() => foo:bar'
+        outputContains 'circular in direct => true'
+        outputContains 'circular in indirect => true'
+        outputContains 'Circular(foo, bar) in direct => true'
+        outputContains 'Circular(foo, bar) in indirect => true'
+        outputContains 'circular === direct.first() => true'
+        outputContains 'circular === indirect.first() => true'
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -246,6 +246,8 @@ class ConfigurationCacheIO internal constructor(
                     initClassLoader(javaClass.classLoader)
                     runReadOperation {
                         readOperation(codecs)
+                    }.also {
+                        finish()
                     }
                 }
             }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Identities.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Identities.kt
@@ -16,6 +16,7 @@
 
 package org.gradle.configurationcache.serialization
 
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet
 import java.util.IdentityHashMap
 
 
@@ -43,5 +44,23 @@ class ReadIdentities {
 
     fun putInstance(id: Int, instance: Any) {
         instanceIds[id] = instance
+    }
+}
+
+
+class CircularReferences {
+
+    private
+    val refs = ReferenceOpenHashSet<Any>()
+
+    fun enter(reference: Any) {
+        require(refs.add(reference))
+    }
+
+    operator fun contains(reference: Any) =
+        refs.contains(reference)
+
+    fun leave(reference: Any) {
+        require(refs.remove(reference))
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -289,7 +289,7 @@ class Codecs(
         bind(ImmutableListCodec)
 
         // Only serialize certain Set implementations for now, as some custom types extend Set (eg DomainObjectContainer)
-        bind(hashSetCodec)
+        bind(HashSetCodec)
         bind(treeSetCodec)
         bind(ImmutableSetCodec)
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/LocalFileDependencyBackedArtifactSetCodec.kt
@@ -117,9 +117,9 @@ class LocalFileDependencyBackedArtifactSetCodec(
                 if (selected == ResolvedArtifactSet.EMPTY) {
                     // Don't need to record the mapping
                 } else if (recordingSet.targetAttributes != null) {
-                    mappings.put(sourceAttributes, TransformMapping(recordingSet.targetAttributes!!, recordingSet.transformation!!))
+                    mappings[sourceAttributes] = TransformMapping(recordingSet.targetAttributes!!, recordingSet.transformation!!)
                 } else {
-                    mappings.put(sourceAttributes, IdentityMapping)
+                    mappings[sourceAttributes] = IdentityMapping
                 }
             }
             write(mappings)
@@ -269,15 +269,15 @@ class FixedVariantSelector(
     override fun select(candidates: ResolvedVariantSet, factory: VariantSelector.Factory): ResolvedArtifactSet {
         require(candidates.variants.size == 1)
         val variant = candidates.variants.first()
-        val spec = transforms.get(variant.attributes.asImmutable())
-        return when (spec) {
-            null ->
-                // was no mapping for extension, so it can be discarded
+        return when (val spec = transforms[variant.attributes.asImmutable()]) {
+            null -> {
+                // no mapping for extension, so it can be discarded
                 if (matchingOnArtifactFormat) {
                     ResolvedArtifactSet.EMPTY
                 } else {
                     variant.artifacts
                 }
+            }
             is IdentityMapping -> variant.artifacts
             is TransformMapping -> factory.asTransformed(variant, spec, EmptyDependenciesResolverFactory(fileCollectionFactory), transformedVariantFactory)
         }
@@ -366,6 +366,7 @@ object NoOpTransformedVariantFactory : TransformedVariantFactory {
 
 private
 object EmptyVariantTransformRegistry : VariantTransformRegistry {
+    @Deprecated("Deprecated in Java", ReplaceWith("throw UnsupportedOperationException(\"Should not be called\")"))
     override fun registerTransform(registrationAction: Action<in VariantTransform>) {
         throw UnsupportedOperationException("Should not be called")
     }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -29,6 +29,7 @@ import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.IsolateOwner
+import org.gradle.configurationcache.serialization.CircularReferences
 import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.ReadIdentities
 import org.gradle.configurationcache.serialization.ReadIsolate
@@ -286,6 +287,9 @@ class ConfigurationCacheFingerprintCheckerTest {
         override val isolate: WriteIsolate
             get() = undefined()
 
+        override val circularReferences: CircularReferences
+            get() = undefined()
+
         override fun beanStateWriterFor(beanType: Class<*>): BeanStateWriter =
             undefined()
 
@@ -378,6 +382,9 @@ class ConfigurationCacheFingerprintCheckerTest {
 
         override val classLoader: ClassLoader
             get() = undefined()
+
+        override fun onFinish(action: () -> Unit) =
+            undefined()
 
         override fun beanStateReaderFor(beanType: Class<*>): BeanStateReader =
             undefined()


### PR DESCRIPTION
Since they may lead to undefined behavior upon deserialization (see https://github.com/gradle/gradle/pull/19491#issuecomment-1009939502).

Hash sets involving circular references will still be deserialized on a best effort basis by deferring the insertion of circular references until the end of the deserialization process.

