### PR TITLE
Improve error messages on non-existing ref within closure

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/util/internal/ClosureBackedAction.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/internal/ClosureBackedAction.java
@@ -18,6 +18,7 @@ package org.gradle.util.internal;
 
 import com.google.common.base.Objects;
 import groovy.lang.Closure;
+import org.codehaus.groovy.runtime.metaclass.MissingMethodExecutionFailed;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidActionClosureException;
 import org.gradle.util.Configurable;
@@ -76,7 +77,8 @@ public class ClosureBackedAction<T> implements Action<T> {
             if (Objects.equal(e.getType(), closure.getClass()) && Objects.equal(e.getMethod(), "doCall")) {
                 throw new InvalidActionClosureException(closure, delegate);
             }
-            throw e;
+            // https://github.com/apache/groovy/commit/75c068207ba24648ea2d698c520601c6fcf0a45b
+            throw new MissingMethodExecutionFailed(e.getMethod(), e.getType(), e.getArguments(), e.isStatic(), e);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/19282
Fixes https://github.com/gradle/gradle/issues/14984

### Context
I must have broken the handling of error messages back when I [upgraded Groovy to 2.5.10](https://github.com/gradle/gradle/commit/08356d1ee2450de52137494cb967c0a7c99f6eac)

This should make the errors when referencing something non-existent within Groovy closures reasonable again.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
