### PR TITLE
Explicitly set PTS server

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.gradle.enterprise.gradleplugin.testdistribution.internal.TestDistributionExtensionInternal
+import com.gradle.enterprise.gradleplugin.testselection.internal.PredictiveTestSelectionExtensionInternal
 import gradlebuild.basics.BuildEnvironment
 import gradlebuild.basics.FlakyTestStrategy
 import gradlebuild.basics.flakyTestStrategy
@@ -321,6 +322,10 @@ fun configureTests() {
             // only supports tasks of the exact type `org.gradle.api.tasks.testing.Test`.
             val supportedTask = taskIdentity.taskType == Test::class.java
 
+            // GitHub actions for contributor PRs uses public build scan instance
+            // in this case we need to explicitly configure the PTS server
+            // Don't move this line into the lambda as it may cause config cache problems
+            (predictiveSelection as PredictiveTestSelectionExtensionInternal).server.set(uri("https://ge.gradle.org"))
             predictiveSelection {
                 enabled.convention(
                     project.predictiveTestSelectionEnabled.zip(project.rerunAllTests) { enabled, rerunAllTests ->


### PR DESCRIPTION
GitHub actions for contributor PRs uses public build scan instance,
in this case we still want to enable PTS, so we need to configure
the server explicitly.
