### PR TITLE
Increase internal socket timeout to 60s

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,8 @@ systemProp.org.gradle.internal.ide.scan=true
 # If you're experimenting with changes and don't want to update the verification file right away, please change the mode to "lenient" (not "off")
 org.gradle.dependency.verification=strict
 
+# The default value is 30s, with which we've seen many timeouts sometimes. Let's increase this to 60s.
+systemProp.org.gradle.internal.http.socketTimeout=60000
 
 # TD releated properties
 gradle.internal.testdistribution.writeTraceFile=true


### PR DESCRIPTION
We've seen many timeout exceptions in build cache, let's try
to increase the timeout.