### PR TITLE
#16498 Add map notation platform dependencies to Kotlin DSL

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensions.kt
@@ -18,6 +18,7 @@ package org.gradle.kotlin.dsl
 
 import org.gradle.api.artifacts.ClientModule
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ProjectDependency
@@ -296,3 +297,75 @@ inline fun <T : ModuleDependency> DependencyHandler.add(
  */
 fun <T : ModuleDependency> T.exclude(group: String? = null, module: String? = null): T =
     uncheckedCast(exclude(excludeMapFor(group, module)))
+
+
+/**
+ * Declares a dependency on a platform. If the target coordinates represent multiple
+ * potential components, the platform component will be selected, instead of the library.
+ *
+ * @param group the group of the platform to be added as a dependency.
+ * @param name the name of the platform to be added as a dependency.
+ * @param version the optional version of the platform to be added as a dependency.
+ * @param configuration the optional configuration of the platform to be added as a dependency.
+ * @param classifier the optional classifier of the platform artifact to be added as a dependency.
+ * @param ext the optional extension of the platform artifact to be added as a dependency.
+ *
+ * @return The dependency.
+ *
+ * @see [DependencyHandler.platform]
+ */
+fun DependencyHandler.platform(
+    group: String,
+    name: String,
+    version: String? = null,
+    configuration: String? = null,
+    classifier: String? = null,
+    ext: String? = null
+): Dependency =
+    platform(
+        mapOfNonNullValuesOf(
+            "group" to group,
+            "name" to name,
+            "version" to version,
+            "configuration" to configuration,
+            "classifier" to classifier,
+            "ext" to ext
+        )
+    )
+
+
+/**
+ * Declares a dependency on an enforced platform. If the target coordinates represent multiple
+ * potential components, the platform component will be selected, instead of the library.
+ * An enforced platform is a platform for which the direct dependencies are forced, meaning
+ * that they would override any other version found in the graph.
+ *
+ * @param group the group of the platform to be added as a dependency.
+ * @param name the name of the platform to be added as a dependency.
+ * @param version the optional version of the platform to be added as a dependency.
+ * @param configuration the optional configuration of the platform to be added as a dependency.
+ * @param classifier the optional classifier of the platform artifact to be added as a dependency.
+ * @param ext the optional extension of the platform artifact to be added as a dependency.
+ *
+ * @return The dependency.
+ *
+ * @see [DependencyHandler.enforcedPlatform]
+ */
+fun DependencyHandler.enforcedPlatform(
+    group: String,
+    name: String,
+    version: String? = null,
+    configuration: String? = null,
+    classifier: String? = null,
+    ext: String? = null
+): Dependency =
+    enforcedPlatform(
+        mapOfNonNullValuesOf(
+            "group" to group,
+            "name" to name,
+            "version" to version,
+            "configuration" to configuration,
+            "classifier" to classifier,
+            "ext" to ext
+        )
+    )

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/DependencyHandlerExtensionsTest.kt
@@ -400,6 +400,64 @@ class DependencyHandlerExtensionsTest {
 
         verify(dependencyHandler).addProvider(eq("config"), eq(notation), any<Action<ExternalModuleDependency>>())
     }
+
+    @Test
+    fun `given group, name, version, configuration, classifier and ext, 'platform' extension will build corresponding map`() {
+
+        val expectedPlatformMap = mapOf(
+            "group" to "g",
+            "name" to "n",
+            "version" to "v",
+            "configuration" to "cfg",
+            "classifier" to "cls",
+            "ext" to "x"
+        )
+
+        val dependencies = newDependencyHandlerMock()
+        val dependency: ExternalModuleDependency = mock()
+        whenever(dependencies.platform(expectedPlatformMap)).thenReturn(dependency)
+
+        assertThat(
+            dependencies.platform(
+                group = "g",
+                name = "n",
+                version = "v",
+                configuration = "cfg",
+                classifier = "cls",
+                ext = "x"
+            ),
+            sameInstance(dependency)
+        )
+    }
+
+    @Test
+    fun `given group, name, version, configuration, classifier and ext, 'enforcedPlatform' extension will build corresponding map`() {
+
+        val expectedEnforcedPlatformMap = mapOf(
+            "group" to "g",
+            "name" to "n",
+            "version" to "v",
+            "configuration" to "cfg",
+            "classifier" to "cls",
+            "ext" to "x"
+        )
+
+        val dependencies = newDependencyHandlerMock()
+        val dependency: ExternalModuleDependency = mock()
+        whenever(dependencies.enforcedPlatform(expectedEnforcedPlatformMap)).thenReturn(dependency)
+
+        assertThat(
+            dependencies.enforcedPlatform(
+                group = "g",
+                name = "n",
+                version = "v",
+                configuration = "cfg",
+                classifier = "cls",
+                ext = "x"
+            ),
+            sameInstance(dependency)
+        )
+    }
 }
 
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #16498 

### Context
As per #16948:

> In the interests of consistency, and hence intuitiveness, platform/BOM dependencies should be declared in the same way as regular module dependencies. For the same reason, notation that is valid in the Groovy DSL should have an analog in the Kotlin DSL.
> 
> In my opinion, map notation is easier to understand, and less prone to fat-finger errors.
> 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
