### PR TITLE
Let config cache report serialization errors for incompatible tasks

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ConfigurationCacheProblems.kt
@@ -107,6 +107,10 @@ class ConfigurationCacheProblems(
             override fun onProblem(problem: PropertyProblem) {
                 onProblem(problem, ProblemSeverity.Suppressed)
             }
+
+            override fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+                onProblem(PropertyProblem(trace, StructuredMessage.build(message), error))
+            }
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
@@ -16,6 +16,8 @@
 
 package org.gradle.configurationcache.problems
 
+import org.gradle.configurationcache.ConfigurationCacheError
+import org.gradle.configurationcache.extensions.maybeUnwrapInvocationTargetException
 import org.gradle.internal.service.scopes.EventScope
 import org.gradle.internal.service.scopes.Scopes
 
@@ -24,6 +26,13 @@ import org.gradle.internal.service.scopes.Scopes
 interface ProblemsListener {
 
     fun onProblem(problem: PropertyProblem)
+
+    fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+        throw ConfigurationCacheError(
+            "${propertyDescriptionFor(trace)}: ${StructuredMessage.build(message)}",
+            error.maybeUnwrapInvocationTargetException()
+        )
+    }
 
     fun forIncompatibleType(): ProblemsListener = this
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Codec.kt
@@ -25,6 +25,7 @@ import org.gradle.configurationcache.DefaultConfigurationCache
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.serialization.beans.BeanStateReader
 import org.gradle.configurationcache.serialization.beans.BeanStateWriter
 import org.gradle.internal.serialize.Decoder
@@ -104,6 +105,8 @@ interface IsolateContext {
     val trace: PropertyTrace
 
     fun onProblem(problem: PropertyProblem)
+
+    fun onError(error: Exception, message: StructuredMessageBuilder)
 }
 
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Contexts.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/Contexts.kt
@@ -25,6 +25,7 @@ import org.gradle.configurationcache.ClassLoaderScopeSpec
 import org.gradle.configurationcache.problems.ProblemsListener
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.serialization.beans.BeanStateReader
 import org.gradle.configurationcache.serialization.beans.BeanStateReaderLookup
 import org.gradle.configurationcache.serialization.beans.BeanStateWriter
@@ -392,6 +393,10 @@ abstract class AbstractIsolateContext<T>(
 
     override fun onProblem(problem: PropertyProblem) {
         currentProblemsListener.onProblem(problem)
+    }
+
+    override fun onError(error: Exception, message: StructuredMessageBuilder) {
+        currentProblemsListener.onError(trace, error, message)
     }
 
     override suspend fun forIncompatibleType(action: suspend () -> Unit) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskNodeCodec.kt
@@ -226,10 +226,10 @@ suspend fun <T> T.withTaskOf(
 ) where T : IsolateContext, T : MutableIsolateContext {
     withIsolate(IsolateOwner.OwnerTask(task), codec) {
         withPropertyTrace(PropertyTrace.Task(taskType, task.path)) {
-            if (!task.isCompatibleWithConfigurationCache) {
-                forIncompatibleType(action)
-            } else {
+            if (task.isCompatibleWithConfigurationCache) {
                 action()
+            } else {
+                forIncompatibleType(action)
             }
         }
     }

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintCheckerTest.kt
@@ -27,6 +27,7 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.configurationcache.CheckedFingerprint
 import org.gradle.configurationcache.problems.PropertyProblem
 import org.gradle.configurationcache.problems.PropertyTrace
+import org.gradle.configurationcache.problems.StructuredMessageBuilder
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.IsolateOwner
 import org.gradle.configurationcache.serialization.CircularReferences
@@ -306,6 +307,9 @@ class ConfigurationCacheFingerprintCheckerTest {
         override fun onProblem(problem: PropertyProblem): Unit =
             undefined()
 
+        override fun onError(error: Exception, message: StructuredMessageBuilder) =
+            undefined()
+
         override fun push(codec: Codec<Any?>): Unit =
             undefined()
 
@@ -407,6 +411,9 @@ class ConfigurationCacheFingerprintCheckerTest {
             set(_) {}
 
         override fun onProblem(problem: PropertyProblem): Unit =
+            undefined()
+
+        override fun onError(error: Exception, message: StructuredMessageBuilder) =
             undefined()
 
         override fun push(codec: Codec<Any?>): Unit =


### PR DESCRIPTION
Instead of failing the build.

Fixes #19959
