### PR TITLE
Support `@Ignore` in verifyPerformanceScenarioDefinitions task

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinitionVerifier.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestScenarioDefinitionVerifier.groovy
@@ -29,7 +29,11 @@ class PerformanceTestScenarioDefinitionVerifier {
         File newFile = new File(args[1])
         PerformanceTestScenarioDefinition oldJson = new ObjectMapper().readValue(oldFile, PerformanceTestScenarioDefinition).sort()
         PerformanceTestScenarioDefinition newJson = new ObjectMapper().readValue(newFile, PerformanceTestScenarioDefinition).sort()
-        if (oldJson != newJson) {
+
+        oldJson.removeIgnoredScenarios(newJson.ignoredScenarios)
+        newJson.removeIgnoredScenarios(newJson.ignoredScenarios)
+
+        if (oldJson.performanceTests != newJson.performanceTests) {
             int size = Math.min(oldJson.performanceTests.size(), newJson.performanceTests.size())
             int firstDifferentElementIndex = size
             for (int i = 0; i < size; ++i) {


### PR DESCRIPTION
Previously, people can't simply `@Ignore` a performance scenario
because that would break `verifyPerformanceScenarioDefinitions`.
Now we scan the `@Ignore` annotated scenarios and take them into
consideration.

The implementation is a bit tricky, though:

Because we can't get the real test id (the `@Unroll`ed test method name) when the test is ignored, we have to store the `testMethodRegex` in JSON. For example, for a Spock feature method `'this is a test #parameter'()`, we store `\Qthis is a test \E.+` as "testMethodRegex", so that we can exclude the ignored scenarios in `verifyPerformanceScenarioDefinitions` task.
