### PR TITLE
Fix dependency metadata rule when removing elements

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintMetadataAdapter.java
@@ -20,11 +20,9 @@ import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 
-import java.util.List;
-
 public class DependencyConstraintMetadataAdapter extends AbstractDependencyMetadataAdapter<DependencyConstraintMetadata> implements DependencyConstraintMetadata {
 
-    public DependencyConstraintMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<ModuleDependencyMetadata> container, int originalIndex) {
-        super(attributesFactory, container, originalIndex);
+    public DependencyConstraintMetadataAdapter(ImmutableAttributesFactory attributesFactory, ModuleDependencyMetadata metadata) {
+        super(attributesFactory, metadata);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
@@ -19,23 +19,26 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
-import java.util.List;
-
-public class DependencyConstraintsMetadataAdapter extends AbstractDependenciesMetadataAdapter<DependencyConstraintMetadata> implements DependencyConstraintsMetadata {
+public class DependencyConstraintsMetadataAdapter extends AbstractDependenciesMetadataAdapter<DependencyConstraintMetadata, DependencyConstraintMetadataAdapter> implements DependencyConstraintsMetadata {
 
     public DependencyConstraintsMetadataAdapter(ImmutableAttributesFactory attributesFactory,
-                                                List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata,
                                                 Instantiator instantiator,
                                                 NotationParser<Object, DependencyConstraintMetadata> dependencyConstraintsNotationParser) {
-        super(attributesFactory, dependenciesMetadata, instantiator, dependencyConstraintsNotationParser);
+        super(attributesFactory, instantiator, dependencyConstraintsNotationParser);
     }
 
     @Override
-    protected Class<? extends DependencyConstraintMetadata> adapterImplementationType() {
+    protected Class<DependencyConstraintMetadataAdapter> adapterImplementationType() {
         return DependencyConstraintMetadataAdapter.class;
+    }
+
+    @Override
+    protected ModuleDependencyMetadata getAdapterMetadata(DependencyConstraintMetadataAdapter adapter) {
+        return adapter.getMetadata();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
@@ -19,22 +19,25 @@ package org.gradle.api.internal.artifacts.repositories.resolver;
 import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 
-import java.util.List;
-
-public class DirectDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter<DirectDependencyMetadata> implements DirectDependenciesMetadata {
+public class DirectDependenciesMetadataAdapter extends AbstractDependenciesMetadataAdapter<DirectDependencyMetadata, DirectDependencyMetadataAdapter> implements DirectDependenciesMetadata {
     public DirectDependenciesMetadataAdapter(ImmutableAttributesFactory attributesFactory,
-                                             List<org.gradle.internal.component.model.DependencyMetadata> dependenciesMetadata,
                                              Instantiator instantiator,
                                              NotationParser<Object, DirectDependencyMetadata> dependencyNotationParser) {
-        super(attributesFactory, dependenciesMetadata, instantiator, dependencyNotationParser);
+        super(attributesFactory, instantiator, dependencyNotationParser);
     }
 
     @Override
-    protected Class<? extends DirectDependencyMetadata> adapterImplementationType() {
+    protected Class<DirectDependencyMetadataAdapter> adapterImplementationType() {
         return DirectDependencyMetadataAdapter.class;
+    }
+
+    @Override
+    protected ModuleDependencyMetadata getAdapterMetadata(DirectDependencyMetadataAdapter adapter) {
+        return adapter.getMetadata();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependencyMetadataAdapter.java
@@ -35,23 +35,23 @@ import java.util.stream.Collectors;
 
 public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataAdapter<DirectDependencyMetadata> implements DirectDependencyMetadata {
 
-    public DirectDependencyMetadataAdapter(ImmutableAttributesFactory attributesFactory, List<ModuleDependencyMetadata> container, int originalIndex) {
-        super(attributesFactory, container, originalIndex);
+    public DirectDependencyMetadataAdapter(ImmutableAttributesFactory attributesFactory, ModuleDependencyMetadata metadata) {
+        super(attributesFactory, metadata);
     }
 
     @Override
     public void endorseStrictVersions() {
-        updateMetadata(getOriginalMetadata().withEndorseStrictVersions(true));
+        updateMetadata(getMetadata().withEndorseStrictVersions(true));
     }
 
     @Override
     public void doNotEndorseStrictVersions() {
-        updateMetadata(getOriginalMetadata().withEndorseStrictVersions(false));
+        updateMetadata(getMetadata().withEndorseStrictVersions(false));
     }
 
     @Override
     public boolean isEndorsingStrictVersions() {
-        return getOriginalMetadata().isEndorsingStrictVersions();
+        return getMetadata().isEndorsingStrictVersions();
     }
 
     @Override
@@ -64,7 +64,7 @@ public class DirectDependencyMetadataAdapter extends AbstractDependencyMetadataA
     }
 
     private List<IvyArtifactName> getIvyArtifacts() {
-        ModuleDependencyMetadata originalMetadata = getOriginalMetadata();
+        ModuleDependencyMetadata originalMetadata = getMetadata();
         if (originalMetadata instanceof ConfigurationBoundExternalDependencyMetadata) {
             ConfigurationBoundExternalDependencyMetadata externalMetadata = (ConfigurationBoundExternalDependencyMetadata) originalMetadata;
             ExternalDependencyDescriptor descriptor = externalMetadata.getDependencyDescriptor();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -148,13 +148,13 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
         private final ImmutableList<? extends DependencyConstraint> dependencyConstraints;
         private final ImmutableList<? extends File> files;
         private final ImmutableCapabilities capabilities;
-        private final ImmutableList<GradleDependencyMetadata> dependencyMetadata;
+        private final ImmutableList<? extends ModuleDependencyMetadata> dependencyMetadata;
         private final boolean externalVariant;
 
         public ImmutableRealisedVariantImpl(ModuleComponentIdentifier componentId, String name, ImmutableAttributes attributes,
                                             ImmutableList<? extends Dependency> dependencies, ImmutableList<? extends DependencyConstraint> dependencyConstraints,
                                             ImmutableList<? extends File> files, ImmutableCapabilities capabilities,
-                                            List<GradleDependencyMetadata> dependencyMetadata,
+                                            List<? extends ModuleDependencyMetadata> dependencyMetadata,
                                             boolean externalVariant) {
             this.componentId = componentId;
             this.name = name;
@@ -197,7 +197,7 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
             return dependencyConstraints;
         }
 
-        public ImmutableList<GradleDependencyMetadata> getDependencyMetadata() {
+        public ImmutableList<? extends ModuleDependencyMetadata> getDependencyMetadata() {
             return dependencyMetadata;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -78,8 +78,10 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
                 AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl realisedVariant = (AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl) variant;
                 encoder.writeString(realisedVariant.getName());
                 encoder.writeSmallInt(realisedVariant.getDependencyMetadata().size());
-                for (GradleDependencyMetadata dependencyMetadata: realisedVariant.getDependencyMetadata()) {
-                    writeDependencyMetadata(encoder, dependencyMetadata);
+                for (ModuleDependencyMetadata dependencyMetadata: realisedVariant.getDependencyMetadata()) {
+                    if (dependencyMetadata instanceof GradleDependencyMetadata) {
+                        writeDependencyMetadata(encoder, (GradleDependencyMetadata) dependencyMetadata);
+                    }
                 }
             } else {
                 throw new IllegalStateException("Unknown type of variant: " + variant.getClass());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -36,7 +36,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
 
     private final VariantMetadataRules componentMetadataRules;
 
-    private List<ModuleDependencyMetadata> calculatedDependencies;
+    private List<? extends ModuleDependencyMetadata> calculatedDependencies;
     private ImmutableList<? extends ModuleComponentArtifactMetadata> calculatedArtifacts;
 
     // Could be precomputed, but we avoid doing so if attributes are never requested

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -112,7 +112,7 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, variant.getCapabilities());
         ImmutableList<? extends ComponentVariant.File> files = variantMetadataRules.applyVariantFilesMetadataRulesToFiles(variant, variant.getFiles(), id);
         boolean force = PlatformSupport.hasForcedDependencies(variant);
-        List<GradleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints(), force));
+        List<? extends ModuleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints(), force));
         return new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(id, variant.getName(), attributes,
             variant.getDependencies(), variant.getDependencyConstraints(), files,
             ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()), dependencies, variant.isExternalVariant());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -81,7 +81,7 @@ public class VariantMetadataRules {
         return capabilities;
     }
 
-    public <T extends ModuleDependencyMetadata> List<T> applyDependencyMetadataRules(VariantResolveMetadata variant, List<T> configDependencies) {
+    public <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> applyDependencyMetadataRules(VariantResolveMetadata variant, List<T> configDependencies) {
         if (dependencyMetadataRules != null) {
             return dependencyMetadataRules.execute(variant, configDependencies);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -24,18 +24,18 @@ import org.gradle.api.artifacts.DependencyConstraintMetadata;
 import org.gradle.api.artifacts.DependencyConstraintsMetadata;
 import org.gradle.api.artifacts.DirectDependenciesMetadata;
 import org.gradle.api.artifacts.DirectDependencyMetadata;
+import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintsMetadataAdapter;
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependenciesMetadataAdapter;
+import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependencyMetadataAdapter;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.component.external.model.GradleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.internal.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -81,20 +81,33 @@ public class DependencyMetadataRules {
     }
 
     private <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {
-        List<T> calculatedDependencies = new ArrayList<>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
-        for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
-            dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
-                DirectDependenciesMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyNotationParser));
+        if (dependencyActions.isEmpty()) {
+            return CollectionUtils.filter(dependencies, DEPENDENCY_FILTER);
         }
-        return calculatedDependencies;
+
+        DirectDependenciesMetadataAdapter adapter = instantiator.newInstance(
+            DirectDependenciesMetadataAdapter.class, attributesFactory, instantiator, dependencyNotationParser);
+        CollectionUtils.filter(dependencies, DEPENDENCY_FILTER).forEach(dep ->
+            adapter.add(instantiator.newInstance(DirectDependencyMetadataAdapter.class, attributesFactory, dep)));
+
+        dependencyActions.forEach(action -> action.maybeExecute(variant, adapter));
+
+        return adapter.getMetadatas();
     }
 
     private <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> executeDependencyConstraintRules(VariantResolveMetadata variant, List<T> dependencies) {
-        List<T> calculatedDependencies = new ArrayList<>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
-        for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
-            dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(
-                DependencyConstraintsMetadataAdapter.class, attributesFactory, calculatedDependencies, instantiator, dependencyConstraintNotationParser));
+        if (dependencyConstraintActions.isEmpty()) {
+            return CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER);
         }
-        return calculatedDependencies;
+
+        DependencyConstraintsMetadataAdapter adapter = instantiator.newInstance(
+            DependencyConstraintsMetadataAdapter.class, attributesFactory, instantiator, dependencyConstraintNotationParser);
+
+        CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER).forEach(dep ->
+            adapter.add(instantiator.newInstance(DependencyConstraintMetadataAdapter.class, attributesFactory, dep)));
+
+        dependencyConstraintActions.forEach(action -> action.maybeExecute(variant, adapter));
+
+        return adapter.getMetadatas();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstra
 import org.gradle.api.internal.artifacts.repositories.resolver.DirectDependenciesMetadataAdapter;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.component.external.model.GradleDependencyMetadata;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.reflect.Instantiator;
@@ -72,14 +73,14 @@ public class DependencyMetadataRules {
         dependencyConstraintActions.add(action);
     }
 
-    public <T extends ModuleDependencyMetadata> List<T> execute(VariantResolveMetadata variant, List<T> dependencies) {
-        ImmutableList.Builder<T> calculatedDependencies = new ImmutableList.Builder<>();
+    public <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> execute(VariantResolveMetadata variant, List<T> dependencies) {
+        ImmutableList.Builder<ModuleDependencyMetadata> calculatedDependencies = new ImmutableList.Builder<>();
         calculatedDependencies.addAll(executeDependencyRules(variant, dependencies));
         calculatedDependencies.addAll(executeDependencyConstraintRules(variant, dependencies));
         return calculatedDependencies.build();
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<>(CollectionUtils.filter(dependencies, DEPENDENCY_FILTER));
         for (VariantMetadataRules.VariantAction<? super DirectDependenciesMetadata> dependenciesMetadataAction : dependencyActions) {
             dependenciesMetadataAction.maybeExecute(variant, instantiator.newInstance(
@@ -88,7 +89,7 @@ public class DependencyMetadataRules {
         return calculatedDependencies;
     }
 
-    private <T extends ModuleDependencyMetadata> List<T> executeDependencyConstraintRules(VariantResolveMetadata variant, List<T> dependencies) {
+    private <T extends ModuleDependencyMetadata> List<? extends ModuleDependencyMetadata> executeDependencyConstraintRules(VariantResolveMetadata variant, List<T> dependencies) {
         List<T> calculatedDependencies = new ArrayList<>(CollectionUtils.filter(dependencies, DEPENDENCY_CONSTRAINT_FILTER));
         for (VariantMetadataRules.VariantAction<? super DependencyConstraintsMetadata> dependencyConstraintsMetadataAction : dependencyConstraintActions) {
             dependencyConstraintsMetadataAction.maybeExecute(variant, instantiator.newInstance(


### PR DESCRIPTION
Fix bug where removing dependencies in a metadata rule would confuse existing dependencies with new ones due to referring to removed dependencies by their previous array indices. Instead, we update to not refer to items by the index but instead reference them directly as a wrapped adapter. 


Fixes #20510
