### PR TITLE
Upgrade to latest nightly and remove workaround for not picking up changes.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220411001643+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220420113638+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to the latest nightly wrapper and removes the workaround introduced by https://github.com/gradle/gradle/pull/20366, since the problem has been fixed in Gradle.