### PR TITLE
Use `-PrerunAllTests` in RerunFlakyTest builds

### DIFF
--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -58,7 +58,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
         steps {
             gradleWrapper {
                 name = "GRADLE_RUNNER_$idx"
-                tasks = "%$testTaskParameterName% --rerun --tests %$testNameParameterName% %$testTaskOptionsParameterName%"
+                tasks = "%$testTaskParameterName% -PrerunAllTests --tests %$testNameParameterName% %$testTaskOptionsParameterName%"
                 gradleParams = parameters
                 executionMode = BuildStep.ExecutionMode.ALWAYS
             }
@@ -103,7 +103,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
             "",
             display = ParameterDisplay.PROMPT,
             allowEmpty = true,
-            description = "Additional options for the test task to run"
+            description = "Additional options for the test task to run (`-PrerunAllTests` is already added implicitly)"
         )
     }
 


### PR DESCRIPTION
Instead of previous `--rerun` because `--rerun` only works
with `DistributionTest`.
