### PR TITLE
Remove obsolete note about buildSrc

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/software-product/composite_builds.adoc
@@ -249,7 +249,3 @@ Limitations of the current implementation include:
 * No support for included builds that have publications that don't mirror the project default configuration. See <<#included_build_substitution_limitations,Cases where composite builds won't work>>.
 * Software model based native builds are not supported. (Binary dependencies are not yet supported for native builds).
 * Multiple composite builds may conflict when run in parallel, if more than one includes the same build. Gradle does not share the project lock of a shared composite build to between Gradle invocation to prevent concurrent execution.
-
-Improvements we have planned for upcoming releases include:
-
-* Making the implicit `buildSrc` project an included build.


### PR DESCRIPTION
### Context

Note is obsolete because [buildSrc is already an included build][source]:

>The directory buildSrc is treated as an included build.

[source]: https://github.com/gradle/gradle/blob/2a382c00f174e33c840f74f66c86ff2a93a212be/subprojects/docs/src/docs/userguide/authoring-builds/organizing_gradle_projects.adoc#use-buildsrc-to-abstract-imperative-logic

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
