### PR TITLE
Fix issue where a producer may start before a destroyer in an earlier ordinal group

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/DestroyerTaskCommandLineOrderIntegrationTest.groovy
@@ -360,9 +360,13 @@ class DestroyerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOr
 
         then:
         result.assertTaskOrder(cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
-        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
-        result.assertTaskOrder(generateFoo.fullPath, generate.fullPath)
-        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+
+        // cleanFoo must run after generateFoo, as cleanFoo finalizes generateFoo
+        // cleanFoo must run after generate, as cleanFoo destroys an output produced by generateFoo and consumed by generate
+        result.assertTaskOrder(generateFoo.fullPath, generate.fullPath, cleanFoo.fullPath, clean.fullPath)
+
+        // cleanBar depends on cleanFoo, but cleanFoo must run after generate (per above)
+        result.assertTaskOrder(generateBar.fullPath, generate.fullPath, cleanFoo.fullPath, cleanBar.fullPath, clean.fullPath)
 
         where:
         type << ProductionType.values()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProducerTaskCommandLineOrderIntegrationTest.groovy
@@ -337,8 +337,8 @@ class ProducerTaskCommandLineOrderIntegrationTest extends AbstractCommandLineOrd
 
         then:
         result.assertTaskOrder(generateBar.fullPath, generateFoo.fullPath, generate.fullPath)
-        result.assertTaskOrder(generateFoo.fullPath, cleanFoo.fullPath, clean.fullPath)
-        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generate.fullPath)
+        // generateBar must run after cleanBar, as generateBar finalizes cleanBar
+        result.assertTaskOrder(cleanBar.fullPath, generateBar.fullPath, generateFoo.fullPath, generate.fullPath)
         result.assertTaskOrder(cleanBar.fullPath, clean.fullPath)
 
         where:

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
@@ -39,6 +39,11 @@ public class CompositeNodeGroup extends HasFinalizers {
         return ordinalGroup.asOrdinal();
     }
 
+    @Override
+    public NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal) {
+        return new CompositeNodeGroup(newOrdinal, finalizerGroups);
+    }
+
     public NodeGroup getOrdinalGroup() {
         return ordinalGroup;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -20,6 +20,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,8 +29,9 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 /**
- * Represents a graph of dependent work items, returned in execution order.
+ * Represents a graph of dependent work items, returned in execution order. The methods of this interface are not thread safe.
  */
+@NotThreadSafe
 public interface ExecutionPlan extends Describable, Closeable {
 
     ExecutionPlan EMPTY = new ExecutionPlan() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -54,6 +54,12 @@ public class FinalizerGroup extends HasFinalizers {
         return delegate;
     }
 
+    @Override
+    public NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal) {
+        ordinal = newOrdinal;
+        return this;
+    }
+
     public NodeGroup getDelegate() {
         return delegate;
     }
@@ -87,13 +93,6 @@ public class FinalizerGroup extends HasFinalizers {
     @Override
     public Collection<Node> getSuccessorsInReverseOrder() {
         return node.getFinalizingSuccessorsInReverseOrder();
-    }
-
-    public void maybeInheritFrom(NodeGroup fromGroup) {
-        OrdinalGroup ordinal = fromGroup.asOrdinal();
-        if (ordinal != null && (this.ordinal == null || this.ordinal.getOrdinal() < ordinal.getOrdinal())) {
-            this.ordinal = ordinal;
-        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
@@ -48,6 +48,11 @@ public abstract class NodeGroup {
         }
 
         @Override
+        public NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal) {
+            return newOrdinal;
+        }
+
+        @Override
         public boolean isReachableFromEntryPoint() {
             return false;
         }
@@ -83,4 +88,6 @@ public abstract class NodeGroup {
 
     public void removeMember(Node node) {
     }
+
+    public abstract NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
@@ -40,6 +40,11 @@ public class OrdinalGroup extends NodeGroup {
     }
 
     @Override
+    public NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal) {
+        return newOrdinal;
+    }
+
+    @Override
     public boolean isReachableFromEntryPoint() {
         return true;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -169,9 +169,6 @@ public abstract class TaskNode extends Node {
             // This node is a finalizer, decorate the current group to add finalizer behaviour
             FinalizerGroup finalizerGroup = new FinalizerGroup(this, getGroup());
             setGroup(finalizerGroup);
-            for (Node node : getFinalizingSuccessors()) {
-                finalizerGroup.maybeInheritFrom(node.getGroup());
-            }
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/WorkSource.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/WorkSource.java
@@ -19,9 +19,14 @@ package org.gradle.execution.plan;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Represents some source of work items of type {@link T}. Implementations must be thread safe.
+ */
+@ThreadSafe
 public interface WorkSource<T> {
     enum State {
         /**


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

Also add some more details to the logging when an unhealthy execution plan is detected.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
