### PR TITLE
Migrate CompileOptions.compilerArgs to a ListProperty<String>

### DIFF
--- a/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
+++ b/subprojects/antlr/src/integTest/groovy/org/gradle/api/plugins/antlr/AbstractAntlrIntegrationTest.groovy
@@ -28,7 +28,7 @@ abstract class AbstractAntlrIntegrationTest extends AbstractIntegrationSpec {
                 apply plugin: 'java'
                 ${mavenCentralRepository()}
                 tasks.withType(JavaCompile) {
-                    options.compilerArgs << "-proc:none"
+                    options.compilerArgs.add("-proc:none")
                 }
             }
             project(":grammar-builder") {

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,20 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.getCompilerArgs()",
+            "acceptation": "Migrated to Property",
+            "changes": [
+                "Method return type has changed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.tasks.compile.CompileOptions",
+            "member": "Method org.gradle.api.tasks.compile.CompileOptions.setCompilerArgs(java.util.List)",
+            "acceptation": "Migrated to Property",
+            "changes": [
+                "Method has been removed"
+            ]
+        }
+    ]
 }

--- a/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
+++ b/subprojects/architecture-test/src/changes/archunit_store/public-api-mutable-properties.txt
@@ -258,7 +258,6 @@ Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryInitialSize()> doe
 Method <org.gradle.api.tasks.compile.BaseForkOptions.getMemoryMaximumSize()> does not have raw return type assignable to org.gradle.api.provider.Property in (BaseForkOptions.java:64)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAllCompilerArgs()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:326)
 Method <org.gradle.api.tasks.compile.CompileOptions.getAnnotationProcessorGeneratedSourcesDirectory()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:505)
-Method <org.gradle.api.tasks.compile.CompileOptions.getCompilerArgs()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:316)
 Method <org.gradle.api.tasks.compile.CompileOptions.getCompilerArgumentProviders()> does not have raw return type assignable to org.gradle.api.provider.Provider in (CompileOptions.java:341)
 Method <org.gradle.api.tasks.compile.CompileOptions.getDebugOptions()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:221)
 Method <org.gradle.api.tasks.compile.CompileOptions.getEncoding()> does not have raw return type assignable to org.gradle.api.provider.Property in (CompileOptions.java:188)

