### PR TITLE
Add a listener to notify buildscan plugin about the execution phase start

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/BuildStateFactory.java
@@ -28,6 +28,7 @@ import org.gradle.internal.build.RootBuildState;
 import org.gradle.internal.build.StandAloneNestedBuild;
 import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.NestedBuildTree;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.service.scopes.GradleUserHomeScopeServiceRegistry;
 import org.gradle.internal.service.scopes.Scopes;
@@ -44,6 +45,7 @@ import static org.gradle.api.internal.SettingsInternal.BUILD_SRC;
 public class BuildStateFactory {
     private final BuildTreeState buildTreeState;
     private final ListenerManager listenerManager;
+    private final GradleEnterprisePluginManager enterprisePluginManager;
     private final GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry;
     private final CrossBuildSessionState crossBuildSessionState;
     private final BuildCancellationToken buildCancellationToken;
@@ -51,19 +53,21 @@ public class BuildStateFactory {
     public BuildStateFactory(
         BuildTreeState buildTreeState,
         ListenerManager listenerManager,
+        GradleEnterprisePluginManager enterprisePluginManager,
         GradleUserHomeScopeServiceRegistry userHomeDirServiceRegistry,
         CrossBuildSessionState crossBuildSessionState,
         BuildCancellationToken buildCancellationToken
     ) {
         this.buildTreeState = buildTreeState;
         this.listenerManager = listenerManager;
+        this.enterprisePluginManager = enterprisePluginManager;
         this.userHomeDirServiceRegistry = userHomeDirServiceRegistry;
         this.crossBuildSessionState = crossBuildSessionState;
         this.buildCancellationToken = buildCancellationToken;
     }
 
     public RootBuildState createRootBuild(BuildDefinition buildDefinition) {
-        return new DefaultRootBuildState(buildDefinition, buildTreeState, listenerManager);
+        return new DefaultRootBuildState(buildDefinition, buildTreeState, listenerManager, enterprisePluginManager);
     }
 
     public StandAloneNestedBuild createNestedBuild(BuildIdentifier buildIdentifier, Path identityPath, BuildDefinition buildDefinition, BuildState owner) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultRootBuildState.java
@@ -39,8 +39,10 @@ import org.gradle.internal.buildtree.BuildTreeState;
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeFinishExecutor;
 import org.gradle.internal.buildtree.DefaultBuildTreeWorkExecutor;
+import org.gradle.internal.buildtree.ExecutionPhaseNotifyingBuildTreeWorkExecutor;
 import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.composite.IncludedRootBuild;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.service.scopes.BuildScopeServices;
@@ -57,7 +59,8 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
     DefaultRootBuildState(
         BuildDefinition buildDefinition,
         BuildTreeState buildTree,
-        ListenerManager listenerManager
+        ListenerManager listenerManager,
+        GradleEnterprisePluginManager enterprisePluginManager
     ) {
         super(buildTree, buildDefinition, null);
         this.listenerManager = listenerManager;
@@ -68,7 +71,9 @@ class DefaultRootBuildState extends AbstractCompositeParticipantBuildState imple
         BuildOperationExecutor buildOperationExecutor = buildScopeServices.get(BuildOperationExecutor.class);
         BuildStateRegistry buildStateRegistry = buildScopeServices.get(BuildStateRegistry.class);
         BuildTreeLifecycleControllerFactory buildTreeLifecycleControllerFactory = buildScopeServices.get(BuildTreeLifecycleControllerFactory.class);
-        BuildTreeWorkExecutor workExecutor = new BuildOperationFiringBuildTreeWorkExecutor(new DefaultBuildTreeWorkExecutor(), buildOperationExecutor);
+        BuildTreeWorkExecutor workExecutor = new ExecutionPhaseNotifyingBuildTreeWorkExecutor(
+            new BuildOperationFiringBuildTreeWorkExecutor(new DefaultBuildTreeWorkExecutor(), buildOperationExecutor),
+            enterprisePluginManager);
         BuildTreeFinishExecutor finishExecutor = new DefaultBuildTreeFinishExecutor(buildStateRegistry, exceptionAnalyser, buildLifecycleController);
         this.buildTreeLifecycleController = buildTreeLifecycleControllerFactory.createRootBuildController(buildLifecycleController, workExecutor, finishExecutor);
     }

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -39,6 +39,7 @@ import org.gradle.internal.build.RootBuildState
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeLifecycleControllerFactory
 import org.gradle.internal.buildtree.BuildTreeState
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.service.DefaultServiceRegistry
@@ -64,7 +65,14 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     def services = new DefaultServiceRegistry()
     def modelServices = Mock(BuildModelControllerServices)
     def buildTree = Mock(BuildTreeState)
-    def factory = new BuildStateFactory(buildTree, listenerManager, Stub(GradleUserHomeScopeServiceRegistry), Stub(CrossBuildSessionState), Stub(BuildCancellationToken))
+    def factory = new BuildStateFactory(
+        buildTree,
+        listenerManager,
+        Stub(GradleEnterprisePluginManager),
+        Stub(GradleUserHomeScopeServiceRegistry),
+        Stub(CrossBuildSessionState),
+        Stub(BuildCancellationToken)
+    )
     def registry = new DefaultIncludedBuildRegistry(
         includedBuildFactory,
         Stub(IncludedBuildDependencySubstitutionsBuilder),

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.buildtree.BuildTreeLifecycleController
 import org.gradle.internal.buildtree.BuildTreeModelAction
 import org.gradle.internal.buildtree.BuildTreeState
 import org.gradle.internal.buildtree.BuildTreeWorkGraph
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.service.DefaultServiceRegistry
@@ -43,6 +44,7 @@ class DefaultRootBuildStateTest extends Specification {
     def controller = Mock(BuildLifecycleController)
     def gradle = Mock(GradleInternal)
     def listenerManager = Mock(ListenerManager)
+    def enterprisePluginManager = Mock(GradleEnterprisePluginManager)
     def lifecycleListener = Mock(RootBuildLifecycleListener)
     def action = Mock(Function)
     def buildTree = Mock(BuildTreeState)
@@ -70,7 +72,7 @@ class DefaultRootBuildStateTest extends Specification {
         _ * gradle.services >> services
         _ * buildTree.services >> services
 
-        build = new DefaultRootBuildState(buildDefinition, buildTree, listenerManager)
+        build = new DefaultRootBuildState(buildDefinition, buildTree, listenerManager, enterprisePluginManager)
     }
 
     def "has identifier"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -58,7 +58,7 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
     def "task output caching key is exposed when scan plugin is applied"() {
         given:
         settingsFile << """
-            services.get($GradleEnterprisePluginManager.name).registerAdapter([buildFinished: {}, shouldSaveToConfigurationCache: { false }] as $GradleEnterprisePluginAdapter.name)
+            services.get($GradleEnterprisePluginManager.name).registerAdapter([buildFinished: {}, shouldSaveToConfigurationCache: { false }, executionPhaseStarted: {}] as $GradleEnterprisePluginAdapter.name)
         """
 
         buildFile << customTaskCode('foo', 'bar')

--- a/subprojects/core/src/main/java/org/gradle/internal/buildtree/ExecutionPhaseNotifyingBuildTreeWorkExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildtree/ExecutionPhaseNotifyingBuildTreeWorkExecutor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.buildtree;
+
+import org.gradle.internal.build.ExecutionResult;
+import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager;
+
+public class ExecutionPhaseNotifyingBuildTreeWorkExecutor implements BuildTreeWorkExecutor {
+    private final BuildTreeWorkExecutor delegate;
+    private final GradleEnterprisePluginManager gradleEnterprisePluginManager;
+
+    public ExecutionPhaseNotifyingBuildTreeWorkExecutor(BuildTreeWorkExecutor delegate, GradleEnterprisePluginManager gradleEnterprisePluginManager) {
+        this.delegate = delegate;
+        this.gradleEnterprisePluginManager = gradleEnterprisePluginManager;
+    }
+
+    @Override
+    public ExecutionResult<Void> execute(BuildTreeWorkGraph graph) {
+        gradleEnterprisePluginManager.executionPhaseStarted();
+        return delegate.execute(graph);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginAdapter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginAdapter.java
@@ -24,6 +24,8 @@ public interface GradleEnterprisePluginAdapter {
 
     void onLoadFromConfigurationCache();
 
+    void executionPhaseStarted();
+
     void buildFinished(@Nullable Throwable buildFailure);
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/enterprise/core/GradleEnterprisePluginManager.java
@@ -71,6 +71,12 @@ public class GradleEnterprisePluginManager {
         return adapter != null;
     }
 
+    public void executionPhaseStarted() {
+        if (adapter != null) {
+            adapter.executionPhaseStarted();
+        }
+    }
+
     public void buildFinished(@Nullable Throwable buildFailure) {
         if (adapter != null) {
             adapter.buildFinished(buildFailure);

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginCheckInFixture.groovy
@@ -35,6 +35,8 @@ import javax.annotation.Nullable
 @SuppressWarnings("GrMethodMayBeStatic")
 class GradleEnterprisePluginCheckInFixture {
 
+    private static final String EXECUTION_PHASE_STARTED_CALLBACK_MSG = "gradleEnterprisePlugin.executionPhaseStarted"
+
     private final TestFile projectDir
     private final MavenFileRepository mavenRepo
     private final GradleExecuter pluginBuildExecuter
@@ -54,11 +56,19 @@ class GradleEnterprisePluginCheckInFixture {
         this.pluginBuildExecuter = pluginBuildExecuter
     }
 
+    String pluginRepository() {
+        return "maven { url '${mavenRepo.uri}' }"
+    }
+
+    String pluginDependency() {
+        return "id '$id' version '$runtimeVersion'"
+    }
+
     String pluginManagement() {
         """
             pluginManagement {
                 repositories {
-                    maven { url '${mavenRepo.uri}' }
+                    ${pluginRepository()}
                 }
             }
         """
@@ -66,7 +76,7 @@ class GradleEnterprisePluginCheckInFixture {
 
     String plugins() {
         """
-            plugins { id "$id" version "$runtimeVersion" }
+            plugins { ${pluginDependency()} }
         """
     }
 
@@ -138,6 +148,10 @@ class GradleEnterprisePluginCheckInFixture {
                                 }
                             }
 
+                            void executionPhaseStarted() {
+                                println "$EXECUTION_PHASE_STARTED_CALLBACK_MSG"
+                            }
+
                             $GradleEnterprisePluginEndOfBuildListener.name getEndOfBuildListener() {
                                 return { $GradleEnterprisePluginEndOfBuildListener.BuildResult.name buildResult ->
                                     println "gradleEnterprisePlugin.endOfBuild.buildResult.failure = \$buildResult.failure"
@@ -174,6 +188,24 @@ class GradleEnterprisePluginCheckInFixture {
 
     void assertUnsupportedMessage(String output, String unsupported) {
         assert output.contains("gradleEnterprisePlugin.checkIn.unsupported.reasonMessage = $unsupported")
+    }
+
+    void invokedExecutionPhaseStartedCallbackOnce(String output) {
+        assert output.count(EXECUTION_PHASE_STARTED_CALLBACK_MSG) == 1
+    }
+
+    void didNotInvokeExecutionPhaseStartedCallback(String output) {
+        assert !output.contains(EXECUTION_PHASE_STARTED_CALLBACK_MSG)
+    }
+
+    void assertMessagePrecedesExecutionPhaseStartedCallback(String output, String message) {
+        int messagePos = output.indexOf(message)
+        assert messagePos >= 0 && messagePos < output.indexOf(EXECUTION_PHASE_STARTED_CALLBACK_MSG)
+    }
+
+    void assertMessageFollowsExecutionPhaseStartedCallback(String output, String message) {
+        int messagePos = output.indexOf(message)
+        assert messagePos >= 0 && messagePos > output.indexOf(EXECUTION_PHASE_STARTED_CALLBACK_MSG)
     }
 
     void assertEndOfBuildWithFailure(String output, @Nullable String failure) {

--- a/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginExecutionPhaseStartedCallbackIntegrationTest.groovy
+++ b/subprojects/enterprise/src/integTest/groovy/org/gradle/internal/enterprise/GradleEnterprisePluginExecutionPhaseStartedCallbackIntegrationTest.groovy
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.enterprise
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.initialization.Settings
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class GradleEnterprisePluginExecutionPhaseStartedCallbackIntegrationTest extends AbstractIntegrationSpec {
+
+    def plugin = new GradleEnterprisePluginCheckInFixture(testDirectory, mavenRepo, createExecuter())
+
+    def setup() {
+        plugin.publishDummyPlugin(executer)
+    }
+
+    def "receives execution phase started callback if build succeeds"() {
+        given:
+        settingsFile << plugin.pluginManagement() << plugin.plugins()
+        buildFile << """
+            tasks.register("success")
+        """
+        when:
+        succeeds "success"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+
+        when:
+        succeeds "success"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+    }
+
+    def "receives execution phase started callback if build fails"() {
+        given:
+        settingsFile << plugin.pluginManagement() << plugin.plugins()
+        buildFile << """
+            tasks.register("failure") {
+                doLast {
+                    throw new GradleException("Expected failure")
+                }
+            }
+        """
+        when:
+        fails "failure"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+
+        when:
+        fails "failure"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+    }
+
+    def "does not receive execution phase started callback if configuration fails"() {
+        given:
+        settingsFile << plugin.pluginManagement() << plugin.plugins()
+        buildFile << """
+            tasks.register("t")
+            throw new GradleException("Expected configuration failure")
+        """
+        when:
+        fails "t"
+
+        then:
+        plugin.didNotInvokeExecutionPhaseStartedCallback(output)
+    }
+
+    def "receives execution phase started callback only once per build tree"() {
+        given:
+        createDir("buildSrc") {
+            file("src/main/groovy/buildsrc-plugin.gradle") << """
+                println "buildSrc project plugin applied"
+            """
+            file("build.gradle") << applyPrecompiledGroovyScriptPlugin()
+        }
+
+        def includedPlugin = createDir("included-plugin") {
+            file("build.gradle") << applyPrecompiledGroovyScriptPlugin() << """
+                gradlePlugin {
+                    plugins.create("javaProjectPlugin") {
+                        id = "project-plugin"
+                        implementationClass = "ProjectPlugin"
+                    }
+                }
+            """
+            file("src/main/groovy/precompiled-project-plugin.gradle") << """
+                println "precompiled project plugin applied"
+            """
+            file("src/main/java/ProjectPlugin.java").java("""
+                import ${Plugin.name};
+                import ${Project.name};
+
+                public class ProjectPlugin implements Plugin<Project> {
+                    @Override public void apply(Project p) {
+                        System.out.println("Project plugin applied");
+                    }
+                }
+            """)
+        }
+
+
+        def includedSettingsPlugin = createDir("included-settings-plugin") {
+            file("build.gradle") << """
+                ${applyPrecompiledGroovyScriptPlugin()}
+                gradlePlugin {
+                    plugins.create("javaSettingsPlugin") {
+                        id = "settings-plugin"
+                        implementationClass = "SettingsPlugin"
+                    }
+                }
+            """
+            file("src/main/java/SettingsPlugin.java") << """
+                import ${Plugin.name};
+                import ${Settings.name};
+
+                public class SettingsPlugin implements Plugin<Settings> {
+                    @Override public void apply(Settings s) {
+                        System.out.println("Settings plugin applied");
+                    }
+                }
+            """
+            file("src/main/groovy/precompiled-settings-plugin.settings.gradle") << """
+                println "precompiled settings plugin applied"
+            """
+        }
+        def includedProject = createDir("included-project") {
+            file("build.gradle") << """
+                tasks.register("includedTask")
+            """
+        }
+        settingsFile << """
+            pluginManagement {
+                repositories {
+                    ${plugin.pluginRepository()}
+                }
+                includeBuild("${includedSettingsPlugin.name}")
+            }
+            plugins {
+                ${plugin.pluginDependency()}
+                id "settings-plugin"
+                id "precompiled-settings-plugin"
+            }
+
+            includeBuild("$includedPlugin.name")
+            includeBuild("$includedProject.name")
+        """
+
+        buildFile << """
+            plugins {
+                id "precompiled-project-plugin"
+                id "project-plugin"
+                id "buildsrc-plugin"
+            }
+
+            tasks.register("success") {
+                dependsOn gradle.includedBuild('$includedProject.name').task(':includedTask')
+            }
+        """
+
+        when:
+        succeeds "success"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+
+        when:
+        succeeds "success"
+
+        then:
+        plugin.invokedExecutionPhaseStartedCallbackOnce(output)
+    }
+
+    def "receives execution phase started callback after TaskExecutionGraph ready callbacks"() {
+        def whenReadyCallbackMsg = "TaskExecutionGraph.whenReady"
+        given:
+        settingsFile << plugin.pluginManagement() << plugin.plugins()
+        buildFile << """
+            gradle.taskGraph.whenReady {
+                println "$whenReadyCallbackMsg"
+            }
+            tasks.register("success")
+        """
+        when:
+        succeeds "success"
+
+        then:
+        plugin.assertMessagePrecedesExecutionPhaseStartedCallback(output, whenReadyCallbackMsg)
+    }
+
+    def "receives execution phase started callback before task execution"() {
+        def taskExecutionMsg = "Task.executed"
+        given:
+        settingsFile << plugin.pluginManagement() << plugin.plugins()
+        buildFile << """
+            tasks.register("success") {
+                doFirst {
+                    println "$taskExecutionMsg"
+                }
+            }
+        """
+        when:
+        succeeds "success"
+
+        then:
+        plugin.assertMessageFollowsExecutionPhaseStartedCallback(output, taskExecutionMsg)
+    }
+
+    private static String applyPrecompiledGroovyScriptPlugin() {
+        return """
+            plugins {
+                id 'groovy-gradle-plugin'
+            }
+        """
+    }
+}

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/GradleEnterprisePluginService.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.enterprise;
 
+import groovy.lang.Closure;
 import org.gradle.internal.operations.notify.BuildOperationNotificationListener;
 
 /**
@@ -31,6 +32,22 @@ public interface GradleEnterprisePluginService {
      * It expects to receive notifications about all operations from the very start of the build.
      */
     BuildOperationNotificationListener getBuildOperationNotificationListener();
+
+    /**
+     * Used to signal a start of the execution of main tasks of a build tree, also known as <a href="https://docs.gradle.org/current/userguide/build_lifecycle.html#sec:build_phases">the "execution phase"</a>.
+     * At this point the configuration phase is already completed and all user code related to it finished executing,
+     * including late callbacks like {@link org.gradle.api.execution.TaskExecutionGraph#whenReady(Closure)}.
+     * This callback is invoked before any of the tasks of the execution phase starts.
+     * However, the tasks of the included builds that contribute project and settings plugins, and tasks of the buildSrc build
+     * run before the execution phase, at the configuration phase, and, therefore, before this callback.
+     *
+     * Expected to be invoked at most once for a build tree, isn't invoked if the configuration phase fails.
+     * The configuration cache doesn't affect this callback, it is invoked regardless of the cache entry being reused.
+     *
+     * @see org.gradle.internal.operations.BuildOperationCategory#RUN_MAIN_TASKS
+     */
+    default void executionPhaseStarted() {
+    }
 
     /**
      * Notified when the build invocation has finished by Gradle.

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/DefaultGradleEnterprisePluginAdapter.java
@@ -72,6 +72,13 @@ public class DefaultGradleEnterprisePluginAdapter implements GradleEnterprisePlu
     }
 
     @Override
+    public void executionPhaseStarted() {
+        if (pluginService != null) {
+            pluginService.executionPhaseStarted();
+        }
+    }
+
+    @Override
     public void buildFinished(@Nullable Throwable buildFailure) {
         if (pluginService != null) {
             pluginService.getEndOfBuildListener().buildFinished(new GradleEnterprisePluginEndOfBuildListener.BuildResult() {

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/enterprise/impl/legacy/LegacyGradleEnterprisePluginCheckInService.java
@@ -203,6 +203,10 @@ public class LegacyGradleEnterprisePluginCheckInService implements BuildScanConf
         }
 
         @Override
+        public void executionPhaseStarted() {
+        }
+
+        @Override
         public void buildFinished(@Nullable Throwable buildFailure) {
             if (listener != null) {
                 listener.execute(new BuildResult() {


### PR DESCRIPTION
With this, the plugin can perform any jobs without worrying about affecting the configuration and accidentally adding inputs to the configuration cache.

Fixes gradle/configuration-cache#573
