### PR TITLE
Add an includeInCheck() method to JvmTestSuite

### DIFF
--- a/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/core-plugins/base_plugin.adoc
@@ -34,7 +34,8 @@ include::sample[dir="snippets/base/basePlugin/kotlin",files="build.gradle.kts[ta
 Deletes the build directory and everything in it, i.e. the path specified by the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:buildDir[Project.getBuildDir()] project property.
 
 `check` — _lifecycle task_::
-Plugins and build authors should attach their verification tasks, such as ones that run tests, to this lifecycle task using `check.dependsOn(__task__)`.
+Plugins and build authors should attach their verification tasks, such as ones that run tests, to this lifecycle task using `check.dependsOn(__task__)`  If defining additional test suites using the <<jvm_test_suite_plugin.adoc#jvm_test_suite_plugin,JVM Test Suite Plugin>>, users should call the
+link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html#org.gradle.api.plugins.jvm.JvmTestSuite:includeInCheck[JvmTestSuite.includeInCheck()] method to configure those suites' `test` tasks to run upon running `check`.
 
 `assemble` — _lifecycle task_::
 Plugins and build authors should attach tasks that produce distributions and other consumable artifacts to this lifecycle task. For example, `jar` produces the consumable artifact for Java libraries. Attach tasks to this lifecycle task using `assemble.dependsOn(__task__)`.

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -105,9 +105,10 @@ include::sample[dir="snippets/testing/test-suite-plugin/kotlin",files="build.gra
 <2> Configure the built-in `test` suite.  This suite is automatically created for backwards compatibility.  You *must* specify a testing framework to use in order to run these tests (e.g. JUnit 4, JUnit Jupiter).  This suite is the only suite that will automatically have access to the production source's `implementation` dependencies, all other suites must explicitly declare these.
 <3> Declare this test suite uses JUnit Jupiter.  The framework's dependencies are automatically included.  It is always necessary to explicitly configure the built-in `test` suite even if JUnit4 is desired.
 <4> Define a new suite called `integrationTest`.  Note that all suites other than the built-in `test` suite will by convention work as if `useJUnitJupiter()` was called.  You do *not* have to explicitly configure the testing framework on these additional suites, unless you wish to change to another framework.
-<5> Add a dependency on the production code of the project to the `integrationTest` suite targets.  By convention, only the built-in `test` suite will automatically have a dependency on the production code of the project.
-<6> Configure all targets of this suite.  By convention, test suite targets have no relationship to other `Test` tasks.  This example shows that the slower integration test suite targets should run after all targets of the `test` suite are complete.
-<7> Configure the `check` task to depend on all `integrationTest` targets.  By convention, test suite targets are not associated with the `check` task.
+<5> Configure the `check` task to depend on all `integrationTest` targets.  By convention, test suite targets are not associated with the `check` task.
+<6> Add a dependency on the production code of the project to the `integrationTest` suite targets.  By convention, only the built-in `test` suite will automatically have a dependency on the production code of the project.
+<7> Configure all targets of this suite.  By convention, test suite targets have no relationship to other `Test` tasks.  This example shows that the slower integration test suite targets should run after all targets of the `test` suite are complete.
+
 
 Invoking the `check` task on the above configured build should show output similar to:
 

--- a/subprojects/docs/src/snippets/testing/test-suite-plugin/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/test-suite-plugin/groovy/build.gradle
@@ -36,11 +36,13 @@ testing {
         }
 
         integrationTest(JvmTestSuite) { // <4>
+            includeInCheck() // <5>
+
             dependencies {
-                implementation project // <5>
+                implementation project // <6>
             }
 
-            targets { // <6>
+            targets { // <7>
                 all {
                     testTask.configure {
                         shouldRunAfter(test)
@@ -49,9 +51,5 @@ testing {
             }
         }
     }
-}
-
-tasks.named('check') { // <7>
-    dependsOn(testing.suites.integrationTest)
 }
 // end::configure-testing-extension[]

--- a/subprojects/docs/src/snippets/testing/test-suite-plugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-plugin/kotlin/build.gradle.kts
@@ -36,11 +36,13 @@ testing {
         }
 
         val integrationTest by registering(JvmTestSuite::class) { // <4>
+            includeInCheck() // <5>
+
             dependencies {
-                implementation(project) // <5>
+                implementation(project) // <6>
             }
 
-            targets { // <6>
+            targets { // <7>
                 all {
                     testTask.configure {
                         shouldRunAfter(test)
@@ -49,9 +51,5 @@ testing {
             }
         }
     }
-}
-
-tasks.named("check") { // <7>
-    dependsOn(testing.suites.named("integrationTest"))
 }
 // end::configure-testing-extension[]

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JvmTestSuitePlugin.java
@@ -98,7 +98,7 @@ public class JvmTestSuitePlugin implements Plugin<Project> {
     }
 
     private String getDefaultTestType(JvmTestSuite testSuite) {
-        return DEFAULT_TEST_SUITE_NAME.equals(testSuite.getName()) ? TestSuiteType.UNIT_TEST : TextUtil.camelToKebabCase(testSuite.getName());
+        return testSuite.isDefaultTestSuite() ? TestSuiteType.UNIT_TEST : TextUtil.camelToKebabCase(testSuite.getName());
     }
 
     private void configureTestDataElementsVariants(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -21,6 +21,7 @@ import org.gradle.api.Buildable;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.TestSuiteType;
+import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.testing.base.TestSuite;
@@ -165,4 +166,22 @@ public interface JvmTestSuite extends TestSuite, Buildable {
      * Configure dependencies for this component.
      */
     void dependencies(Action<? super JvmComponentDependencies> dependencies);
+
+    /**
+     * Adds this suite's test tasks as a task dependency of this project's {@code check} task.
+     *
+     * @since 7.6
+     */
+    void includeInCheck();
+
+    /**
+     * Checks whether this is the default (unit) test suite for this project.
+     *
+     * @return {@code true} if so; {@code false} otherwise
+     *
+     * @since 7.6
+     */
+    default boolean isDefaultTestSuite() {
+        return JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME.equals(getName());
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.jvm.internal;
 import com.google.common.base.Preconditions;
 import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -31,7 +32,6 @@ import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFram
 import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
-import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.plugins.jvm.JvmComponentDependencies;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.plugins.jvm.JvmTestSuiteTarget;
@@ -39,6 +39,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -123,7 +124,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
         // We could then always add these dependencies.
         this.attachDependencyAction = x -> attachDependenciesForTestFramework(dependencies, implementation);
 
-        if (!name.equals(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME)) {
+        if (!isDefaultTestSuite()) {
             useJUnitJupiter();
         } else {
             // for the built-in test suite, we don't express an opinion, so we will not add any dependencies
@@ -204,7 +205,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     public void addDefaultTestTarget() {
         final String target;
-        if (getName().equals(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME)) {
+        if (isDefaultTestSuite()) {
             target = JavaPlugin.TEST_TASK_NAME;
         } else {
             target = getName(); // For now, we'll just name the test task for the single target for the suite with the suite name
@@ -286,5 +287,13 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
                 getTargets().forEach(context::add);
             }
         };
+    }
+
+    @Inject
+    public abstract Project getProject();
+
+    @Override
+    public void includeInCheck() {
+        getProject().getTasks().getByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(this);
     }
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/AbstractTestFrameworkOptionsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/AbstractTestFrameworkOptionsIntegrationTest.groovy
@@ -28,8 +28,6 @@ abstract class AbstractTestFrameworkOptionsIntegrationTest extends AbstractInteg
             }
 
             ${mavenCentralRepository()}
-
-            check.dependsOn testing.suites
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/JUnitJupiterOptionsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/JUnitJupiterOptionsIntegrationTest.groovy
@@ -51,6 +51,7 @@ class JUnitJupiterOptionsIntegrationTest extends AbstractTestFrameworkOptionsInt
                 suites {
                     integrationTest(JvmTestSuite) {
                         useJUnitJupiter()
+                        includeInCheck()
                         targets.all {
                             testTask.configure {
                                 options {
@@ -75,6 +76,7 @@ class JUnitJupiterOptionsIntegrationTest extends AbstractTestFrameworkOptionsInt
             testing {
                 suites {
                     integrationTest(JvmTestSuite) {
+                        includeInCheck()
                         targets.all {
                             testTask.configure {
                                 options {
@@ -101,6 +103,7 @@ class JUnitJupiterOptionsIntegrationTest extends AbstractTestFrameworkOptionsInt
                     integrationTest(JvmTestSuite) {
                         useJUnit() // use JUnit4
                         useJUnitJupiter() // on second thought, use JUnit Jupiter
+                        includeInCheck()
                         targets.all {
                             testTask.configure {
                                 options {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/JUnitOptionsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/JUnitOptionsIntegrationTest.groovy
@@ -36,7 +36,7 @@ class JUnitOptionsIntegrationTest extends AbstractTestFrameworkOptionsIntegratio
                     }
                 }
             }
-            
+
         """
         writeSources(file("src/test/java"))
 
@@ -52,6 +52,7 @@ class JUnitOptionsIntegrationTest extends AbstractTestFrameworkOptionsIntegratio
                 suites {
                     integrationTest(JvmTestSuite) {
                         useJUnit()
+                        includeInCheck()
                         targets.all {
                             testTask.configure {
                                 options {
@@ -77,6 +78,7 @@ class JUnitOptionsIntegrationTest extends AbstractTestFrameworkOptionsIntegratio
                 suites {
                     integrationTest(JvmTestSuite) {
                         useJUnitJupiter()
+                        includeInCheck()
                         dependencies {
                             implementation "junit:junit:4.13"
                         }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestNGOptionsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestNGOptionsIntegrationTest.groovy
@@ -51,6 +51,7 @@ class TestNGOptionsIntegrationTest extends AbstractTestFrameworkOptionsIntegrati
                 suites {
                     integrationTest(JvmTestSuite) {
                         useTestNG()
+                        includeInCheck()
                         targets.all {
                             testTask.configure {
                                 options {


### PR DESCRIPTION
- Allows for keeping configuration of common suite behavior within the suite block itself = more declarative.
- Updated samples in docs to demonstrate, updated existing tests to use.
- Add help method to JvmTestSuite to centralize check if this is the default test suite.

- Looks like this:
![image](https://user-images.githubusercontent.com/44197/171447243-b6292fdf-c981-45fa-9492-a7438e01c3f6.png)
