### PR TITLE
Add pgp.mit.edu to default key servers

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultKeyServers.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/DefaultKeyServers.java
@@ -26,7 +26,8 @@ public abstract class DefaultKeyServers {
     private final static List<URI> DEFAULT_KEYSERVERS = ImmutableList.of(
         uri("hkp://ha.pool.sks-keyservers.net"),
         uri("https://keyserver.ubuntu.com"),
-        uri("https://keys.openpgp.org")
+        uri("https://keys.openpgp.org"),
+        uri("https://pgp.mit.edu")
     );
 
     private static URI uri(String uri) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -8,6 +8,7 @@ Include only their name, impactful features should be called out separately belo
  [Some person](https://github.com/some-person)
 -->
 [altrisi](https://github.com/altrisi)
+[Frosty-J](https://github.com/Frosty-J)
 
 ## Upgrade instructions
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #20728.

### Context
It's a trivial change, so there are no tests. As stated by @yogurtearl, `pgp.mit.edu` is one of the three GPG [key servers listed by Maven](https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key), so we might as well have it.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
