### PR TITLE
Simplify documentation for missing inputs

### DIFF
--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -282,7 +282,7 @@ The symptoms are similar to <<implicit_dependency>> except that in this case the
 
 Please refer to the <<implicit_dependency>> section for possible solutions.
 If the file isn't produced by another task, you may want to make sure that it exists before the task is called.
-If what you want to declare is that it doesn't matter that the file exists or not when the task is executed, you can use an `@Optional` input to allow Gradle to capture the input's state:
+If what you want to declare is that it doesn't matter that the file exists or not when the task is executed, you can use `@InputFiles` that won't fail for non-existing inputs:
 
 ====
 include::sample[dir="snippets/tasks/customTaskWithMissingFileProperty/groovy",files="build.gradle[tags=task]"]

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/groovy/build.gradle
@@ -2,14 +2,8 @@
 // tag::task[]
 abstract class GreetingFileTask extends DefaultTask {
 
-    @Internal
+    @InputFiles
     abstract RegularFileProperty getSource()
-
-    @InputFile
-    @Optional
-    protected Provider<RegularFile> getSourceInternal() {
-        source.map { it.asFile.exists() ? it : null }
-    }
 
     @OutputFile
     abstract RegularFileProperty getDestination()

--- a/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tasks/customTaskWithMissingFileProperty/kotlin/build.gradle.kts
@@ -2,12 +2,8 @@
 // tag::task[]
 abstract class GreetingFileTask : DefaultTask() {
 
-    @get:Internal
+    @get:InputFiles
     abstract val source: RegularFileProperty
-
-    @InputFile
-    @Optional
-    protected fun getSourceInternal() = source.map { if (it.asFile.exists()) it else null }
 
     @get:OutputFile
     abstract val destination: RegularFileProperty


### PR DESCRIPTION
You can use `@InputFiles` instead to tell Gradle that it's okay if the file does not exist.
