### PR TITLE
Honor `mustRunAfter` constraints for finalizer task dependencies

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -280,6 +280,37 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         }
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/20800")
+    void 'finalizedBy dependencies can run before finalized task to honour mustRunAfter constraints'() {
+        given:
+        buildFile '''
+            task dockerTest {
+                dependsOn 'dockerUp'     // dependsOn createContainer mustRunAfter removeContainer
+                finalizedBy 'dockerStop' // dependsOn removeContainer
+            }
+
+            task dockerUp {
+                dependsOn 'createContainer'
+            }
+
+            task dockerStop {
+                dependsOn 'removeContainer'
+            }
+
+            task createContainer {
+                mustRunAfter 'removeContainer'
+            }
+
+            task removeContainer {
+            }
+        '''
+
+        expect:
+        succeeds 'dockerTest'
+
+        and:
+        result.assertTasksExecutedInOrder ':removeContainer', ':createContainer', ':dockerUp', ':dockerTest', ':dockerStop'
+    }
 
     void 'finalizer task can be used by multiple tasks that depend on one another'() {
         buildFile """

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -206,8 +206,10 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
                 // Make sure it has been configured
                 node.prepareForExecution(this::monitoredNodeReady);
                 node.resolveDependencies(dependencyResolver);
-                for (Node successor : node.getDependencySuccessorsInReverseOrder()) {
+                for (Node successor : node.getHardSuccessors()) {
                     successor.maybeInheritOrdinalAsDependency(node.getGroup());
+                }
+                for (Node successor : node.getDependencySuccessorsInReverseOrder()) {
                     if (!visiting.contains(successor)) {
                         queue.addFirst(successor);
                     }


### PR DESCRIPTION
Fixes #20910