### PR TITLE
Remove build listener usage

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
+++ b/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.process.ExecOperations
+import java.util.Timer
+import javax.inject.Inject
+import kotlin.concurrent.timerTask
+
+
+abstract class PrintStackTracesOnTimeoutBuildService : BuildService<PrintStackTracesOnTimeoutBuildService.Params>, AutoCloseable {
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    interface Params : BuildServiceParameters {
+        val timeoutMillis: Property<Long>
+        val projectDirectory: DirectoryProperty
+    }
+
+    private
+    lateinit var timer: Timer
+
+    fun startTimer() {
+        if (!this::timer.isInitialized) {
+            timer = Timer(true).apply {
+                schedule(
+                    timerTask {
+                        execOperations.exec {
+                            commandLine(
+                                "${System.getProperty("java.home")}/bin/java",
+                                parameters.projectDirectory.file("subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").get().asFile.absolutePath,
+                                parameters.projectDirectory.asFile.get().absolutePath
+                            )
+                        }
+                    },
+                    parameters.timeoutMillis.get()
+                )
+            }
+        }
+    }
+
+    override fun close() {
+        timer.cancel()
+    }
+}

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -16,8 +16,6 @@
 
 import gradlebuild.basics.BuildEnvironment
 import java.time.Duration
-import java.util.Timer
-import kotlin.concurrent.timerTask
 
 // Lifecycle tasks used to to fan out the build into multiple builds in a CI pipeline.
 
@@ -39,7 +37,6 @@ val soakTest = "soakTest"
 
 val smokeTest = "smokeTest"
 
-
 setupTimeoutMonitorOnCI()
 setupGlobalState()
 
@@ -51,24 +48,11 @@ tasks.registerEarlyFeedbackRootLifecycleTasks()
  * Print all stacktraces of running JVMs on the machine upon timeout. Helps us diagnose deadlock issues.
  */
 fun setupTimeoutMonitorOnCI() {
-    if (BuildEnvironment.isCiServer && project.name != "gradle-kotlin-dsl-accessors") {
-        val timer = Timer(true).apply {
-            schedule(
-                timerTask {
-                    exec {
-                        commandLine(
-                            "${System.getProperty("java.home")}/bin/java",
-                            project.layout.projectDirectory.file("subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").asFile,
-                            project.layout.projectDirectory.asFile.absolutePath
-                        )
-                    }
-                },
-                determineTimeoutMillis()
-            )
-        }
-        gradle.buildFinished {
-            timer.cancel()
-        }
+    if (BuildEnvironment.isCiServer) {
+        project.gradle.sharedServices.registerIfAbsent("printStackTracesOnTimeoutBuildService", PrintStackTracesOnTimeoutBuildService::class.java) {
+            parameters.timeoutMillis.set(determineTimeoutMillis())
+            parameters.projectDirectory.set(layout.projectDirectory)
+        }.get().startTimer()
     }
 }
 

--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -48,11 +48,11 @@ tasks.registerEarlyFeedbackRootLifecycleTasks()
  * Print all stacktraces of running JVMs on the machine upon timeout. Helps us diagnose deadlock issues.
  */
 fun setupTimeoutMonitorOnCI() {
-    if (BuildEnvironment.isCiServer) {
+    if (BuildEnvironment.isCiServer && project.name != "gradle-kotlin-dsl-accessors") {
         project.gradle.sharedServices.registerIfAbsent("printStackTracesOnTimeoutBuildService", PrintStackTracesOnTimeoutBuildService::class.java) {
             parameters.timeoutMillis.set(determineTimeoutMillis())
             parameters.projectDirectory.set(layout.projectDirectory)
-        }.get().startTimer()
+        }.get()
     }
 }
 


### PR DESCRIPTION
So that we don't get deprecation warnings of configuration cache.
