### PR TITLE
Simplify `DefaultVersionCatalogBuilder` integration with the config cache

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/InstrumentedInputAccessListener.kt
@@ -117,6 +117,10 @@ class InstrumentedInputAccessListener(
         undeclaredInputBroadcast.fileOpened(file, consumer)
     }
 
+    override fun fileObserved(file: File, consumer: String?) {
+        undeclaredInputBroadcast.fileObserved(file, consumer)
+    }
+
     override fun fileCollectionObserved(fileCollection: FileCollection, consumer: String) {
         undeclaredInputBroadcast.fileCollectionObserved(fileCollection, consumer)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/UndeclaredBuildInputListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/UndeclaredBuildInputListener.kt
@@ -34,4 +34,6 @@ interface UndeclaredBuildInputListener {
     fun fileOpened(file: File, consumer: String?)
 
     fun fileCollectionObserved(fileCollection: FileCollection, consumer: String)
+
+    fun fileObserved(file: File, consumer: String?)
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -198,9 +198,14 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     override fun fileObserved(file: File) {
+        fileObserved(file, null)
+    }
+
+    override fun fileObserved(file: File, consumer: String?) {
         if (inputTrackingDisabledForThread) {
             return
         }
+        // Ignore consumer for now, only used by Gradle internals and so shouldn't appear in the report.
         captureFile(file)
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/Instrumented.java
@@ -67,6 +67,10 @@ public class Instrumented {
         }
 
         @Override
+        public void fileObserved(File file, String consumer) {
+        }
+
+        @Override
         public void fileCollectionObserved(FileCollection fileCollection, String consumer) {
         }
     };
@@ -357,6 +361,10 @@ public class Instrumented {
         listener().fileCollectionObserved(fileCollection, consumer);
     }
 
+    public static void fileObserved(File file, String consumer) {
+        listener().fileObserved(absoluteFileOf(file), consumer);
+    }
+
     public static void fileOpened(File file, String consumer) {
         listener().fileOpened(absoluteFileOf(file), consumer);
     }
@@ -482,6 +490,8 @@ public class Instrumented {
          * @param consumer the name of the class that is opening the file
          */
         void fileOpened(File file, String consumer);
+
+        void fileObserved(File file, String consumer);
 
         /**
          * Invoked when configuration logic observes the given file collection.


### PR DESCRIPTION
By introducing the static `Instrumented.fileObserved` which can be used from different service scopes.
