### PR TITLE
Fix composite build sample documentation

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -76,7 +76,7 @@ abstract class MavenConversionIntegrationTest extends AbstractInitIntegrationSpe
         !warSubprojectBuildFile.text.contains("options.encoding")
 
         assertContainsPublishingConfig(conventionPluginScript, scriptDsl)
-        conventionPluginScript.text.contains("options.encoding = 'UTF-8'") || conventionPluginScript.text.contains('options.encoding = "UTF-8"')
+        assertContainsEncodingConfig(conventionPluginScript, scriptDsl, 'UTF-8')
         conventionPluginScript.text.contains(TextUtil.toPlatformLineSeparators('''
 java {
     withSourcesJar()
@@ -207,6 +207,29 @@ Root project 'webinar-parent'
         targetDir.file("build/libs/util-2.5.jar").exists()
         failure.assertHasDescription("Execution failed for task ':test'.")
         failure.assertHasCause("There were failing tests.")
+    }
+
+    private static void assertContainsEncodingConfig(TestFile buildScript, BuildInitDsl dsl, String encoding) {
+        def text = buildScript.text
+        if (dsl == BuildInitDsl.GROOVY) {
+            assert text.contains(TextUtil.toPlatformLineSeparators("""
+tasks.withType(JavaCompile) {
+    options.encoding = '$encoding'
+}
+
+tasks.withType(Javadoc) {
+    options.encoding = '$encoding'
+}"""))
+        } else {
+            assert text.contains(TextUtil.toPlatformLineSeparators("""
+tasks.withType<JavaCompile>() {
+    options.encoding = "$encoding"
+}
+
+tasks.withType<Javadoc>() {
+    options.encoding = "$encoding"
+}"""))
+        }
     }
 
     private static void assertContainsPublishingConfig(TestFile buildScript, BuildInitDsl dsl, String indent = "", List<String> additionalArchiveTasks = []) {

--- a/subprojects/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/Maven2Gradle.java
+++ b/subprojects/build-init/src/main/java/org/gradleinternal/buildinit/plugins/internal/maven/Maven2Gradle.java
@@ -430,6 +430,7 @@ public class Maven2Gradle {
         String encoding = (String) project.getProperties().get("project.build.sourceEncoding");
         if (StringUtils.isNotEmpty(encoding)) {
             builder.taskPropertyAssignment(null, "JavaCompile", "options.encoding", encoding);
+            builder.taskPropertyAssignment(null, "Javadoc", "options.encoding", encoding);
         }
     }
 

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/README.adoc
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/README.adoc
@@ -26,14 +26,14 @@ gradle run
 And the 'dependencies' report shows the dependency substitution in action:
 
 ```
-gradle dependencies --configuration runtimeClasspath
+gradle app:dependencies --configuration runtimeClasspath
 ```
 
 ```
 runtimeClasspath - Runtime classpath of source set 'main'.
 +--- org.sample:number-utils:1.0 -> project :number-utils
 \--- org.sample:string-utils:1.0 -> project :string-utils
-     \--- org.apache.commons:commons-lang3:3.4
+     \--- org.apache.commons:commons-lang3:3.12.0
 ```
 
 == Switching to use binary dependency
@@ -69,14 +69,14 @@ Note that the `number-utils` dependency is still satisfied by the included build
 The 'dependencies' report shows the dependency substitution in action:
 
 ```
-gradle dependencies --configuration runtimeClasspath
+gradle app:dependencies --configuration runtimeClasspath
 ```
 
 ```
 runtimeClasspath - Runtime classpath of source set 'main'.
 +--- org.sample:number-utils:1.0 -> project :number-utils
 \--- org.sample:string-utils:1.0
-     \--- org.apache.commons:commons-lang3:3.4
+     \--- org.apache.commons:commons-lang3:3.12.0
 ```
 
 == Including an external library as a submodule
@@ -84,7 +84,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
 The power of this configuration can be demonstrated by adding the external 'commons-lang' build directly to the composite.
 
 ```
-git clone http://git-wip-us.apache.org/repos/asf/commons-lang.git modules/commons-lang --branch master --depth 1
+git clone http://gitbox.apache.org/repos/asf/commons-lang.git modules/commons-lang --branch rel/commons-lang-3.12.0 --depth 1
 gradle --project-dir modules/commons-lang init
 gradle run
 ```
@@ -92,5 +92,5 @@ gradle run
 You can see the external transitive dependency `commons-lang` being replaced with the local project dependency by running:
 
 ```
-gradle dependencies --configuration compile
+gradle app:dependencies --configuration runtimeClasspath
 ```

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/app/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
 repositories {
     maven {
-        url project.file("../../local-repo")
+        url project.file("../local-repo")
     }
     mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/build.gradle
@@ -1,3 +1,3 @@
 tasks.register('publishDeps') {
-    dependsOn gradle.includedBuilds*.task(':publishIvyPublicationToIvyRepository')
+    dependsOn gradle.includedBuilds*.task(':publishMavenPublicationToMavenRepository')
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/number-utils/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/number-utils/build.gradle
@@ -6,17 +6,10 @@ plugins {
 group "org.sample"
 version "1.0"
 
-repositories {
-    ivy {
-        name 'localrepo'
-        url file("../../../local-repo")
-    }
-}
-
 publishing {
     repositories {
         maven {
-            url file("../../../local-repo")
+            url file("../../local-repo")
         }
     }
     publications {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/string-utils/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/groovy/modules/string-utils/build.gradle
@@ -7,21 +7,17 @@ group "org.sample"
 version "1.0"
 
 dependencies {
-    implementation "org.apache.commons:commons-lang3:3.4"
+    implementation "org.apache.commons:commons-lang3:3.12.0"
 }
 
 repositories {
-    maven {
-        name 'localrepo'
-        url file("../../../local-repo")
-    }
     mavenCentral()
 }
 
 publishing {
     repositories {
         maven {
-            url file("../../../local-repo")
+            url file("../../local-repo")
         }
     }
     publications {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 
 repositories {
     maven {
-        url = uri(project.file("../../local-repo"))
+        url = uri(project.file("../local-repo"))
     }
     mavenCentral()
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/number-utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/number-utils/build.gradle.kts
@@ -6,17 +6,10 @@ plugins {
 group = "org.sample"
 version = "1.0"
 
-repositories {
-    ivy {
-        name = "localrepo"
-        url = uri(file("../../../local-repo"))
-    }
-}
-
 publishing {
     repositories {
-        ivy {
-            setUrl(file("../../../local-repo"))
+        maven {
+            setUrl(file("../../local-repo"))
         }
     }
     publications {

--- a/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/string-utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/hierarchical-multirepo/kotlin/modules/string-utils/build.gradle.kts
@@ -7,22 +7,17 @@ group = "org.sample"
 version = "1.0"
 
 dependencies {
-    implementation("org.apache.commons:commons-lang3:3.4")
+    implementation("org.apache.commons:commons-lang3:3.12.0")
 }
 
 repositories {
-    maven {
-        name = "localrepo"
-        url = uri(file("../../../local-repo"))
-    }
     mavenCentral()
 }
-
 
 publishing {
     repositories {
         maven {
-            setUrl(file("../../../local-repo"))
+            setUrl(file("../../local-repo"))
         }
     }
     publications {


### PR DESCRIPTION
Fixes: #19953

This sample has gone out of date and no longer executes properly when running
the steps in the documentation as directed. In order to get the sample working
correctly, the following changes were made:
1) Update all local publishing to use maven instead of ivy
2) Update commons-lang dependency to 3.12.0 from 3.4. The directions tell the user
   to clone the commons-lang repo, but said to clone the  branch. The mainline
   code was updated to use non-ascii encoding for the java files, which exposed a bug
   in the way we convert maven POMs to gradle files when running . So,
   we update the readme to instruct the user to explicitly clone the 3.12.0 branch
   so future changes to commons-lang will not affect this sample.
3) Remove unused repository declarations
4) Update Maven2Gradle conversion code (and tests) to ensure the javadoc task is also
   informed of file encoding instead of only the JavaCompile tasks.
5) Update README to direct the user to run the  task instead of just .
6) Use a modern git repo URL for the commons-lang repo.

Additionally, in order to have the sample project not escape the sample directory
and modify external files, the location of the  was moved one directory
down.

Tested by running  with the Maven2Gradle changes and running through the
updated procedure with the sample zips output after these changes.
