### PR TITLE
Improve performance of missing dependency detection

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -204,7 +204,7 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
         node.getHardSuccessors().forEach(successor -> {
             // We are searching for dependencies between tasks, so we can skip everything which is not a task when searching.
             // For example we can skip all the transform nodes between two task nodes.
-            if (successor instanceof TaskNode) {
+            if (successor instanceof TaskNode || successor instanceof OrdinalNode) {
                 if (seenNodes.add(successor)) {
                     queue.add(successor);
                 }


### PR DESCRIPTION
when there are many ordinal nodes.

There is a performance optimization in `LocalTaskNodeExecutor. addHardSuccessorTasksToQueue` which doesn't add  nodes to the queue which only have one (or no) hard successor. Before the addition of `OrdinalNode`s, only `LocalTaskNode`s could have more than one. `OrdinalNode`s should be treated the same as `LocalTaskNode`s, so we don't run over and over while determining their dependencies.

#20741