### PR TITLE
Workaround for srcDistribution causing up-to-date jar tasks

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.distributions.gradle.kts
@@ -161,10 +161,15 @@ consumablePlatformVariant("runtimePlatform", listOf(coreRuntimeOnly, pluginsRunt
 val buildDists by tasks.registering
 
 configureDistribution("normalized", binDistributionSpec(), buildDists, true)
-configureDistribution("bin", binDistributionSpec(), buildDists)
+val binDistributionTasks = configureDistribution("bin", binDistributionSpec(), buildDists)
 configureDistribution("all", allDistributionSpec(), buildDists)
 configureDistribution("docs", docsDistributionSpec(), buildDists)
-configureDistribution("src", srcDistributionSpec(), buildDists)
+configureDistribution("src", srcDistributionSpec(), buildDists).forEach {
+    // Workaround for the source distribution task reading/storing too much things in the VFS
+    // which may cause incorrect JAR tasks. The mustRunAfter adds it after all the JAR tasks, since
+    // the bin distribution depends on them.
+    it.configure { mustRunAfter(binDistributionTasks) }
+}
 
 fun pluginsManifestTask(runtimeClasspath: Configuration, coreRuntimeClasspath: Configuration, api: GradleModuleApiAttribute) =
     tasks.registering(PluginsManifest::class) {
@@ -178,7 +183,7 @@ fun pluginsManifestTask(runtimeClasspath: Configuration, coreRuntimeClasspath: C
         manifestFile.set(generatedPropertiesFileFor("gradle${if (api == GradleModuleApiAttribute.API) "" else "-implementation"}-plugins"))
     }
 
-fun configureDistribution(name: String, distributionSpec: CopySpec, buildDistLifecycleTask: TaskProvider<Task>, normalized: Boolean = false) {
+fun configureDistribution(name: String, distributionSpec: CopySpec, buildDistLifecycleTask: TaskProvider<Task>, normalized: Boolean = false): List<TaskProvider<*>> {
     val disDir = if (normalized) "normalized-distributions" else "distributions"
     val zipRootFolder = if (normalized) {
         moduleIdentity.version.map { "gradle-${it.baseVersion.version}" }
@@ -213,6 +218,7 @@ fun configureDistribution(name: String, distributionSpec: CopySpec, buildDistLif
     consumableVariant("${name}Installation", "gradle-$name-installation", Bundling.EMBEDDED, emptyList(), installation)
     // A variant providing the zipped distribution as additional input for tests that test the final distribution or require a distribution as test data
     consumableVariant("${name}DistributionZip", "gradle-$name-distribution-zip", Bundling.EMBEDDED, emptyList(), distributionZip)
+    return listOf(installation, distributionZip)
 }
 
 fun generatedBinFileFor(name: String) =


### PR DESCRIPTION
This cherry-picks #20366 to `release`. Also see https://github.com/gradle/gradle/issues/20680

This moves the source distribution tasks after
the bin distribution tasks, so it doesn't run
in parallel with the source distribution tasks
which may cause incorrect builds.

So the general problem is again that if some task C reads the output directory
after the task action of a task P started, then we may read stale data from the
VFS when task P finishes, since we only invalidate the output of P at the start
of P, but not just before we snapshot them after P did execute.

So in our case, we have the task C: `:distributions-full:srcDistributionZip`,
https://ge.gradle.org/s/akx6ljbtairda/timeline?details=ox4zjugq5bm4q&end=1649037234419&start=1649037234409
And P is `:execution:jar`:
https://ge.gradle.org/s/akx6ljbtairda/timeline?details=xqkf55kdgcruq&end=1649037234419&start=1649037234409
The trick here is that srcDistributionZip does not declare all of the
directories as an input, but only some filtered part:
https://github
.com/gradle/gradle/blob/45e8762d131f22fdf2c11eb528a93e7d24afc51d/build-logic/packaging/src/main/kotlin/gradlebuild/packaging/GradleDistributionSpecs.kt#L91-L116
Normally, we’d detect that we didn’t include the subprojects/execution/build
directory and then see that the snapshot isn’t complete. Though if none of the
:execution subproject tasks did run, that means that Gradle may detect the
directory as complete - there isn’t a build directory so nothing has been
excluded. And if the read starts before the task in the execution project run
and finished after they ran than we have a problem: We have the wrong state in
the VFS and think it is up-to-date. We also ignore file system events for those
locations, since they are part of the outputs. All in all, Gradle would think
that the JAR task did output nothing.

Coming back to the build scan above:
`:distributions-full:srcDistributionZip` started at 7.683s and it took 0.494s to
finish input snapshotting - which puts the end of input snapshotting at 8.177s
`:execution:jar` started at 8.070s and took 0.036s which puts it end at 8.106s.
While 8.177s is after 8.106s, it may still be that the inputs have been stored
in time in the VFS before the jar task finished causing it to think that it
didn’t produce any outputs.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
