### PR TITLE
Fix regex performance issue in AbstractCheckOrUpdateContributorsInReleaseNotes

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/AbstractCheckOrUpdateContributorsInReleaseNotes.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/AbstractCheckOrUpdateContributorsInReleaseNotes.kt
@@ -45,10 +45,6 @@ data class GitHubPullRequest(
 )
 
 
-val contributorSectionRegex =
-    "(?s)(.*We would like to thank the following community members for their contributions to this release of Gradle:\\n)(.*)(\\n<!--\nInclude only their name.*)".toRegex()
-
-
 val contributorLineRegex = "\\[(.*)]\\(https://github.com/(.*)\\)".toRegex()
 
 
@@ -71,16 +67,32 @@ abstract class AbstractCheckOrUpdateContributorsInReleaseNotes : DefaultTask() {
     @Internal
     protected
     fun getContributorsInReleaseNotes(): Set<GitHubUser> {
-        val releaseNotesText = releaseNotes.asFile.get().readText()
-        if (!contributorSectionRegex.containsMatchIn(releaseNotesText)) {
-            throw IllegalStateException("Can't find the contributors section in the release notes $releaseNotes. You may need to update the regular expression.")
-        }
-        return contributorSectionRegex.find(releaseNotesText)!!.groupValues[2].lines()
+        val (_, contributorLines, _) = parseReleaseNotes()
+        return contributorLines
             .map { it.trim() }
             .filter { it.isNotEmpty() }
             .onEach { if (!contributorLineRegex.containsMatchIn(it)) throw IllegalStateException("Invalid contributor line: $it") }
             .map { GitHubUser(contributorLineRegex.find(it)!!.groupValues[2], contributorLineRegex.find(it)!!.groupValues[1]) }
             .toSet()
+    }
+
+    /**
+     * Parses the release notes file and returns the triple: (linesBeforeContributors, contributorLines, linesAfterContributors)
+     */
+    protected
+    fun parseReleaseNotes(): Triple<List<String>, List<String>, List<String>> {
+        val releaseNotesLines: List<String> = releaseNotes.asFile.get().readLines()
+        val contributorSectionBeginIndex = releaseNotesLines.indexOfFirst { it.startsWith("We would like to thank the following community members for their contributions to this release of Gradle:") } + 1
+
+        if (contributorSectionBeginIndex == 0) {
+            throw IllegalStateException("Can't find the contributors section in the release notes $releaseNotes.")
+        }
+
+        val contributorSectionEndIndex = (contributorSectionBeginIndex until releaseNotesLines.size).firstOrNull {
+            val line = releaseNotesLines[it].trim()
+            line.isNotEmpty() && !line.startsWith("[")
+        } ?: throw IllegalStateException("Can't find the contributors section end in the release notes $releaseNotes.")
+        return Triple(releaseNotesLines.subList(0, contributorSectionBeginIndex), releaseNotesLines.subList(contributorSectionBeginIndex, contributorSectionEndIndex), releaseNotesLines.subList(contributorSectionEndIndex, releaseNotesLines.size))
     }
 
     @Internal

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateContributorsInReleaseNotes.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateContributorsInReleaseNotes.kt
@@ -30,10 +30,9 @@ abstract class UpdateContributorsInReleaseNotes : AbstractCheckOrUpdateContribut
         val unrecognizedContributors = contributorsFromPullRequests.keys - contributorsInReleaseNotes.keys
         if (unrecognizedContributors.isNotEmpty()) {
             val contributorsToUpdate = contributorsInReleaseNotes + unrecognizedContributors.map { it to contributorsFromPullRequests[it]!! }
-            val textBeforeContributorsSection = contributorSectionRegex.find(releaseNotes.asFile.get().readText())!!.groupValues[1]
-            val textAfterContributorsSection = contributorSectionRegex.find(releaseNotes.asFile.get().readText())!!.groupValues[3]
+            val (linesBeforeContributors, _, linesAfterContributors) = parseReleaseNotes()
             releaseNotes.asFile.get().writeText(
-                "$textBeforeContributorsSection${contributorsToUpdate.entries.joinToString(",\n") { "[${it.value.name ?: it.key}](https://github.com/${it.key})" }}\n$textAfterContributorsSection"
+                "${linesBeforeContributors.joinToString("\n")}\n${contributorsToUpdate.entries.joinToString(",\n") { "[${it.value.name ?: it.key}](https://github.com/${it.key})" }}\n\n${linesAfterContributors.joinToString("\n")}"
             )
         } else {
             println("Contributors in the release notes are up to date.")

--- a/subprojects/docs/src/docs/release/notes-template.md
+++ b/subprojects/docs/src/docs/release/notes-template.md
@@ -2,11 +2,11 @@ The Gradle team is excited to announce Gradle @version@.
 
 This release features [1](), [2](), ... [n](), and more.
 
-We would like to thank the following community members for their contributions to this release of Gradle:
 <!-- 
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 -->
+We would like to thank the following community members for their contributions to this release of Gradle:
 
 ## Upgrade instructions
 


### PR DESCRIPTION
The regex we used to parse release notes had performance issues
in some cases. Use string manipulation instead.

```
"Execution worker" #1824 prio=5 os_prio=0 cpu=354271.15ms elapsed=390.89s tid=0x00007f43e8005000 nid=0x2c62ba runnable  [0x00007f4298cd7000]
   java.lang.Thread.State: RUNNABLE
	at java.util.regex.Pattern$CharPropertyGreedy.match(java.base@11.0.15/Pattern.java:4297)
	at java.util.regex.Pattern$GroupHead.match(java.base@11.0.15/Pattern.java:4804)
	at java.util.regex.Pattern$Start.match(java.base@11.0.15/Pattern.java:3619)
	at java.util.regex.Matcher.search(java.base@11.0.15/Matcher.java:1729)
	at java.util.regex.Matcher.find(java.base@11.0.15/Matcher.java:746)
	at kotlin.text.Regex.containsMatchIn(Regex.kt:110)
	at gradlebuild.buildutils.tasks.AbstractCheckOrUpdateContributorsInReleaseNotes.getContributorsInReleaseNotes(AbstractCheckOrUpdateContributorsInReleaseNotes.kt:75)
	at gradlebuild.buildutils.tasks.CheckContributorsInReleaseNotes.check(CheckContributorsInReleaseNotes.kt:28)
```