### PR TITLE
Fix incorrect and duplicate links in deprecation warnings

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/SnapshotTaskInputsOperationIntegrationTest.groovy
@@ -27,13 +27,14 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginAdapter
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
 
-class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker {
+class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, ExecutionOptimizationDeprecationFixture {
 
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
@@ -149,16 +150,14 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         """
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             implementationOfTask(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        }
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
+        }
         succeeds('customTask', '--build-cache')
 
         then:
@@ -188,11 +187,10 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         """
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('A')
-            includeLink()
-        })
+        }
         succeeds('customTask', '--build-cache')
 
         then:
@@ -491,11 +489,10 @@ class SnapshotTaskInputsOperationIntegrationTest extends AbstractIntegrationSpec
         """
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('bean')
             unknownClassloader('A')
-            includeLink()
-        })
+        }
         succeeds('customTask', '--build-cache')
 
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/BuildResultLoggerIntegrationTest.groovy
@@ -221,7 +221,7 @@ class BuildResultLoggerIntegrationTest extends AbstractIntegrationSpec implement
             tasks.register("invalid", InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem())
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem(), 'id', 'section')
 
         when:
         run "invalid"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -830,7 +830,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         """
 
         executer.beforeExecute {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'input'))
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'input'), 'id', 'section')
         }
 
         when:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
@@ -25,7 +26,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
-class IncrementalBuildIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, DirectoryBuildCacheFixture {
+class IncrementalBuildIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, DirectoryBuildCacheFixture, ExecutionOptimizationDeprecationFixture {
 
     def setup() {
         expectReindentedValidationMessage()
@@ -1108,31 +1109,27 @@ task b(dependsOn: a)
             }
         """
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             implementationOfTask(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        }
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
+        }
         succeeds "customTask"
         then:
         noneSkipped()
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             implementationOfTask(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        }
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTask_Decorated')
-            includeLink()
-        })
+        }
         succeeds "customTask"
         then:
         noneSkipped()
@@ -1164,16 +1161,14 @@ task b(dependsOn: a)
             }
         """
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             implementationOfTask(':customTask')
             unknownClassloader('CustomTaskFromUnknownClassloader_Decorated')
-            includeLink()
-        })
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        }
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTaskFromUnknownClassloader_Decorated')
-            includeLink()
-        })
+        }
         withBuildCache().run "customTask", "-PunknownClassloader"
         then:
         executedAndNotSkipped(":customTask")
@@ -1189,16 +1184,14 @@ task b(dependsOn: a)
         skipped(":customTask")
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             implementationOfTask(':customTask')
             unknownClassloader('CustomTaskFromUnknownClassloader_Decorated')
-            includeLink()
-        })
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        }
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTaskFromUnknownClassloader_Decorated')
-            includeLink()
-        })
+        }
         withBuildCache().run "customTask", "-PunknownClassloader"
         then:
         executedAndNotSkipped(":customTask")
