### PR TITLE
Save and reload BuildCacheServiceRegistration from configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -26,6 +26,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.services.internal.BuildServiceProvider
 import org.gradle.api.services.internal.BuildServiceRegistryInternal
 import org.gradle.caching.configuration.BuildCache
+import org.gradle.caching.configuration.internal.BuildCacheServiceRegistration
 import org.gradle.configuration.BuildOperationFiringProjectsPreparer
 import org.gradle.configuration.project.LifecycleProjectEvaluator
 import org.gradle.configurationcache.CachedProjectState.Companion.computeCachedState
@@ -490,6 +491,7 @@ class ConfigurationCacheState(
         gradle.settings.buildCache.let { buildCache ->
             write(buildCache.local)
             write(buildCache.remote)
+            write(buildCache.registrations)
         }
     }
 
@@ -498,6 +500,7 @@ class ConfigurationCacheState(
         gradle.settings.buildCache.let { buildCache ->
             buildCache.local = readNonNull()
             buildCache.remote = read() as BuildCache?
+            buildCache.setRegistrations(read() as MutableSet<BuildCacheServiceRegistration>)
         }
         RootBuildCacheControllerSettingsProcessor.process(gradle)
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedImplementationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedImplementationIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.api.tasks
 
 import org.gradle.caching.configuration.AbstractBuildCache
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.plugin.PluginBuilder
 
 class CachedImplementationIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeFixedForConfigurationCache(because = "InMemoryBuildCache has not been registered.")
     def "can use full Java build cache service implementation"() {
         def pluginJar = file("plugin.jar")
         def pluginBuilder = new PluginBuilder(file("plugin"))

--- a/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/BuildCacheConfigurationInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/BuildCacheConfigurationInternal.java
@@ -23,6 +23,7 @@ import org.gradle.caching.local.DirectoryBuildCache;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 @ServiceScope(Scopes.Build.class)
@@ -41,4 +42,14 @@ public interface BuildCacheConfigurationInternal extends BuildCacheConfiguration
      * Replaces remote build cache.
      */
     void setRemote(@Nullable BuildCache remote);
+
+    /**
+     * Gets build cache service registrations
+     */
+    Set<BuildCacheServiceRegistration> getRegistrations();
+
+    /**
+     * Replaces build cache service registrations
+     */
+    void setRegistrations(Set<BuildCacheServiceRegistration> registrations);
 }

--- a/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
@@ -29,7 +29,6 @@ import org.gradle.internal.reflect.Instantiator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
@@ -111,7 +110,6 @@ public class DefaultBuildCacheConfiguration implements BuildCacheConfigurationIn
         configuration.execute(remote);
     }
 
-    @Nonnull
     @Override
     public Set<BuildCacheServiceRegistration> getRegistrations() {
         return registrations;

--- a/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/configuration/internal/DefaultBuildCacheConfiguration.java
@@ -29,6 +29,7 @@ import org.gradle.internal.reflect.Instantiator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
@@ -41,7 +42,7 @@ public class DefaultBuildCacheConfiguration implements BuildCacheConfigurationIn
     private DirectoryBuildCache local;
     private BuildCache remote;
 
-    private final Set<BuildCacheServiceRegistration> registrations;
+    private Set<BuildCacheServiceRegistration> registrations;
 
     public DefaultBuildCacheConfiguration(Instantiator instantiator, List<BuildCacheServiceRegistration> allBuiltInBuildCacheServices) {
         this.instantiator = instantiator;
@@ -108,6 +109,17 @@ public class DefaultBuildCacheConfiguration implements BuildCacheConfigurationIn
             throw new IllegalStateException("A type for the remote build cache must be configured first.");
         }
         configuration.execute(remote);
+    }
+
+    @Nonnull
+    @Override
+    public Set<BuildCacheServiceRegistration> getRegistrations() {
+        return registrations;
+    }
+
+    @Override
+    public void setRegistrations(Set<BuildCacheServiceRegistration> registrations) {
+        this.registrations = registrations;
     }
 
     private static DirectoryBuildCache createLocalCacheConfiguration(Instantiator instantiator, Set<BuildCacheServiceRegistration> registrations) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -34,6 +34,7 @@ We would like to thank the following community members for their contributions t
 [Edgars Jasmans](https://github.com/yasmans),
 [Simão Gomes Viana](https://github.com/xdevs23),
 [Lajos Veres](https://github.com/vlajos)
+[Jeff](https://github.com/mathjeff)
 
 <!--
 Include only their name, impactful features should be called out separately below.


### PR DESCRIPTION
Fixes: #14874
Followup to #20494 