### PR TITLE
Instrument indy-based Groovy call sites

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithIndyIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithIndyIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+class ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithIndyIntegrationTest extends AbstractConfigurationCacheExternalProcessInstrumentationInDynamicGroovyIntegrationTest {
+    @Override
+    boolean enableIndy() {
+        return true
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithoutIndyIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithoutIndyIntegrationTest.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+class ConfigurationCacheExternalProcessInstrumentationInDynamicGroovyWithoutIndyIntegrationTest extends AbstractConfigurationCacheExternalProcessInstrumentationInDynamicGroovyIntegrationTest {
+    @Override
+    boolean enableIndy() {
+        return false
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/AbstractInvocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/AbstractInvocation.java
@@ -16,14 +16,14 @@
 
 package org.gradle.internal.classpath.intercept;
 
-import org.codehaus.groovy.runtime.wrappers.Wrapper;
+import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
 
 /**
  * A base implementation of the Invocation that provides everything except {@link #callOriginal()}.
  *
  * @param <R> the type of the receiver
  */
-abstract class AbstractInvocation<R> implements CallInterceptor.Invocation {
+abstract class AbstractInvocation<R> implements Invocation {
     protected final R receiver;
     protected final Object[] args;
 
@@ -47,10 +47,4 @@ abstract class AbstractInvocation<R> implements CallInterceptor.Invocation {
         return unwrap(args[pos]);
     }
 
-    private static Object unwrap(Object obj) {
-        if (obj instanceof Wrapper) {
-            return ((Wrapper) obj).unwrap();
-        }
-        return obj;
-    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/Invocation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.intercept;
+
+import org.codehaus.groovy.runtime.callsite.CallSite;
+
+/**
+ * Represents a single invocation of the intercepted method/constructor/property.
+ */
+public interface Invocation {
+    /**
+     * Returns the receiver of the invocation.
+     * It can be a {@link Class} if the invocation targets constructor, static method, or static property.
+     * It can be the instance if the invocation targets the instance method or property.
+     *
+     * @return the receiver of the method
+     * @see CallSite
+     */
+    Object getReceiver();
+
+    /**
+     * Returns a number of arguments supplied for this invocation.
+     */
+    int getArgsCount();
+
+    /**
+     * Returns an <b>unwrapped</b> argument at the position {@code pos}.
+     * Arguments are numbered left-to-right, from 0 to {@code getArgsCount() - 1} inclusive.
+     * Throws {@link ArrayIndexOutOfBoundsException} if {@code pos} is outside the bounds.
+     *
+     * @param pos the position of the argument
+     * @return the unwrapped value of the argument
+     */
+    Object getArgument(int pos);
+
+    /**
+     * Returns an <b>unwrapped</b> argument at the position {@code pos} or {@code null} if the {@code pos} is greater or equal than {@link #getArgsCount()}.
+     * This method is useful for handling optional arguments represented as "telescopic" overloads, like the one of the {@code Runtime.exec}:
+     * <pre>
+     *     Runtime.exec("/usr/bin/echo")
+     *     Runtime.exec("/usr/bin/echo", new String[] {"FOO=BAR"})
+     * </pre>
+     *
+     * @param pos the position of the argument
+     * @return the unwrapped value of the argument or {@code null} if {@code pos >= getArgsCount()}
+     */
+    default Object getOptionalArgument(int pos) {
+        return pos < getArgsCount() ? getArgument(pos) : null;
+    }
+
+    /**
+     * Forwards the call to the original Groovy implementation and returns the result.
+     *
+     * @return the value produced by the original Groovy implementation
+     * @throws Throwable if the original Groovy implementation throws
+     */
+    Object callOriginal() throws Throwable;
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/InvocationUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.intercept;
+
+import org.codehaus.groovy.runtime.wrappers.Wrapper;
+
+class InvocationUtils {
+    private InvocationUtils() {}
+
+    static Object unwrap(Object obj) {
+        if (obj instanceof Wrapper) {
+            return ((Wrapper) obj).unwrap();
+        }
+        return obj;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/intercept/MethodHandleInvocation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.classpath.intercept;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.gradle.internal.classpath.intercept.InvocationUtils.unwrap;
+
+/**
+ * The implementation of {@link Invocation} that forwards the call to a MethodHandle. Supports both normal and spread Groovy calls.
+ */
+class MethodHandleInvocation implements Invocation {
+    private final MethodHandle original;
+    private final Object[] originalArgs;
+    private final Object[] unspreadArgs;
+    private final int unspreadArgsOffset;
+
+    public MethodHandleInvocation(MethodHandle original, Object[] originalArgs, boolean isSpread) {
+        this.original = original;
+        this.originalArgs = originalArgs;
+        if (isSpread) {
+            unspreadArgs = (Object[]) originalArgs[1];
+            unspreadArgsOffset = 0;
+        } else {
+            unspreadArgs = originalArgs;
+            unspreadArgsOffset = 1;
+        }
+    }
+
+    @Override
+    public Object getReceiver() {
+        return unwrap(originalArgs[0]);
+    }
+
+    @Override
+    public int getArgsCount() {
+        return unspreadArgs.length - unspreadArgsOffset;
+    }
+
+    @Override
+    public Object getArgument(int pos) {
+        return unwrap(unspreadArgs[pos + unspreadArgsOffset]);
+    }
+
+    @Override
+    public Object callOriginal() throws Throwable {
+        return original.invokeExact(originalArgs);
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -235,7 +235,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
+        def cachedFile = testDir.file("cached/16fa923fc1ec782f28887195acdc5401/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -263,7 +263,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def dir = testDir.file("thing.dir")
         classesDir(dir)
         def classpath = DefaultClassPath.of(dir)
-        def cachedFile = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
+        def cachedFile = testDir.file("cached/d4d760260e067b91216f90d0d5a7ac5c/thing.dir.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -293,8 +293,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(dir, file)
-        def cachedDir = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
-        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
+        def cachedDir = testDir.file("cached/d4d760260e067b91216f90d0d5a7ac5c/thing.dir.jar")
+        def cachedFile = testDir.file("cached/16fa923fc1ec782f28887195acdc5401/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -351,8 +351,8 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file3 = testDir.file("thing3.jar")
         jar(file3)
         def classpath = DefaultClassPath.of(dir, file, dir2, file2, dir3, file3)
-        def cachedDir = testDir.file("cached/2a394a2c80ba9bd4e62f7bfe48f4367c/thing.dir.jar")
-        def cachedFile = testDir.file("cached/a0ff919f7115600becaeee69464d82cf/thing.jar")
+        def cachedDir = testDir.file("cached/d4d760260e067b91216f90d0d5a7ac5c/thing.dir.jar")
+        def cachedFile = testDir.file("cached/16fa923fc1ec782f28887195acdc5401/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic)
@@ -372,7 +372,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         def file = testDir.file("thing.jar")
         jar(file)
         def classpath = DefaultClassPath.of(file)
-        def cachedFile = testDir.file("cached/f5f441108338e7d1bebb5460a1fce0d9/thing.jar")
+        def cachedFile = testDir.file("cached/90b54e71cfa1cf2192b11e3e12e93caa/thing.jar")
 
         when:
         def cachedClasspath = transformer.transform(classpath, BuildLogic, transform)


### PR DESCRIPTION
Modern Groovy versions use Java 7's invokedynamic instruction to do a
dynamic dispatch of methods/constructors/properties. This commits
enables the configuration cache to intercept such dynamic calls and
infer implicit build inputs used in code compiled with invokedynamic
option enabled.

This is a prerequisite to the migration to Groovy 4 as a runtime for the
Gradle build scripts because Groovy 4 has indy as the only option.

<!--- The issue this PR addresses -->
Fixes #20794 