@@ -1262,21 +1255,19 @@ task b(dependsOn: a)
             }
         """
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTaskAction')
-            includeLink()
-        })
+        }
         succeeds "customTask"
         then:
         noneSkipped()
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':customTask')
             unknownClassloader('CustomTaskAction')
-            includeLink()
-        })
+        }
         succeeds "customTask"
         then:
         noneSkipped()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
@@ -25,7 +26,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
-class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, DirectoryBuildCacheFixture {
+class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, DirectoryBuildCacheFixture, ExecutionOptimizationDeprecationFixture {
 
     def "implementation of nested property in Groovy build script is tracked"() {
         setupTaskClassWithActionProperty()
@@ -96,31 +97,28 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         buildFile.makeOlder()
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('action')
             implementedByLambda('LambdaActionOriginal')
-            includeLink()
-        })
+        }
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('action')
             implementedByLambda('LambdaActionOriginal')
-            includeLink()
-        })
+        }
         run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('action')
             implementedByLambda('LambdaActionChanged')
-            includeLink()
-        })
+        }
         run 'myTask', '-Pchanged'
         then:
         executedAndNotSkipped(':myTask')
@@ -148,11 +146,10 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         buildFile.makeOlder()
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('action')
             implementedByLambda('LambdaAction')
-            includeLink()
-        })
+        }
         run 'myTask'
         then:
         withBuildCache().executedAndNotSkipped(':myTask')
@@ -168,11 +165,10 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         skipped(':myTask')
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('action')
             implementedByLambda('LambdaAction')
-            includeLink()
-        })
+        }
         withBuildCache().run 'myTask'
         then:
         executedAndNotSkipped(':myTask')
@@ -249,19 +245,28 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         """
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown { additionalTaskAction(':myTask').implementedByLambda('LambdaActionOriginal').includeLink() })
+        expectImplementationUnknownDeprecation {
+            additionalTaskAction(':myTask')
+            implementedByLambda('LambdaActionOriginal')
+        }
         run "myTask"
         then:
         executedAndNotSkipped(":myTask")
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown { additionalTaskAction(':myTask').implementedByLambda('LambdaActionOriginal').includeLink() })
+        expectImplementationUnknownDeprecation {
+            additionalTaskAction(':myTask')
+            implementedByLambda('LambdaActionOriginal')
+        }
         run "myTask"
         then:
         executedAndNotSkipped(":myTask")
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown { additionalTaskAction(':myTask').implementedByLambda('LambdaActionChanged').includeLink() })
+        expectImplementationUnknownDeprecation {
+            additionalTaskAction(':myTask')
+            implementedByLambda('LambdaActionChanged')
+        }
         run "myTask", "-Pchanged"
         then:
         executedAndNotSkipped(":myTask")
@@ -292,11 +297,10 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         """
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':myTask')
             implementedByLambda('LambdaAction')
-            includeLink()
-        })
+        }
         withBuildCache().run "myTask"
         then:
         executedAndNotSkipped(":myTask")
@@ -312,11 +316,10 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         skipped(":myTask")
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':myTask')
             implementedByLambda('LambdaAction')
-            includeLink()
-        })
+        }
         withBuildCache().run "myTask"
         then:
         executedAndNotSkipped(":myTask")
@@ -343,11 +346,10 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
 
         when:
         // There shouldn't be a deprecation message
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             additionalTaskAction(':myTask')
             implementedByLambda('LambdaAction')
-            includeLink()
-        })
+        }
         run "myTask"
         then:
         executedAndNotSkipped(":myTask")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/MissingTaskDependenciesIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.tasks
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.MissingTaskDependenciesFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationTestFor
@@ -30,7 +30,7 @@ import static org.gradle.internal.reflect.validation.TypeValidationProblemRender
 @ValidationTestFor(
     ValidationProblemId.IMPLICIT_DEPENDENCY
 )
-class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec implements MissingTaskDependenciesFixture {
+class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec implements ExecutionOptimizationDeprecationFixture {
 
     @Rule
     BlockingHttpServer server = new BlockingHttpServer()
@@ -571,11 +571,10 @@ class MissingTaskDependenciesIntegrationTest extends AbstractIntegrationSpec imp
         def expectedWarning = unresolvableInput({
             property('invalidInputFileCollection')
             conversionProblem(rootCause.stripIndent())
-            includeLink()
         }, false)
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, expectedWarning)
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, expectedWarning, 'validation_problems', 'unresolvable_input')
 
         run "broken"
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.internal.reflect.problems.ValidationProblemId
@@ -29,7 +30,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
-class NestedInputIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, ValidationMessageChecker {
+class NestedInputIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, ValidationMessageChecker, ExecutionOptimizationDeprecationFixture {
 
     def setup() {
         expectReindentedValidationMessage()
@@ -780,21 +781,19 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         buildFile << taskWithNestedBeanFromCustomClassLoader()
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('bean')
             unknownClassloader('NestedBean')
-            includeLink()
-        })
+        }
         run "customTask"
         then:
         executedAndNotSkipped ":customTask"
 
         when:
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown {
+        expectImplementationUnknownDeprecation {
             nestedProperty('bean')
             unknownClassloader('NestedBean')
-            includeLink()
-        })
+        }
         run "customTask"
         then:
         executedAndNotSkipped ":customTask"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskParametersIntegrationTest.groovy
@@ -393,7 +393,7 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'), 'id', 'section')
 
         when:
         run "invalid", "--info"
@@ -419,7 +419,7 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'), 'id', 'section')
 
         when:
         run "invalid"
@@ -445,7 +445,7 @@ task someTask {
             task invalid(type: InvalidTask)
         """
 
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'))
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidTask', 'inputFile'), 'id', 'section')
 
         when:
         run "invalid"

