### PR TITLE
Workaround for Jacoco Aggregation Plugin + Kotlin-JVM Plugin

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
@@ -106,8 +106,6 @@ class JacocoTransitiveAggregationTest extends AbstractIntegrationSpec {
                 }
             """
 
-            file("parents/build.gradle") << ""
-
             file("parent/subTransitiveTest/build.gradle") << """
                 plugins {
                     id 'java-library'

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.jacoco.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
+import spock.lang.Issue
+
+class JacocoTransitiveAggregationTest extends AbstractIntegrationSpec {
+    def setup() {
+        multiProjectBuild("root", ["direct", "transitiveTest"]) {
+            buildFile.text = """
+                apply plugin: 'jacoco-report-aggregation'
+
+                repositories {
+                    ${mavenCentralRepository()}
+                }
+
+                dependencies {
+                    jacocoAggregation project(":direct")
+                }
+
+                reporting {
+                    reports {
+                        testCodeCoverageReport(JacocoCoverageReport) {
+                            testType = TestSuiteType.UNIT_TEST
+                        }
+                    }
+                }
+
+                subprojects {
+                    repositories {
+                        ${mavenCentralRepository()}
+                    }
+
+                    plugins.withId('java') {
+                        testing {
+                            suites {
+                                test {
+                                    useJUnit()
+                                }
+                            }
+                        }
+                    }
+                }
+            """ + buildFile.text
+
+            file("direct/build.gradle") << """
+                plugins {
+                    id 'java-library'
+                    id 'jacoco'
+                }
+
+                dependencies {
+                    testImplementation project(":transitiveTest")
+                }
+            """
+            file("direct/src/main/java/direct/Multiplier.java").java """
+                package direct;
+
+                public class Multiplier {
+                    int multiply(int x, int y) {
+                        return x*y;
+                    }
+                }
+            """
+            file("direct/src/test/java/direct/MultiplierTest.java").java """
+                package direct;
+
+                import org.junit.Assert;
+                import org.junit.Test;
+                import transitiveTest.Powerize;
+
+                public class MultiplierTest {
+                    @Test
+                    public void testMultiply() {
+                        Multiplier multiplier = new Multiplier();
+                        Assert.assertEquals(1, multiplier.multiply(1, 1));
+                        Assert.assertEquals(4, multiplier.multiply(2, 2));
+                        Assert.assertEquals(2, multiplier.multiply(1, 2));
+                    }
+
+                    @Test
+                    public void testPowerize() {
+                        Powerize powerizer = new Powerize();
+                        Assert.assertEquals(4, powerizer.pow(2, 2));
+                    }
+                }
+            """
+
+            file("transitiveTest/build.gradle") << """
+                plugins {
+                    id 'java-library'
+                }
+            """
+            file("transitiveTest/src/main/java/transitiveTest/Powerize.java").java """
+                package transitiveTest;
+
+                public class Powerize {
+                    public int pow(int x, int y) {
+                        return (int)Math.pow(x, y);
+                    }
+                }
+            """
+        }
+    }
+
+    @Issue("20532") // Not sure why this reproducer doesn't fail like the provided example.  Maybe Kotlin DSL vs. Groovy?
+    def "can aggregate jacoco execution data from subprojects"() {
+        given:
+
+        when:
+        succeeds(":testCodeCoverageReport")
+
+        then:
+        file("transitiveTest/build/jacoco/test.exec").assertDoesNotExist()
+        file("direct/build/jacoco/test.exec").assertExists()
+
+        file("build/reports/jacoco/testCodeCoverageReport/html/index.html").assertExists()
+
+        def report = new JacocoReportXmlFixture(file("build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
+        report.assertHasClassCoverage("direct.Multiplier")
+    }
+}

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoTransitiveAggregationTest.groovy
@@ -111,6 +111,7 @@ class JacocoTransitiveAggregationTest extends AbstractIntegrationSpec {
             file("parent/subTransitiveTest/build.gradle") << """
                 plugins {
                     id 'java-library'
+                    id 'org.jetbrains.kotlin.jvm' version '1.6.21'
                 }
             """
             file("parent/subTransitiveTest/src/main/java/subTransitiveTest/Powerize.java").java """
@@ -125,7 +126,7 @@ class JacocoTransitiveAggregationTest extends AbstractIntegrationSpec {
         }
     }
 
-    @Issue("20532") // Not sure why this reproducer doesn't fail like the provided example.  Maybe Kotlin DSL vs. Groovy?
+    @Issue("20532")
     def "can aggregate jacoco execution data from subprojects"() {
         when:
         succeeds(":testCodeCoverageReport")


### PR DESCRIPTION
Fixes #20532

When the `kotlin-jvm` plugin is applied to a project, it changes the legacy `default` configuration from:

```--------------------------------------------------
Variant default (l)
--------------------------------------------------
Configuration for default artifacts.

Capabilities
    - org.test:subTransitiveTest:1.0 (default capability)
Artifacts
    - build/libs/subTransitiveTest-1.0.jar (artifactType = jar)
 ```

to:

```--------------------------------------------------
Variant default (l)
--------------------------------------------------
Configuration for default artifacts.

Capabilities
    - org.test:subTransitiveTest:1.0 (default capability)
Attributes
    - org.gradle.jvm.environment         = standard-jvm
    - org.jetbrains.kotlin.platform.type = jvm
Artifacts
    - build/libs/subTransitiveTest-1.0.jar (artifactType = jar)
```

The addition of the `org.gradle.jvm.environment` attribute, in the absence of of actual test data variants which will **not** be created if the `jacoco` plugin is **not** applied, causes it to be selected by the `jacoco-aggregation-plugin` when looking for test coverage data.  Then the plugin throws an error, since the jar artifact here does not contain valid coverage data.

The workaround for this for now is for the aggregation plugin to file out resolved artifacts which are zip files, if any should wind up resolved via this problem.