### PR TITLE
Consume class directories, not jars, for aggregated Jacoco report

### DIFF
--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing.jacoco.plugins
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.testing.jacoco.plugins.fixtures.JacocoReportXmlFixture
+import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.startsWith
 
@@ -187,6 +188,34 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         then:
         def report = new JacocoReportXmlFixture(file("application/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml"))
         report.assertDoesNotContainClass("org.apache.commons.io.IOUtils")
+    }
+
+    @Issue('https://github.com/gradle/gradle/issues/20432')
+    def "aggregated report resolves classes variant of project dependencies"() {
+        given:
+        file("application/build.gradle") << """
+            apply plugin: 'org.gradle.jacoco-report-aggregation'
+
+            tasks.register('dumpAllCodeCoverageReportClassDirectoriesConfiguration') {
+                logger.lifecycle(configurations.allCodeCoverageReportClassDirectories.asPath)
+            }
+        """
+        file("transitive/build.gradle") << """
+            dependencies {
+                implementation 'org.apache.commons:commons-io:1.3.2'
+            }
+        """
+
+        when:
+        succeeds(':application:dumpAllCodeCoverageReportClassDirectoriesConfiguration')
+
+        then:
+        outputContains('application/build/classes/java/main')
+        outputDoesNotContain('application/build/libs/application-1.0.jar')
+        outputContains('direct/build/classes/java/main')
+        outputDoesNotContain('direct/build/libs/direct-1.0.jar')
+        outputContains('transitive/build/classes/java/main')
+        outputDoesNotContain('transitive/build/libs/transitive-1.0.jar')
     }
 
     def 'aggregated report infers dependency versions from platform'() {

--- a/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
+++ b/subprojects/jacoco/src/integTest/groovy/org/gradle/testing/jacoco/plugins/JacocoAggregationIntegrationTest.groovy
@@ -210,12 +210,12 @@ class JacocoAggregationIntegrationTest extends AbstractIntegrationSpec {
         succeeds(':application:dumpAllCodeCoverageReportClassDirectoriesConfiguration')
 
         then:
-        outputContains('application/build/classes/java/main')
-        outputDoesNotContain('application/build/libs/application-1.0.jar')
-        outputContains('direct/build/classes/java/main')
-        outputDoesNotContain('direct/build/libs/direct-1.0.jar')
-        outputContains('transitive/build/classes/java/main')
-        outputDoesNotContain('transitive/build/libs/transitive-1.0.jar')
+        outputContains(file('application/build/classes/java/main').absolutePath)
+        outputDoesNotContain(file('application/build/libs/application-1.0.jar').absolutePath)
+        outputContains(file('direct/build/classes/java/main').absolutePath)
+        outputDoesNotContain(file('direct/build/libs/direct-1.0.jar').absolutePath)
+        outputContains(file('transitive/build/classes/java/main').absolutePath)
+        outputDoesNotContain(file('transitive/build/libs/transitive-1.0.jar').absolutePath)
     }
 
     def 'aggregated report infers dependency versions from platform'() {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.LibraryElements;
 import org.gradle.api.attributes.TestSuiteType;
 import org.gradle.api.attributes.VerificationType;
 import org.gradle.api.file.FileCollection;
@@ -87,6 +88,9 @@ public abstract class JacocoReportAggregationPlugin implements Plugin<Project> {
         classDirectoriesConf.setVisible(false);
         classDirectoriesConf.setCanBeConsumed(false);
         classDirectoriesConf.setCanBeResolved(true);
+        classDirectoriesConf.attributes(attributes -> {
+            attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.class, LibraryElements.CLASSES));
+        });
 
         ArtifactView classDirectories = classDirectoriesConf.getIncoming().artifactView(view -> {
             view.componentFilter(id -> id instanceof ProjectComponentIdentifier);


### PR DESCRIPTION
Fixes #20432. Configuration `allCodeCoverageReportClassDirectories` was not explicitly requesting the correct `LibraryElements` attribute and incorrectly consuming jars instead of the classes directories.