### PR TITLE
Extract registering `javaToolchains` extension to a separate plugin `jvm-toolchains`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/plugins/ApplyPluginBuildOperationIntegrationTest.groovy
@@ -46,6 +46,7 @@ class ApplyPluginBuildOperationIntegrationTest extends AbstractIntegrationSpec {
             "org.gradle.api.plugins.JavaPlugin": "org.gradle.java",
             "org.gradle.api.plugins.JavaBasePlugin": null,
             "org.gradle.api.plugins.JvmEcosystemPlugin": null,
+            "org.gradle.api.plugins.JvmToolchainsPlugin": null,
             "org.gradle.api.plugins.BasePlugin": null,
             "org.gradle.language.base.plugins.LifecycleBasePlugin": null,
             "org.gradle.api.plugins.ReportingBasePlugin": null,

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -52,7 +52,6 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.deprecation.DeprecatableConfiguration;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
 import org.gradle.jvm.toolchain.internal.ToolchainSpecInternal;
@@ -117,6 +116,7 @@ public class JavaBasePlugin implements Plugin<Project> {
         project.getPluginManager().apply(BasePlugin.class);
         project.getPluginManager().apply(JvmEcosystemPlugin.class);
         project.getPluginManager().apply(ReportingBasePlugin.class);
+        project.getPluginManager().apply(JvmToolchainsPlugin.class);
 
         DefaultJavaPluginExtension javaPluginExtension = addExtensions(projectInternal);
 
@@ -134,7 +134,6 @@ public class JavaBasePlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = (SourceSetContainer) project.getExtensions().getByName("sourceSets");
         DefaultJavaPluginExtension javaPluginExtension = (DefaultJavaPluginExtension) project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, project, sourceSets, toolchainSpec, jvmPluginServices);
         project.getConvention().getPlugins().put("java", new DefaultJavaPluginConvention(project, javaPluginExtension));
-        project.getExtensions().create(JavaToolchainService.class, "javaToolchains", DefaultJavaToolchainService.class, getJavaToolchainQueryService());
         return javaPluginExtension;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmToolchainsPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmToolchainsPlugin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.internal.DefaultJavaToolchainService;
+import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
+
+import javax.inject.Inject;
+
+/**
+ * A plugin that provides JVM toolchains for projects that need to execute Java from local JVM installations or run the tools included in a JDK.
+ * The plugin makes {@link JavaToolchainService} available via a project extension.
+ *
+ * @since 7.6
+ */
+@Incubating
+public class JvmToolchainsPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project target) {
+        target.getExtensions().create(JavaToolchainService.class, "javaToolchains", DefaultJavaToolchainService.class, javaToolchainQueryService);
+    }
+
+    private final JavaToolchainQueryService javaToolchainQueryService;
+
+    @Inject
+    public JvmToolchainsPlugin(JavaToolchainQueryService javaToolchainQueryService) {
+        this.javaToolchainQueryService = javaToolchainQueryService;
+    }
+}

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.jvm-toolchains.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.jvm-toolchains.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.JvmToolchainsPlugin

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JvmToolchainsPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JvmToolchainsPluginTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+
+class JvmToolchainsPluginTest extends AbstractProjectBuilderSpec {
+
+    def setup() {
+        project.pluginManager.apply(JvmToolchainsPlugin)
+    }
+
+    def "available under jvm-toolchains id"() {
+        expect:
+        project.pluginManager.hasPlugin("jvm-toolchains")
+    }
+
+    def "registers javaToolchains extension"() {
+        expect:
+        project.extensions.getByType(JavaToolchainService) == project.extensions.getByName("javaToolchains")
+    }
+
+    def "toolchain service dependencies are satisfied"() {
+        expect:
+        project.extensions.getByType(JavaToolchainService).launcherFor(new CurrentJvmToolchainSpec(project.objects)).get().executablePath.asFile.isFile()
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -207,7 +207,19 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
 
         then:
         def plugins = getPluginConfigurationOperationResult(":").getPluginApplicationResults().collect { it.plugin.displayName }
-        if (targetVersion > GradleVersion.version("7.2")) {
+        if (targetVersion >= GradleVersion.version("7.6")) {
+            assert plugins == [
+                "org.gradle.help-tasks", "org.gradle.build-init", "org.gradle.wrapper",
+                "build.gradle", "script.gradle",
+                "org.gradle.java", "org.gradle.api.plugins.JavaBasePlugin",
+                "org.gradle.api.plugins.BasePlugin",
+                "org.gradle.language.base.plugins.LifecycleBasePlugin",
+                "org.gradle.api.plugins.JvmEcosystemPlugin",
+                "org.gradle.api.plugins.ReportingBasePlugin",
+                "org.gradle.api.plugins.JvmToolchainsPlugin",
+                "org.gradle.jvm-test-suite", "org.gradle.test-suite-base"
+            ]
+        } else if (targetVersion > GradleVersion.version("7.2")) {
             assert plugins == [
                 "org.gradle.help-tasks", "org.gradle.build-init", "org.gradle.wrapper",
                 "build.gradle", "script.gradle",


### PR DESCRIPTION
Fixes #19234