### PR TITLE
Sort script application operations by start time in IsolatedProjectsToolingApiParallelConfigurationIntegrationTest

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsFixture.groovy
@@ -170,7 +170,8 @@ class IsolatedProjectsFixture {
         // Scripts - one or more for settings, and one for each project build script
         def scripts = buildOperations.all(ApplyScriptPluginBuildOperationType)
         assert !scripts.empty
-        assert scripts.first().details.targetType == "settings"
+        def sortedScripts = scripts.toSorted { it -> it.startTime }
+        assert sortedScripts.first().details.targetType == "settings"
         def otherScripts = scripts.findAll { it.details.targetType != "settings" }
         assert otherScripts.size() == projectsWithScripts(details.projects).size()
     }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/isolated/IsolatedProjectsToolingApiParallelConfigurationIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.configurationcache.isolated
 
-import org.gradle.test.fixtures.Flaky
+
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
@@ -30,7 +30,6 @@ class IsolatedProjectsToolingApiParallelConfigurationIntegrationTest extends Abs
         server.start()
     }
 
-    @Flaky(because = "https://github.com/gradle/gradle-private/issues/3495")
     def "projects are configured and models created in parallel when project scoped model is queried concurrently"() {
         withSomeToolingModelBuilderPluginInBuildSrc("""
             ${server.callFromBuildUsingExpression("'model-' + project.name")}


### PR DESCRIPTION
when trying to find out the first one. The order in the JSON/List is different since the different apply script operations have separate parent `Tooling API client action` operations which run in parallel.

Fixes https://github.com/gradle/gradle-private/issues/3495.