--- a/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/patch-module/groovy/build.gradle
@@ -9,7 +9,7 @@ repositories {
 def moduleName = "org.gradle.sample"
 def patchArgs = ["--patch-module", "$moduleName=${tasks.compileJava.destinationDirectory.asFile.get().path}"]
 tasks.named('compileTestJava') {
-    options.compilerArgs += patchArgs
+    options.compilerArgs.addAll(patchArgs)
 }
 tasks.named('test') {
     jvmArgs += patchArgs

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AbstractIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -96,7 +96,7 @@ abstract class AbstractIncrementalAnnotationProcessingIntegrationTest extends Ab
 
     def "explicit -processor option overrides automatic detection"() {
         buildFile << """
-            compileJava.options.compilerArgs << "-processor" << "unknown.Processor"
+            compileJava.options.compilerArgs.addAll("-processor", "unknown.Processor")
         """
         java "class A {}"
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -463,7 +463,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")
             }
-            compileJava.options.compilerArgs += [ "-Werror", "-Amessage=fromOptions" ]
+            compileJava.options.compilerArgs.addAll("-Werror", "-Amessage=fromOptions")
         """
         java "@Helper class A {}"
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -238,7 +238,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
                 implementation project(":processor")
             }
             compileJava {
-                options.compilerArgs << "-proc:none"
+                options.compilerArgs.add("-proc:none")
             }
         """
         removeUseOfGeneratedClass()
@@ -256,7 +256,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
                 annotationProcessor project(":processor")
             }
             compileJava {
-                options.compilerArgs << "-proc:none"
+                options.compilerArgs.add("-proc:none")
             }
         """
         removeUseOfGeneratedClass()
@@ -277,7 +277,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")
             }
-            compileJava.options.compilerArgs << "-processor" << "unknown.Processor"
+            compileJava.options.compilerArgs.addAll("-processor", "unknown.Processor")
         """
 
         expect:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -52,7 +52,7 @@ class JavaCompileIntegrationTest extends AbstractIntegrationSpec {
             subprojects {
                 apply plugin: 'java'
                 tasks.withType(JavaCompile) {
-                    options.compilerArgs << '-Xlint:all' << '-Werror'
+                    options.compilerArgs.addAll('-Xlint:all', '-Werror')
                 }
             }
             project(':b') {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -400,7 +400,7 @@ public class Foo {
                 }
             }
             tasks.withType(JavaCompile).configureEach {
-                options.compilerArgs << "-Xlint:deprecation"
+                options.compilerArgs.add("-Xlint:deprecation")
             }
         """
 
@@ -420,7 +420,7 @@ public class Foo {
             }
         """
 
-        executer.expectDeprecationWarning("$fileWithDeprecation:5: warning: $deprecationMessage");
+        executer.expectDeprecationWarning("$fileWithDeprecation:5: warning: $deprecationMessage")
 
         when:
         runWithToolchainConfigured(jdk)

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/compile/JavaModuleCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/jpms/compile/JavaModuleCompileIntegrationTest.groovy
@@ -118,7 +118,7 @@ class JavaModuleCompileIntegrationTest extends AbstractJavaModuleCompileIntegrat
 
         buildFile << """
             tasks.withType(JavaCompile) {
-                options.compilerArgs += ['--add-reads', 'consumer=ALL-UNNAMED']
+                options.compilerArgs.addAll('--add-reads', 'consumer=ALL-UNNAMED')
             }
         """
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.model.ReplacedBy;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Classpath;
@@ -76,7 +77,7 @@ public class CompileOptions extends AbstractOptions {
 
     private String extensionDirs;
 
-    private List<String> compilerArgs = Lists.newArrayList();
+    private final ListProperty<String> compilerArgs;
     private final List<CommandLineArgumentProvider> compilerArgumentProviders = Lists.newArrayList();
 
     private boolean incremental = true;
@@ -100,6 +101,7 @@ public class CompileOptions extends AbstractOptions {
         this.generatedSourceOutputDirectory = objectFactory.directoryProperty();
         this.headerOutputDirectory = objectFactory.directoryProperty();
         this.release = objectFactory.property(Integer.class);
+        this.compilerArgs = objectFactory.listProperty(String.class);
     }
 
     /**
@@ -312,7 +314,7 @@ public class CompileOptions extends AbstractOptions {
      * are ignored.
      */
     @Input
-    public List<String> getCompilerArgs() {
+    public ListProperty<String> getCompilerArgs() {
         return compilerArgs;
     }
 
@@ -324,7 +326,7 @@ public class CompileOptions extends AbstractOptions {
     @Internal
     public List<String> getAllCompilerArgs() {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
-        builder.addAll(CollectionUtils.stringize(getCompilerArgs()));
+        builder.addAll(CollectionUtils.stringize(getCompilerArgs().get()));
         for (CommandLineArgumentProvider compilerArgumentProvider : getCompilerArgumentProviders()) {
             builder.addAll(compilerArgumentProvider.asArguments());
         }
@@ -339,14 +341,6 @@ public class CompileOptions extends AbstractOptions {
     @Nested
     public List<CommandLineArgumentProvider> getCompilerArgumentProviders() {
         return compilerArgumentProviders;
-    }
-
-    /**
-     * Sets any additional arguments to be passed to the compiler.
-     * Defaults to the empty list.
-     */
-    public void setCompilerArgs(List<String> compilerArgs) {
-        this.compilerArgs = compilerArgs;
     }
 
     /**

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/CompileOptionsTest.groovy
@@ -43,7 +43,7 @@ class CompileOptionsTest extends Specification {
         !compileOptions.verbose
         !compileOptions.fork
 
-        compileOptions.compilerArgs.empty
+        compileOptions.compilerArgs.get().empty
         compileOptions.encoding == null
         compileOptions.bootstrapClasspath == null
         compileOptions.extensionDirs == null
@@ -94,7 +94,7 @@ class CompileOptionsTest extends Specification {
 
     def "converts GStrings to Strings when getting all compiler arguments"() {
         given:
-        compileOptions.compilerArgs << "Foo${23}"
+        compileOptions.compilerArgs.add("Foo${23}")
 
         expect:
         compileOptions.allCompilerArgs.contains('Foo23')

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -314,7 +314,7 @@ task wrongValueTypeDsl {
 
 task wrongRuntimeElementType {
     doLast {
-        verify.prop = [123]
+        verify.prop = [java.time.LocalDate.now()]
         verify.prop.get()
     }
 }
@@ -356,7 +356,7 @@ task wrongPropertyElementTypeApi {
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongRuntimeElementType'.")
-        failure.assertHasCause("Cannot get the value of a property of type java.util.List with element type java.lang.String as the source value contains an element of type java.lang.Integer.")
+        failure.assertHasCause("Cannot get the value of a property of type java.util.List with element type java.lang.String as the source value contains an element of type java.time.LocalDate.")
 
         when:
         fails("wrongPropertyTypeDsl")

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -393,14 +393,14 @@ task thing {
 
         task wrongRuntimeKeyType {
             doLast {
-                verify.prop = [123: 'value']
+                verify.prop = [(java.time.LocalDate.now()): 'value']
                 verify.prop.get()
             }
         }
 
         task wrongRuntimeValueType {
             doLast {
-                verify.prop = ['key': 123]
+                verify.prop = ['key': java.time.LocalDate.now()]
                 verify.prop.get()
             }
         }
@@ -452,13 +452,13 @@ task thing {
         fails('wrongRuntimeKeyType')
         then:
         failure.assertHasDescription("Execution failed for task ':wrongRuntimeKeyType'.")
-        failure.assertHasCause('Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a key of type java.lang.Integer.')
+        failure.assertHasCause('Cannot get the value of a property of type java.util.Map with key type java.lang.String as the source contains a key of type java.time.LocalDate.')
 
         when:
         fails('wrongRuntimeValueType')
         then:
         failure.assertHasDescription("Execution failed for task ':wrongRuntimeValueType'.")
-        failure.assertHasCause('Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a value of type java.lang.Integer.')
+        failure.assertHasCause('Cannot get the value of a property of type java.util.Map with value type java.lang.String as the source contains a value of type java.time.LocalDate.')
 
         when:
         fails('wrongPropertyTypeDsl')

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -390,13 +390,13 @@ extensions.create('custom', SomeExtension)
 
 task wrongValueTypeDsl {
     doLast {
-        custom.prop = 123
+        custom.prop = java.time.LocalDate.now()
     }
 }
 
 task wrongValueTypeApi {
     doLast {
-        custom.prop.set(123)
+        custom.prop.set(java.time.LocalDate.now())
     }
 }
 
@@ -414,14 +414,14 @@ task wrongPropertyTypeApi {
 
 task wrongRuntimeType {
     doLast {
-        custom.prop = providers.provider { 123 }
+        custom.prop = providers.provider { java.time.LocalDate.now() }
         custom.prop.get()
     }
 }
 
 task wrongConventionValueType {
     doLast {
-        custom.prop.convention(123)
+        custom.prop.convention(java.time.LocalDate.now())
     }
 }
 
@@ -433,7 +433,7 @@ task wrongConventionPropertyType {
 
 task wrongConventionRuntimeValueType {
     doLast {
-        custom.prop.convention(providers.provider { 123 })
+        custom.prop.convention(providers.provider { java.time.LocalDate.now() })
         custom.prop.get()
     }
 }
@@ -444,14 +444,14 @@ task wrongConventionRuntimeValueType {
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongValueTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.time.LocalDate.")
 
         when:
         fails("wrongValueTypeApi")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongValueTypeApi'.")
-        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.time.LocalDate.")
 
         when:
         fails("wrongPropertyTypeDsl")
@@ -472,14 +472,14 @@ task wrongConventionRuntimeValueType {
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongRuntimeType'.")
-        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
+        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.time.LocalDate.")
 
         when:
         fails("wrongConventionValueType")
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongConventionValueType'.")
-        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.lang.Integer.")
+        failure.assertHasCause("Cannot set the value of extension 'custom' property 'prop' of type java.lang.String using an instance of type java.time.LocalDate.")
 
         when:
         fails("wrongConventionPropertyType")
@@ -493,7 +493,7 @@ task wrongConventionRuntimeValueType {
 
         then:
         failure.assertHasDescription("Execution failed for task ':wrongConventionRuntimeValueType'.")
-        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.lang.Integer.")
+        failure.assertHasCause("Cannot get the value of extension 'custom' property 'prop' of type java.lang.String as the provider associated with this property returned a value of type java.time.LocalDate.")
     }
 
     def "fails when specialized factory method is not used"() {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSanitizers.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSanitizers.java
@@ -27,7 +27,7 @@ public class ValueSanitizers {
         @Override
         @Nullable
         public Object sanitize(@Nullable Object value) {
-            if (value instanceof GString) {
+            if (value instanceof GString || value instanceof Number) {
                 return value.toString();
             } else {
                 return value;

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -198,7 +198,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
 
         buildFile << """
             compileGroovy {
-                options.compilerArgs << '-proc:none'
+                options.compilerArgs.add('-proc:none')
             }
         """
 
@@ -315,7 +315,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
 
         buildFile << """
             compileGroovy {
-                options.compilerArgs << '-proc:none'
+                options.compilerArgs.add('-proc:none')
             }
         """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -304,7 +304,7 @@ compileJava {
     def "compile with target compatibility"() {
         given:
         goodCode()
-        buildFile.text = buildFile.text.replace("<< '-Werror'", '') // warning: [options] bootstrap class path not set in conjunction with -source 8
+        buildFile.text = buildFile.text.replace(", '-Werror')", ')') // warning: [options] bootstrap class path not set in conjunction with -source 8
         buildFile << """
 java.targetCompatibility = JavaVersion.VERSION_1_9 // ignored
 compileJava.targetCompatibility = '1.8'
@@ -327,7 +327,7 @@ compileJava {
     def "compile with target compatibility set in plugin extension"() {
         given:
         goodCode()
-        buildFile.text = buildFile.text.replace("<< '-Werror'", '') // warning: [options] bootstrap class path not set in conjunction with -source 8
+        buildFile.text = buildFile.text.replace(", '-Werror')", ')') // warning: [options] bootstrap class path not set in conjunction with -source 8
         buildFile << """
 java.targetCompatibility = JavaVersion.VERSION_1_8
 java.sourceCompatibility = JavaVersion.VERSION_1_8

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/JavaCompilerIntegrationSpec.groovy
@@ -21,7 +21,7 @@ abstract class JavaCompilerIntegrationSpec extends BasicJavaCompilerIntegrationS
     def setup() {
         buildFile << """
         tasks.withType(JavaCompile) {
-            options.compilerArgs << '-Xlint:all' << '-Werror'
+            options.compilerArgs.addAll('-Xlint:all', '-Werror')
         }
 """
     }

--- a/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
+++ b/subprojects/plugins/src/integTest/resources/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec/compileJavaFx8Code/build.gradle
@@ -6,7 +6,7 @@ repositories {
 
 compileGroovy {
     if (JavaVersion.current().isJava9()) {
-        options.compilerArgs += ['--add-modules', 'javafx.graphics']
+        options.compilerArgs.addAll(['--add-modules', 'javafx.graphics'])
         groovyOptions.forkOptions.jvmArgs += ['--add-modules', 'javafx.graphics']
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmPluginServices.java
@@ -222,7 +222,7 @@ public class DefaultJvmPluginServices implements JvmPluginServices {
                     if (compileTask.getOptions().getRelease().isPresent()) {
                         majorVersion = Math.max(majorVersion, compileTask.getOptions().getRelease().get());
                     } else {
-                        int releaseFlag = getReleaseOption(compileTask.getOptions().getCompilerArgs());
+                        int releaseFlag = getReleaseOption(compileTask.getOptions().getCompilerArgs().get());
                         if (releaseFlag != 0) {
                             majorVersion = Math.max(majorVersion, releaseFlag);
                         } else {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestingIntegrationTest.groovy
@@ -26,7 +26,9 @@ import org.hamcrest.CoreMatchers
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
-import static org.gradle.testing.fixture.JUnitCoverage.*
+import static org.gradle.testing.fixture.JUnitCoverage.getJUNIT_4_LATEST
+import static org.gradle.testing.fixture.JUnitCoverage.getJUNIT_VINTAGE_JUPITER
+import static org.gradle.testing.fixture.JUnitCoverage.getNEWEST
 import static org.hamcrest.CoreMatchers.equalTo
 
 /**
@@ -325,7 +327,7 @@ class TestingIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             }
             tasks.withType(JavaCompile) {
                 options.with {
-                    compilerArgs << '-parameters'
+                    compilerArgs.add('-parameters')
                 }
             }
         """


### PR DESCRIPTION
To try out if we can mitigate the effects of the change. It seems like the santa tracker smoke tests are failling, since the Android plugin configures compiler arguments.