### PR TITLE
Fix Java incremental compilation corner cases related to generics

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.java.compile.incremental
 
-import groovy.test.NotYetImplemented
+
 import org.gradle.integtests.fixtures.CompiledLanguage
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -411,33 +411,90 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as class type parameter"() {
-        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
 
-        source "interface Super <T> { T getResult(); }"
-        source "interface Sub extends Super<Deleted> { }"
+        source "interface Super <T, R> { T getResult(R r); }"
+        source "interface Sub extends Super<" + t + ", " + r + "> { }"
         def deleted = source "interface Deleted { }"
         outputs.snapshot { run language.compileTaskName }
 
         expect:
         deleted.delete()
         recompiledWithFailure('symbol: class Deleted', 'Sub')
+
+        where:
+        t         | r
+        "Deleted" | "String"
+        "String"  | "Deleted"
     }
 
-    @NotYetImplemented
     @Issue("https://github.com/gradle/gradle/issues/20478")
-    def "can detect deletion of class used as static method type parameter"() {
-        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+    def "can detect deletion of class used as method parameter type"() {
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
 
-        source """
-            class A {
-                public static <Deleted> void doSomething(Deleted d) {
-                }
-            }"""
+        source "interface A { void doSomething(Deleted d); }"
         def deleted = source "interface Deleted { }"
         outputs.snapshot { run language.compileTaskName }
 
         expect:
         deleted.delete()
-        recompiledWithFailure('symbol: class Deleted', 'Sub')
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as method parameter type bound"() {
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+
+        source "interface A { <T extends Deleted> void doSomething(T t); }"
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as method return type"() {
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+
+        source "interface A { Deleted doSomething(); }"
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as method return type bound"() {
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+
+        source "interface A { <T extends Deleted> T doSomething(); }"
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as field type parameter"() {
+        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+
+        source """
+            import java.util.List;
+            class A {
+                private List<Deleted> list; 
+            }
+            """
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
@@ -409,11 +409,30 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
         outputs.recompiledClasses('A', 'B')
     }
 
-    @NotYetImplemented
     @Issue("https://github.com/gradle/gradle/issues/20478")
-    def "can detect deletion of class used as type parameter"() {
+    def "can detect deletion of class used as class type parameter"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
         source "interface Super <T> { T getResult(); }"
         source "interface Sub extends Super<Deleted> { }"
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('symbol: class Deleted', 'Sub')
+    }
+
+    @NotYetImplemented
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as static method type parameter"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
+        source """
+            class A {
+                public static <Deleted> void doSomething(Deleted d) {
+                }
+            }"""
         def deleted = source "interface Deleted { }"
         outputs.snapshot { run language.compileTaskName }
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/JavaClassChangeIncrementalCompilationIntegrationTest.groovy
@@ -411,7 +411,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as class type parameter"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source "interface Super <T, R> { T getResult(R r); }"
         source "interface Sub extends Super<" + t + ", " + r + "> { }"
@@ -430,7 +430,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as method parameter type"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source "interface A { void doSomething(Deleted d); }"
         def deleted = source "interface Deleted { }"
@@ -443,7 +443,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as method parameter type bound"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source "interface A { <T extends Deleted> void doSomething(T t); }"
         def deleted = source "interface Deleted { }"
@@ -456,7 +456,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as method return type"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source "interface A { Deleted doSomething(); }"
         def deleted = source "interface Deleted { }"
@@ -469,7 +469,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as method return type bound"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source "interface A { <T extends Deleted> T doSomething(); }"
         def deleted = source "interface Deleted { }"
@@ -482,7 +482,7 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
 
     @Issue("https://github.com/gradle/gradle/issues/20478")
     def "can detect deletion of class used as field type parameter"() {
-        executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache //todo: comment out
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
 
         source """
             import java.util.List;
@@ -491,6 +491,81 @@ class JavaClassChangeIncrementalCompilationIntegrationTest extends BaseJavaClass
             }
             """
         def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as local variable type parameter"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
+        source """
+            import java.util.List;
+            import java.util.ArrayList;
+            class A {
+                public void method() {
+                    List<Deleted> l = new ArrayList<Deleted>();
+                    System.out.println(l.hashCode()); 
+                }
+            }
+            """
+        def deleted = source "interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as class annotation"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
+        source """
+            @Deleted
+            class A {}
+            """
+        def deleted = source "@interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as method annotation"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
+        source """
+            class A {
+                @Deleted
+                public void method() {
+                }
+            }
+            """
+        def deleted = source "@interface Deleted { }"
+        outputs.snapshot { run language.compileTaskName }
+
+        expect:
+        deleted.delete()
+        recompiledWithFailure('class Deleted', 'A')
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20478")
+    def "can detect deletion of class used as field annotation"() {
+        //executer.requireOwnGradleUserHomeDir()  //use when debugging to bypass cache
+
+        source """
+            class A {
+                @Deleted
+                String s;
+            }
+            """
+        def deleted = source "@interface Deleted { }"
         outputs.snapshot { run language.compileTaskName }
 
         expect:

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -242,20 +242,20 @@ public class ClassDependenciesVisitor extends ClassVisitor {
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            maybeAddDependentType(privateTypes, Type.getType(descriptor));
-            return new AnnotationVisitor(privateTypes);
+            maybeAddDependentType(types, Type.getType(descriptor));
+            return new AnnotationVisitor(types);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
-            maybeAddDependentType(privateTypes, Type.getType(descriptor));
-            return new AnnotationVisitor(privateTypes);
+            maybeAddDependentType(types, Type.getType(descriptor));
+            return new AnnotationVisitor(types);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            maybeAddDependentType(privateTypes, Type.getType(descriptor));
-            return new AnnotationVisitor(privateTypes);
+            maybeAddDependentType(types, Type.getType(descriptor));
+            return new AnnotationVisitor(types);
         }
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -63,7 +63,7 @@ public class ClassDependenciesVisitor extends ClassVisitor {
 
     public static ClassAnalysis analyze(String className, ClassReader reader, StringInterner interner) {
         ClassDependenciesVisitor visitor = new ClassDependenciesVisitor(new ClassRelevancyFilter(className), reader, interner);
-        reader.accept(visitor, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+        reader.accept(visitor, ClassReader.SKIP_FRAMES);
 
         // Remove the "API accessible" types from the "privately used types"
         visitor.privateTypes.removeAll(visitor.accessibleTypes);
@@ -235,6 +235,7 @@ public class ClassDependenciesVisitor extends ClassVisitor {
 
         @Override
         public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
+            maybeAddClassTypesFromSignature(signature, types);
             maybeAddDependentType(types, Type.getType(desc));
             super.visitLocalVariable(name, desc, signature, start, end, index);
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassDependenciesVisitor.java
@@ -235,27 +235,27 @@ public class ClassDependenciesVisitor extends ClassVisitor {
 
         @Override
         public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
-            maybeAddClassTypesFromSignature(signature, types);
-            maybeAddDependentType(types, Type.getType(desc));
+            maybeAddClassTypesFromSignature(signature, privateTypes);
+            maybeAddDependentType(privateTypes, Type.getType(desc));
             super.visitLocalVariable(name, desc, signature, start, end, index);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
-            maybeAddDependentType(types, Type.getType(descriptor));
-            return new AnnotationVisitor(types);
+            maybeAddDependentType(privateTypes, Type.getType(descriptor));
+            return new AnnotationVisitor(privateTypes);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
-            maybeAddDependentType(types, Type.getType(descriptor));
-            return new AnnotationVisitor(types);
+            maybeAddDependentType(privateTypes, Type.getType(descriptor));
+            return new AnnotationVisitor(privateTypes);
         }
 
         @Override
         public org.objectweb.asm.AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-            maybeAddDependentType(types, Type.getType(descriptor));
-            return new AnnotationVisitor(types);
+            maybeAddDependentType(privateTypes, Type.getType(descriptor));
+            return new AnnotationVisitor(privateTypes);
         }
     }
 


### PR DESCRIPTION
Fixes #20478 

Doesn't solve however the same problem if the generic type belongs to a static method, not the class. Have added a test for this scenario too.