### PR TITLE
Always set TD-specific server to avoid creating conflicting clients

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -286,6 +286,12 @@ fun configureTests() {
         configureSpock()
         configureFlakyTest()
 
+        distribution {
+            this as TestDistributionExtensionInternal
+            // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
+            server.set(uri("https://ge-td-dogfooding.grdev.net"))
+        }
+
         if (project.testDistributionEnabled && !isUnitTest()) {
             println("Remote test distribution has been enabled for $testName")
 
@@ -297,8 +303,6 @@ fun configureTests() {
                 }
                 // No limit; use all available executors
                 distribution.maxRemoteExecutors.set(if (project.isPerformanceProject()) 0 else null)
-                // Dogfooding TD against ge-td-dogfooding in order to test new features and benefit from bug fixes before they are released
-                server.set(uri("https://ge-td-dogfooding.grdev.net"))
 
                 if (BuildEnvironment.isCiServer) {
                     when {


### PR DESCRIPTION
When PTS is enabled but TD is disabled, the TD Gradle plugin creates a
client service with the server configuration of that test task. If a
later test task enables TD with a different server, an exception is
thrown. This failure is now avoided by always configuring the
TD-specific server, even if TD is disabled.