### PR TITLE
Avoid realizing set of all dependencies when creating buildNeeded/buildDependents tasks

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ProviderApiDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ProviderApiDependenciesIntegrationTest.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Issue
+
+class ProviderApiDependenciesIntegrationTest extends AbstractIntegrationSpec {
+    @Issue("https://github.com/gradle/gradle/issues/20722")
+    def "can add dependency with addLater derived from another provider with Java plugin"() {
+        buildFile << """
+plugins {
+    id 'java'
+}
+
+def version = objects.property(String)
+
+configurations.testImplementation.dependencies.addLater(version.map { project.dependencies.create("com.example:artifact:\${it}") })
+
+tasks.all {} // force realize all tasks
+
+version.set('5.6')
+
+assert configurations.testRuntimeClasspath.allDependencies.size() == 1 
+        """
+        expect:
+        succeeds("help")
+    }
+
+    def "can add dependency with addLater derived from another provider indirectly with Java plugin"() {
+        buildFile << """
+plugins {
+    id 'java'
+}
+
+def version = objects.property(String)
+
+configurations.testImplementation.dependencies.addLater(provider { project.dependencies.create("com.example:artifact:\${version.get()}") })
+
+tasks.all {} // force realize all tasks 
+
+version.set('5.6') // later set the provider value
+
+assert configurations.testRuntimeClasspath.allDependencies.size() == 1
+        """
+        expect:
+        succeeds("help")
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -901,7 +901,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public TaskDependency getTaskDependencyFromProjectDependency(final boolean useDependedOn, final String taskName) {
         if (useDependedOn) {
-            return new TasksFromProjectDependencies(taskName, getAllDependencies());
+            return new TasksFromProjectDependencies(taskName, this::getAllDependencies);
         } else {
             return new TasksFromDependentProjects(taskName, getName());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependencies.java
@@ -24,19 +24,20 @@ import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 
 import java.util.Set;
+import java.util.function.Supplier;
 
 class TasksFromProjectDependencies extends AbstractTaskDependency {
     private final String taskName;
-    private final DependencySet dependencies;
+    private final Supplier<DependencySet> dependencies;
 
-    public TasksFromProjectDependencies(String taskName, DependencySet dependencies) {
+    public TasksFromProjectDependencies(String taskName, Supplier<DependencySet> dependencies) {
         this.taskName = taskName;
         this.dependencies = dependencies;
     }
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        resolveProjectDependencies(context, dependencies.withType(ProjectDependency.class));
+        resolveProjectDependencies(context, dependencies.get().withType(ProjectDependency.class));
     }
 
     void resolveProjectDependencies(TaskDependencyResolveContext context, Set<ProjectDependency> projectDependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/TasksFromProjectDependenciesTest.groovy
@@ -26,9 +26,11 @@ import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
+import java.util.function.Supplier
+
 class TasksFromProjectDependenciesTest extends AbstractProjectBuilderSpec {
 
-    def dependencies = Mock(DependencySet)
+    def dependencies = { Mock(DependencySet) } as Supplier<DependencySet>
     def context = Mock(TaskDependencyResolveContext)
     def project1State = Mock(ProjectState)
     def project2State = Mock(ProjectState)


### PR DESCRIPTION

Previously, we would immediately build a list of all dependencies, which caused any
dependency added via addLater to be resolved.

fixes #20722
