### PR TITLE
Fix iteration over a `FileCollection` that contains resolved dependency artifacts from a thread that is not managed by Gradle

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseRegistry.java
@@ -38,7 +38,7 @@ public interface WorkerLeaseRegistry {
      * {@link ResourceLock#tryLock()} is called from a {@link org.gradle.internal.resources.ResourceLockCoordinationService#withStateLock(org.gradle.api.Transformer)}
      * transform.
      */
-    WorkerLease getWorkerLease();
+    WorkerLease newWorkerLease();
 
     interface WorkerLease extends ResourceLock {
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerThreadRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerThreadRegistry.java
@@ -31,6 +31,8 @@ public interface WorkerThreadRegistry {
      * the lease prior to doing any meaningful work.
      *
      * This method is reentrant so that a thread can call this method from the given action.
+     *
+     * This method blocks until a worker lease is available.
      */
     <T> T runAsWorkerThread(Factory<T> action);
 
@@ -40,8 +42,18 @@ public interface WorkerThreadRegistry {
      * the lease prior to doing any meaningful work.
      *
      * This method is reentrant so that a thread can call this method from the given action.
+     *
+     * This method blocks until a worker lease is available.
      */
     void runAsWorkerThread(Runnable action);
+
+    /**
+     * Runs the given action as an unmanaged worker, if not already a worker. This is basically the same as {@link #runAsWorkerThread(Runnable)} but does not block waiting for a lease.
+     * Instead, a temporary lease is granted to the current thread.
+     *
+     * You should avoid using this method and prefer {@link #runAsWorkerThread(Runnable)} instead. This method is here to allow some backwards compatibility constraints to be honored.
+     */
+    void runAsUnmanagedWorkerThread(Runnable action);
 
     /**
      * Starts a new lease for the current thread. Marks the reservation of a lease. Blocks until a lease is available.

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -503,7 +503,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
         when:
         async {
             start {
-                def workerLease = workerLeaseService.getWorkerLease()
+                def workerLease = workerLeaseService.newWorkerLease()
                 workerLeaseService.withLocks([projectLock, workerLease]) {
                     workerLeaseService.runAsIsolatedTask {
                         thread.blockUntil.projectLocked
@@ -515,7 +515,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
             workerLeaseService.withLocks([projectLock]) {
                 instant.projectLocked
                 start {
-                    def workerLease = workerLeaseService.getWorkerLease()
+                    def workerLease = workerLeaseService.newWorkerLease()
                     coordinationService.withStateLock(lock(workerLease))
                     try {
                         instant.worker2Executed
@@ -599,7 +599,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
     }
 
     def "releases worker lease but does not release project locks in blocking action when changes to locks are disallowed"() {
-        def lease = workerLeaseService.workerLease
+        def lease = workerLeaseService.newWorkerLease()
         def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
 
         expect:
@@ -618,7 +618,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
     }
 
     def "releases and reacquires project locks in blocking action when changes to locks are allowed"() {
-        def lease = workerLeaseService.workerLease
+        def lease = workerLeaseService.newWorkerLease()
         def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
 
         expect:
@@ -651,7 +651,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
 
     def "releases worker lease but does not release project locks in blocking action when thread has uncontrolled access to any project"() {
         def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
-        def lease = workerLeaseService.workerLease
+        def lease = workerLeaseService.newWorkerLease()
 
         expect:
         workerLeaseService.withLocks([projectLock, lease]) {
@@ -695,7 +695,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends AbstractWorkerLeaseServic
     }
 
     def "does not gather statistics when not acquiring project lock"() {
-        def workerLease = workerLeaseService.getWorkerLease()
+        def workerLease = workerLeaseService.newWorkerLease()
 
         when:
         System.setProperty(DefaultWorkerLeaseService.PROJECT_LOCK_STATS_PROPERTY, "")

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
@@ -320,7 +320,7 @@ public class DefaultPlanExecutor implements PlanExecutor, Stoppable {
 
             boolean releaseLeaseOnCompletion;
             if (workerLease == null) {
-                workerLease = workerLeaseService.getWorkerLease();
+                workerLease = workerLeaseService.newWorkerLease();
                 releaseLeaseOnCompletion = true;
             } else {
                 releaseLeaseOnCompletion = false;

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 
 class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDependencyResolutionTest {
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
@@ -60,8 +61,8 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         outputContains("Resolution of the configuration :bar:bar was attempted from a context different than the project context.")
     }
 
-    @ToBeFixedForConfigurationCache
-    def "exception when configuration is resolved from a non-gradle thread"() {
+    @UnsupportedWithConfigurationCache(because = "resolves configuration from background thread")
+    def "exception when non-gradle thread resolves dependency graph"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 
         settingsFile << """
@@ -70,18 +71,6 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         """
 
         buildFile << """
-            task resolve {
-                def thread = new Thread({
-                    file('bar') << project(':bar').configurations.bar.files
-                })
-                doFirst {
-                    thread.start()
-                    thread.join()
-                    // this should fail
-                    assert file('bar').exists()
-                }
-            }
-
             project(':bar') {
                 repositories {
                     maven { url '${mavenRepo.uri}' }
@@ -95,15 +84,165 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
                     bar "test:test-jar:1.0"
                 }
             }
+
+            task resolve {
+                doFirst {
+                    def failure = null
+                    def thread = new Thread({
+                        try {
+                            file('bar') << project(':bar').configurations.bar.${expression}
+                        } catch(Throwable t) {
+                            failure = t
+                        }
+                    })
+                    thread.start()
+                    thread.join()
+                    throw failure
+                }
+            }
         """
 
         when:
-        executer.withArgument("--parallel")
-        executer.withStackTraceChecksDisabled()
         fails(":resolve")
 
         then:
-        failure.assertHasErrorOutput("The configuration :bar:bar was resolved from a thread not managed by Gradle.")
+        failure.assertHasFailure("Execution failed for task ':resolve'.") {
+            it.assertHasCause("The configuration :bar:bar was resolved from a thread not managed by Gradle.")
+        }
+
+        where:
+        expression << [
+            "files",
+            "incoming.resolutionResult.root",
+            "incoming.resolutionResult.rootComponent.get()",
+            "incoming.artifacts.artifactFiles.files",
+            "incoming.artifacts.artifacts",
+            "incoming.artifactView { }.files.files",
+            "incoming.artifactView { }.artifacts.artifacts",
+            "incoming.artifactView { }.artifacts.resolvedArtifacts.get()",
+            "incoming.artifactView { }.artifacts.failures",
+            "incoming.artifactView { }.artifacts.artifactFiles.files",
+            "resolve()",
+            "files { true }",
+            "fileCollection { true }.files",
+            "resolvedConfiguration.files",
+            "resolvedConfiguration.resolvedArtifacts"
+        ]
+    }
+
+    def "no exception when non-gradle thread iterates over dependency artifacts that were declared as task inputs"() {
+        mavenRepo.module("test", "test-jar", "1.0").publish()
+
+        settingsFile << """
+            rootProject.name = "foo"
+            include(':bar')
+        """
+
+        buildFile << """
+            project(':bar') {
+                repositories {
+                    maven { url '${mavenRepo.uri}' }
+                }
+
+                configurations {
+                    bar
+                }
+
+                dependencies {
+                    bar "test:test-jar:1.0"
+                }
+            }
+
+            task resolve {
+                def configuration = project(':bar').configurations.bar
+                inputs.files(configuration)
+                doFirst {
+                    def failure = null
+                    def thread = new Thread({
+                        try {
+                            file('bar') << configuration.${expression}
+                        } catch(Throwable t) {
+                            failure = t
+                        }
+                    })
+                    thread.start()
+                    thread.join()
+                    if (failure != null) {
+                        throw failure
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
+
+        where:
+        expression << [
+            "files",
+            "incoming.resolutionResult.root",
+            "incoming.resolutionResult.rootComponent.get()",
+            "incoming.artifacts.artifactFiles.files",
+            "incoming.artifacts.artifacts",
+            "incoming.artifactView { }.files.files",
+            "incoming.artifactView { }.artifacts.artifacts",
+            "incoming.artifactView { }.artifacts.resolvedArtifacts.get()",
+            "incoming.artifactView { }.artifacts.failures",
+            "incoming.artifactView { }.artifacts.artifactFiles.files",
+            "resolve()",
+            "files { true }",
+            "fileCollection { true }.files",
+            "resolvedConfiguration.files",
+            "resolvedConfiguration.resolvedArtifacts"
+        ]
+    }
+
+    def "no exception when non-gradle thread iterates over dependency artifacts that were previously iterated"() {
+        mavenRepo.module("test", "test-jar", "1.0").publish()
+
+        settingsFile << """
+            rootProject.name = "foo"
+            include(':bar')
+        """
+
+        buildFile << """
+            project(':bar') {
+                repositories {
+                    maven { url '${mavenRepo.uri}' }
+                }
+
+                configurations {
+                    bar
+                }
+
+                dependencies {
+                    bar "test:test-jar:1.0"
+                }
+            }
+
+            task resolve {
+                def configuration = project(':bar').configurations.bar
+                doFirst {
+                    configuration.files
+                    def failure = null
+                    def thread = new Thread({
+                        try {
+                            file('bar') << configuration.files
+                        } catch(Throwable t) {
+                            failure = t
+                        }
+                    })
+                    thread.start()
+                    thread.join()
+                    if (failure != null) {
+                        throw failure
+                    }
+                }
+            }
+        """
+
+        expect:
+        succeeds(":resolve")
     }
 
     def "deprecation warning when configuration is resolved while evaluating a different project"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -140,6 +140,7 @@ import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.vfs.FileSystemAccess;
+import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.util.internal.SimpleMapInterner;
 import org.gradle.vcs.internal.VcsMappingsStore;
 
@@ -495,7 +496,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                        BuildState currentBuild,
                                                        TransformedVariantFactory transformedVariantFactory,
                                                        DependencyVerificationOverride dependencyVerificationOverride,
-                                                       ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory) {
+                                                       ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
+                                                       WorkerLeaseService workerLeaseService) {
             return new ErrorHandlingConfigurationResolver(
                 new ShortCircuitEmptyConfigurationResolver(
                     new DefaultConfigurationResolver(
@@ -522,7 +524,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                         currentBuild.getBuildIdentifier(),
                         new AttributeDesugaring(attributesFactory),
                         dependencyVerificationOverride,
-                        componentSelectionDescriptorFactory),
+                        componentSelectionDescriptorFactory,
+                        workerLeaseService),
                     componentIdentifierFactory,
                     moduleIdentifierFactory,
                     currentBuild.getBuildIdentifier()));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -70,6 +70,7 @@ import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.locking.DependencyLockingArtifactVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.Collections;
 import java.util.List;
@@ -93,6 +94,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final AttributeDesugaring attributeDesugaring;
     private final DependencyVerificationOverride dependencyVerificationOverride;
     private final ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory;
+    private final WorkerLeaseService workerLeaseService;
 
     public DefaultConfigurationResolver(ArtifactDependencyResolver resolver,
                                         RepositoriesSupplier repositoriesSupplier,
@@ -108,7 +110,8 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
                                         AttributeContainerSerializer attributeContainerSerializer,
                                         BuildIdentifier currentBuild, AttributeDesugaring attributeDesugaring,
                                         DependencyVerificationOverride dependencyVerificationOverride,
-                                        ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory) {
+                                        ComponentSelectionDescriptorFactory componentSelectionDescriptorFactory,
+                                        WorkerLeaseService workerLeaseService) {
         this.resolver = resolver;
         this.repositoriesSupplier = repositoriesSupplier;
         this.metadataHandler = metadataHandler;
@@ -125,6 +128,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.attributeDesugaring = attributeDesugaring;
         this.dependencyVerificationOverride = dependencyVerificationOverride;
         this.componentSelectionDescriptorFactory = componentSelectionDescriptorFactory;
+        this.workerLeaseService = workerLeaseService;
     }
 
     @Override
@@ -217,7 +221,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
 
         TransientConfigurationResultsLoader transientConfigurationResultsFactory = new TransientConfigurationResultsLoader(transientConfigurationResultsBuilder, graphResults);
 
-        DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, resolveState.failures, artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, artifactTransforms, buildOperationExecutor, dependencyVerificationOverride);
+        DefaultLenientConfiguration result = new DefaultLenientConfiguration(configuration, resolveState.failures, artifactResults, resolveState.fileDependencyResults, transientConfigurationResultsFactory, artifactTransforms, buildOperationExecutor, dependencyVerificationOverride, workerLeaseService);
         results.artifactsResolved(new DefaultResolvedConfiguration(result), result);
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultLenientConfigurationTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.transform.ArtifactTransforms
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.specs.Spec
 import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.test.fixtures.work.TestWorkerLeaseService
 import spock.lang.Specification
 
 class DefaultLenientConfigurationTest extends Specification {
@@ -56,7 +57,7 @@ class DefaultLenientConfigurationTest extends Specification {
         rootNode.children.add(child)
         def expectedResults = [child] as Set
 
-        def lenientConfiguration = new DefaultLenientConfiguration(configuration, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride)
+        def lenientConfiguration = newConfiguration()
 
         when:
         def results = lenientConfiguration.getFirstLevelModuleDependencies()
@@ -79,7 +80,7 @@ class DefaultLenientConfigurationTest extends Specification {
         def firstLevelDependencies = [(Mock(ModuleDependency)): node1, (Mock(ModuleDependency)): node2, (Mock(ModuleDependency)): node3]
         def firstLevelDependenciesEntries = firstLevelDependencies.entrySet() as List
 
-        def lenientConfiguration = new DefaultLenientConfiguration(configuration, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride)
+        def lenientConfiguration = newConfiguration()
 
         when:
         def result = lenientConfiguration.getFirstLevelModuleDependencies(spec)
@@ -97,7 +98,7 @@ class DefaultLenientConfigurationTest extends Specification {
 
     def "should flatten all resolved dependencies in dependency tree"() {
         given:
-        def lenientConfiguration = new DefaultLenientConfiguration(configuration, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor ,dependencyVerificationOverride)
+        def lenientConfiguration = newConfiguration()
 
         def (expected, root) = generateDependenciesWithChildren(treeStructure)
 
@@ -117,6 +118,10 @@ class DefaultLenientConfigurationTest extends Specification {
         [0: [1, 2, 3, 4, 5], 5: [6, 7, 8], 7: [9, 10], 9: [11, 12]] | 12
     }
 
+    private DefaultLenientConfiguration newConfiguration() {
+        new DefaultLenientConfiguration(configuration, null, artifactsResults, fileDependencyResults, resultsLoader, transforms, buildOperationExecutor, dependencyVerificationOverride, new TestWorkerLeaseService())
+    }
+
     def generateDependenciesWithChildren(Map treeStructure) {
         Map<Integer, TestResolvedDependency> dependenciesById = [:]
         for (Map.Entry entry : treeStructure.entrySet()) {
@@ -127,7 +132,7 @@ class DefaultLenientConfigurationTest extends Specification {
             Integer id = entry.getKey() as Integer
             dependenciesById.get(id).children = entry.getValue().collect {
                 def child = dependenciesById.get(it)
-                if(child == null) {
+                if (child == null) {
                     child = new TestResolvedDependency()
                     dependenciesById.put(it, child)
                 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -83,6 +83,11 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
+    void runAsUnmanagedWorkerThread(Runnable action) {
+        action.run()
+    }
+
+    @Override
     Synchronizer newResource() {
         return new Synchronizer() {
             @Override
@@ -113,7 +118,7 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    WorkerLease getWorkerLease() {
+    WorkerLease newWorkerLease() {
         return workerLease()
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

In releases prior to 7.4, iterating over a `FileCollection` that contains resolved artifacts from a thread that is not managed used to work by coincidence when that file collection was declared as a task input or the dependencies eagerly resolved in a task action. This was never really supported (ie tested) and broke in Gradle 7.4. This PR restores the behaviour and adds some tests (thereby making it supported, I guess).

It is still an error to trigger dependency resolution from a thread that is not managed. The artifacts must already be resolved in order for the file collection to be iterated.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
