### PR TITLE
Reuse VersionParser and preserve it across builds

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -58,6 +58,7 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.DependencyVerificationOverride;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.FileStoreAndIndexProvider;
@@ -297,7 +298,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 NamedObjectInstantiator instantiator,
                 DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
                 ChecksumService checksumService,
-                ProviderFactory providerFactory
+                ProviderFactory providerFactory,
+                VersionParser versionParser
         ) {
             return new DefaultBaseRepositoryFactory(
                 localMavenRepositoryLocator,
@@ -321,7 +323,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 callbackDecorator,
                 urlArtifactRepositoryFactory,
                 checksumService,
-                providerFactory
+                providerFactory,
+                versionParser
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -621,10 +621,6 @@ class DependencyManagementBuildScopeServices {
         return new DefaultComponentSelectorConverter(componentIdentifierFactory, localComponentRegistry);
     }
 
-    VersionParser createVersionParser() {
-        return new VersionParser();
-    }
-
     VersionSelectorScheme createVersionSelectorScheme(VersionComparator versionComparator, VersionParser versionParser) {
         DefaultVersionSelectorScheme delegate = new DefaultVersionSelectorScheme(versionComparator, versionParser);
         CachingVersionSelectorScheme selectorScheme = new CachingVersionSelectorScheme(delegate);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultIvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.ModuleSelectorStringNotationConverter;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.DefaultLocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultDependencyDescriptorFactory;
@@ -93,6 +94,10 @@ class DependencyManagementGlobalScopeServices {
             .toType(ComponentSelector.class)
             .converter(new CrossBuildCachingNotationConverter<>(new ModuleSelectorStringNotationConverter(moduleIdentifierFactory), cacheFactory.newCache()))
             .toComposite();
+    }
+
+    VersionParser createVersionParser() {
+        return new VersionParser();
     }
 
     IvyContextManager createIvyContextManager() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -109,7 +109,7 @@ class ModuleResolveState implements CandidateModule {
         this.rootModule = rootModule;
         this.pendingDependencies = new PendingDependencies(id);
         this.selectorStateResolver = selectorStateResolver;
-        this.selectors = new ModuleSelectors<>(versionComparator);
+        this.selectors = new ModuleSelectors<>(versionComparator, versionParser);
         this.conflictResolution = conflictResolution;
         this.attributeDesugaring = attributeDesugaring;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -141,7 +141,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         nodes.put(root.getResolvedConfigurationId(), root);
         root.getComponent().getModule().select(root.getComponent());
         this.replaceSelectionWithConflictResultAction = new ReplaceSelectionWithConflictResultAction(this);
-        selectorStateResolver = new SelectorStateResolver<>(conflictResolver, this, rootVersion, resolveOptimizations, versionComparator);
+        selectorStateResolver = new SelectorStateResolver<>(conflictResolver, this, rootVersion, resolveOptimizations, versionComparator, versionParser);
         getModule(rootResult.getModuleVersionId().getModule()).setSelectorStateResolver(selectorStateResolver);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.UnionVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
@@ -49,14 +50,16 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
     private final ModuleIdentifier rootModuleId;
     private final ResolveOptimizations resolveOptimizations;
     private final Comparator<Version> versionComparator;
+    private final VersionParser versionParser;
 
-    public SelectorStateResolver(ModuleConflictResolver<T> conflictResolver, ComponentStateFactory<T> componentFactory, T rootComponent, ResolveOptimizations resolveOptimizations, Comparator<Version> versionComparator) {
+    public SelectorStateResolver(ModuleConflictResolver<T> conflictResolver, ComponentStateFactory<T> componentFactory, T rootComponent, ResolveOptimizations resolveOptimizations, Comparator<Version> versionComparator, VersionParser versionParser) {
         this.conflictResolver = conflictResolver;
         this.componentFactory = componentFactory;
         this.rootComponent = rootComponent;
         this.rootModuleId = rootComponent.getId().getModule();
         this.resolveOptimizations = resolveOptimizations;
         this.versionComparator = versionComparator;
+        this.versionParser = versionParser;
     }
 
     public T selectBest(ModuleIdentifier moduleId, ModuleSelectors<? extends ResolvableSelectorState> selectors) {
@@ -122,7 +125,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
      * If not, a minimal set of versions will be provided in the result, and conflict resolution will be required to choose.
      */
     private List<T> buildResolveResults(ModuleSelectors<? extends ResolvableSelectorState> selectors, VersionSelector allRejects) {
-        SelectorStateResolverResults results = new SelectorStateResolverResults(versionComparator, selectors.size());
+        SelectorStateResolverResults results = new SelectorStateResolverResults(versionComparator, versionParser, selectors.size());
         TreeSet<ComponentIdResolveResult> preferResults = null; // Created only on demand
 
         for (ResolvableSelectorState selector : selectors) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -33,11 +33,12 @@ import java.util.List;
 import java.util.Set;
 
 class SelectorStateResolverResults {
-    private static final VersionParser VERSION_PARSER = new VersionParser();
     private final Comparator<Version> versionComparator;
+    private final VersionParser versionParser;
     private final List<Registration> results;
 
-    public SelectorStateResolverResults(Comparator<Version> versionComparator, int size) {
+    public SelectorStateResolverResults(Comparator<Version> versionComparator, VersionParser versionParser, int size) {
+        this.versionParser = versionParser;
         results = Lists.newArrayListWithCapacity(size);
         this.versionComparator = versionComparator;
     }
@@ -161,8 +162,8 @@ class SelectorStateResolverResults {
 
     private boolean lowerVersion(ComponentIdResolveResult existing, ComponentIdResolveResult resolveResult) {
         if (existing.getFailure() == null && resolveResult.getFailure() == null) {
-            Version existingVersion = VERSION_PARSER.transform(existing.getModuleVersionId().getVersion());
-            Version candidateVersion = VERSION_PARSER.transform(resolveResult.getModuleVersionId().getVersion());
+            Version existingVersion = versionParser.transform(existing.getModuleVersionId().getVersion());
+            Version candidateVersion = versionParser.transform(resolveResult.getModuleVersionId().getVersion());
 
             int comparison = versionComparator.compare(candidateVersion, existingVersion);
             return comparison < 0;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepository.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.MetadataSupplierAware;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalRepositoryResourceAccessor;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport;
 import org.gradle.api.model.ObjectFactory;
@@ -56,9 +57,11 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
     private Action<? super ActionConfiguration> componentMetadataListerRuleConfiguration;
     private final ObjectFactory objectFactory;
     private final Supplier<RepositoryContentDescriptorInternal> repositoryContentDescriptor = Suppliers.memoize(this::createRepositoryDescriptor)::get;
+    private final VersionParser versionParser;
 
-    protected AbstractArtifactRepository(ObjectFactory objectFactory) {
+    protected AbstractArtifactRepository(ObjectFactory objectFactory, VersionParser versionParser) {
        this.objectFactory = objectFactory;
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -110,7 +113,7 @@ public abstract class AbstractArtifactRepository implements ArtifactRepositoryIn
 
     @Override
     public RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultRepositoryContentDescriptor(this::getDisplayName);
+        return new DefaultRepositoryContentDescriptor(this::getDisplayName, versionParser);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepository.java
@@ -19,6 +19,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.credentials.Credentials;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
@@ -38,8 +39,8 @@ public abstract class AbstractAuthenticationSupportedRepository extends Abstract
     private final AuthenticationSupporter delegate;
     private final ProviderFactory providerFactory;
 
-    AbstractAuthenticationSupportedRepository(Instantiator instantiator, AuthenticationContainer authenticationContainer, ObjectFactory objectFactory, ProviderFactory providerFactory) {
-        super(objectFactory);
+    AbstractAuthenticationSupportedRepository(Instantiator instantiator, AuthenticationContainer authenticationContainer, ObjectFactory objectFactory, ProviderFactory providerFactory, VersionParser versionParser) {
+        super(objectFactory, versionParser);
         this.delegate = new AuthenticationSupporter(instantiator, objectFactory, authenticationContainer, providerFactory);
         this.providerFactory = providerFactory;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractResolutionAwareArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/AbstractResolutionAwareArtifactRepository.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories;
 
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.model.ObjectFactory;
 
@@ -23,8 +24,8 @@ public abstract class AbstractResolutionAwareArtifactRepository extends Abstract
 
     private RepositoryDescriptor descriptor;
 
-    protected AbstractResolutionAwareArtifactRepository(ObjectFactory objectFactory) {
-        super(objectFactory);
+    protected AbstractResolutionAwareArtifactRepository(ObjectFactory objectFactory, VersionParser versionParser) {
+        super(objectFactory, versionParser);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
@@ -80,6 +81,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     private final DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory;
     private final ChecksumService checksumService;
     private final ProviderFactory providerFactory;
+    private final VersionParser versionParser;
 
     public DefaultBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator,
                                         FileResolver fileResolver,
@@ -102,7 +104,9 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
                                         CollectionCallbackActionDecorator callbackActionDecorator,
                                         DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
                                         ChecksumService checksumService,
-                                        ProviderFactory providerFactory) {
+                                        ProviderFactory providerFactory,
+                                        VersionParser versionParser
+    ) {
         this.localMavenRepositoryLocator = localMavenRepositoryLocator;
         this.fileResolver = fileResolver;
         this.fileCollectionFactory = fileCollectionFactory;
@@ -126,11 +130,12 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         this.urlArtifactRepositoryFactory = urlArtifactRepositoryFactory;
         this.checksumService = checksumService;
         this.providerFactory = providerFactory;
+        this.versionParser = versionParser;
     }
 
     @Override
     public FlatDirectoryArtifactRepository createFlatDirRepository() {
-        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, ivyMetadataFactory, instantiatorFactory, objectFactory, checksumService);
+        return instantiator.newInstance(DefaultFlatDirArtifactRepository.class, fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactFileStore, ivyMetadataFactory, instantiatorFactory, objectFactory, checksumService, versionParser);
     }
 
     @Override
@@ -143,7 +148,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     @Override
     public MavenArtifactRepository createMavenLocalRepository() {
-        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService);
+        MavenArtifactRepository mavenRepository = instantiator.newInstance(DefaultMavenLocalArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, versionParser);
         File localMavenRepository = localMavenRepositoryLocator.getLocalMavenRepository();
         mavenRepository.setUrl(localMavenRepository);
         return mavenRepository;
@@ -172,16 +177,16 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
 
     @Override
     public IvyArtifactRepository createIvyRepository() {
-        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, ivyMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory);
+        return instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactFileStore, externalResourcesFileStore, createAuthenticationContainer(), ivyContextManager, moduleIdentifierFactory, instantiatorFactory, fileResourceRepository, metadataParser, ivyMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory, versionParser);
     }
 
     @Override
     public MavenArtifactRepository createMavenRepository() {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory, versionParser);
     }
 
     public MavenArtifactRepository createMavenRepository(Transformer<String, MavenArtifactRepository> describer) {
-        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory);
+        return instantiator.newInstance(DefaultMavenArtifactRepository.class, describer, fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, createAuthenticationContainer(), externalResourcesFileStore, fileResourceRepository, mavenMetadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory, versionParser);
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepository.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryResourceAccessor;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.FlatDirRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultArtifactMetadataSource;
@@ -74,8 +75,10 @@ public class DefaultFlatDirArtifactRepository extends AbstractResolutionAwareArt
                                             IvyMutableModuleMetadataFactory metadataFactory,
                                             InstantiatorFactory instantiatorFactory,
                                             ObjectFactory objectFactory,
-                                            ChecksumService checksumService) {
-        super(objectFactory);
+                                            ChecksumService checksumService,
+                                            VersionParser versionParser
+    ) {
+        super(objectFactory, versionParser);
         this.fileCollectionFactory = fileCollectionFactory;
         this.transportFactory = transportFactory;
         this.locallyAvailableResourceFinder = locallyAvailableResourceFinder;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModu
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.IvyRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.layout.AbstractRepositoryLayout;
@@ -116,8 +117,10 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
                                         ObjectFactory objectFactory,
                                         DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
                                         ChecksumService checksumService,
-                                        ProviderFactory providerFactory) {
-        super(instantiatorFactory.decorateLenient(), authenticationContainer, objectFactory, providerFactory);
+                                        ProviderFactory providerFactory,
+                                        VersionParser versionParser
+    ) {
+        super(instantiatorFactory.decorateLenient(), authenticationContainer, objectFactory, providerFactory, versionParser);
         this.fileResolver = fileResolver;
         this.urlArtifactRepository = urlArtifactRepositoryFactory.create("Ivy", this::getDisplayName);
         this.transportFactory = transportFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolver
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.MavenRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
@@ -99,6 +100,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final ChecksumService checksumService;
     private final MavenMetadataSources metadataSources = new MavenMetadataSources();
     private final InstantiatorFactory instantiatorFactory;
+    private VersionParser versionParser;
 
     public DefaultMavenArtifactRepository(FileResolver fileResolver,
                                           RepositoryTransportFactory transportFactory,
@@ -115,10 +117,12 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           ObjectFactory objectFactory,
                                           DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
                                           ChecksumService checksumService,
-                                          ProviderFactory providerFactory) {
+                                          ProviderFactory providerFactory,
+                                          VersionParser versionParser
+    ) {
         this(new DefaultDescriber(), fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory,
             artifactFileStore, pomParser, metadataParser, authenticationContainer,
-            resourcesFileStore, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory);
+            resourcesFileStore, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, providerFactory, versionParser);
     }
 
     public DefaultMavenArtifactRepository(Transformer<String, MavenArtifactRepository> describer,
@@ -137,8 +141,10 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           ObjectFactory objectFactory,
                                           DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
                                           ChecksumService checksumService,
-                                          ProviderFactory providerFactory) {
-        super(instantiatorFactory.decorateLenient(), authenticationContainer, objectFactory, providerFactory);
+                                          ProviderFactory providerFactory,
+                                          VersionParser versionParser
+    ) {
+        super(instantiatorFactory.decorateLenient(), authenticationContainer, objectFactory, providerFactory, versionParser);
         this.describer = describer;
         this.fileResolver = fileResolver;
         this.urlArtifactRepository = urlArtifactRepositoryFactory.create("Maven", this::getDisplayName);
@@ -154,6 +160,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         this.checksumService = checksumService;
         this.metadataSources.setDefaults();
         this.instantiatorFactory = instantiatorFactory;
+        this.versionParser = versionParser;
     }
 
     @Override
@@ -354,7 +361,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     @Override
     public RepositoryContentDescriptorInternal createRepositoryDescriptor() {
-        return new DefaultMavenRepositoryContentDescriptor(this::getDisplayName);
+        return new DefaultMavenRepositoryContentDescriptor(this::getDisplayName, versionParser);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenPomMetadataSource;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenLocalPomMetadataSource;
@@ -61,8 +62,10 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
                                                IsolatableFactory isolatableFactory,
                                                ObjectFactory objectFactory,
                                                DefaultUrlArtifactRepository.Factory urlArtifactRepositoryFactory,
-                                               ChecksumService checksumService) {
-        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, null, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, null);
+                                               ChecksumService checksumService,
+                                               VersionParser versionParser
+    ) {
+        super(fileResolver, transportFactory, locallyAvailableResourceFinder, instantiatorFactory, artifactFileStore, pomParser, metadataParser, authenticationContainer, null, fileResourceRepository, metadataFactory, isolatableFactory, objectFactory, urlArtifactRepositoryFactory, checksumService, null, versionParser);
         this.checksumService = checksumService;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenRepositoryContentDescriptor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.internal.Actions;
 
 import java.util.function.Supplier;
@@ -27,8 +28,8 @@ class DefaultMavenRepositoryContentDescriptor extends DefaultRepositoryContentDe
     private boolean snapshots = true;
     private boolean releases = true;
 
-    public DefaultMavenRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier) {
-        super(repositoryNameSupplier);
+    public DefaultMavenRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier, VersionParser versionParser) {
+        super(repositoryNameSupplier, versionParser);
     }
 
     @Override
@@ -69,7 +70,7 @@ class DefaultMavenRepositoryContentDescriptor extends DefaultRepositoryContentDe
 
     @Override
     public RepositoryContentDescriptorInternal asMutableCopy() {
-        DefaultMavenRepositoryContentDescriptor copy = new DefaultMavenRepositoryContentDescriptor(getRepositoryNameSupplier());
+        DefaultMavenRepositoryContentDescriptor copy = new DefaultMavenRepositoryContentDescriptor(getRepositoryNameSupplier(), getVersionParser());
         if (getIncludedConfigurations() != null) {
             copy.setIncludedConfigurations(Sets.newHashSet(getIncludedConfigurations()));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptor.java
@@ -54,9 +54,16 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
     private final VersionSelectorScheme versionSelectorScheme;
     private final ConcurrentHashMap<String, VersionSelector> versionSelectors = new ConcurrentHashMap<>();
 
-    public DefaultRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier) {
-        this.versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser());
+    private final VersionParser versionParser;
+
+    public DefaultRepositoryContentDescriptor(Supplier<String> repositoryNameSupplier, VersionParser versionParser) {
+        this.versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser);
         this.repositoryNameSupplier = repositoryNameSupplier;
+        this.versionParser = versionParser;
+    }
+
+    protected VersionParser getVersionParser() {
+        return versionParser;
     }
 
     private void assertMutable() {
@@ -87,7 +94,7 @@ class DefaultRepositoryContentDescriptor implements RepositoryContentDescriptorI
 
     @Override
     public RepositoryContentDescriptorInternal asMutableCopy() {
-        DefaultRepositoryContentDescriptor copy = new DefaultRepositoryContentDescriptor(repositoryNameSupplier);
+        DefaultRepositoryContentDescriptor copy = new DefaultRepositoryContentDescriptor(repositoryNameSupplier, getVersionParser());
         if (includedConfigurations != null) {
             copy.includedConfigurations = Sets.newHashSet(includedConfigurations);
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.ExactVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.LatestVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState
 import spock.lang.Specification
 import spock.lang.Subject
@@ -29,7 +30,7 @@ class ModuleSelectorsTest extends Specification {
 
     Comparator<Version> versionComparator = new DefaultVersionComparator().asVersionComparator()
     @Subject
-    ModuleSelectors selectors = new ModuleSelectors(versionComparator)
+    ModuleSelectors selectors = new ModuleSelectors(versionComparator, new VersionParser())
     int dynCount = 1
 
     def 'empty by default'() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -73,8 +73,9 @@ class SelectorStateResolverTest extends Specification {
     private final componentFactory = new TestComponentFactory()
     private final ModuleIdentifier moduleId = DefaultModuleIdentifier.newId("org", "module")
     private final ResolveOptimizations resolveOptimizations = new ResolveOptimizations()
-    private final SelectorStateResolver conflictHandlingResolver = new SelectorStateResolver(conflictResolver, componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator())
-    private final SelectorStateResolver failingResolver = new SelectorStateResolver(new FailingConflictResolver(), componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator())
+    private final VersionParser versionParser = new VersionParser()
+    private final SelectorStateResolver conflictHandlingResolver = new SelectorStateResolver(conflictResolver, componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator(), versionParser)
+    private final SelectorStateResolver failingResolver = new SelectorStateResolver(new FailingConflictResolver(), componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator(), versionParser)
 
     def "resolve selector #permutation"() {
         given:
@@ -177,7 +178,7 @@ class SelectorStateResolverTest extends Specification {
         def nine = new TestProjectSelectorState(projectId)
         def otherNine = new TestProjectSelectorState(projectId)
         ModuleConflictResolver mockResolver = Mock()
-        SelectorStateResolver resolverWithMock = new SelectorStateResolver(mockResolver, componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator())
+        SelectorStateResolver resolverWithMock = new SelectorStateResolver(mockResolver, componentFactory, root, resolveOptimizations, versionComparator.asVersionComparator(), versionParser)
 
         when:
         def selected = resolverWithMock.selectBest(moduleId, moduleSelectors([nine, otherNine]))
@@ -237,7 +238,7 @@ class SelectorStateResolverTest extends Specification {
     }
 
     ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
-        def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>(versionComparator.asVersionComparator())
+        def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>(versionComparator.asVersionComparator(), versionParser)
         selectors.forEach { moduleSelectors.add(it, false) }
         return moduleSelectors
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepositoryChangingNameAfterContainerInclusion.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepositoryChangingNameAfterContainerInclusion.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories
 
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
 class AbstractArtifactRepositoryChangingNameAfterContainerInclusion extends AbstractProjectBuilderSpec {
@@ -36,7 +37,7 @@ class AbstractArtifactRepositoryChangingNameAfterContainerInclusion extends Abst
 
     class TestRepo extends AbstractArtifactRepository {
         def TestRepo() {
-            super(null)
+            super(null, new VersionParser())
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.credentials.Credentials
 import org.gradle.api.credentials.HttpHeaderCredentials
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor
 import org.gradle.authentication.Authentication
 import org.gradle.internal.authentication.DefaultAuthenticationContainer
@@ -224,7 +225,7 @@ class AbstractAuthenticationSupportedRepositoryTest extends Specification {
 
     class AuthSupportedRepository extends AbstractAuthenticationSupportedRepository {
         AuthSupportedRepository(Instantiator instantiator, AuthenticationContainer authenticationContainer) {
-            super(instantiator, authenticationContainer, TestUtil.objectFactory(), null)
+            super(instantiator, authenticationContainer, TestUtil.objectFactory(), null, new VersionParser())
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -66,7 +67,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
             CollectionCallbackActionDecorator.NOOP,
             urlArtifactRepositoryFactory,
             TestUtil.checksumService,
-            providerFactory
+            providerFactory, new VersionParser()
     )
 
     def testCreateFlatDirResolver() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -41,7 +42,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
     final DefaultArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final IvyMutableModuleMetadataFactory metadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
 
-    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory), TestUtil.checksumService)
+    final DefaultFlatDirArtifactRepository repository = new DefaultFlatDirArtifactRepository(fileCollectionFactory, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, metadataFactory, Mock(InstantiatorFactory), Mock(ObjectFactory), TestUtil.checksumService, new VersionParser())
 
     def "creates a repository with multiple root directories"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -66,7 +67,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager,
         moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser,
         metadataFactory, SnapshotTestUtil.isolatableFactory(), TestUtil.objectFactory(), urlArtifactRepositoryFactory,
-        TestUtil.checksumService, providerFactory
+        TestUtil.checksumService, providerFactory, new VersionParser()
     )
 
     def "default values"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -58,10 +59,10 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final ProviderFactory providerFactory = Mock()
 
     final DefaultMavenArtifactRepository repository = new DefaultMavenArtifactRepository(
-        resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(),
-        artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, externalResourceFileStore,
-        Mock(FileResourceRepository), mavenMetadataFactory, SnapshotTestUtil.isolatableFactory(),
-        TestUtil.objectFactory(), urlArtifactRepositoryFactory, TestUtil.checksumService, providerFactory)
+            resolver, transportFactory, locallyAvailableResourceFinder, TestUtil.instantiatorFactory(),
+            artifactIdentifierFileStore, pomParser, metadataParser, authenticationContainer, externalResourceFileStore,
+            Mock(FileResourceRepository), mavenMetadataFactory, SnapshotTestUtil.isolatableFactory(),
+            TestUtil.objectFactory(), urlArtifactRepositoryFactory, TestUtil.checksumService, providerFactory, new VersionParser())
 
     def "creates local repository"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.artifacts.DependencyManagementTestUtil
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
@@ -65,7 +66,8 @@ class DefaultMavenLocalRepositoryTest extends Specification {
             SnapshotTestUtil.isolatableFactory(),
             TestUtil.objectFactory(),
             urlArtifactRepositoryFactory,
-            TestUtil.checksumService
+            TestUtil.checksumService,
+            new VersionParser()
 
         )
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultRepositoryContentDescriptorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.repositories
 
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import spock.lang.Specification
 import spock.lang.Subject
@@ -25,7 +26,7 @@ import spock.lang.Subject
 class DefaultRepositoryContentDescriptorTest extends Specification {
 
     @Subject
-    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor({ throw new RuntimeException("only required in error cases") })
+    DefaultRepositoryContentDescriptor descriptor = new DefaultMavenRepositoryContentDescriptor({ throw new RuntimeException("only required in error cases") }, new VersionParser())
 
     def "reasonable error message when input is incorrect (include string)"() {
         when:
@@ -206,7 +207,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
     def "can exclude or include whole groups using #method(#expr)"() {
         def fooMod = DefaultModuleIdentifier.newId(group, module)
         def details = Mock(ArtifactResolutionDetails)
-        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
 
         given:
         descriptor."exclude$method"(expr)
@@ -226,7 +227,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
 
         when:
-        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
         descriptor."include$method"(expr)
         action = descriptor.toContentFilter()
         details.moduleId >> fooMod
@@ -254,7 +255,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
     def "can exclude or include whole modules using #method(#expr)"() {
         def fooMod = DefaultModuleIdentifier.newId(group, module)
         def details = Mock(ArtifactResolutionDetails)
-        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
 
         given:
         descriptor."exclude$method"(group, expr)
@@ -274,7 +275,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
 
         when:
-        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
         descriptor."include$method"(group, expr)
         action = descriptor.toContentFilter()
         details.moduleId >> fooMod
@@ -302,7 +303,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
     def "can exclude or include specific versions using #method(#expr)"() {
         def fooMod = DefaultModuleIdentifier.newId(group, module)
         def details = Mock(ArtifactResolutionDetails)
-        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        def descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
 
         given:
         descriptor."exclude$method"(group, module, expr)
@@ -322,7 +323,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
 
         when:
-        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo"})
+        descriptor = new DefaultRepositoryContentDescriptor({ "my-repo" }, new VersionParser())
         descriptor."include$method"(group, module, expr)
         action = descriptor.toContentFilter()
         details.moduleId >> fooMod
@@ -357,7 +358,7 @@ class DefaultRepositoryContentDescriptorTest extends Specification {
 
     def "cannot update repository content filter after resolution happens"() {
         given:
-        def descriptor = new DefaultRepositoryContentDescriptor({ "repoName" })
+        def descriptor = new DefaultRepositoryContentDescriptor({ "repoName" }, new VersionParser())
         descriptor.toContentFilter()
 
         when:

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ClassPathRegistry;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.tasks.scala.ScalaCompilerFactory;
 import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
 import org.gradle.api.model.ObjectFactory;
@@ -54,6 +55,11 @@ public class ScalaCompile extends AbstractScalaCompile {
     public ScalaCompile() {
         ObjectFactory objectFactory = getObjectFactory();
         this.scalaRuntime = objectFactory.property(ScalaRuntime.class);
+    }
+
+    @Inject
+    protected VersionParser getVersionParser() {
+        throw new UnsupportedOperationException();
     }
 
     @Nested
@@ -96,7 +102,7 @@ public class ScalaCompile extends AbstractScalaCompile {
 
     @Override
     protected ScalaJavaJointCompileSpec createSpec() {
-        ScalaCompileOptionsConfigurer.configure(getScalaCompileOptions(), getToolchain(), getScalaClasspath().getFiles());
+        ScalaCompileOptionsConfigurer.configure(getScalaCompileOptions(), getToolchain(), getScalaClasspath().getFiles(), getVersionParser());
         ScalaJavaJointCompileSpec spec = super.createSpec();
         if (getScalaCompilerPlugins() != null) {
             spec.setScalaCompilerPlugins(ImmutableList.copyOf(getScalaCompilerPlugins()));

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/internal/ScalaCompileOptionsConfigurer.java
@@ -34,10 +34,9 @@ import java.util.Set;
  * @since 7.3
  */
 public class ScalaCompileOptionsConfigurer {
-    private static final VersionParser VERSION_PARSER = new VersionParser();
     private static final DefaultVersionComparator VERSION_COMPARATOR = new DefaultVersionComparator();
 
-    public static void configure(ScalaCompileOptions scalaCompileOptions, JavaInstallationMetadata toolchain, Set<File> scalaClasspath) {
+    public static void configure(ScalaCompileOptions scalaCompileOptions, JavaInstallationMetadata toolchain, Set<File> scalaClasspath, VersionParser versionParser) {
         if (toolchain == null) {
             return;
         }
@@ -57,7 +56,7 @@ public class ScalaCompileOptionsConfigurer {
         }
 
         Integer jvmVersion = toolchain.getLanguageVersion().asInt();
-        String targetParameter = determineTargetParameter(scalaVersion, jvmVersion);
+        String targetParameter = determineTargetParameter(scalaVersion, jvmVersion, versionParser);
         if(scalaCompileOptions.getAdditionalParameters() == null) {
             scalaCompileOptions.setAdditionalParameters(Collections.singletonList(targetParameter));
         } else {
@@ -65,9 +64,9 @@ public class ScalaCompileOptionsConfigurer {
         }
     }
 
-    private static String determineTargetParameter(String scalaVersion, Integer jvmVersion) {
-        VersionInfo currentScalaVersion = new VersionInfo(VERSION_PARSER.transform(scalaVersion));
-        int compareWith2131 = VERSION_COMPARATOR.compare(currentScalaVersion, new VersionInfo(VERSION_PARSER.transform("2.13.1")));
+    private static String determineTargetParameter(String scalaVersion, Integer jvmVersion, VersionParser versionParser) {
+        VersionInfo currentScalaVersion = new VersionInfo(versionParser.transform(scalaVersion));
+        int compareWith2131 = VERSION_COMPARATOR.compare(currentScalaVersion, new VersionInfo(versionParser.transform("2.13.1")));
         if(compareWith2131 < 0) {
             return String.format("-target:jvm-1.%s", jvmVersion);
         } else {

--- a/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.scala.compile.internal
 
 import org.gradle.api.file.Directory
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.tasks.ScalaRuntime
 import org.gradle.api.tasks.scala.ScalaCompileOptions
 import org.gradle.api.tasks.scala.internal.ScalaCompileOptionsConfigurer
@@ -30,6 +31,7 @@ import spock.lang.Subject
 class ScalaCompileOptionsConfigurerTest extends Specification {
 
     private final ScalaRuntime scalaRuntime = Mock(ScalaRuntime)
+    private final VersionParser versionParser = new VersionParser()
 
     def 'configuring target jvm for JVM #javaVersion and Scala #scalaLibraryVersion results in #expectedTarget'() {
         given:
@@ -38,7 +40,7 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
         Set<File> classpath = [scalaLibrary]
 
         when:
-        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(javaVersion), classpath)
+        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(javaVersion), classpath, versionParser)
 
         then:
         !scalaCompileOptions.additionalParameters.empty
@@ -73,7 +75,7 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
         Set<File> classpath = [scalaLibrary]
 
         when:
-        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, null, classpath)
+        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, null, classpath, getVersionParser())
 
         then:
         !scalaCompileOptions.additionalParameters
@@ -86,7 +88,7 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
         Set<File> classpath = [scalaLibrary]
 
         when:
-        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(8), classpath)
+        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(8), classpath, getVersionParser())
 
         then:
         !scalaCompileOptions.additionalParameters
@@ -105,7 +107,7 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
         Set<File> classpath = [new File("scala-library-2.13.1.jar")]
 
         when:
-        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(8), classpath)
+        ScalaCompileOptionsConfigurer.configure(scalaCompileOptions, createToolchain(8), classpath, getVersionParser())
 
         then:
         scalaCompileOptions.additionalParameters


### PR DESCRIPTION
Ensures there is only one globally scoped version parser (promoted from
build scoped) that is shared with all places that need a version parser.

VersionParser keeps a cache of previously parsed versions, to avoid
creating Version objects unnecessarily. However, we had a few places
creating their own long-living copy of VersionParser, and in other
places we where using short-lived VersionParser instances, which
defeated the point of keeping a pool of versions. Also, the existing
shared instance of VersionParser was build-scoped, and this changes
it to be globally scoped so it stays around between builds using the
same daemon, potentially improving performance of the following builds.

Issue: #18144

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

### Manual verification

To test this, I added a few couters to VersionParser so we could print some statistics, and implemented a custom task that showed those statistics.

#### Changes to VersionParser (not committed)

```diff
diff --git a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
index 669bee7085a..aa64effabe8 100644
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/VersionParser.java
@@ -23,19 +23,36 @@
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
 
 public class VersionParser implements Transformer<Version, String> {
     private final Map<String, Version> cache = Maps.newConcurrentMap();
+    private LongAdder accesses = new LongAdder();
+    private LongAdder misses = new LongAdder();
 
     public VersionParser() {
     }
 
+    public int poolSize() {
+        return cache.size();
+    }
+
+    public long accesses() {
+        return accesses.longValue();
+    }
+
+    public long misses() {
+        return misses.longValue();
+    }
+
     @Override
     public Version transform(String original) {
+        accesses.increment();
         return cache.computeIfAbsent(original, this::parse);
     }
 
     private Version parse(String original) {
+        misses.increment();
         List<String> parts = new ArrayList<>();
         boolean digit = false;
         int startPart = 0;
```        

#### Custom task

```groovy

import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser

tasks.register('countVersions', CountVersions) {
}

abstract class CountVersions extends DefaultTask {
    private final VersionParser versionParser

    @Inject
    CountVersions(VersionParser versionParser) {
        this.versionParser = versionParser
    }

    @TaskAction
    void countVersions() {
        logger.quiet('VersionParser pool size: ' + versionParser.poolSize())
        def accesses = versionParser.accesses()
        def misses = versionParser.misses()
        logger.quiet('VersionParser accesses: ' + accesses)
        logger.quiet('VersionParser misses: ' + misses)
        logger.quiet('VersionParser hit rate: ' + (100.0 * (accesses - misses) / accesses) + '%')
    }
}
```

#### Results with this branch

(using [this performance testing repo](https://github.com/gradle/performance-comparisons/tree/master/exclude-merging))

```
➜  exclude-merging git:(master) ✗ ~/.gradle/gradle-install/bin/gradle --stop                                                             
Stopping Daemon(s)
2 Daemons stopped
➜  exclude-merging git:(master) ✗ ~/.gradle/gradle-install/bin/gradle clean assemble countVersions --console=verbose -q --no-build-cache 

VersionParser pool size: 16
VersionParser accesses: 161
VersionParser misses: 16
VersionParser hit rate: 90.0621118012%
➜  exclude-merging git:(master) ✗ ~/.gradle/gradle-install/bin/gradle clean assemble countVersions --console=verbose -q --no-build-cache 

VersionParser pool size: 1703
VersionParser accesses: 33509
VersionParser misses: 1703
VersionParser hit rate: 94.9177832821%
➜  exclude-merging git:(master) ✗ ~/.gradle/gradle-install/bin/gradle clean assemble countVersions --console=verbose -q --no-build-cache 

VersionParser pool size: 1703
VersionParser accesses: 66858
VersionParser misses: 1703
VersionParser hit rate: 97.4528104341%
```

#### Using `jmap -histo`

##### This branch

```
➜  exclude-merging git:(master) ✗ jmap -histo `jps | grep Daemon | cut -f 1 -d ' '` | grep VersionParser
 278:          1745          55840  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$DefaultVersion
 319:          2812          44992  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$$Lambda$702/0x00000008006e6440
1052:           174           2784  org.gradle.api.internal.catalog.parser.StrictVersionParser
4517:             1             40  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$accesses$0
4518:             1             40  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$misses$1
4519:             1             40  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$poolSize
5266:             1             24  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
5278:             1             24  org.gradle.api.internal.catalog.parser.StrictVersionParser$RichVersion
```

##### master

```
➜  exclude-merging git:(master) ✗ jmap -histo `jps | grep Daemon | cut -f 1 -d ' '` | grep \.VersionParser                                    
 178:          7540         120640  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$$Lambda$702/0x00000008006e6440
 248:          2457          78624  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$DefaultVersion
1470:            58            928  org.gradle.api.internal.catalog.parser.StrictVersionParser
1473:            38            912  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
5021:             1             24  org.gradle.api.internal.catalog.parser.StrictVersionParser$RichVersion
```

after a few more builds:

```
➜  exclude-merging git:(master) ✗ jmap -histo `jps | grep Daemon | cut -f 1 -d ' '` | grep VersionParser                                   
 224:          5945         190240  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$DefaultVersion
 228:         11631         186096  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser$$Lambda$702/0x00000008006e6440
1310:           174           2784  org.gradle.api.internal.catalog.parser.StrictVersionParser
1325:           110           2640  org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
5320:             1             24  org.gradle.api.internal.catalog.parser.StrictVersionParser$RichVersion
```

which shows the number of VersionParsers and DefaultVersion instances keeps growing.