### PR TITLE
Fix issue loading from configuration cache when a task runs at both configuration and execution time

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildLogicIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIncludedBuildLogicIntegrationTest.groovy
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.test.fixtures.file.TestFile
+
+class ConfigurationCacheIncludedBuildLogicIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+    TestFile pluginSourceFile
+
+    def setup() {
+        settingsFile << "includeBuild('build-logic')"
+        def rootDir = file("build-logic")
+        rootDir.file("settings.gradle") << """
+            rootProject.name="lib"
+        """
+        rootDir.file("build.gradle") << """
+            plugins {
+                id("java-gradle-plugin")
+            }
+            group="lib"
+            gradlePlugin {
+                plugins {
+                    p {
+                        id = "test.plugin"
+                        implementationClass = "test.PluginImpl"
+                    }
+                }
+            }
+        """
+        pluginSourceFile = rootDir.file("src/main/java/test/PluginImpl.java")
+        pluginSourceFile << """
+            package test;
+
+            import ${Project.name};
+            import ${Plugin.name};
+
+            public class PluginImpl implements Plugin<Project> {
+                public void apply(Project project) { }
+            }
+        """
+        buildFile("""
+            plugins {
+                id("test.plugin")
+            }
+        """)
+    }
+
+    def "does not run build logic tasks when loaded from cache"() {
+        def fixture = newConfigurationCacheFixture()
+        buildFile("""
+            task assemble {
+            }
+        """)
+
+        when:
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar",
+            ":assemble")
+        fixture.assertStateStored()
+
+        when:
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(":assemble")
+        fixture.assertStateLoaded()
+
+        when:
+        pluginSourceFile << """
+            // some change
+        """
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar",
+            ":assemble")
+        fixture.assertStateStored()
+    }
+
+    def "does not run build logic tasks when loaded from the cache even when the tasks are requested on the command-line"() {
+        def fixture = newConfigurationCacheFixture()
+
+        when:
+        configurationCacheRun(":build-logic:classes")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar")
+        fixture.assertStateStored()
+
+        when:
+        configurationCacheRun(":build-logic:classes")
+
+        then:
+        result.assertTasksExecuted()
+        fixture.assertStateLoaded()
+
+        when:
+        pluginSourceFile << """
+            // some change
+        """
+        configurationCacheRun(":build-logic:classes")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar")
+        fixture.assertStateStored()
+    }
+
+    def "does not run build logic tasks when loaded from the cache even when the tasks are also dependencies of requested tasks"() {
+        def fixture = newConfigurationCacheFixture()
+        buildFile("""
+            plugins {
+                id("java-library")
+            }
+            dependencies {
+                implementation("lib:lib:1.0")
+            }
+        """)
+
+        when:
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar",
+            ":processResources",
+            ":compileJava",
+            ":classes",
+            ":jar",
+            ":assemble"
+        )
+        fixture.assertStateStored()
+
+        when:
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(
+            ":processResources",
+            ":compileJava",
+            ":classes",
+            ":jar",
+            ":assemble"
+        )
+        fixture.assertStateLoaded()
+
+        when:
+        pluginSourceFile << """
+            // some change
+        """
+        configurationCacheRun("assemble")
+
+        then:
+        result.assertTasksExecuted(
+            ":build-logic:compileJava",
+            ":build-logic:pluginDescriptors",
+            ":build-logic:processResources",
+            ":build-logic:classes",
+            ":build-logic:jar",
+            ":processResources",
+            ":compileJava",
+            ":classes",
+            ":jar",
+            ":assemble")
+        fixture.assertStateStored()
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -543,9 +543,18 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
 
     @Override
     public ScheduledNodes getScheduledNodes() {
-        // Take an immutable copy, as this can be mutated (eg if the result is used after execution has completed and clear() has been called).
-        ImmutableList<Node> nodes = ImmutableList.copyOf(nodeMapping.nodes);
-        return visitor -> lockCoordinator.withStateLock(() -> visitor.accept(nodes));
+        // Take an immutable copy of the nodes, as the set of nodes for this plan can be mutated (e.g. if the result is used after execution has completed and clear() has been called).
+        ImmutableList.Builder<Node> builder = ImmutableList.builderWithExpectedSize(nodeMapping.nodes.size());
+        for (Node node : nodeMapping.nodes) {
+            // Do not include a task from another build when that task has already executed
+            // Most nodes that have already executed are filtered in `doAddNodes()` but these particular nodes are node
+            // It would be better to also remove these nodes in `doAddNodes()`
+            if (node instanceof TaskInAnotherBuild && ((TaskInAnotherBuild) node).getTask().getState().getExecuted()) {
+                continue;
+            }
+            builder.add(node);
+        }
+        return visitor -> lockCoordinator.withStateLock(() -> visitor.accept(builder.build()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -73,7 +73,8 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName(), readAttributes(decoder), readCapabilities(decoder));
+            String projectName = decoder.readString();
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, projectName, readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
@@ -111,7 +112,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             return Collections.emptyList();
         }
         ImmutableList.Builder<Capability> builder = ImmutableList.builderWithExpectedSize(size);
-        for (int i=0; i<size; i++) {
+        for (int i = 0; i < size; i++) {
             builder.add(new ImmutableCapability(decoder.readString(), decoder.readString(), decoder.readNullableString()));
         }
         return builder.build();
@@ -160,6 +161,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
+            encoder.writeString(projectComponentSelector.getProjectName());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
             writeCapabilities(encoder, projectComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
@@ -207,11 +209,15 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             if (projectComponentSelector.getIdentityPath().equals(Path.ROOT) && isARootProject) {
                 return Implementation.ROOT_PROJECT;
             }
-            if (projectComponentSelector.getIdentityPath().equals(projectComponentSelector.projectPath()) && projectComponentSelector.projectPath().getName().equals(projectComponentSelector.getProjectName())) {
-                return Implementation.ROOT_BUILD_PROJECT;
-            }
-            if (isARootProject && projectComponentSelector.getProjectName().equals(projectComponentSelector.getIdentityPath().getName())) {
+            if (isARootProject) {
                 return Implementation.OTHER_BUILD_ROOT_PROJECT;
+            }
+            // For non-root project, project name must be the last element of the project path
+            if (!projectComponentSelector.getProjectName().equals(projectComponentSelector.projectPath().getName())) {
+                throw new IllegalArgumentException("Unexpected name for project " + projectComponentSelector.projectPath() + ". Expected: " + projectComponentSelector.projectPath().getName() + ", found: " + projectComponentSelector.getProjectName());
+            }
+            if (projectComponentSelector.getIdentityPath().equals(projectComponentSelector.projectPath())) {
+                return Implementation.ROOT_BUILD_PROJECT;
             }
             return Implementation.OTHER_BUILD_PROJECT;
         } else if (value instanceof DefaultLibraryComponentSelector) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -92,7 +92,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes other build root ProjectComponentSelector"() {
         given:
-        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), path(":prefix:a:someProject"), Path.ROOT, "someProject", ImmutableAttributes.EMPTY, capabilities())
+        def selector = new DefaultProjectComponentSelector(new DefaultBuildIdentifier("build"), path(":prefix"), Path.ROOT, "someProject", ImmutableAttributes.EMPTY, capabilities())
 
         when:
         def result = serialize(selector, serializer)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
