### PR TITLE
add suiteThreadPoolSize option

### DIFF
--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/testng/TestNGOptionsTest.groovy
@@ -38,6 +38,7 @@ class TestNGOptionsTest extends Specification {
             listeners.empty
             parallel == null
             threadCount == -1
+            suiteThreadPoolSize == 1
             suiteName == 'Gradle suite'
             testName == 'Gradle test'
             configFailurePolicy == DEFAULT_CONFIG_FAILURE_POLICY

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGVersionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/AbstractTestNGVersionIntegrationTest.groovy
@@ -28,4 +28,8 @@ class AbstractTestNGVersionIntegrationTest extends MultiVersionIntegrationSpec {
     static boolean supportConfigFailurePolicy() {
         return versionNumber >= VersionNumber.parse('5.13')
     }
+
+    static boolean supportSuiteThreadPoolSize() {
+        return versionNumber >= VersionNumber.parse('5.14')
+    }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -45,6 +45,9 @@ class TestNGFailurePolicyIntegrationTest extends AbstractTestNGVersionIntegratio
     }
 
     def "skips tests after a config method failure by default"() {
+        given:
+        assumeTrue(supportSuiteThreadPoolSize())
+
         expect:
         fails "test"
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
@@ -29,6 +29,7 @@ public class TestNGSpec implements Serializable {
     private final String defaultTestName;
     private final String parallel;
     private final int threadCount;
+    private final int suiteThreadPoolSize;
     private final boolean useDefaultListener;
     private final Set<String> includeGroups;
     private final Set<String> excludeGroups;
@@ -45,6 +46,7 @@ public class TestNGSpec implements Serializable {
         this.defaultTestName = options.getTestName();
         this.parallel = options.getParallel();
         this.threadCount = options.getThreadCount();
+        this.suiteThreadPoolSize = options.getSuiteThreadPoolSize();
         this.useDefaultListener = options.getUseDefaultListeners();
         this.includeGroups = options.getIncludeGroups();
         this.excludeGroups = options.getExcludeGroups();
@@ -75,6 +77,10 @@ public class TestNGSpec implements Serializable {
 
     public int getThreadCount() {
         return threadCount;
+    }
+
+    public int getSuiteThreadPoolSize() {
+        return suiteThreadPoolSize;
     }
 
     public String getParallel() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -110,7 +110,7 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         if (options.getThreadCount() > 0) {
             testNg.setThreadCount(options.getThreadCount());
         }
-
+        testNg.setSuiteThreadPoolSize(options.getSuiteThreadPoolSize());
         Class<?> configFailurePolicyArgType = getConfigFailurePolicyArgType(testNg);
         Object configFailurePolicyArgValue = getConfigFailurePolicyArgValue(testNg);
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/testng/TestNGOptions.java
@@ -49,6 +49,7 @@ public class TestNGOptions extends TestFrameworkOptions {
     public static final String DEFAULT_CONFIG_FAILURE_POLICY = "skip";
     private static final String DEFAULT_PARALLEL_MODE = null;
     private static final int DEFAULT_THREAD_COUNT = -1;
+    private static final int SUITE_THREAD_POOL_SIZE_DEFAULT = 1;
 
     private File outputDirectory;
 
@@ -63,6 +64,8 @@ public class TestNGOptions extends TestFrameworkOptions {
     private String parallel = DEFAULT_PARALLEL_MODE;
 
     private int threadCount = DEFAULT_THREAD_COUNT;
+
+    private int suiteThreadPoolSize = SUITE_THREAD_POOL_SIZE_DEFAULT;
 
     private boolean useDefaultListeners;
 
@@ -283,6 +286,18 @@ public class TestNGOptions extends TestFrameworkOptions {
 
     public void setThreadCount(int threadCount) {
         this.threadCount = threadCount;
+    }
+
+    /**
+     * The number of XML suites will run parallel
+     */
+    @Internal
+    public int getSuiteThreadPoolSize() {
+        return suiteThreadPoolSize;
+    }
+
+    public void setSuiteThreadPoolSize(int suiteThreadPoolSize) {
+        this.suiteThreadPoolSize = suiteThreadPoolSize;
     }
 
     @Internal


### PR DESCRIPTION
Signed-off-by: sergey gotovsky <thomas56miller@gmail.com>

<!--- The issue this PR addresses -->
Fixes #20773

### Context
TestNg have an option to run xml suites in parallel. It's very useful feature for project with big count tests stored in xml (with other params like parallel/threads-count/parameter/etc), but we still can't set up this option via gradle. In this pr I try to add this option. 

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
