### PR TITLE
Fix issue assigning ordinal group to task that is the target of 'shouldRunAfter'

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractCommandLineOrderTaskIntegrationTest.groovy
@@ -131,6 +131,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
         final Set<TaskFixture> dependencies = []
         final Set<TaskFixture> finalizers = []
         final Set<TaskFixture> mustRunAfter = []
+        final Set<TaskFixture> shouldRunAfter = []
         final Set<String> destroys = []
         final Set<String> produces = []
         final Set<String> localState = []
@@ -144,6 +145,11 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
 
         TaskFixture dependsOn(TaskFixture dependency) {
             dependencies.add(dependency)
+            return this
+        }
+
+        TaskFixture shouldRunAfter(TaskFixture dependency) {
+            shouldRunAfter.add(dependency)
             return this
         }
 
@@ -206,6 +212,7 @@ abstract class AbstractCommandLineOrderTaskIntegrationTest extends AbstractInteg
                     ${dependencies.collect {'dependsOn ' + dependencyFor(it) }.join('\n\t\t\t\t')}
                     ${finalizers.collect { 'finalizedBy ' + dependencyFor(it) }.join('\n\t\t\t\t')}
                     ${mustRunAfter.collect { 'mustRunAfter ' + dependencyFor(it) }.join('\n\t\t\t\t')}
