### PR TITLE
Fix TestLauncher cross-version test failure

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTestSpecCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTestSpecCrossVersionSpec.groovy
@@ -33,7 +33,7 @@ class TestLauncherTestSpecCrossVersionSpec extends TestLauncherSpec {
         withFailingTest() // ensures that withTestsFor statements are not ignored
     }
 
-    @TargetGradleVersion('>=2.6 <7.6')
+    @TargetGradleVersion('>=2.7 <7.6')
     def "older Gradle versions ignore withTestsFor calls"() {
         when:
         launchTests { TestLauncher launcher ->


### PR DESCRIPTION
The TAPI protocol interfaces exercised in the test were introduced
in Gradle 2.7, therefore it is expected that the assertions are only
valid starting from that version.
