### PR TITLE
Relax the restrictions for the external processes at the configuration time

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheProcessInstrumentationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/AbstractConfigurationCacheProcessInstrumentationIntegrationTest.groovy
@@ -26,6 +26,7 @@ abstract class AbstractConfigurationCacheProcessInstrumentationIntegrationTest e
 
     def setup() {
         testDirectory.createDir(pwd)
+        settingsFile("enableFeaturePreview('STABLE_CONFIGURATION_CACHE')")
     }
 
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInInitScriptIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInInitScriptIntegrationTest.groovy
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache
 
+import spock.lang.Ignore
+
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.exec
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.javaexec
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.processBuilder
@@ -23,6 +25,7 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.runt
 import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stringArrayExecute
 
 class ConfigurationCacheExternalProcessInInitScriptIntegrationTest extends AbstractConfigurationCacheExternalProcessIntegrationTest {
+    @Ignore("init scripts are evaluated too early for feature flag to take effect")
     def "using #snippetsFactory.summary in initialization script #file is a problem"() {
         given:
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginBuildScriptIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginBuildScriptIntegrationTest.groovy
@@ -25,17 +25,17 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ConfigurationCacheExternalProcessInPluginBuildScriptIntegrationTest extends AbstractConfigurationCacheExternalProcessIntegrationTest {
     def "using #snippetsFactory.summary in included plugin settings #file is a problem"() {
         given:
+        settingsFileWithStableConfigurationCache("""
+            pluginManagement {
+                includeBuild('included')
+            }
+        """)
+
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file(file) << """
             ${snippets.imports}
             ${snippets.body}
         """
-
-        settingsFile("""
-            pluginManagement {
-                includeBuild('included')
-            }
-        """)
 
         when:
         configurationCacheFails(":help")
@@ -62,6 +62,12 @@ class ConfigurationCacheExternalProcessInPluginBuildScriptIntegrationTest extend
 
     def "using #snippetsFactory.summary in included plugin build #file is a problem"() {
         given:
+        settingsFileWithStableConfigurationCache("""
+            pluginManagement {
+                includeBuild('included')
+            }
+        """)
+
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         def includedBuildFile = testDirectory.file(file)
         includedBuildFile << """
@@ -74,12 +80,6 @@ class ConfigurationCacheExternalProcessInPluginBuildScriptIntegrationTest extend
         testDirectory.file("included/src/main/groovy/test-convention-plugin.gradle") << """
             println("Applied script plugin")
         """
-
-        settingsFile("""
-            pluginManagement {
-                includeBuild('included')
-            }
-        """)
 
         buildFile("""
             plugins {

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.process.ExecOperations
+import spock.lang.Ignore
 
 import javax.inject.Inject
 
@@ -32,6 +33,7 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ConfigurationCacheExternalProcessInPluginIntegrationTest extends AbstractConfigurationCacheExternalProcessIntegrationTest {
     def "using #snippetsFactory.summary in convention plugin #file is a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle.kts") << """
             plugins {
@@ -54,6 +56,8 @@ class ConfigurationCacheExternalProcessInPluginIntegrationTest extends AbstractC
                 id("test-convention-plugin")
             }
         """)
+
+        executer.noDeprecationChecks()
 
         when:
         configurationCacheFails(":help")
@@ -82,6 +86,7 @@ class ConfigurationCacheExternalProcessInPluginIntegrationTest extends AbstractC
 
     def "using #snippetsFactory.summary in java project plugin application is a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyPlugin.java") << """
             import ${ExecOperations.name};
@@ -125,6 +130,7 @@ class ConfigurationCacheExternalProcessInPluginIntegrationTest extends AbstractC
         runtimeExec().java                   | _
     }
 
+    @Ignore("settings plugins are applied too early for feature flag to take effect")
     def "using #snippetsFactory.summary in java settings plugin application is a problem"() {
         given:
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInTaskIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInTaskIntegrationTest.groovy
@@ -35,6 +35,7 @@ import static org.gradle.configurationcache.fixtures.ExternalProcessFixture.stri
 class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractConfigurationCacheExternalProcessIntegrationTest {
     def "using #snippetsFactory.summary in task configuration is a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -82,6 +83,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
 
     def "using #snippetsFactory.summary in task action is not a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -122,6 +124,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
 
     def "using #snippetsFactory.summary in task action of buildSrc is not a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name};
@@ -165,6 +168,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
 
     def "using #snippetsFactory.summary in worker task action of buildSrc is not a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name}
@@ -258,7 +262,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
             println("Applied script plugin")
         """
 
-        settingsFile("""
+        settingsFileWithStableConfigurationCache("""
             pluginManagement {
                 includeBuild('included')
             }
@@ -287,6 +291,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
 
     def "using #snippetsFactory.summary in task up-to-date is not a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/src/main/java/SneakyTask.java") << """
             import ${DefaultTask.name};
@@ -332,6 +337,7 @@ class ConfigurationCacheExternalProcessInTaskIntegrationTest extends AbstractCon
 
     def "using #snippetsFactory.summary in up-to-date task of buildSrc is not a problem"() {
         given:
+        settingsFileWithStableConfigurationCache()
         def snippets = snippetsFactory.newSnippets(execOperationsFixture)
         testDirectory.file("buildSrc/build.gradle") << """
             import ${DefaultTask.name};

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheStableConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheStableConfigurationCacheIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,22 @@
 
 package org.gradle.configurationcache
 
-
 import org.gradle.configurationcache.fixtures.ExternalProcessFixture
-import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
 
-abstract class AbstractConfigurationCacheExternalProcessIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
-    ExternalProcessFixture execOperationsFixture = new ExternalProcessFixture(testDirectory)
+class ConfigurationCacheStableConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    def "external processes at the configuration time do not fail build if the flag is not enabled"() {
+        given:
+        def snippets = ExternalProcessFixture.processBuilder().groovy.newSnippets(new ExternalProcessFixture(testDirectory))
 
-    def settingsFileWithStableConfigurationCache() {
-        settingsFileWithStableConfigurationCache("")
-    }
+        buildFile("""
+            ${snippets.imports}
+            ${snippets.body}
+        """)
 
-    def settingsFileWithStableConfigurationCache(@GroovyBuildScriptLanguage String script) {
-        settingsFile << script
-        settingsFile << """
-            enableFeaturePreview('STABLE_CONFIGURATION_CACHE')
-        """
+        when:
+        configurationCacheRun(":help")
+
+        then:
+        outputContains("Hello")
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/initialization/ConfigurationCacheProblemsListener.kt
@@ -19,6 +19,7 @@ package org.gradle.configurationcache.initialization
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.internal.BuildScopeListenerRegistrationListener
 import org.gradle.api.internal.ExternalProcessStartedListener
+import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal.BUILD_SRC
@@ -48,6 +49,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     private val userCodeApplicationContext: UserCodeApplicationContext,
     private val configurationTimeBarrier: ConfigurationTimeBarrier,
     private val taskExecutionTracker: TaskExecutionTracker,
+    private val featurePreviews: FeaturePreviews,
 ) : ConfigurationCacheProblemsListener {
 
     override fun onProjectAccess(invocationDescription: String, task: TaskInternal) {
@@ -65,7 +67,7 @@ class DefaultConfigurationCacheProblemsListener internal constructor(
     }
 
     override fun onExternalProcessStarted(command: String, consumer: String?) {
-        if (!atConfigurationTime() || taskExecutionTracker.currentTask.isPresent) {
+        if (!featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.STABLE_CONFIGURATION_CACHE) || !atConfigurationTime() || taskExecutionTracker.currentTask.isPresent) {
             return
         }
         problems.onProblem(

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -106,6 +106,14 @@ method has remained the same, this only affects the CLI.
 ==== Groovydoc `includePrivate` property is deprecated
 There is a new `link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Groovydoc.html#org.gradle.api.tasks.javadoc.Groovydoc:access[access]` property that allows finer control over what is included in the Groovydoc.
 
+[[use_providers_to_run_external_processes]]
+==== Provider-based API must be used to run external processes at the configuration time
+
+Using `Project.exec`, `Project.javaexec`, and standard Java and Groovy APIs to run external processes at the configuration time is now deprecated when the configuration cache is enabled.
+It will be an error in Gradle 8.0 and later.
+Gradle 7.5 introduces configuration cache-compatible ways to execute and obtain output of an external process with the link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html[provider-based APIs] or a custom implementation of the link:{javadocPath}/org/gradle/api/provider/ValueSource.html[`ValueSource`] interface.
+The <<configuration_cache#config_cache:requirements:external_processes,configuration cache chapter>> has more details to help with the migration to the new APIs.
+
 [[changes_7.4]]
 == Upgrading from 7.3 and earlier
 

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -829,7 +829,7 @@ If necessary, only configuration-cache-compatible APIs should be used instead of
 `Project.exec`, `Project.javaexec`, and their likes in settings and init scripts.
 For simpler cases, when grabbing the output of the process is enough,
 link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#exec-org.gradle.api.Action-[providers.exec()] and
-link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec-org.gradle.api.Action-[providers.javaExec()] can be used:
+link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#javaexec-org.gradle.api.Action-[providers.javaexec()] can be used:
 
 ====
 include::sample[dir="snippets/valueProviders/externalProcessProvider/groovy",files="build.gradle[]"]


### PR DESCRIPTION
Fail the build only if the STABLE_CONFIGURATION_CACHE feature is enabled.

Some popular plugins start external processes at the configuration time
and haven't had time to adapt. Making the process start a hard failure
can hurt the user's ability to adopt the configuration cache. This
commit hides the error behind a feature flag, so the build and plugin
authors can enable stricter validation.

One downside of the feature flag-based approach is that it doesn't allow
to cover init scripts and settings plugins, as these are
evaluated/applied before the actual settings script is executed.