### PR TITLE
Enable configuration caching for running :kotlin-dsl* integration tests

### DIFF
--- a/build-logic-settings/build-logic-settings-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/build-logic-settings-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -21,9 +21,14 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
         // Working tasks that would otherwise be matched by filters below
         task.name in listOf(
             "publishLocalPublicationToLocalRepository",
-            "validateExternalPlugins",
+            "publishEmbeddedKotlinPluginMarkerMavenPublicationToTestRepository",
+            "publishKotlinDslBasePluginMarkerMavenPublicationToTestRepository",
+            "publishKotlinDslCompilerSettingsPluginMarkerMavenPublicationToTestRepository",
+            "publishKotlinDslPluginMarkerMavenPublicationToTestRepository",
+            "publishKotlinDslPrecompiledScriptPluginsPluginMarkerMavenPublicationToTestRepository",
+            "publishPluginMavenPublicationToTestRepository",
+            "publishPluginsToTestRepository",
         ) -> false
-        task.name.startsWith("validatePluginWithId") -> false
 
         // Core tasks
         task.name in listOf(

--- a/build-logic/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.kotlin-dsl-plugin-bundle.gradle.kts
@@ -58,12 +58,13 @@ val localRepository = layout.buildDirectory.dir("repository")
 
 val publishPluginsToTestRepository by tasks.registering {
     dependsOn("publishPluginMavenPublicationToTestRepository")
+    val repoDir = localRepository // Prevent capturing the Gradle script instance for configuration cache compatibility
     // This should be unified with publish-public-libraries if possible
     doLast {
-        localRepository.get().asFileTree.matching { include("**/maven-metadata.xml") }.forEach {
+        repoDir.get().asFileTree.matching { include("**/maven-metadata.xml") }.forEach {
             it.writeText(it.readText().replace("\\Q<lastUpdated>\\E\\d+\\Q</lastUpdated>\\E".toRegex(), "<lastUpdated>${Year.now().value}0101000000</lastUpdated>"))
         }
-        localRepository.get().asFileTree.matching { include("**/*.module") }.forEach {
+        repoDir.get().asFileTree.matching { include("**/*.module") }.forEach {
             val content = it.readText()
                 .replace("\"buildId\":\\s+\"\\w+\"".toRegex(), "\"buildId\": \"\"")
                 .replace("\"size\":\\s+\\d+".toRegex(), "\"size\": 0")


### PR DESCRIPTION
By fixing a task and declaring involved supported tasks as compatible.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
