### PR TITLE
Use openjdk for windows performance tests

### DIFF
--- a/.teamcity/src/main/kotlin/common/Os.kt
+++ b/.teamcity/src/main/kotlin/common/Os.kt
@@ -75,7 +75,8 @@ enum class Os(
         androidHome = """C:\Program Files\android\sdk""",
         jprofilerHome = """C:\Program Files\jprofiler\jprofiler11.1.4""",
         killAllGradleProcesses = killAllGradleProcessesWindows,
-        perfTestWorkingDir = "P:/"
+        perfTestWorkingDir = "P:/",
+        perfTestJavaVendor = "openjdk"
     ),
     MACOS(
         "Mac",


### PR DESCRIPTION
Because we don't maintain Oracle Java 8 on Windows anymore.
