### PR TITLE
Add ConnectionClosedException as transient error

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.transport;
 
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpStatus;
 import org.apache.http.NoHttpResponseException;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
@@ -39,7 +40,7 @@ public class NetworkingIssueVerifier {
      * </ul>
      */
     public static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
-        if (failure instanceof SocketException || failure instanceof SocketTimeoutException || failure instanceof NoHttpResponseException) {
+        if (failure instanceof SocketException || failure instanceof SocketTimeoutException || failure instanceof NoHttpResponseException || failure instanceof ConnectionClosedException) {
             return true;
         }
         if (failure instanceof DefaultMultiCauseException) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.transport
 
+import org.apache.http.ConnectionClosedException
 import org.apache.http.NoHttpResponseException
 import org.apache.http.conn.HttpHostConnectException
 import org.gradle.internal.exceptions.DefaultMultiCauseException
@@ -37,6 +38,7 @@ class NetworkingIssueVerifierTest extends Specification {
         "SocketException"                                           | new SocketException()
         "SocketTimeoutException"                                    | new SocketTimeoutException()
         "NoHttpResponseException"                                   | new NoHttpResponseException("something went wrong")
+        "ConnectionClosedException"                                 | new ConnectionClosedException("something went wrong")
         "HttpHostConnectException"                                  | new HttpHostConnectException(new IOException("something went wrong"), null, null)
         "DefaultMultiCauseException"                                | new DefaultMultiCauseException("something went wrong", new SocketTimeoutException())
         "HttpErrorStatusCodeException with server error"            | new HttpErrorStatusCodeException("something", "something", 503, "something")


### PR DESCRIPTION
Fixes #16642

TL;DR: By adding Apache's ConnectionClosedException, when the exception occurs, the build doesn't fail but instead retries the request.