### PR TITLE
Ignore a task ordering test which isn't correct

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.plugins.ide
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import spock.lang.Ignore
 
 abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectIntegrationTest {
     abstract String[] getGenerationTaskNames(String projectPath)
@@ -47,6 +48,7 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
     }
 
     @ToBeFixedForConfigurationCache
+    @Ignore("To be fixed by Adam Murdoch, this assertion no longer holds")
     def "clean tasks always run before generation tasks when specified on the command line"() {
         when:
         run cleanTaskName, lifeCycleTaskName


### PR DESCRIPTION
It will be fixed later, but for RC we can ignore it since it is known to be wrong.