### PR TITLE
Add support for built-in per-task rerun option

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionIntegrationTest.groovy
@@ -125,14 +125,14 @@ class CachedTaskExecutionIntegrationTest extends AbstractIntegrationSpec impleme
         cacheDir.listFiles() as List == []
 
         when:
-        withBuildCache().run"compileJava", "jar"
+        withBuildCache().run "compileJava", "jar"
         def originalCacheContents = listCacheFiles()
         def originalModificationTimes = originalCacheContents.collect { file -> TestFile.makeOlder(file); file.lastModified() }
         then:
         noneSkipped()
 
         when:
-        withBuildCache().run"compileJava", "jar", "--rerun"
+        withBuildCache().run "compileJava", "jar", "--rerun"
         then:
         skipped ":compileJava"
         executedAndNotSkipped ":jar"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
@@ -34,7 +34,10 @@ abstract class AbstractOptionElement implements OptionElement {
         this(readDescription(option, optionName, declaringClass), optionName, optionType);
     }
 
-    private AbstractOptionElement(String description, String optionName, Class<?> optionType) {
+    protected AbstractOptionElement(String description, String optionName, Class<?> optionType) {
+        if (description == null) {
+            throw new OptionValidationException(String.format("No description set on option '%s'.", optionName));
+        }
         this.description = description;
         this.optionName = optionName;
         this.optionType = optionType;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/AbstractOptionElement.java
@@ -35,9 +35,6 @@ abstract class AbstractOptionElement implements OptionElement {
     }
 
     protected AbstractOptionElement(String description, String optionName, Class<?> optionType) {
-        if (description == null) {
-            throw new OptionValidationException(String.format("No description set on option '%s'.", optionName));
-        }
         this.description = description;
         this.optionName = optionName;
         this.optionType = optionType;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BuiltInOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BuiltInOptionElement.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.options;
+
+import org.gradle.api.Task;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Built-in options are additional task options available
+ * to all tasks.
+ *
+ * A built-in option is always a flag/modifier,
+ * and, as such, does not take an argument.
+ */
+public class BuiltInOptionElement extends AbstractOptionElement {
+    /**
+     * The action to be performed in case the option is specified.
+     */
+    private final Consumer<Task> optionAction;
+
+    public BuiltInOptionElement(String description, String optionName, Consumer<Task> optionAction) {
+        super(description, optionName, Void.TYPE);
+        this.optionAction = optionAction;
+    }
+
+    @Override
+    public Set<String> getAvailableValues() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void apply(Object object, List<String> parameterValues) {
+        optionAction.accept((Task) object);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BuiltInOptionElement.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/BuiltInOptionElement.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Built-in options are additional task options available
  * to all tasks.
@@ -37,8 +39,8 @@ public class BuiltInOptionElement extends AbstractOptionElement {
     private final Consumer<Task> optionAction;
 
     public BuiltInOptionElement(String description, String optionName, Consumer<Task> optionAction) {
-        super(description, optionName, Void.TYPE);
-        this.optionAction = optionAction;
+        super(requireNonNull(description), requireNonNull(optionName), Void.TYPE);
+        this.optionAction = requireNonNull(optionAction);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/options/OptionReader.java
@@ -75,7 +75,7 @@ public class OptionReader {
             options.put(optionElement.getOptionName(), new InstanceOptionDescriptor(target, optionElement, optionValueMethod));
         }
         List<OptionDescriptor> taskOptions = CollectionUtils.sort(options.values());
-        // add additional built-in options only if they not clash with declared options
+        // add additional built-in options only if they do not clash with declared options
         for (OptionDescriptor builtInOption : buildBuiltInOptions(target)) {
             if (!options.containsKey(builtInOption.getName())) {
                 taskOptions.add(builtInOption);

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -25,6 +25,9 @@ class HelpTaskIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     public final TestResources resources = new TestResources(temporaryFolder)
     def version = GradleVersion.current().version
+    def builtInOptions = """
+     --rerun     Causes the task to be re-run even if up-to-date.
+""".readLines().tail().join("\n")
 
     def "shows help message when tasks #tasks run in a directory with no build definition present"() {
         useTestDirectoryThatIsNotEmbeddedInAnotherBuild()
@@ -224,6 +227,8 @@ Type
 Options
      --configuration     The configuration to generate the report for.
 
+${builtInOptions}
+
 Description
      Displays all dependencies declared in root project '${testDirectory.getName()}'.
 
@@ -247,6 +252,8 @@ Type
 
 Options
      --task     The task to show help for.
+
+${builtInOptions}
 
 Description
      Displays a help message.
@@ -283,6 +290,9 @@ Paths
 
 Type
      Task (org.gradle.api.Task)
+
+Options
+${builtInOptions}
 
 Descriptions
      (:hello) hello task from root
@@ -328,6 +338,9 @@ Paths
 Type
      Task (org.gradle.api.Task)
 
+Options
+${builtInOptions}
+
 Description
      -
 
@@ -354,6 +367,9 @@ Path
 Type
      Jar (org.gradle.api.tasks.bundling.Jar)
 
+Options
+${builtInOptions}
+
 Description
      Assembles a jar archive containing the main classes.
 
@@ -373,6 +389,9 @@ Paths
 
 Type
      Jar (org.gradle.api.tasks.bundling.Jar)
+
+Options
+${builtInOptions}
 
 Description
      Assembles a jar archive containing the main classes.
@@ -408,6 +427,9 @@ Path
 Type
      Copy (org.gradle.api.tasks.Copy)
 
+Options
+${builtInOptions}
+
 Description
      a copy operation
 
@@ -421,6 +443,9 @@ Path
 
 Type
      Jar (org.gradle.api.tasks.bundling.Jar)
+
+Options
+${builtInOptions}
 
 Description
      an archiving operation
@@ -458,6 +483,9 @@ Path
 
 Type
      Task (org.gradle.api.Task)
+
+Options
+${builtInOptions}
 
 Description
      a description
@@ -506,6 +534,8 @@ Options
                           DEF
                           GHIJKL
 
+${builtInOptions}
+
 Description
      -
 
@@ -534,6 +564,8 @@ Options
                             optionA
                             optionB
                             optionC
+
+${builtInOptions}
 
 Description
      -

--- a/subprojects/docs/src/samples/writing-tasks/task-with-arguments/tests/help.out
+++ b/subprojects/docs/src/samples/writing-tasks/task-with-arguments/tests/help.out
@@ -12,6 +12,8 @@ Options
                        JSON
                        PLAIN
 
+     --rerun     Causes the task to be re-run even if up-to-date.
+
 Description
      Displays current project info
 

--- a/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/tests/helpTaskOptions.out
+++ b/subprojects/docs/src/snippets/tasks/commandLineOption-optionValues/tests/helpTaskOptions.out
@@ -14,6 +14,8 @@ Options
 
      --url     Configures the URL to be write to the output.
 
+     --rerun     Causes the task to be re-run even if up-to-date.
+
 Description
      -
 

--- a/subprojects/docs/src/snippets/tutorial/projectReports/tests/taskHelp.out
+++ b/subprojects/docs/src/snippets/tutorial/projectReports/tests/taskHelp.out
@@ -7,6 +7,9 @@ Paths
 Type
      Task (org.gradle.api.Task)
 
+Options
+     --rerun     Causes the task to be re-run even if up-to-date.
+
 Description
      Builds the JAR
 


### PR DESCRIPTION
Issue  #9166 description provides a great summary, but the primary
reason is to allow users to rerun specific tasks (that would otherwise
not be run), like test, without incurring the overhead of re-running all
other tasks (be it for the sake of time saving, or such as when
benchmarking a specific task, such as in #20641).

Additionally, when Gradle has a cache corruption issue (see “Corrupt
plugin jars end up in Gradle's local caches #20830”), rerunning the
affected tasks is the easiest and finest-grained workaround instead of
messing up with local cache state (or resorting to a full re-run of the
task graph).

Issues: #9166, #20641

[Spec doc](https://docs.google.com/document/d/1nmw8IW89NOD4R_ipsYOOTa3pE8VjRdhxQlgiMIWZb-8/edit?usp=sharing ) (please request access if needed)

### Notes to the reader

This change set includes changes to existing tests/sample files that require to know the exact output of a help task invocation, and this change affects the output of every help task invocation as there is now a built-in --rerun option showing there.