### PR TITLE
Fix links in plugin doc which go to non-existant DSL pages

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -85,9 +85,9 @@ Types can be used to group related test suites across multiple Gradle projects w
 
 The type of a test suite can be configured using the suites's link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html#getTestType[test type property].
 The type *must be unique* across all test suites in the same Gradle project.
-By convention, the type is set to the name of the test suite, converted to dash-case - with the exception of the built-in test suite, which uses the value link:{groovyDslPath}/org.gradle.api.attributes.TestSuiteType.html#UNIT_TEST['unit-test'].
+By convention, the type is set to the name of the test suite, converted to dash-case - with the exception of the built-in test suite, which uses the value link:{javadocPath}/org/gradle/api/attributes/TestSuiteType.html#UNIT_TEST--['unit-test'].
 
-Common values are available as constants in link:{groovyDslPath}/org.gradle.api.attributes.TestSuiteType.html[TestSuiteType].
+Common values are available as constants in link:{javadocPath}/org/gradle/api/attributes/TestSuiteType.html[TestSuiteType].
 
 [[sec:jvm_test_suite_examples]]
 [discrete]


### PR DESCRIPTION
- Go to existant javadoc instead.