### PR TITLE
Disable PTS for unit test

### DIFF
--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -310,7 +310,7 @@ fun configureTests() {
             }
         }
 
-        if (project.supportsPredictiveTestSelection()) {
+        if (project.supportsPredictiveTestSelection() && !isUnitTest()) {
             // Temporary workaround for Gradle Enterprise issue which in 2022.2 and 2022.2.1
             // only supports tasks of the exact type `org.gradle.api.tasks.testing.Test`.
             val supportedTask = taskIdentity.taskType == Test::class.java


### PR DESCRIPTION
We found a few classloader issues in unit tests:

https://github.com/gradle/ge/issues/15437

Now let's disable PTS (and TD) for unit tests.
