### PR TITLE
Fixes for Master Nightly Snapshot build configuration in TC

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/VcsTriggers.kt
+++ b/.teamcity/src/main/kotlin/configurations/VcsTriggers.kt
@@ -31,6 +31,5 @@ fun VersionedSettingsBranch.branchFilter() = """
 
 fun branchesFilterExcluding(vararg excludedBranch: String) = """
 +:*
--:<default>
 ${excludedBranch.joinToString("\n") { "-:$it" }}
 """

--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -41,6 +41,7 @@ abstract class BasePublishGradleDistribution(
 
         dependencies {
             snapshot(RelativeId("Check_Stage_${this@BasePublishGradleDistribution.triggerName}_Trigger")) {
+                synchronizeRevisions = false
             }
         }
     }


### PR DESCRIPTION
- This should prevent Nightly Snapshots on master from failing to start with "Builds in default branch are disabled in build configuration".
- This will also remove the need to synchronize build revisions during publishing.