### PR TITLE
Provide version-info properties file as build artifact in TC

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -37,6 +37,7 @@ abstract class BasePublishGradleDistribution(
         **/build/website-checkout/data/releases.xml
         **/build/git-checkout/build/reports/integTest/** => distribution-tests
         **/smoke-tests/build/reports/tests/** => post-smoke-tests
+        **/build/version-info.properties => version-info.properties
         """.trimIndent()
 
         dependencies {


### PR DESCRIPTION
This is the file used to communicate between step 1 and step 2 of the new promotion build in Team City.