+                    ${shouldRunAfter.collect { 'shouldRunAfter ' + dependencyFor(it) }.join('\n\t\t\t\t')}
                     ${produces.collect { 'outputs.file file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
                     ${destroys.collect { 'destroyables.register file(' + quote(it) + ')' }.join('\n\t\t\t\t')}
                     ${localState.collect { 'localState.register file(' + quote(it) + ')' }.join('\n\t\t\t\t')}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -81,7 +81,7 @@ public abstract class Node implements Comparable<Node> {
         if (isComplete()) {
             return this + " (state=" + state + ")";
         } else {
-            return this + " (state=" + state + ", dependencies=" + dependenciesState + ", group=" + group + ", successors=" + getAllSuccessors() + ")";
+            return this + " (state=" + state + ", dependencies=" + dependenciesState + ", group=" + group + ", successors=" + getHardSuccessors() + ")";
         }
     }
 
@@ -165,7 +165,7 @@ public abstract class Node implements Comparable<Node> {
     public void maybeUpdateOrdinalGroup() {
         OrdinalGroup ordinal = getGroup().asOrdinal();
         OrdinalGroup newOrdinal = ordinal;
-        for (Node successor : getAllSuccessors()) {
+        for (Node successor : getHardSuccessors()) {
             OrdinalGroup successorOrdinal = successor.getGroup().asOrdinal();
             if (successorOrdinal != null && (ordinal == null || successorOrdinal.getOrdinal() > ordinal.getOrdinal())) {
                 newOrdinal = successorOrdinal;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -19,32 +19,25 @@ package org.gradle.execution.plan;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 
-import java.util.Collection;
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.TreeMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
  * A factory for creating and accessing ordinal nodes
  */
 public class OrdinalNodeAccess {
-    TreeMap<Integer, OrdinalNode> destroyerLocationNodes = Maps.newTreeMap();
-    TreeMap<Integer, OrdinalNode> producerLocationNodes = Maps.newTreeMap();
+    private final Map<Integer, OrdinalGroup> groups = Maps.newHashMap();
+    private final Map<OrdinalGroup, OrdinalNode> destroyerLocationNodes = Maps.newHashMap();
+    private final Map<OrdinalGroup, OrdinalNode> producerLocationNodes = Maps.newHashMap();
 
     OrdinalNode getOrCreateDestroyableLocationNode(OrdinalGroup ordinal) {
-        return destroyerLocationNodes.computeIfAbsent(ordinal.getOrdinal(), i -> createDestroyerLocationNode(ordinal));
+        return destroyerLocationNodes.computeIfAbsent(ordinal, i -> createDestroyerLocationNode(ordinal));
     }
 
     OrdinalNode getOrCreateOutputLocationNode(OrdinalGroup ordinal) {
-        return producerLocationNodes.computeIfAbsent(ordinal.getOrdinal(), i -> createProducerLocationNode(ordinal));
-    }
-
-    Collection<OrdinalNode> getPrecedingDestroyerLocationNodes(int from) {
-        return destroyerLocationNodes.headMap(from).values();
-    }
-
-    Collection<OrdinalNode> getPrecedingProducerLocationNodes(int from) {
-        return producerLocationNodes.headMap(from).values();
+        return producerLocationNodes.computeIfAbsent(ordinal, i -> createProducerLocationNode(ordinal));
     }
 
     List<OrdinalNode> getAllNodes() {
@@ -57,8 +50,22 @@ public class OrdinalNodeAccess {
      * the ordinal group it represents have no explicit dependencies.
      */
     void createInterNodeRelationships() {
-        destroyerLocationNodes.forEach((ordinal, destroyer) -> getPrecedingProducerLocationNodes(ordinal).forEach(destroyer::addDependencySuccessor));
-        producerLocationNodes.forEach((ordinal, producer) -> getPrecedingDestroyerLocationNodes(ordinal).forEach(producer::addDependencySuccessor));
+        destroyerLocationNodes.forEach((ordinal, destroyer) -> {
+            for (int i = 0; i < ordinal.getOrdinal(); i++) {
+                Node precedingNode = destroyerLocationNodes.get(group(i));
+                if (precedingNode != null) {
+                    destroyer.addDependencySuccessor(precedingNode);
+                }
+            }
+        });
+        producerLocationNodes.forEach((ordinal, producer) -> {
+            for (int i = 0; i < ordinal.getOrdinal(); i++) {
+                Node precedingNode = producerLocationNodes.get(group(i));
+                if (precedingNode != null) {
+                    producer.addDependencySuccessor(precedingNode);
+                }
+            }
+        });
     }
 
     private OrdinalNode createDestroyerLocationNode(OrdinalGroup ordinal) {
@@ -76,6 +83,24 @@ public class OrdinalNodeAccess {
     }
 
     public OrdinalGroup group(int ordinal) {
-        return new OrdinalGroup(ordinal);
+        return groups.computeIfAbsent(ordinal, integer -> new OrdinalGroup(ordinal));
+    }
+
+    @Nullable
+    public Node getPrecedingProducerLocationNode(OrdinalGroup ordinal) {
+        if (ordinal.getOrdinal() == 0) {
+            return null;
+        } else {
+            return getOrCreateOutputLocationNode(group(ordinal.getOrdinal() - 1));
+        }
+    }
+
+    @Nullable
+    public Node getPrecedingDestroyerLocationNode(OrdinalGroup ordinal) {
+        if (ordinal.getOrdinal() == 0) {
+            return null;
+        } else {
+            return getOrCreateDestroyableLocationNode(group(ordinal.getOrdinal() - 1));
+        }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -67,7 +67,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         _ * task.taskDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
         _ * task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
         _ * task.finalizedBy >> taskDependencyResolvingTo(task, options.finalizedBy ?: [])
-        _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, [])
+        _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, options.shouldRunAfter ?: [])
         _ * task.mustRunAfter >> taskDependencyResolvingTo(task, options.mustRunAfter ?: [])
         _ * task.sharedResources >> (options.resources ?: [])
         TaskStateInternal state = Mock()
@@ -1123,6 +1123,64 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         selectNextTask() == producer
     }
 
+    def "producer ordered before destroyer on command-line overrides conflicting shouldRunAfter relationship"() {
+        given:
+        Task destroyer = task("destroyer", type: AsyncWithDestroysFile)
+        _ * destroyer.destroysFile >> file("inputDir")
+        Task producer = task("producer", type: AsyncWithOutputDirectory, shouldRunAfter: [destroyer])
+        _ * producer.outputDirectory >> file("inputDir")
+
+        when:
+        addToGraphAndPopulate(producer, destroyer)
+
+        then:
+        // TODO - this is the wrong order (the order of this list does not take ordinal groups into account)
+        executionPlan.tasks as List == [destroyer, producer]
+        ordinalGroups == [1, 0]
+        assertLastTaskOfGroupReady(producer)
+        assertLastTaskOfGroupReadyAndNoMoreToStart(destroyer)
+        assertAllWorkComplete()
+    }
+
+    def "destroyer ordered before producer on command-line overrides conflicting shouldRunAfter relationship"() {
+        given:
+        Task producer = task("producer", type: AsyncWithOutputDirectory)
+        _ * producer.outputDirectory >> file("inputDir")
+        Task destroyer = task("destroyer", type: AsyncWithDestroysFile, shouldRunAfter: [producer])
+        _ * destroyer.destroysFile >> file("inputDir")
+
+        when:
+        addToGraphAndPopulate(destroyer, producer)
+
+        then:
+        // TODO - this is the wrong order (the order of this list does not take ordinal groups into account)
+        executionPlan.tasks as List == [producer, destroyer]
+        ordinalGroups == [1, 0]
+        assertLastTaskOfGroupReady(destroyer)
+        assertLastTaskOfGroupReadyAndNoMoreToStart(producer)
+        assertAllWorkComplete()
+    }
+
+    def "non-conflicting producers in all later groups can start once destroyer is complete"() {
+        given:
+        Task producer1 = task("producer1", type: AsyncWithOutputDirectory)
+        _ * producer1.outputDirectory >> file("dir1")
+        Task producer2 = task("producer2", type: AsyncWithOutputDirectory)
+        _ * producer2.outputDirectory >> file("dir2")
+        Task destroyer = task("destroyer", type: AsyncWithDestroysFile)
+        _ * destroyer.destroysFile >> file("dir3")
+
+        when:
+        addToGraphAndPopulate(destroyer, producer1, producer2)
+
+        then:
+        executionPlan.tasks as List == [destroyer, producer1, producer2]
+        ordinalGroups == [0, 1, 2]
+        assertLastTaskOfGroupReady(destroyer)
+        assertLastTasksOfGroupReadyAndNoMoreToStart(producer1, producer2)
+        assertAllWorkComplete()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/20559")
     def "a task that destroys the output of a task in another project runs first if it is ordered first"() {
         given:
@@ -1616,11 +1674,37 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         finishedExecuting(node)
     }
 
+    void assertLastTaskOfGroupReady(Task task, boolean needToSelect = true) {
+        def node = selectNextTaskNode()
+        assert node.task == task
+        def ordinalNode = selectNextNode()
+        assert ordinalNode instanceof OrdinalNode
+        if (needToSelect) {
+            assertNoWorkReadyToStartAfterSelect()
+        } else {
+            assertNoWorkReadyToStart()
+        }
+        finishedExecuting(node)
+        assertNoWorkReadyToStart()
+        finishedExecuting(ordinalNode)
+    }
+
     void assertTaskReadyAndNoMoreToStart(Task task, boolean needToSelect = false) {
         def node = selectNextTaskNode()
         assert node.task == task
         assertNoMoreWorkToStartButNotAllComplete(needToSelect)
         finishedExecuting(node)
+    }
+
+    void assertLastTaskOfGroupReadyAndNoMoreToStart(Task task, boolean needToSelect = false) {
+        def node = selectNextTaskNode()
+        assert node.task == task
+        def ordinalNode = selectNextNode()
+        assert ordinalNode instanceof OrdinalNode
+        assertNoMoreWorkToStartButNotAllComplete(needToSelect)
+        finishedExecuting(node)
+        assertNoMoreWorkToStartButNotAllComplete(false)
+        finishedExecuting(ordinalNode)
     }
 
     void assertTasksReady(Task task1, Task task2, boolean needToSelect = true) {
@@ -1644,7 +1728,27 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assert node2.task == task2
         assertNoMoreWorkToStartButNotAllComplete(needToSelect)
         finishedExecuting(node2)
+        assertNoMoreWorkToStartButNotAllComplete(false)
         finishedExecuting(node1)
+    }
+
+    void assertLastTasksOfGroupReadyAndNoMoreToStart(Task task1, Task task2, boolean needToSelect = false) {
+        def node1 = selectNextTaskNode()
+        assert node1.task == task1
+        def node2 = selectNextTaskNode()
+        assert node2.task == task2
+        def node3 = selectNextNode()
+        assert node3 instanceof OrdinalNode
+        assertNoWorkReadyToStartAfterSelect()
+        finishedExecuting(node2)
+        assertNoWorkReadyToStart()
+        finishedExecuting(node1)
+        assertNoWorkReadyToStart()
+        finishedExecuting(node3)
+        def node4 = selectNextNode()
+        assert node4 instanceof OrdinalNode
+        assertNoMoreWorkToStartButNotAllComplete(needToSelect)
+        finishedExecuting(node4)
     }
 
     void assertTasksReadyAndNoMoreToStart(Task task1, Task task2, Task task3, boolean needToSelect = false) {
@@ -1656,7 +1760,9 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assert node3.task == task3
         assertNoMoreWorkToStartButNotAllComplete(needToSelect)
         finishedExecuting(node3)
+        assertNoMoreWorkToStartButNotAllComplete(needToSelect)
         finishedExecuting(node2)
+        assertNoMoreWorkToStartButNotAllComplete(needToSelect)
         finishedExecuting(node1)
     }
 

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.plugins.ide
 
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import spock.lang.Ignore
 
 abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectIntegrationTest {
     abstract String[] getGenerationTaskNames(String projectPath)
@@ -48,7 +47,6 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
     }
 
     @ToBeFixedForConfigurationCache
-    @Ignore("To be fixed by Adam Murdoch, this assertion no longer holds")
     def "clean tasks always run before generation tasks when specified on the command line"() {
         when:
         run cleanTaskName, lifeCycleTaskName
@@ -60,12 +58,7 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
         run lifeCycleTaskName, cleanTaskName
 
         then:
-        assertCleanTasksRunBeforeGenerationTasks()
-
-        and:
-        projectName(".") == "root"
-        projectName("foo") == "foo"
-        projectName("foo/bar") == "bar"
+        assertGenerationTasksRunBeforeCleanTasks()
     }
 
     @ToBeFixedForConfigurationCache
@@ -93,6 +86,14 @@ abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectInt
         [":", ":foo", ":foo:bar"].each { projectPath ->
             getGenerationTaskNames(projectPath).each { taskName ->
                 result.assertTaskOrder(getCleanTaskName(taskName), taskName)
+            }
+        }
+    }
+
+    def assertGenerationTasksRunBeforeCleanTasks() {
+        [":", ":foo", ":foo:bar"].each { projectPath ->
+            getGenerationTaskNames(projectPath).each { taskName ->
+                result.assertTaskOrder(taskName, getCleanTaskName(taskName))
             }
         }
     }


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