--- a/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/execution/taskgraph/ParallelTaskExecutionIntegrationTest.groovy
@@ -531,7 +531,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
 
         expect:
         2.times {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'))
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'), 'id', 'section')
 
             blockingServer.expect(":aInvalidPing")
             blockingServer.expectConcurrent(":bPing", ":cPing")
@@ -557,7 +557,7 @@ class ParallelTaskExecutionIntegrationTest extends AbstractIntegrationSpec imple
 
         expect:
         2.times {
-            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'))
+            expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, dummyValidationProblem('InvalidPing', 'invalidInput'), 'id', 'section')
 
             blockingServer.expectConcurrent(":aPing", ":bPing")
             blockingServer.expect(":cInvalidPing")

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -24,7 +24,6 @@ import org.gradle.internal.reflect.validation.TypeValidationProblem;
 import org.gradle.internal.reflect.validation.UserManualReference;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.convertToSingleLine;
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.renderMinimalInformationAbout;
@@ -41,14 +40,7 @@ public class DefaultNodeValidator implements NodeValidator {
         problems.stream()
             .filter(problem -> problem.getSeverity().isWarning())
             .forEach(problem -> {
-                Optional<UserManualReference> userManualReference = problem.getUserManualReference();
-                String docId = "more_about_tasks";
-                String section = "sec:up_to_date_checks";
-                if (userManualReference.isPresent()) {
-                    UserManualReference docref = userManualReference.get();
-                    docId = docref.getId();
-                    section = docref.getSection();
-                }
+                UserManualReference userManualReference = problem.getUserManualReference();
                 // Because our deprecation warning system doesn't support multiline strings (bummer!) both in rendering
                 // **and** testing (no way to capture multiline deprecation warnings), we have to resort to removing details
                 // and rendering
@@ -56,7 +48,7 @@ public class DefaultNodeValidator implements NodeValidator {
                 DeprecationLogger.deprecateBehaviour(warning)
                     .withContext("Execution optimizations are disabled to ensure correctness.")
                     .willBeRemovedInGradle8()
-                    .withUserManual(docId, section)
+                    .withUserManual(userManualReference.getId(), userManualReference.getSection())
                     .nagUser();
             });
         return !problems.isEmpty();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -137,6 +137,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .reportAs(WARNING)
                     .forProperty(metadata.propertyName)
                     .withDescription("is broken")
+                    .documentedAt("id", "section")
                     .happensBecause("Test")
             }
         }
@@ -151,7 +152,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         propertiesMetadata.size() == 1
         def propertyMetadata = propertiesMetadata.first()
         propertyMetadata.propertyName == 'searchPath'
-        collectProblems(typeMetadata) == [dummyValidationProblem(null, 'searchPath', 'is broken', 'Test').trim()]
+        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim()]
     }
 
     def "custom annotation that is not relevant can have validation problems"() {
@@ -164,6 +165,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                     .reportAs(WARNING)
                     .forProperty(metadata.propertyName)
                     .withDescription("is broken")
+                    .documentedAt("id", "section")
                     .happensBecause("Test")
             }
         }
