### PR TITLE
Set IntelliJ continuation indent size to the regular indent size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ root = true
 # Change these settings to your own preference
 indent_style = space
 indent_size = 4
+ij_continuation_indent_size = 4
 
 # We recommend you to keep these unchanged
 end_of_line = lf


### PR DESCRIPTION
Since that's what [we are using these days](https://github.com/gradle/gradle/blob/ae2ba4e325f2cf67575a297166eb9d38313672d8/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java#L60-L68).