### PR TITLE
Add coverage for building `kotlin-dsl` plugins against Java 11

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaClassUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaClassUtil.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.jvm
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class JavaClassUtil {
+
+    static int getClassMajorVersion(Class<?> javaClass) {
+        def classPath = javaClass.name.replace('.', '/') + '.class'
+        return new DataInputStream(javaClass.classLoader.getResourceAsStream(classPath)).withCloseable { data ->
+            int magicBytes = (int) 0xCAFEBABE
+            int header = data.readInt()
+            if (magicBytes != header) {
+                throw new IOException("Invalid class header $header")
+            }
+            data.readUnsignedShort() // minor
+            data.readUnsignedShort() // major
+        }
+    }
+
+    private JavaClassUtil() {}
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaClassUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaClassUtil.groovy
@@ -23,14 +23,17 @@ class JavaClassUtil {
 
     static int getClassMajorVersion(Class<?> javaClass) {
         def classPath = javaClass.name.replace('.', '/') + '.class'
-        return new DataInputStream(javaClass.classLoader.getResourceAsStream(classPath)).withCloseable { data ->
+        def data = new DataInputStream(javaClass.classLoader.getResourceAsStream(classPath))
+        try {
             int magicBytes = (int) 0xCAFEBABE
             int header = data.readInt()
             if (magicBytes != header) {
                 throw new IOException("Invalid class header $header")
             }
             data.readUnsignedShort() // minor
-            data.readUnsignedShort() // major
+            return data.readUnsignedShort() // major
+        } finally {
+            data.close()
         }
     }
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.plugins.dsl
+
+import org.gradle.kotlin.dsl.fixtures.AbstractKotlinIntegrationTest
+import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+/**
+ * Assert that the cross-version protocol between `:kotlin-dsl-plugins` and `:kotlin-dsl-provider-plugins` is not broken.
+ */
+class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
+
+    @Test
+    fun `can run with first major of current kotlin-dsl plugin version`() {
+
+        assumeNonEmbeddedGradleExecuter()
+        executer.noDeprecationChecks()
+
+        val testedVersion = "2.0.0"
+
+        withDefaultSettingsIn("buildSrc")
+        withBuildScriptIn("buildSrc", scriptWithKotlinDslPlugin(testedVersion)).appendText(
+            """
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                kotlinOptions.freeCompilerArgs += "-Xskip-metadata-version-check"
+            }
+            """
+        )
+        withFile("buildSrc/src/main/kotlin/some.gradle.kts", """println("some!")""")
+
+        withDefaultSettings()
+        withBuildScript("""plugins { id("some") }""")
+
+        build("help").apply {
+
+            assertThat(
+                output,
+                containsString("This version of Gradle expects version '$expectedKotlinDslPluginsVersion' of the `kotlin-dsl` plugin but version '$testedVersion' has been applied to project ':buildSrc'. Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.")
+            )
+
+            assertThat(
+                output,
+                containsString("some!")
+            )
+        }
+    }
+}

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -22,6 +22,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 
+
 /**
  * Assert that the cross-version protocol between `:kotlin-dsl-plugins` and `:kotlin-dsl-provider-plugins` is not broken.
  */

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginCrossVersionSmokeTest.kt
@@ -32,6 +32,7 @@ class KotlinDslPluginCrossVersionSmokeTest : AbstractKotlinIntegrationTest() {
     fun `can run with first major of current kotlin-dsl plugin version`() {
 
         assumeNonEmbeddedGradleExecuter()
+        assumeJavaLessThan17() // Previous Kotlin versions did not work on Java 17
         executer.noDeprecationChecks()
 
         val testedVersion = "2.0.0"

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -335,7 +335,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                 }
 
                 dependencies {
-                    implementation(files("${utils}"))
+                    implementation(files("$utils"))
                 }
             """.trimIndent()
         )

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -325,7 +325,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
 
         assumeJava11()
 
-        val utils = withClassJar("utils.jar", JavaClassUtil::class.java)
+        withClassJar("buildSrc/utils.jar", JavaClassUtil::class.java)
 
         withDefaultSettingsIn("buildSrc")
         withKotlinDslPluginIn("buildSrc").appendText(
@@ -335,7 +335,7 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                 }
 
                 dependencies {
-                    implementation(files("$utils"))
+                    implementation(files("utils.jar"))
                 }
             """.trimIndent()
         )

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginTest.kt
@@ -1,5 +1,6 @@
 package org.gradle.kotlin.dsl.plugins.dsl
 
+import org.gradle.integtests.fixtures.jvm.JavaClassUtil
 import org.gradle.kotlin.dsl.fixtures.AbstractPluginTest
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
@@ -316,6 +317,47 @@ class KotlinDslPluginTest : AbstractPluginTest() {
                 output,
                 not(containsString(samConversionForKotlinFunctions))
             )
+        }
+    }
+
+    @Test
+    fun `can use a different jvmTarget to compile kotlin-dsl plugins`() {
+
+        assumeJava11()
+
+        val utils = withClassJar("utils.jar", JavaClassUtil::class.java)
+
+        withDefaultSettingsIn("buildSrc")
+        withKotlinDslPluginIn("buildSrc").appendText(
+            """
+                kotlinDslPluginOptions {
+                    jvmTarget.set("11")
+                }
+
+                dependencies {
+                    implementation(files("${utils}"))
+                }
+            """.trimIndent()
+        )
+
+        withFile(
+            "buildSrc/src/main/kotlin/some.gradle.kts",
+            """
+                import org.gradle.integtests.fixtures.jvm.JavaClassUtil
+
+                println("Java Class Major Version = ${'$'}{JavaClassUtil.getClassMajorVersion(this::class.java)}")
+            """.trimIndent()
+        )
+        withBuildScript(
+            """
+            plugins {
+                id("some")
+            }
+            """.trimIndent()
+        )
+
+        build("help").apply {
+            assertThat(output, containsString("Java Class Major Version = 55"))
         }
     }
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -277,7 +277,7 @@ fun Project.enableScriptCompilationOf(
                 metadataDir.set(accessorsMetadata)
                 classPathFiles.from(compileClasspath)
                 onConfigure { resolverEnvironment ->
-                    objects.withInstance<TaskContainerScope>() {
+                    objects.withInstance<TaskContainerScope> {
                         configureScriptResolverEnvironment(resolverEnvironment)
                     }
                 }
@@ -299,7 +299,7 @@ fun Task.configureScriptResolverEnvironmentOnDoFirst(
     accessorsMetadata: Provider<Directory>
 ) {
     doFirst {
-        objects.withInstance<ResolverEnvironmentScope>() {
+        objects.withInstance<ResolverEnvironmentScope> {
             configureScriptResolverEnvironment(
                 resolverEnvironmentStringFor(
                     implicitImports,

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
@@ -25,6 +25,14 @@ import java.io.File
 import java.util.function.Consumer
 
 
+/**
+ * Protocol between `:kotlin-dsl-plugins` and `:kotlin-dsl-provider-plugins`.
+ *
+ * `:kotlin-dsl-plugins` is published to the plugin portal.
+ * `:kotlin-dsl-provider-plugins` is shipped with the distribution.
+ *
+ * This needs to be cross-version compatible.
+ */
 interface PrecompiledScriptPluginsSupport {
 
     @Deprecated("Use enableOn(Target)")

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -150,7 +150,7 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     fun scriptWithKotlinDslPlugin(version: String? = null): String =
         """
             plugins {
-                `kotlin-dsl`${if(version == null) "" else " version \"$version\""}
+                `kotlin-dsl`${if (version == null) "" else " version \"$version\""}
             }
 
             $repositoriesBlock

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -233,6 +233,11 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     }
 
     protected
+    fun assumeJavaLessThan17() {
+        assumeTrue("Test disabled under JDK 17 and higher", JavaVersion.current() < JavaVersion.VERSION_17)
+    }
+
+    protected
     fun assumeJava11() {
         assumeTrue("Test requires Java 11 or higher", JavaVersion.current().isJava11Compatible)
     }

--- a/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/testFixtures/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -147,10 +147,10 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
         withBuildScriptIn(baseDir, scriptWithKotlinDslPlugin())
 
     protected
-    fun scriptWithKotlinDslPlugin(): String =
+    fun scriptWithKotlinDslPlugin(version: String? = null): String =
         """
             plugins {
-                `kotlin-dsl`
+                `kotlin-dsl`${if(version == null) "" else " version \"$version\""}
             }
 
             $repositoriesBlock


### PR DESCRIPTION
Adds missing coverage for setting `kotlinDslPluginOptions.jvmTarget` to a higher target (11) than the default (8).

This PR also adds documentation and missing test coverage for the cross-version protocol between `:kotlin-dsl-plugins` and `:kotlin-dsl-provider-plugins` plus some other minor refinements.

See https://github.com/gradle/gradle/issues/18227