### PR TITLE
Add a configure method to the testing block to allow for configuring multiple test suites and avoid duplication

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/TestingExtension.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/TestingExtension.java
@@ -16,8 +16,11 @@
 
 package org.gradle.testing.base;
 
+import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.Incubating;
+
+import java.util.List;
 
 /**
  * This DSL element exists to contain a collection of {@link TestSuite}s.
@@ -32,4 +35,38 @@ public interface TestingExtension {
      * The type of test suites available depend on which other plugins are applied.
      */
     ExtensiblePolymorphicDomainObjectContainer<TestSuite> getSuites();
+
+    /**
+     * Eagerly configure the given test suites.
+     * <p>
+     * This method can be used to avoid duplicating common configuration logic which is shared between test suites.  The test suites must
+     * exist at the time this method is called.
+     * <p>
+     * <pre><code>
+     *  testing {
+     *      suites {
+     *          test { ...}
+     *          integrationTest(JvmTestSuite) { ...}
+     *          functionalTest(JvmTestSuite) { ...}
+     *
+     *          // Add AssertJ to the default and integration test suites, but NOT the functional test suite
+     *          configure([test, integrationTest]) {
+     *              dependencies {
+     *                  implementation 'org.assertj:assertj-core:3.21.0'
+     *              }
+     *          }
+     *      }
+     *  }
+     * </code></pre>
+     * <p>
+     * See also: {@link ExtensiblePolymorphicDomainObjectContainer#configureEach(Action)} and {@link ExtensiblePolymorphicDomainObjectContainer#withType(Class, Action)}
+     * for alternate means of configuring multiple test suites within this container.
+     *
+     * @param testSuites list of test suites to configure
+     * @param configureAction action to apply to each test suite
+     *
+     * @since 7.6
+     */
+    @Incubating
+    void configure(List<TestSuite> testSuites, Action<? super TestSuite> configureAction);
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/testing/base/internal/DefaultTestingExtension.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/testing/base/internal/DefaultTestingExtension.java
@@ -16,14 +16,20 @@
 
 package org.gradle.testing.base.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.testing.base.TestSuite;
 import org.gradle.testing.base.TestingExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.List;
 
 public abstract class DefaultTestingExtension implements TestingExtension {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultTestingExtension.class);
+
     private final ExtensiblePolymorphicDomainObjectContainer<TestSuite> suites;
 
     @Inject
@@ -37,5 +43,12 @@ public abstract class DefaultTestingExtension implements TestingExtension {
     @Override
     public ExtensiblePolymorphicDomainObjectContainer<TestSuite> getSuites() {
         return suites;
+    }
+
+    @Override
+    public void configure(List<TestSuite> testSuites, Action<? super TestSuite> configureAction) {
+        for (TestSuite testSuite : testSuites) {
+            configureAction.execute(testSuite);
+        }
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Related to #19870 and #19686
