### PR TITLE
Expect CACHE_MISS for GroovyCompile tasks on M1

### DIFF
--- a/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
+++ b/build-logic-commons/gradle-plugin/src/main/kotlin/gradlebuild.cache-miss-monitor.gradle.kts
@@ -18,6 +18,7 @@
 
 import com.gradle.scan.plugin.BuildScanExtension
 import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.internal.os.OperatingSystem
 import java.util.concurrent.atomic.AtomicBoolean
 
 val gradleRootProject = when {
@@ -61,7 +62,10 @@ fun Task.isCompileCacheMissMonitoredTask() = isMonitoredCompileTask() && !isExpe
 
 fun isAsciidoctorCacheMissTask() = isMonitoredAsciidoctorTask() && !isExpectedAsciidoctorCacheMiss()
 
-fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this.isClasspathManifest()) && !this.isKotlinJsIrLink()
+fun Task.isMonitoredCompileTask() = (this is AbstractCompile || this.isClasspathManifest()) && !isKotlinJsIrLink() && !isGroovyCompileOnM1Mac()
+
+// vendor is an input of GroovyCompile, so GroovyCompile on M1 mac is definitely a cache miss
+fun Task.isGroovyCompileOnM1Mac() = this is GroovyCompile && OperatingSystem.current().isMacOsX && System.getProperty("os.arch") == "aarch64"
 
 fun Task.isClasspathManifest() = this.javaClass.simpleName.startsWith("ClasspathManifest")
 


### PR DESCRIPTION
JDK vendor is an input of `GroovyCompile` tasks so
it's an expected CACHE_MISS.
