### PR TITLE
Split AndroidSantaTrackerSmokeTest & use TeamCity parallel tests

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
     <name>Gradle_Check Config DSL Script</name>
     <properties>
-        <kotlin.version>1.5.31</kotlin.version>
-        <teamcity.dsl.version>2021.2</teamcity.dsl.version>
+        <kotlin.version>1.6.21</kotlin.version>
+        <teamcity.dsl.version>2022.04</teamcity.dsl.version>
         <mockk.version>1.9</mockk.version>
         <bytebuddy.version>1.10.6</bytebuddy.version>
         <junit.version>5.8.1</junit.version>

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -2,16 +2,22 @@ package configurations
 
 import common.JvmCategory
 import common.toCapitalized
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.parallelTests
 import model.CIBuildModel
 import model.Stage
 
-class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task: String = "smokeTest") : BaseGradleBuildType(stage = stage, init = {
+class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task: String = "smokeTest", splitNumber: Int = 1) : BaseGradleBuildType(stage = stage, init = {
     id("${model.projectId}_${task.toCapitalized()}s${testJava.version.name.toCapitalized()}")
     name = "Smoke Tests with 3rd Party Plugins ($task) - ${testJava.version.name.toCapitalized()} Linux"
     description = "Smoke tests against third party plugins to see if they still work with the current Gradle version"
 
     features {
         publishBuildStatusToGithub(model)
+        if (splitNumber > 1) {
+            parallelTests {
+                numberOfBatches = splitNumber
+            }
+        }
     }
 
     applyTestDefaults(

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -389,12 +389,12 @@ enum class SpecificBuild {
     },
     SantaTrackerSmokeTests {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "santaTrackerSmokeTest")
+            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "santaTrackerSmokeTest", 2)
         }
     },
     ConfigCacheSantaTrackerSmokeTests {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "configCacheSantaTrackerSmokeTest")
+            return SmokeTests(model, stage, JvmCategory.SANTA_TRACKER_SMOKE_TEST_VERSION, "configCacheSantaTrackerSmokeTest", 2)
         }
     },
     GradleBuildSmokeTests {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidSantaTrackerSmokeTest.groovy
@@ -21,8 +21,34 @@ import org.gradle.util.GradleVersion
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest {
+abstract class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest {
+    static class AndroidLintDeprecations extends BaseDeprecations implements WithAndroidDeprecations {
+        AndroidLintDeprecations(SmokeTestGradleRunner runner) {
+            super(runner)
+        }
 
+        void expectAndroidLintDeprecations(String agpVersion, List<String> artifacts) {
+            artifacts.each { artifact ->
+                runner.expectLegacyDeprecationWarningIf(
+                    agpVersion.startsWith("4.1"),
+                    "In plugin 'com.android.internal.version-check' type 'com.android.build.gradle.tasks.LintPerVariantTask' property 'allInputs' cannot be resolved:  " +
+                        "Cannot convert the provided notation to a File or URI: $artifact. " +
+                        "The following types/formats are supported:  - A String or CharSequence path, for example 'src/main/java' or '/usr/include'. - A String or CharSequence URI, for example 'file:/usr/include'. - A File instance. - A Path instance. - A Directory instance. - A RegularFile instance. - A URI or URL instance. - A TextResource instance. " +
+                        "Reason: An input file collection couldn't be resolved, making it impossible to determine task inputs. " +
+                        "This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. " +
+                        "Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/${GradleVersion.current().version}/userguide/validation_problems.html#unresolvable_input for more details."
+                )
+            }
+            expectAndroidFileTreeForEmptySourcesDeprecationWarnings(agpVersion, "sourceFiles", "sourceDirs")
+            if (agpVersion.startsWith("7.")) {
+                expectAndroidFileTreeForEmptySourcesDeprecationWarnings(agpVersion, "inputFiles", "resources")
+            }
+            expectAndroidIncrementalTaskInputsDeprecation(agpVersion)
+        }
+    }
+}
+
+class AndroidSantaTrackerDeprecationSmokeTest extends AndroidSantaTrackerSmokeTest {
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "check deprecation warnings produced by building Santa Tracker (agp=#agpVersion)"() {
 
@@ -42,7 +68,9 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         where:
         agpVersion << TESTED_AGP_VERSIONS
     }
+}
 
+class AndroidSantaTrackerIncrementalCompilationSmokeTest extends AndroidSantaTrackerSmokeTest {
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "incremental Java compilation works for Santa Tracker (agp=#agpVersion)"() {
 
@@ -79,7 +107,9 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
         where:
         agpVersion << TESTED_AGP_VERSIONS
     }
+}
 
+class AndroidSantaTrackerLintSmokeTest extends AndroidSantaTrackerSmokeTest {
     @UnsupportedWithConfigurationCache(iterationMatchers = [AGP_NO_CC_ITERATION_MATCHER])
     def "can lint Santa-Tracker (agp=#agpVersion)"() {
 
@@ -128,30 +158,5 @@ class AndroidSantaTrackerSmokeTest extends AbstractAndroidSantaTrackerSmokeTest 
 
         where:
         agpVersion << TESTED_AGP_VERSIONS
-    }
-
-    static class AndroidLintDeprecations extends BaseDeprecations implements WithAndroidDeprecations {
-        AndroidLintDeprecations(SmokeTestGradleRunner runner) {
-            super(runner)
-        }
-
-        void expectAndroidLintDeprecations(String agpVersion, List<String> artifacts) {
-            artifacts.each { artifact ->
-                runner.expectLegacyDeprecationWarningIf(
-                    agpVersion.startsWith("4.1"),
-                    "In plugin 'com.android.internal.version-check' type 'com.android.build.gradle.tasks.LintPerVariantTask' property 'allInputs' cannot be resolved:  " +
-                        "Cannot convert the provided notation to a File or URI: $artifact. " +
-                        "The following types/formats are supported:  - A String or CharSequence path, for example 'src/main/java' or '/usr/include'. - A String or CharSequence URI, for example 'file:/usr/include'. - A File instance. - A Path instance. - A Directory instance. - A RegularFile instance. - A URI or URL instance. - A TextResource instance. " +
-                        "Reason: An input file collection couldn't be resolved, making it impossible to determine task inputs. " +
-                        "This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. " +
-                        "Execution optimizations are disabled to ensure correctness. See https://docs.gradle.org/${GradleVersion.current().version}/userguide/validation_problems.html#unresolvable_input for more details."
-                )
-            }
-            expectAndroidFileTreeForEmptySourcesDeprecationWarnings(agpVersion, "sourceFiles", "sourceDirs")
-            if (agpVersion.startsWith("7.")) {
-                expectAndroidFileTreeForEmptySourcesDeprecationWarnings(agpVersion, "inputFiles", "resources")
-            }
-            expectAndroidIncrementalTaskInputsDeprecation(agpVersion)
-        }
     }
 }


### PR DESCRIPTION
As part of PullRequestFeedback, `santaTrackerSmokeTest` and `configCacheSantaTrackerSmokeTest` is too slow (45m~1h). This PR splits `AndroidSantaTrackerSmokeTest` into smaller classes and enables [TeamCity Parallel Test](https://www.jetbrains.com/help/teamcity/parallel-tests.html). The total build time almost halved.

<img width="1318" alt="image" src="https://user-images.githubusercontent.com/12689835/167528066-da4aba16-6d1c-40ba-b2d6-09e6e0fbae4c.png">

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/12689835/167528168-8a9d7dd6-3f5f-4b08-b27f-830275cfa945.png">