@@ -176,7 +178,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
 
         then:
         propertiesMetadata.empty
-        collectProblems(typeMetadata) == [dummyValidationProblem(null, 'searchPath', 'is broken', 'Test').trim()]
+        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(null, 'searchPath', 'is broken', 'Test').trim()]
     }
 
     def "custom type annotation handler can inspect for static type problems"() {
@@ -187,6 +189,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
                 .withId(ValidationProblemId.TEST_PROBLEM)
                 .forType(type)
                 .withDescription("type is broken")
+                .documentedAt("id", "section")
                 .happensBecause("Test")
             }
         }
@@ -203,7 +206,7 @@ class DefaultTypeMetadataStoreTest extends Specification implements ValidationMe
         def typeMetadata = metadataStore.getTypeMetadata(TypeWithCustomAnnotation)
 
         then:
-        collectProblems(typeMetadata) == [dummyValidationProblem(TypeWithCustomAnnotation.canonicalName, null, 'type is broken', 'Test').trim()]
+        collectProblems(typeMetadata) == [dummyValidationProblemWithLink(TypeWithCustomAnnotation.canonicalName, null, 'type is broken', 'Test').trim()]
     }
 
     def "can override @#parentAnnotation.simpleName property type with @#childAnnotation.simpleName"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationIntegrityCheckIntegTest.groovy
@@ -1244,7 +1244,7 @@ This can indicate that a dependency has been compromised. Please carefully verif
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.")
+        executer.expectDocumentedDeprecationWarning("Reason: An input file collection couldn't be resolved, making it impossible to determine task inputs. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/current/userguide/validation_problems.html#unresolvable_input for more details.")
         fails ":printConfigurations"
 
         then:

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -297,6 +297,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
                     it.withId(ValidationProblemId.TEST_PROBLEM)
                         .reportAs(WARNING)
                         .withDescription("Validation problem")
+                        .documentedAt("id", "section")
                         .happensBecause("Test")
                 }
             }
@@ -605,6 +606,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
                         .reportAs(ERROR)
                         .forType(Object)
                         .withDescription("Validation error")
+                        .documentedAt("id", "section")
                         .happensBecause("Test")
                 }
             }
@@ -617,7 +619,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
         then:
         def ex = thrown WorkValidationException
         WorkValidationExceptionChecker.check(ex) {
-            hasProblem dummyValidationProblem('java.lang.Object', null, 'Validation error', 'Test').trim()
+            hasProblem dummyValidationProblemWithLink('java.lang.Object', null, 'Validation error', 'Test').trim()
         }
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidateStep.java
@@ -18,8 +18,8 @@ package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedSet;
 import org.gradle.api.internal.GeneratedSubclasses;
 import org.gradle.internal.MutableReference;
 import org.gradle.internal.execution.UnitOfWork;
@@ -32,6 +32,7 @@ import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.internal.reflect.validation.Severity;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.reflect.validation.TypeValidationProblem;
 import org.gradle.internal.reflect.validation.ValidationProblemBuilder;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
