### PR TITLE
Fix version catalog alias snippets

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/groovy/settings.gradle
@@ -90,8 +90,8 @@ dependencyResolutionManagement {
     versionCatalogs {
         testLibs {
             def junit5 = version('junit5', '5.7.1')
-            library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').version(junit5)
-            library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').version(junit5)
+            library('junit-api', 'org.junit.jupiter', 'junit-jupiter-api').versionRef(junit5)
+            library('junit-engine', 'org.junit.jupiter', 'junit-jupiter-engine').versionRef(junit5)
         }
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/catalogs-settings/kotlin/settings.gradle.kts
@@ -114,8 +114,8 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("testLibs") {
             val junit5 = version("junit5", "5.7.1")
-            library("junit-api", "org.junit.jupiter", "junit-jupiter-api").version(junit5)
-            library("junit-engine", "org.junit.jupiter", "junit-jupiter-engine").version(junit5)
+            library("junit-api", "org.junit.jupiter", "junit-jupiter-api").versionRef(junit5)
+            library("junit-engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef(junit5)
         }
     }
 }


### PR DESCRIPTION
Fixes #20852

### Context
The snippet meant to build the alias with a `versionRef`, created just above it.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
