### PR TITLE
Fix documentation of missing input file workaround

### DIFF
--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -282,23 +282,12 @@ The symptoms are similar to <<implicit_dependency>> except that in this case the
 
 Please refer to the <<implicit_dependency>> section for possible solutions.
 If the file isn't produced by another task, you may want to make sure that it exists before the task is called.
-If what you want to declare is that it doesn't matter that the file exists or not when the task is executed, you can configure the input as `@Optional` and make it return null when the file is absent:
+If what you want to declare is that it doesn't matter that the file exists or not when the task is executed, you can use an `@Optional` input to allow Gradle to capture the input's state:
 
-```
-public abstract class SomeTask extends DefaultTask {
-    @InputFile
-    @Optional
-    public abstract RegularFileProperty getSomeOptionalFile();
-
-    @TaskAction
-    public void run() {
-        RegularFile optionalFile = getSomeOptionalFile().getOrNull();
-        if (optionalFile != null) {
-           ...
-        }
-    }
-}
-```
+====
+include::sample[dir="snippets/tasks/customTaskWithMissingFileProperty/groovy",files="build.gradle[tags=task]"]
+include::sample[dir="snippets/tasks/customTaskWithMissingFileProperty/kotlin",files="build.gradle.kts[tags=task]"]
+====
 
 [[unexpected_input_file_type]]
 == Unexpected input file or directory

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/build.gradle
@@ -1,0 +1,47 @@
+// tag::all[]
+// tag::task[]
+abstract class GreetingFileTask extends DefaultTask {
+
+    @Internal
+    abstract RegularFileProperty getSource()
+
+    @InputFile
+    @Optional
+    protected Provider<RegularFile> getSourceInternal() {
+        source.map { it.asFile.exists() ? it : null }
+    }
+
+    @OutputFile
+    abstract RegularFileProperty getDestination()
+
+    @TaskAction
+    def greet() {
+        def file = getDestination().get().asFile
+        if (source.get().asFile.exists()) {
+            file.write("Hello ${source.get().asFile.text}!")
+        } else {
+            file.write 'Hello missing file!'
+        }
+    }
+}
+// end::task[]
+
+// tag::config[]
+def greetingFile = objects.fileProperty()
+
+tasks.register('greet', GreetingFileTask) {
+    source = layout.projectDirectory.file("missing.txt")
+    destination = greetingFile
+}
+
+tasks.register('sayGreeting') {
+    dependsOn greet
+    doLast {
+        def file = greetingFile.get().asFile
+        println "${file.text} (file: ${file.name})"
+    }
+}
+
+greetingFile.set(layout.buildDirectory.file('hello.txt'))
+// end::config[]
+// end::all[]

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'custom-task-with-missing-file-property'

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/build.gradle.kts
@@ -1,0 +1,45 @@
+// tag::all[]
+// tag::task[]
+abstract class GreetingFileTask : DefaultTask() {
+
+    @get:Internal
+    abstract val source: RegularFileProperty
+
+    @InputFile
+    @Optional
+    protected fun getSourceInternal() = source.map { if (it.asFile.exists()) it else null }
+
+    @get:OutputFile
+    abstract val destination: RegularFileProperty
+
+    @TaskAction
+    fun greet() {
+        val file = destination.get().asFile
+        if (source.get().asFile.exists()) {
+            file.writeText("Hello ${source.get().asFile.readText()}")
+        } else {
+            file.writeText("Hello missing file!")
+        }
+    }
+}
+// end::task[]
+
+// tag::config[]
+val greetingFile = objects.fileProperty()
+
+tasks.register<GreetingFileTask>("greet") {
+    source.set(layout.projectDirectory.file("missing.txt"))
+    destination.set(greetingFile)
+}
+
+tasks.register("sayGreeting") {
+    dependsOn("greet")
+    doLast {
+        val file = greetingFile.get().asFile
+        println("${file.readText()} (file: ${file.name})")
+    }
+}
+
+greetingFile.set(layout.buildDirectory.file("hello.txt"))
+// end::config[]
+// end::all[]

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "custom-task-with-missing-file-property"

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/tests/missingFileProperties.out
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/tests/missingFileProperties.out
@@ -1,0 +1,1 @@
+Hello missing file! (file: hello.txt)

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/tests/missingFileProperties.sample.conf
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/tests/missingFileProperties.sample.conf
@@ -1,0 +1,7 @@
+# tag::cli[]
+# gradle --quiet sayGreeting
+# end::cli[]
+executable: gradle
+args: sayGreeting
+flags: --quiet
+expected-output-file: missingFileProperties.out


### PR DESCRIPTION
The documentation has a sample that does not actually solve the problem. This one does, though it's still a workaround.

We should eventually add direct support for allowing missing `@InputFile`s.