@@ -46,12 +47,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
-import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.convertToSingleLine;
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.renderMinimalInformationAbout;
 
 public class ValidateStep<C extends BeforeExecutionContext, R extends Result> implements Step<C, R> {
@@ -79,13 +80,13 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
         context.getBeforeExecutionState()
             .ifPresent(beforeExecutionState -> validateImplementations(work, beforeExecutionState, validationContext));
 
-        Map<Severity, List<String>> problems = validationContext.getProblems()
+        Map<Severity, List<TypeValidationProblem>> problems = validationContext.getProblems()
             .stream()
             .collect(
                 groupingBy(BaseProblem::getSeverity,
-                mapping(ValidateStep::renderedMessage, toList())));
-        ImmutableCollection<String> warnings = ImmutableList.copyOf(problems.getOrDefault(Severity.WARNING, ImmutableList.of()));
-        ImmutableCollection<String> errors = ImmutableList.copyOf(problems.getOrDefault(Severity.ERROR, ImmutableList.of()));
+                mapping(Function.identity(), toList())));
+        ImmutableCollection<TypeValidationProblem> warnings = ImmutableList.copyOf(problems.getOrDefault(Severity.WARNING, ImmutableList.of()));
+        ImmutableCollection<TypeValidationProblem> errors = ImmutableList.copyOf(problems.getOrDefault(Severity.ERROR, ImmutableList.of()));
 
         if (!warnings.isEmpty()) {
             warningReporter.recordValidationWarnings(work, warnings);
@@ -93,8 +94,8 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
 
         if (!errors.isEmpty()) {
             int maxErrCount = Integer.getInteger(MAX_NB_OF_ERRORS, 5);
-            ImmutableSortedSet<String> uniqueSortedErrors = ImmutableSortedSet.copyOf(errors);
-            throw WorkValidationException.forProblems(uniqueSortedErrors)
+            ImmutableSet<String> uniqueErrors = errors.stream().map(ValidateStep::renderedErrorMessage).collect(ImmutableSet.toImmutableSet());
+            throw WorkValidationException.forProblems(uniqueErrors)
                 .limitTo(maxErrCount)
                 .withSummary(helper ->
                     String.format("%s found with the configuration of %s (%s).",
@@ -226,10 +227,7 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
             .documentedAt("validation_problems", "implementation_unknown");
     }
 
-    private static String renderedMessage(org.gradle.internal.reflect.validation.TypeValidationProblem p) {
-        if (p.getSeverity().isWarning()) {
-            return convertToSingleLine(renderMinimalInformationAbout(p, true, false));
-        }
+    private static String renderedErrorMessage(TypeValidationProblem p) {
         return renderMinimalInformationAbout(p);
     }
 
@@ -244,6 +242,6 @@ public class ValidateStep<C extends BeforeExecutionContext, R extends Result> im
     }
 
     public interface ValidationWarningRecorder {
-        void recordValidationWarnings(UnitOfWork work, Collection<String> warnings);
+        void recordValidationWarnings(UnitOfWork work, Collection<TypeValidationProblem> warnings);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationFinishedContext.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ValidationFinishedContext.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableCollection;
+import org.gradle.internal.reflect.validation.TypeValidationProblem;
 
 import java.util.Optional;
 
@@ -27,6 +28,6 @@ public interface ValidationFinishedContext extends BeforeExecutionContext {
     Optional<ValidationResult> getValidationProblems();
 
     interface ValidationResult {
-        ImmutableCollection<String> getWarnings();
+        ImmutableCollection<TypeValidationProblem> getWarnings();
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -19,14 +19,14 @@ package org.gradle.integtests
 import org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.MissingTaskDependenciesFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
-class StaleOutputIntegrationTest extends AbstractIntegrationSpec implements MissingTaskDependenciesFixture {
+class StaleOutputIntegrationTest extends AbstractIntegrationSpec implements ExecutionOptimizationDeprecationFixture {
 
     @Issue(['GRADLE-2440', 'GRADLE-2579'])
     def 'stale output file is removed after input source directory is emptied.'() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/validation/ValidationProblemPropertyAnnotationHandler.java
@@ -61,6 +61,7 @@ class ValidationProblemPropertyAnnotationHandler implements PropertyAnnotationHa
                 .withId(ValidationProblemId.TEST_PROBLEM)
                 .reportAs(annotationValue(propertyMetadata))
                 .withDescription("test problem")
+                .documentedAt("id", "section")
                 .happensBecause("this is a test")
         );
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocWorkAvoidanceIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.javadoc
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.MissingTaskDependenciesFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationTestFor
@@ -27,7 +27,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 @IgnoreIf({ GradleContextualExecuter.parallel })
-class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec implements MissingTaskDependenciesFixture {
+class JavadocWorkAvoidanceIntegrationTest extends AbstractIntegrationSpec implements ExecutionOptimizationDeprecationFixture {
     def setup() {
         settingsFile << "include 'a', 'b'"
         buildFile << '''

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultPropertyValidationProblemBuilder.java
@@ -65,6 +65,9 @@ public class DefaultPropertyValidationProblemBuilder extends AbstractValidationP
         if (shortProblemDescription == null) {
             throw new IllegalStateException("You must provide at least a short description of the problem");
         }
+        if (userManualReference == null) {
+            throw new IllegalStateException("You must provide a user manual reference");
+        }
         return new TypeValidationProblem(
             problemId,
             severity,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/DefaultTypeValidationProblemBuilder.java
@@ -41,6 +41,9 @@ public class DefaultTypeValidationProblemBuilder extends AbstractValidationProbl
         if (shortProblemDescription == null) {
             throw new IllegalStateException("You must provide at least a short description of the problem");
         }
+        if (userManualReference == null) {
+            throw new IllegalStateException("You must provide a user manual reference");
+        }
         return new TypeValidationProblem(
             problemId,
             severity,

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/validation/TypeValidationProblem.java
@@ -19,13 +19,10 @@ import org.gradle.internal.reflect.problems.ValidationProblemId;
 import org.gradle.problems.BaseProblem;
 import org.gradle.problems.Solution;
 
-import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Severity, TypeValidationProblemLocation> {
-    @Nullable
     private final UserManualReference userManualReference;
     private final boolean onlyAffectsCacheableWork;
 
@@ -36,7 +33,7 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
                                  Supplier<String> longDescription,
                                  Supplier<String> reason,
                                  boolean onlyAffectsCacheableWork,
-                                 @Nullable UserManualReference userManualReference,
+                                 UserManualReference userManualReference,
                                  List<Supplier<Solution>> solutions) {
         super(id,
             severity,
@@ -50,8 +47,8 @@ public class TypeValidationProblem extends BaseProblem<ValidationProblemId, Seve
         this.onlyAffectsCacheableWork = onlyAffectsCacheableWork;
     }
 
-    public Optional<UserManualReference> getUserManualReference() {
-        return Optional.ofNullable(userManualReference);
+    public UserManualReference getUserManualReference() {
+        return userManualReference;
     }
 
     public boolean isOnlyAffectsCacheableWork() {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/integtests/fixtures/ExecutionOptimizationDeprecationFixture.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/integtests/fixtures/ExecutionOptimizationDeprecationFixture.groovy
@@ -20,10 +20,17 @@ import groovy.transform.SelfType
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
 @SelfType(AbstractIntegrationSpec)
-trait MissingTaskDependenciesFixture extends ValidationMessageChecker {
+trait ExecutionOptimizationDeprecationFixture extends ValidationMessageChecker {
     void expectMissingDependencyDeprecation(String producer, String consumer, File producedConsumedLocation) {
-        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer,
-            implicitDependency({ at(producedConsumedLocation).consumer(consumer).producer(producer).includeLink() }, false)
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(
+            executer,
+            implicitDependency({ at(producedConsumedLocation).consumer(consumer).producer(producer) }, false),
+            'validation_problems',
+            'implicit_dependency'
         )
+    }
+
+    void expectImplementationUnknownDeprecation(@DelegatesTo(value = UnknownImplementation, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+        expectThatExecutionOptimizationDisabledWarningIsDisplayed(executer, implementationUnknown(spec), 'validation_problems', 'implementation_unknown')
     }
 }

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -401,6 +401,20 @@ trait ValidationMessageChecker {
     @ValidationTestFor(
         ValidationProblemId.TEST_PROBLEM
     )
+    String dummyValidationProblemWithLink(String onType = 'InvalidTask', String onProperty = 'dummy', String desc = 'test problem', String testReason = 'this is a test') {
+        display(SimpleMessage, 'dummy') {
+            type(onType).property(onProperty)
+            description(desc)
+            reason(testReason)
+            includeLink()
+            documentationId("id")
+            documentationSection("section")
+        }.render()
+    }
+
+    @ValidationTestFor(
+        ValidationProblemId.TEST_PROBLEM
+    )
     String dummyValidationProblem(@DelegatesTo(value = SimpleMessage, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         display(SimpleMessage, 'dummy') {
             type('InvalidTask').property('dummy')

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageDisplayConfiguration.groovy
@@ -31,6 +31,7 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     String typeName
     String property
     String section
+    String documentationId = "validation_problems"
     boolean includeLink = false
 
     T inPlugin(String pluginId) {
@@ -73,6 +74,16 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
         this
     }
 
+    T documentationSection(String documentationSection) {
+        section = documentationSection
+        this
+    }
+
+    T documentationId(String id) {
+        documentationId = id
+        this
+    }
+
     String getPropertyIntro() {
         "property"
     }
@@ -91,7 +102,7 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
     }
 
     private String getOutro() {
-        includeLink ? "${checker.learnAt("validation_problems", section)}." : ""
+        includeLink ? "${checker.learnAt(documentationId, section)}." : ""
     }
 
     static String formatEntry(String entry) {
@@ -121,9 +132,9 @@ class ValidationMessageDisplayConfiguration<T extends ValidationMessageDisplayCo
             } else {
                 sb.append("Possible solution: ${formatEntry(solutions[0])}$newLine")
             }
+            sb.append(newLine)
         }
         if (outro) {
-            sb.append(newLine)
             sb.append(outro)
         }
         sb.toString().trim()

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
@@ -75,6 +75,7 @@ public abstract class SimpleReport implements ConfigurableReport {
     }
 
     @Override
+    @Deprecated
     public void setDestination(Provider<File> provider) {
         getOutputLocation().fileProvider(provider);
     }

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/antmigration/SamplesAntImportIntegrationTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.integtests.samples.antmigration
 
 import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
-import org.gradle.integtests.fixtures.MissingTaskDependenciesFixture
+import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UsesSample
@@ -25,7 +25,7 @@ import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.junit.Rule
 
-class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest implements MissingTaskDependenciesFixture {
+class SamplesAntImportIntegrationTest extends AbstractSampleIntegrationTest implements ExecutionOptimizationDeprecationFixture {
 
     @Rule
     Sample sample = new Sample(testDirectoryProvider)

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -143,9 +143,8 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
                         "Cannot convert the provided notation to a File or URI: $artifact. " +
                         "The following types/formats are supported:  - A String or CharSequence path, for example 'src/main/java' or '/usr/include'. - A String or CharSequence URI, for example 'file:/usr/include'. - A File instance. - A Path instance. - A Directory instance. - A RegularFile instance. - A URI or URL instance. - A TextResource instance. " +
                         "Reason: An input file collection couldn't be resolved, making it impossible to determine task inputs. " +
-                        "Please refer to https://docs.gradle.org/${GradleVersion.current().version}/userguide/validation_problems.html#unresolvable_input for more details about this problem. " +
                         "This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. " +
-                        "Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/${GradleVersion.current().version}/userguide/more_about_tasks.html#sec:up_to_date_checks for more details."
+                        "Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/${GradleVersion.current().version}/userguide/validation_problems.html#unresolvable_input for more details."
                 )
             }
             expectAndroidFileTreeForEmptySourcesDeprecationWarnings(agpVersion, "sourceFiles", "sourceDirs")


### PR DESCRIPTION
In deprecation warnings created by TaskValidaitonProblems, we ensure the
documentation links from the problems themselves are used for the
deprecation warning and are not included in the message.

Fixes #20517