### PR TITLE
Fixes #16897 by introducing `JvmImplementation.ANY` to truly mean "any implementation"

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JvmImplementation.java
@@ -25,6 +25,14 @@ package org.gradle.jvm.toolchain;
 public final class JvmImplementation {
 
     /**
+     * Any virtual machine implementation.
+     *
+     * Matches any implementation from any vendor.
+     * Does not prefer a "vendor-specific" implementation over known implementations.
+     */
+    public static final JvmImplementation ANY = new JvmImplementation("any");
+
+    /**
      * Vendor-specific virtual machine implementation.
      *
      * Acts as a placeholder and matches any implementation from any vendor.

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/ToolchainMatcher.java
@@ -41,8 +41,10 @@ public class ToolchainMatcher implements Predicate<JavaToolchain> {
 
     private Predicate<? super JavaToolchain> implementationPredicate() {
         return toolchain -> {
+            final JvmImplementation requested = filter.getImplementation().get();
+            if (requested == JvmImplementation.ANY) return true;
             final boolean isJ9Vm = toolchain.getMetadata().hasCapability(JvmInstallationMetadata.JavaInstallationCapability.J9_VIRTUAL_MACHINE);
-            final boolean j9Requested = filter.getImplementation().get() == JvmImplementation.J9;
+            final boolean j9Requested = requested == JvmImplementation.J9;
             return j9Requested == isJ9Vm;
         };
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -136,6 +136,23 @@ class JavaToolchainQueryServiceTest extends Specification {
         toolchain.getInstallationPath().toString() == systemSpecificAbsolutePath("/path/8.0.1.hs")
     }
 
+    def "select any implementation, with no preference" () {
+        given:
+        def registry = createInstallationRegistry(["8.0.2.j9", "8.0.1.hs"])
+        def toolchainFactory = newToolchainFactory()
+        def queryService = new JavaToolchainQueryService(registry, toolchainFactory, Mock(JavaToolchainProvisioningService), createProviderFactory())
+
+        when:
+        def filter = new DefaultToolchainSpec(TestUtil.objectFactory())
+        filter.languageVersion.set(JavaLanguageVersion.of(8))
+        filter.implementation.set(JvmImplementation.ANY)
+        def toolchain = queryService.findMatchingToolchain(filter).get()
+
+        then:
+        toolchain.languageVersion == JavaLanguageVersion.of(8)
+        toolchain.getInstallationPath().toString() == systemSpecificAbsolutePath("/path/8.0.2.j9")
+    }
+
     def "ignores invalid toolchains when finding a matching one"() {
         given:
         def registry = createInstallationRegistry(["8.0", "8.0.242.hs-adpt", "8.0.broken"])


### PR DESCRIPTION
Fixes #16897 by introducing `JvmImplementation.ANY` to truly mean "any implementation".

### Context

`JvmImplementation.VENDOR_SPECIFIC` says "matches any implementation from any vendor".

However, `ToolchainMatcher.implementationPredicate` will select a J9 implementation if and only if a J9 implementation is explicitly selected, else it will reject a J9 implementation.

This behaviour seems by design since automated tests such as `JavaToolchainQueryServiceTest."prefer vendor-specific over other implementation if not requested"` explicitly depend on it.

Since `VENDOR_SPECIFIC` is the default value for `implementation`, this means Gradle will never select a J9 implementation to build a default configured project.

Additionally, there is no way to express "any implementation whatsoever", which I suppose is the case for the vast majority of JVM projects.

A sensible default would allow testing architectures to easily test a single project with multiple implementations by just varying environment variables such as `JAVA_HOME`. At this time, in order to convince Gradle to exercise some project with a J9 implementation, one is forced to override `java.toolchain.implementation` on that project somehow. This is very unfortunate.

This PR adds `JvmImplementation.ANY` to mean "any vendor whatsoever".

It does not change the default.
Changing the default causes many tests to break.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
