### PR TITLE
Fix graph resolution corner case

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -131,8 +131,8 @@ class EdgeState implements DependencyGraphEdge {
 
     void attachToTargetConfigurations() {
         ComponentState targetComponent = getTargetComponent();
-        if (targetComponent == null) {
-            // The selector failed or the module has been deselected. Do not attach.
+        if (targetComponent == null || !isUsed()) {
+            // The selector failed or the module has been deselected or the edge source has been deselected. Do not attach.
             return;
         }
 


### PR DESCRIPTION
BOM deselection can cause the node currently traversed to be deselected.
In that case, graph selection should no longer resolve dependency edges.