### PR TITLE
Mention help task from help option

### DIFF
--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -343,7 +343,8 @@ image::gradle-completion-4.0.gif[]
 == Debugging options
 
 `-?`, `-h`, `--help`::
-Shows a help message with all available CLI options.
+Shows a help message with the built-in CLI options.
+To show project-contextual options, including help on a specific task, see the `help` task.
 
 `-v`, `--version`::
 Prints Gradle, Groovy, Ant, JVM, and operating system version information and exit without executing any tasks.

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -181,6 +181,10 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
 
         @Override
         public void execute(ExecutionListener executionListener) {
+            System.out.println();
+            System.out.print("To see help contextual to the project, use ");
+            clientMetaData().describeCommand(System.out, "help");
+            System.out.println();
             showUsage(System.out, parser);
         }
     }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -185,6 +185,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         commandLineExecution.execute(executionListener)
 
         then:
+        outputs.stdOut.contains('To see help contextual to the project, use gradle help')
         outputs.stdOut.contains('USAGE: gradle [option...] [task...]')
         outputs.stdOut.contains('--help')
         outputs.stdOut.contains('--some-option')
@@ -205,6 +206,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         commandLineExecution.execute(executionListener)
 
         then:
+        outputs.stdOut.contains('To see help contextual to the project, use gradle-app help')
         outputs.stdOut.contains('USAGE: gradle-app [option...] [task...]')
     }
 


### PR DESCRIPTION
Fixes #19296

### Context

Users using the --help option don't understand that plug-in contributed options are not included in the description produced by --help. The help task should be used for that. This PR adds a highly evident blurb to the output produced by the --help option to direct the user to the help task. It also makes some clarification on the documentation for the -help option.
   