### PR TITLE
Enable Predictive Test Selection

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -50,7 +50,6 @@ import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.STUDIO_HOME
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_ENABLED
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_PARTITION_SIZE
-import gradlebuild.basics.BuildParams.TEST_FILTERING_ENABLED
 import gradlebuild.basics.BuildParams.TEST_JAVA_VENDOR
 import gradlebuild.basics.BuildParams.TEST_JAVA_VERSION
 import gradlebuild.basics.BuildParams.TEST_SPLIT_EXCLUDE_TEST_CLASSES
@@ -113,7 +112,6 @@ object BuildParams {
     const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"
-    const val TEST_FILTERING_ENABLED = "gradle.internal.testselection.enabled"
     const val TEST_SPLIT_INCLUDE_TEST_CLASSES = "includeTestClasses"
     const val TEST_SPLIT_EXCLUDE_TEST_CLASSES = "excludeTestClasses"
     const val TEST_SPLIT_ONLY_TEST_GRADLE_VERSION = "onlyTestGradleVersion"
@@ -282,8 +280,8 @@ val Project.gradleInstallPath: Provider<String>
     )
 
 
-val Project.rerunAllTests: Provider<String>
-    get() = gradleProperty(RERUN_ALL_TESTS)
+val Project.rerunAllTests: Provider<Boolean>
+    get() = gradleProperty(RERUN_ALL_TESTS).map { true }.orElse(false)
 
 
 val Project.testJavaVendor: Provider<JvmVendorSpec>
@@ -306,19 +304,15 @@ val Project.testSplitOnlyTestGradleVersion: String
     get() = project.stringPropertyOrEmpty(TEST_SPLIT_ONLY_TEST_GRADLE_VERSION)
 
 
-val Project.isExperimentalTestFilteringEnabled: Boolean
-    get() = systemProperty(TEST_FILTERING_ENABLED).getOrElse("false").toBoolean()
-
-
-val Project.predictiveTestSelectionEnabled: Boolean
+val Project.predictiveTestSelectionEnabled: Provider<Boolean>
     get() = systemProperty(PREDICTIVE_TEST_SELECTION_ENABLED)
         .map { it.toBoolean() }
-        .orElse(provider {
-            val protectedBranches = listOf("master", "release")
-            val branch: String? = environmentVariable("BUILD_BRANCH").orNull
-            (branch == null || !protectedBranches.contains(branch) && !branch.startsWith("pre-test/"))
-        })
-        .get()
+        .orElse(
+            buildBranch.zip(buildRunningOnCi) { branch, ci ->
+                val protectedBranches = listOf("master", "release")
+                ci && !protectedBranches.contains(branch) && !branch.startsWith("pre-test/")
+            }
+        )
 
 
 val Project.testDistributionEnabled: Boolean

--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -44,6 +44,7 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_DB_USERNAME
 import gradlebuild.basics.BuildParams.PERFORMANCE_DEPENDENCY_BUILD_IDS
 import gradlebuild.basics.BuildParams.PERFORMANCE_MAX_PROJECTS
 import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
+import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
 import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
 import gradlebuild.basics.BuildParams.STUDIO_HOME
@@ -109,6 +110,7 @@ object BuildParams {
     const val PERFORMANCE_DEPENDENCY_BUILD_IDS = "org.gradle.performance.dependencyBuildIds"
     const val PERFORMANCE_MAX_PROJECTS = "maxProjects"
     const val RERUN_ALL_TESTS = "rerunAllTests"
+    const val PREDICTIVE_TEST_SELECTION_ENABLED = "enablePredictiveTestSelection"
     const val TEST_DISTRIBUTION_ENABLED = "enableTestDistribution"
     const val TEST_DISTRIBUTION_PARTITION_SIZE = "testDistributionPartitionSizeInSeconds"
     const val TEST_FILTERING_ENABLED = "gradle.internal.testselection.enabled"
@@ -306,6 +308,17 @@ val Project.testSplitOnlyTestGradleVersion: String
 
 val Project.isExperimentalTestFilteringEnabled: Boolean
     get() = systemProperty(TEST_FILTERING_ENABLED).getOrElse("false").toBoolean()
+
+
+val Project.predictiveTestSelectionEnabled: Boolean
+    get() = systemProperty(PREDICTIVE_TEST_SELECTION_ENABLED)
+        .map { it.toBoolean() }
+        .orElse(provider {
+            val protectedBranches = listOf("master", "release")
+            val branch: String? = environmentVariable("BUILD_BRANCH").orNull
+            (branch == null || !protectedBranches.contains(branch) && !branch.startsWith("pre-test/"))
+        })
+        .get()
 
 
 val Project.testDistributionEnabled: Boolean

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -318,9 +318,11 @@ fun configureTests() {
             val supportedTask = taskIdentity.taskType == Test::class.java
 
             predictiveSelection {
-                enabled.convention(project.predictiveTestSelectionEnabled.zip(project.rerunAllTests) { enabled, rerunAllTests ->
-                    enabled && !rerunAllTests && supportedTask
-                })
+                enabled.convention(
+                    project.predictiveTestSelectionEnabled.zip(project.rerunAllTests) { enabled, rerunAllTests ->
+                        enabled && !rerunAllTests && supportedTask
+                    }
+                )
             }
         }
     }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -21,6 +21,7 @@ import gradlebuild.basics.flakyTestStrategy
 import gradlebuild.basics.isExperimentalTestFilteringEnabled
 import gradlebuild.basics.maxParallelForks
 import gradlebuild.basics.maxTestDistributionPartitionSecond
+import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.rerunAllTests
 import gradlebuild.basics.tasks.ClasspathManifest
 import gradlebuild.basics.testDistributionEnabled
@@ -318,6 +319,10 @@ fun configureTests() {
                     requirements.set(listOf("gbt-dogfooding"))
                 }
             }
+        }
+
+        predictiveSelection {
+            enabled.set(project.predictiveTestSelectionEnabled)
         }
     }
 }

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -34,7 +34,6 @@ import gradlebuild.jvm.extension.UnitTestAndCompileExtension
 import org.gradle.internal.os.OperatingSystem
 import java.time.Duration
 import java.util.jar.Attributes
-import kotlin.reflect.full.superclasses
 
 plugins {
     groovy
@@ -316,8 +315,7 @@ fun configureTests() {
         if (project.supportsPredictiveTestSelection()) {
             // Temporary workaround for Gradle Enterprise issue which in 2022.2 and 2022.2.1
             // only supports tasks of the exact type `org.gradle.api.tasks.testing.Test`.
-            // We have to look for the first super class since Gradle passes a decorator.
-            val supportedTask = this::class.superclasses.first() == Test::class
+            val supportedTask = taskIdentity.taskType == Test::class.java
 
             predictiveSelection {
                 enabled.convention(project.predictiveTestSelectionEnabled.zip(project.rerunAllTests) { enabled, rerunAllTests ->

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("javax.activation:activation")
     implementation("javax.xml.bind:jaxb-api")
     implementation("org.gradle:test-retry-gradle-plugin")
+    implementation("com.gradle.enterprise:test-distribution-gradle-plugin")
 
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("junit:junit")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -228,6 +228,8 @@ class PerformanceTestPlugin : Plugin<Project> {
 
             outputs.cacheIf { false }
             outputs.file(outputJson)
+
+            predictiveSelection.enabled.set(false)
         }
 
     private


### PR DESCRIPTION
Enable PTS for all local builds and CI builds for branches other than
`master`, `release`, and `pre-test/*` by default. It can be manually
enabled by passing `-DenablePredictiveTestSelection=false` to the build.