### PR TITLE
Fix sibling versioning for optimistic locking

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/VersionHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/VersionHierarchy.java
@@ -23,22 +23,34 @@ import org.gradle.internal.snapshot.VfsRelativePath;
 
 import javax.annotation.CheckReturnValue;
 
+/**
+ * Node in a structure for tracking modifications in a hierarchy.
+ *
+ * Allows doing optimistic locking to check whether anything in a hierarchy changed.
+ */
 public class VersionHierarchy {
     private final long version;
-    private final long unrelatedToAnyChildVersion;
+    // We store the maximum version as a performance optimization, so we don't need
+    // to query the children every time we query the version for a hierarchy.
+    private final long maxVersionInHierarchy;
     private final ChildMap<VersionHierarchy> children;
 
-    public static VersionHierarchy empty(long rootVersion) {
-        return new VersionHierarchy(EmptyChildMap.getInstance(), rootVersion, rootVersion);
+    public static VersionHierarchy empty(long version) {
+        return new VersionHierarchy(EmptyChildMap.getInstance(), version, version);
     }
 
-    private VersionHierarchy(ChildMap<VersionHierarchy> children, long version, long unrelatedToAnyChildVersion) {
+    private VersionHierarchy(ChildMap<VersionHierarchy> children, long version, long maxVersionInHierarchy) {
         this.children = children;
         this.version = version;
-        this.unrelatedToAnyChildVersion = unrelatedToAnyChildVersion;
+        this.maxVersionInHierarchy = maxVersionInHierarchy;
     }
 
-   public long getVersion(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
+    /**
+     * Queries the version for the hierarchy at relative path.
+     *
+     * The version for the hierarchy is the maximum version of all the locations in the hierarchy.
+     */
+    public long getVersion(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
         return children.withNode(relativePath, caseSensitivity, new ChildMap.NodeHandler<VersionHierarchy, Long>() {
             @Override
             public Long handleAsDescendantOfChild(VfsRelativePath pathInChild, VersionHierarchy child) {
@@ -47,21 +59,29 @@ public class VersionHierarchy {
 
             @Override
             public Long handleAsAncestorOfChild(String childPath, VersionHierarchy child) {
-                return child.getVersion();
+                return child.getMaxVersionInHierarchy();
             }
 
             @Override
             public Long handleExactMatchWithChild(VersionHierarchy child) {
-                return child.getVersion();
+                return child.getMaxVersionInHierarchy();
             }
 
             @Override
             public Long handleUnrelatedToAnyChild() {
-                return unrelatedToAnyChildVersion;
+                return version;
             }
         });
     }
 
+    /**
+     * Creates a new {@link VersionHierarchy} from this {@link VersionHierarchy} with `newVersion` at `relativePath`.
+     *
+     * This method keeps the invariant that the version of a child is bigger than the version of the parent.
+     * This is because modifying the parent implies that all of its children have been modified, so they need to have at least the same version.
+     *
+     * @param newVersion The new version. Must be bigger than the current maximum version in this hierarchy.
+     */
     @CheckReturnValue
     public VersionHierarchy updateVersion(VfsRelativePath relativePath, long newVersion, CaseSensitivity caseSensitivity) {
         ChildMap<VersionHierarchy> newChildren = children.store(relativePath, caseSensitivity, new ChildMap.StoreHandler<VersionHierarchy>() {
@@ -87,13 +107,13 @@ public class VersionHierarchy {
 
             @Override
             public VersionHierarchy createNodeFromChildren(ChildMap<VersionHierarchy> children) {
-                return new VersionHierarchy(children, newVersion, unrelatedToAnyChildVersion);
+                return new VersionHierarchy(children, version, newVersion);
             }
         });
-        return new VersionHierarchy(newChildren, newVersion, unrelatedToAnyChildVersion);
+        return new VersionHierarchy(newChildren, version, newVersion);
     }
 
-    public long getVersion() {
-        return version;
+    public long getMaxVersionInHierarchy() {
+        return maxVersionInHierarchy;
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/VersionHierarchy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/impl/VersionHierarchy.java
@@ -25,15 +25,17 @@ import javax.annotation.CheckReturnValue;
 
 public class VersionHierarchy {
     private final long version;
+    private final long unrelatedToAnyChildVersion;
     private final ChildMap<VersionHierarchy> children;
 
     public static VersionHierarchy empty(long rootVersion) {
-        return new VersionHierarchy(EmptyChildMap.getInstance(), rootVersion);
+        return new VersionHierarchy(EmptyChildMap.getInstance(), rootVersion, rootVersion);
     }
 
-    private VersionHierarchy(ChildMap<VersionHierarchy> children, long version) {
+    private VersionHierarchy(ChildMap<VersionHierarchy> children, long version, long unrelatedToAnyChildVersion) {
         this.children = children;
         this.version = version;
+        this.unrelatedToAnyChildVersion = unrelatedToAnyChildVersion;
     }
 
    public long getVersion(VfsRelativePath relativePath, CaseSensitivity caseSensitivity) {
@@ -55,7 +57,7 @@ public class VersionHierarchy {
 
             @Override
             public Long handleUnrelatedToAnyChild() {
-                return getVersion();
+                return unrelatedToAnyChildVersion;
             }
         });
     }
@@ -85,10 +87,10 @@ public class VersionHierarchy {
 
             @Override
             public VersionHierarchy createNodeFromChildren(ChildMap<VersionHierarchy> children) {
-                return new VersionHierarchy(children, newVersion);
+                return new VersionHierarchy(children, newVersion, unrelatedToAnyChildVersion);
             }
         });
-        return new VersionHierarchy(newChildren, newVersion);
+        return new VersionHierarchy(newChildren, newVersion, unrelatedToAnyChildVersion);
     }
 
     public long getVersion() {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractVirtualFileSystemTest.groovy
@@ -35,12 +35,6 @@ class AbstractVirtualFileSystemTest extends ConcurrentSpec implements TestSnapsh
         }
     }
 
-    def setup() {
-        ['/my', '/my/location/child', '/my/location/sibling', '/my/location/new/other'].each {
-            vfs.invalidate([it])
-        }
-    }
-
     def "does not store snapshot when invalidation happened in between"() {
         def location = '/my/location/new'
         when:

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/VersionHierarchyRootTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/VersionHierarchyRootTest.groovy
@@ -25,7 +25,6 @@ class VersionHierarchyRootTest extends Specification {
     def "#description change implies #result"() {
         updateVersions('/my/path', '/my/sibling', '/my/path/some/child')
 
-
         def versionBefore = versionHierarchyRoot.getVersion("/my/path")
         def versionAtRootBefore = versionHierarchyRoot.getVersion('')
         when:
@@ -50,7 +49,7 @@ class VersionHierarchyRootTest extends Specification {
     }
 
     def "does not update siblings"() {
-        updateVersions('/my', '/my/some/location')
+        updateVersions('/my/some/sibling')
 
         def versionBefore = versionHierarchyRoot.getVersion('/my/some/location')
         when:

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/VersionHierarchyRootTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/VersionHierarchyRootTest.groovy
@@ -58,6 +58,39 @@ class VersionHierarchyRootTest extends Specification {
         versionHierarchyRoot.getVersion('/my/some/location') == versionBefore
     }
 
+    def "sibling is not updated when changing ancestor of child"() {
+        updateVersions('/my/some/child')
+
+        def siblingLocation = "/my/other/sibling"
+        def siblingVersionBefore = versionHierarchyRoot.getVersion(siblingLocation)
+        when:
+        updateVersions('/my/some')
+        then:
+        versionHierarchyRoot.getVersion(siblingLocation) == siblingVersionBefore
+    }
+
+    def "sibling is not updated when changing child with common prefix"() {
+        updateVersions('/my/some/child1')
+
+        def siblingLocation = "/my/other/sibling"
+        def siblingVersionBefore = versionHierarchyRoot.getVersion(siblingLocation)
+        when:
+        updateVersions('/my/some/child2')
+        then:
+        versionHierarchyRoot.getVersion(siblingLocation) == siblingVersionBefore
+    }
+
+    def "sibling is updated when changing ancestor of it"() {
+        updateVersions('/my/some/child')
+
+        def siblingLocation = "/my/some/sibling"
+        def siblingVersionBefore = versionHierarchyRoot.getVersion(siblingLocation)
+        when:
+        updateVersions('/my/some')
+        then:
+        versionHierarchyRoot.getVersion(siblingLocation) > siblingVersionBefore
+    }
+
     def "can query and update the root '#root'"() {
         def locations = ['/my/path', '/my/sibling', '/my/path/some/child']
         updateVersions('/my/path', '/my/sibling', '/my/path/some/child')


### PR DESCRIPTION
The version shouldn't increase if a sibling of a location changes. I found this by looking at the failure of `FileSystemWatchingSoakTest.file watching works with multiple builds on the same
 daemon()`:
 We hadn't been storing the result of snapshotting `src/main/java` in the VFS because some unrelated child in the project directory changed. Since we never invalidated `src/main/java`, we never stored an independent version there.

 This PR fixes the problem by keeping two versions in the `VersionHierarchy`: One for things related to some known invalidated locations and one for the things unrelated to any invalidated location.