### PR TITLE
Remove workaround for src distribution task

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220504230242+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220510234126+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[Optimistic locking](https://github.com/gradle/gradle/pull/20687) should fix the problem, so we can remove the workaround again.

This reverts commit f4c719b319eb35ca4de47cbaef668fc5d7c7bf53 and updates the wrapper to a nightly containing the fix.