### PR TITLE
Use mirrored mavenCentral in configuration cache tests

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInPluginIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.initialization.Settings
 import org.gradle.process.ExecOperations
+import org.gradle.test.fixtures.dsl.GradleDsl
 
 import javax.inject.Inject
 
@@ -38,9 +39,7 @@ class ConfigurationCacheExternalProcessInPluginIntegrationTest extends AbstractC
                 `$plugin`
             }
 
-            repositories {
-               mavenCentral()
-            }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
         """
         def conventionPluginFile = testDirectory.file(file)
         conventionPluginFile << """

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -1027,9 +1027,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         """
         buildFile << """
             apply from: 'script.gradle'
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
             configurations {
                 thing
             }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/SystemPropertyInstrumentationInKotlinIntegrationTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.configurationcache.inputs.undeclared
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.configurationcache.AbstractConfigurationCacheIntegrationTest
+import org.gradle.test.fixtures.dsl.GradleDsl
 
 class SystemPropertyInstrumentationInKotlinIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
     def "#method is instrumented in Kotlin"() {
@@ -43,9 +44,7 @@ class SystemPropertyInstrumentationInKotlinIntegrationTest extends AbstractConfi
             plugins {
                 `kotlin-dsl`
             }
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository(GradleDsl.KOTLIN)}
         """
 
         buildScript("""


### PR DESCRIPTION
Mirror prevents network-caused flakes of Central being unreachable.
