### PR TITLE
w dependencies with explicit artifacts to skip metadata fetching

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,20 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.artifacts.DependencyArtifact",
+            "member": "Method org.gradle.api.artifacts.DependencyArtifact.getClassifier()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.DependencyArtifact",
+            "member": "Method org.gradle.api.artifacts.DependencyArtifact.getExtension()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        }
+    ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyArtifact.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.artifacts;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>An {@code Artifact} represents an artifact included in a {@link org.gradle.api.artifacts.Dependency}.</p>
  * An artifact is an (immutable) value object.
@@ -37,7 +39,7 @@ public interface DependencyArtifact {
      * but sometimes this is not the case. For example for an ivy XML module descriptor, the type is
      * <em>ivy</em> and the extension is <em>xml</em>.
      *
-     * @see #getExtension() 
+     * @see #getExtension()
      */
     String getType();
 
@@ -51,28 +53,30 @@ public interface DependencyArtifact {
      * but sometimes this is not the case. For example for an ivy XML module descriptor, the type is
      * <em>ivy</em> and the extension is <em>xml</em>.
      *
-     * @see #getType() 
+     * @see #getType()
      */
+    @Nullable
     String getExtension();
 
     /**
      * Sets the extension of this artifact.
      */
-    void setExtension(String extension);
+    void setExtension(@Nullable String extension);
 
     /**
      * Returns the classifier of this artifact.
      */
+    @Nullable
     String getClassifier();
 
     /**
      * Sets the classifier of this artifact.
      */
-    void setClassifier(String classifier);
+    void setClassifier(@Nullable String classifier);
 
     /**
-     * Returns an URL under which this artifact can be retrieved. If not
-     * specified the user repositories are used for retrieving. 
+     * Returns a URL under which this artifact can be retrieved. If not
+     * specified the user repositories are used for retrieving.
      */
     String getUrl();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -133,19 +133,10 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     public DependencyArtifact artifact(Action<? super DependencyArtifact> configureAction) {
         validateNotVariantAware();
         validateNoTargetConfiguration();
-        DefaultDependencyArtifact artifact = createDependencyArtifactWithDefaults();
+        DefaultDependencyArtifact artifact = new DefaultDependencyArtifact(getName(), "jar", null, null, null);
         configureAction.execute(artifact);
         artifact.validate();
         artifacts.add(artifact);
-        return artifact;
-    }
-
-    private DefaultDependencyArtifact createDependencyArtifactWithDefaults() {
-        DefaultDependencyArtifact artifact = new DefaultDependencyArtifact();
-        // Sets the default artifact name to this dependency name
-        // and the type to "jar" by default
-        artifact.setName(getName());
-        artifact.setType("jar");
         return artifact;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.dependencies;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyArtifact;
 
+import javax.annotation.Nullable;
+
 public class DefaultDependencyArtifact implements DependencyArtifact {
     private String name;
     private String type;
@@ -25,10 +27,7 @@ public class DefaultDependencyArtifact implements DependencyArtifact {
     private String classifier;
     private String url;
 
-    public DefaultDependencyArtifact() {
-    }
-
-    public DefaultDependencyArtifact(String name, String type, String extension, String classifier, String url) {
+    public DefaultDependencyArtifact(String name, String type, @Nullable String extension, @Nullable String classifier, @Nullable String url) {
         this.name = name;
         this.type = type;
         this.extension = extension;
@@ -63,23 +62,25 @@ public class DefaultDependencyArtifact implements DependencyArtifact {
         this.type = type;
     }
 
+    @Nullable
     @Override
     public String getExtension() {
         return extension;
     }
 
     @Override
-    public void setExtension(String extension) {
+    public void setExtension(@Nullable String extension) {
         this.extension = extension;
     }
 
+    @Nullable
     @Override
     public String getClassifier() {
         return classifier;
     }
 
     @Override
-    public void setClassifier(String classifier) {
+    public void setClassifier(@Nullable String classifier) {
         this.classifier = classifier;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ParsedModuleStringNotation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ParsedModuleStringNotation.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.IllegalDependencyNotation;
 
+import javax.annotation.Nullable;
+
 public class ParsedModuleStringNotation {
     private String group;
     private String name;
@@ -24,7 +26,7 @@ public class ParsedModuleStringNotation {
     private String classifier;
     private final String artifactType;
 
-    public ParsedModuleStringNotation(String moduleNotation, String artifactType) {
+    public ParsedModuleStringNotation(String moduleNotation, @Nullable String artifactType) {
         assignValuesFromModuleNotation(moduleNotation);
         this.artifactType = artifactType;
     }
@@ -80,6 +82,7 @@ public class ParsedModuleStringNotation {
         return classifier;
     }
 
+    @Nullable
     public String getArtifactType() {
         return artifactType;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelper.java
@@ -19,8 +19,10 @@ import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
 
+import javax.annotation.Nullable;
+
 public class ModuleFactoryHelper {
-    public static void addExplicitArtifactsIfDefined(ExternalDependency moduleDependency, String artifactType, String classifier) {
+    public static void addExplicitArtifactsIfDefined(ExternalDependency moduleDependency, @Nullable String artifactType, @Nullable String classifier) {
         String actualArtifactType = artifactType;
         if (actualArtifactType == null) {
             if (classifier != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -163,7 +163,7 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
     }
 
     private ImmutableMetadataSources createMetadataSources() {
-        MetadataSource<MutableModuleComponentResolveMetadata> artifactMetadataSource = new DefaultArtifactMetadataSource(metadataFactory);
+        MetadataSource<MutableModuleComponentResolveMetadata> artifactMetadataSource = new DefaultArtifactMetadataSource(metadataFactory, true);
         return new DefaultImmutableMetadataSources(Collections.singletonList(artifactMetadataSource));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -247,6 +247,8 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
     private ImmutableMetadataSources createMetadataSources() {
         ImmutableList.Builder<MetadataSource<?>> sources = ImmutableList.builder();
+        sources.add(new DefaultArtifactMetadataSource(metadataFactory, false));
+
         DefaultGradleModuleMetadataSource gradleModuleMetadataSource = new DefaultGradleModuleMetadataSource(moduleMetadataParser, metadataFactory, true, checksumService);
         if (metadataSources.gradleMetadata) {
             sources.add(gradleModuleMetadataSource);
@@ -260,7 +262,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
             }
         }
         if (metadataSources.artifact) {
-            sources.add(new DefaultArtifactMetadataSource(metadataFactory));
+            sources.add(new DefaultArtifactMetadataSource(metadataFactory, true));
         }
         return new DefaultImmutableMetadataSources(sources.build());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -293,6 +293,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     ImmutableMetadataSources createMetadataSources(MavenMetadataLoader mavenMetadataLoader) {
         ImmutableList.Builder<MetadataSource<?>> sources = ImmutableList.builder();
+        sources.add(new DefaultArtifactMetadataSource(metadataFactory, false));
+
         // Don't list versions for gradleMetadata if maven-metadata.xml will be checked.
         boolean listVersionsForGradleMetadata = !metadataSources.mavenPom;
         MetadataSource<MutableModuleComponentResolveMetadata> gradleModuleMetadataSource =
@@ -311,7 +313,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             }
         }
         if (metadataSources.artifact) {
-            sources.add(new DefaultArtifactMetadataSource(metadataFactory));
+            sources.add(new DefaultArtifactMetadataSource(metadataFactory, true));
         }
         return new DefaultImmutableMetadataSources(sources.build());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyNotationParser.java
@@ -84,9 +84,7 @@ public class DependencyNotationParser {
                 moduleDependency.capabilities(dependencyVariant::mutateCapabilities);
                 String classifier = dependencyVariant.getClassifier();
                 String artifactType = dependencyVariant.getArtifactType();
-                if (classifier != null || artifactType != null) {
-                    ModuleFactoryHelper.addExplicitArtifactsIfDefined(moduleDependency, artifactType, classifier);
-                }
+                ModuleFactoryHelper.addExplicitArtifactsIfDefined(moduleDependency, artifactType, classifier);
             }
             result.converted(moduleDependency);
         }
@@ -94,7 +92,5 @@ public class DependencyNotationParser {
         @Override
         public void describe(DiagnosticsVisitor visitor) {
         }
-
-
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyStringNotationConverter.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.notations;
 
 import com.google.common.collect.Interner;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.DependencyConstraint;
@@ -72,7 +73,7 @@ public class DependencyStringNotationConverter<T> implements NotationConverter<S
         if (version.strictly != null) {
             Action<MutableVersionConstraint> versionAction = v -> {
                 v.strictly(version.strictly);
-                if (!version.prefer.isEmpty()) {
+                if (!StringUtils.isEmpty(version.prefer)) {
                     v.prefer(version.prefer);
                 }
             };

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.component.external.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
 
@@ -45,8 +45,8 @@ public class DefaultModuleComponentArtifactIdentifier implements ModuleComponent
 
     @Override
     public String getFileName() {
-        String classifier = GUtil.isTrue(name.getClassifier()) ? "-" + name.getClassifier() : "";
-        String extension = GUtil.isTrue(name.getExtension()) ? "." + name.getExtension() : "";
+        String classifier = StringUtils.isNotEmpty(name.getClassifier()) ? "-" + name.getClassifier() : "";
+        String extension = StringUtils.isNotEmpty(name.getExtension()) ? "." + name.getExtension() : "";
         return name.getName() + "-" + componentIdentifier.getVersion() + classifier + extension;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentOverrideMetadata.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.model;
 import org.gradle.api.artifacts.ClientModule;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * Metadata about a component that will override the information obtained when resolving, typically specified by a dependency descriptor.
@@ -29,9 +28,10 @@ import java.util.List;
 public interface ComponentOverrideMetadata {
 
     /**
-     * If the dependency declared artifacts for the component, return them. Empty otherwise.
+     * If the dependency declared an artifact for the component, return it. Empty otherwise.
      */
-    List<IvyArtifactName> getArtifacts();
+    @Nullable
+    IvyArtifactName getArtifact();
 
     /**
      * If the request originated from a ClientModule, return it. Null otherwise.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -16,20 +16,17 @@
 
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
 
 public class DefaultComponentOverrideMetadata implements ComponentOverrideMetadata {
-    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata(false, (IvyArtifactName) null, null);
+    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata(false, null, null);
 
     private final boolean changing;
-    private final List<IvyArtifactName> artifacts;
+    private final IvyArtifactName artifact;
     private final ClientModule clientModule;
 
     public static ComponentOverrideMetadata forDependency(boolean changing, @Nullable IvyArtifactName mainArtifact, @Nullable ClientModule clientModule) {
@@ -40,12 +37,8 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
     }
 
     private DefaultComponentOverrideMetadata(boolean changing, @Nullable IvyArtifactName artifact, @Nullable ClientModule clientModule) {
-        this(changing, artifact == null ? Collections.emptyList() : ImmutableList.of(artifact), clientModule);
-    }
-
-    private DefaultComponentOverrideMetadata(boolean changing, List<IvyArtifactName> artifacts, @Nullable ClientModule clientModule) {
         this.changing = changing;
-        this.artifacts = artifacts;
+        this.artifact = artifact;
         this.clientModule = clientModule;
     }
 
@@ -62,12 +55,12 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
 
     @Override
     public ComponentOverrideMetadata withChanging() {
-        return new DefaultComponentOverrideMetadata(true, artifacts, clientModule);
+        return new DefaultComponentOverrideMetadata(true, artifact, clientModule);
     }
 
     @Override
-    public List<IvyArtifactName> getArtifacts() {
-        return artifacts;
+    public IvyArtifactName getArtifact() {
+        return artifact;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelperTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelperTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dsl.dependencies
+
+import com.google.common.collect.ImmutableSet
+import org.gradle.api.artifacts.DependencyArtifact
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import spock.lang.Specification
+
+class ModuleFactoryHelperTest extends Specification {
+
+    private static final String MODULE_NAME = 'name'
+
+    private static final DependencyArtifact ARTIFACT =
+        new DefaultDependencyArtifact('name', 'type', 'classifier', 'extension', 'url')
+
+    def "adds new artifact and properly sets transitive if type or classifier is set"() {
+        given:
+        ExternalModuleDependency dep = new DefaultExternalModuleDependency('group', MODULE_NAME, 'version', null)
+        initialArtifacts.each { dep.addArtifact(it) }
+
+        when:
+        ModuleFactoryHelper.addExplicitArtifactsIfDefined(dep, type, classifier)
+
+        then:
+        dep.transitive == transitive
+        dep.artifacts == ImmutableSet.copyOf(artifacts)
+
+        where:
+        initialArtifacts | type  | classifier | transitive | artifacts
+        []               | null  | null       | true       | []
+        [ARTIFACT]       | null  | null       | true       | [ARTIFACT]
+        []               | 'jar' | null       | false      | [newArtifact('jar', null)]
+        [ARTIFACT]       | 'jar' | null       | false      | [ARTIFACT, newArtifact('jar', null)]
+        []               | null  | 'class'    | true       | [newArtifact('jar', 'class')]
+        [ARTIFACT]       | null  | 'class'    | true       | [ARTIFACT, newArtifact('jar', 'class')]
+        []               | 'jar' | 'class'    | false      | [newArtifact('jar', 'class')]
+        [ARTIFACT]       | 'jar' | 'class'    | false      | [ARTIFACT, newArtifact('jar', 'class')]
+    }
+
+    def newArtifact(String type, String classifier) {
+        new DefaultDependencyArtifact(MODULE_NAME, type, type, classifier, null)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.notations
 
 import org.gradle.api.InvalidUserCodeException
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.internal.artifacts.dependencies.DefaultClientModule
@@ -28,7 +27,7 @@ import org.gradle.util.internal.SimpleMapInterner
 import spock.lang.Specification
 
 class DependencyStringNotationConverterTest extends Specification {
-    def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultExternalModuleDependency.class, SimpleMapInterner.notThreadSafe());
+    def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultExternalModuleDependency.class, SimpleMapInterner.notThreadSafe())
 
     def "with artifact"() {
         when:
@@ -171,7 +170,7 @@ class DependencyStringNotationConverterTest extends Specification {
     }
 
     def "can create client module"() {
-        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe());
+        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe())
 
         when:
         def d = parse(parser, 'org.gradle:gradle-core:10')
@@ -191,7 +190,7 @@ class DependencyStringNotationConverterTest extends Specification {
     }
 
     def "client module ignores the artifact only notation"() {
-        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe());
+        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe())
 
         when:
         def d = parse(parser, 'org.gradle:gradle-core:10@jar')
@@ -212,7 +211,7 @@ class DependencyStringNotationConverterTest extends Specification {
     }
 
     def "parses short hand-notation #notation for strict dependencies"() {
-        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe());
+        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe())
 
         when:
         def d = parse(parser, "org.foo:bar:$notation")
@@ -233,7 +232,7 @@ class DependencyStringNotationConverterTest extends Specification {
     }
 
     def "rejects short hand notation for strict if it starts with double-bang"() {
-        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe());
+        def parser = new DependencyStringNotationConverter(TestUtil.instantiatorFactory().decorateLenient(), DefaultClientModule, SimpleMapInterner.notThreadSafe())
 
         when:
         parse(parser, "org.foo:bar:!!1.0")
@@ -244,6 +243,6 @@ class DependencyStringNotationConverterTest extends Specification {
     }
 
     def parse(def parser, def value) {
-        return NotationParserBuilder.toType(Dependency).fromCharSequence(parser).toComposite().parseNotation(value)
+        return NotationParserBuilder.toType(ExternalModuleDependency).fromCharSequence(parser).toComposite().parseNotation(value)
     }
 }


### PR DESCRIPTION
Fixes: #20696

Allow dependencies with explicit artifacts to skip metadata fetching

Allow dependencies declared with an explicit artifact (classifier or extension) to skip metadata fetching (POM/IvyDescriptor). This was implemented by updating the `Default[Ivy,Maven]ArtifactRepository` classes to always add a modified version of the `DefaultArtifactMetadataSource` which attempts to fetch an explicitly declared artifact if defined. This MetadataSource is added before any other metadata source so that it will override any other declared sources.  

This was not caught in the past, as the test we used to verify this functionality was improperly written. It never published the test artifact without a POM and continued to verify that the POM was being fetched. 

Additionally, clean up some code found along the way by:
 * Adding `@Nullable` annotations where applicable
 * Updating `ComponentOverrideMetadata` to return only a single artifact instead of a List since it was only ever initialized with a single value. 
 * Remove `DefaultDependencyArtifact`'s no-arg constructor in favor of using the parameterized constructor. 
 * Replace usage of `GUtil.isTrue` with `StringUtils.isNotEmpty` when we explicitly know a `String` is being used. 
 * Avoid potential NPE in `DependencyStringNotationConverter` by using `StringUtils.isEmpty`
 * Remove semicolons in Groovy test code.
 * Add unit test to `ModuleFactoryHelper`
 