### PR TITLE
Fix native build init templates for unknown host and architectures in…

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CppProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/CppProjectInitDescriptor.java
@@ -94,6 +94,10 @@ public abstract class CppProjectInitDescriptor extends LanguageLibraryProjectIni
 
     protected String getHostTargetMachineDefinition() {
         DefaultNativePlatform host = DefaultNativePlatform.host();
+        return buildNativeHostTargetDefinition(host);
+    }
+
+    static String buildNativeHostTargetDefinition(DefaultNativePlatform host) {
         String definition = "machines.";
 
         if (host.getOperatingSystem().isWindows()) {
@@ -103,7 +107,7 @@ public abstract class CppProjectInitDescriptor extends LanguageLibraryProjectIni
         } else if (host.getOperatingSystem().isLinux()) {
             definition += "linux";
         } else {
-            definition += "os('" + host.getOperatingSystem().toFamilyName() + "')";
+            definition += "os(\"" + host.getOperatingSystem().toFamilyName() + "\")";
         }
 
         definition += ".";
@@ -113,7 +117,7 @@ public abstract class CppProjectInitDescriptor extends LanguageLibraryProjectIni
         } else if (host.getArchitecture().isAmd64()) {
             definition += "x86_64";
         } else {
-            definition += "architecture('" + host.getArchitecture().getName() + "')";
+            definition += "architecture(\"" + host.getArchitecture().getName() + "\")";
         }
 
         return definition;

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SwiftProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SwiftProjectInitDescriptor.java
@@ -95,20 +95,7 @@ public abstract class SwiftProjectInitDescriptor extends LanguageLibraryProjectI
     protected String getHostTargetMachineDefinition() {
         DefaultNativePlatform host = DefaultNativePlatform.host();
         assert !host.getOperatingSystem().isWindows();
-
-        String definition = "machines.";
-
-        if (host.getOperatingSystem().isMacOsX()) {
-            definition += "macOS";
-        } else if (host.getOperatingSystem().isLinux()) {
-            definition += "linux";
-        } else {
-            definition += "os('" + host.getOperatingSystem().toFamilyName() + "')";
-        }
-
-        definition += ".x86_64";
-
-        return definition;
+        return CppProjectInitDescriptor.buildNativeHostTargetDefinition(host);
     }
 
     protected void configureTargetMachineDefinition(ScriptBlockBuilder buildScriptBuilder) {


### PR DESCRIPTION
… Kotlin DSL

on macOS with Apple Silicon, we would generate a method call like:

machines.macOS.architecture('aarch64')

This script fails to compile because of the single quotes.

We would also use single quotes around an unknown OS.
