### PR TITLE
Consolidate IvyArtifactName serialization

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactIdentifier.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.api.artifacts.ArtifactIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -26,21 +28,16 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier.n
 
 public class DefaultArtifactIdentifier implements ArtifactIdentifier {
     private final ModuleVersionIdentifier moduleVersionIdentifier;
-    private final String name;
-    private final String type;
-    private final String extension;
-    private final String classifier;
+    private final IvyArtifactName name;
 
     public DefaultArtifactIdentifier(ModuleVersionIdentifier moduleVersionIdentifier, String name, String type, @Nullable String extension, @Nullable String classifier) {
         this.moduleVersionIdentifier = moduleVersionIdentifier;
-        this.name = name;
-        this.type = type;
-        this.extension = extension;
-        this.classifier = classifier;
+        this.name = new DefaultIvyArtifactName(name, type, extension, classifier);
     }
 
     public DefaultArtifactIdentifier(DefaultModuleComponentArtifactIdentifier id) {
-        this(newId(id.getComponentIdentifier()), id.getName().getName(), id.getName().getType(), id.getName().getExtension(), id.getName().getClassifier());
+        this.moduleVersionIdentifier = newId(id.getComponentIdentifier());
+        this.name = id.getName();
     }
 
     @Override
@@ -50,27 +47,27 @@ public class DefaultArtifactIdentifier implements ArtifactIdentifier {
 
     @Override
     public String getName() {
-        return name;
+        return name.getName();
     }
 
     @Override
     public String getType() {
-        return type;
+        return name.getType();
     }
 
     @Override
     public String getExtension() {
-        return extension;
+        return name.getExtension();
     }
 
     @Override
     public String getClassifier() {
-        return classifier;
+        return name.getClassifier();
     }
 
     @Override
     public String toString() {
-        return String.format("module: %s, name: %s, ext: %s, classifier: %s", moduleVersionIdentifier, name, extension, classifier);
+        return String.format("module: %s, name: %s", moduleVersionIdentifier, name);
     }
 
     @Override
@@ -84,28 +81,16 @@ public class DefaultArtifactIdentifier implements ArtifactIdentifier {
 
         DefaultArtifactIdentifier that = (DefaultArtifactIdentifier) o;
 
-        if (!Objects.equals(classifier, that.classifier)) {
-            return false;
-        }
-        if (!Objects.equals(extension, that.extension)) {
-            return false;
-        }
         if (!Objects.equals(moduleVersionIdentifier, that.moduleVersionIdentifier)) {
             return false;
         }
-        if (!Objects.equals(name, that.name)) {
-            return false;
-        }
-        return Objects.equals(type, that.type);
+        return Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
         int result = moduleVersionIdentifier != null ? moduleVersionIdentifier.hashCode() : 0;
         result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (extension != null ? extension.hashCode() : 0);
-        result = 31 * result + (classifier != null ? classifier.hashCode() : 0);
         return result;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/ModuleFactoryHelper.java
@@ -19,8 +19,10 @@ import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyArtifact;
 
+import javax.annotation.Nullable;
+
 public class ModuleFactoryHelper {
-    public static void addExplicitArtifactsIfDefined(ExternalDependency moduleDependency, String artifactType, String classifier) {
+    public static void addExplicitArtifactsIfDefined(ExternalDependency moduleDependency, @Nullable String artifactType, @Nullable String classifier) {
         String actualArtifactType = artifactType;
         if (actualArtifactType == null) {
             if (classifier != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DependencyVerifyingModuleComponentRepository.java
@@ -269,7 +269,7 @@ public class DependencyVerifyingModuleComponentRepository implements ModuleCompo
                 // This is a bit hackish but the mapping from file names to ivy artifact names is completely broken
                 String fileName = artifactIdentifier.getFileName().replace("-" + artifactIdentifier.getComponentIdentifier().getVersion(), "");
                 fileName = Files.getNameWithoutExtension(fileName); // removes the .asc
-                DefaultIvyArtifactName base = DefaultIvyArtifactName.forFileName(fileName, null);
+                IvyArtifactName base = DefaultIvyArtifactName.forFileName(fileName, null);
                 return new DefaultIvyArtifactName(
                     base.getName(),
                     "asc",

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -45,8 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This a straight copy of org.apache.ivy.plugins.parser.m2.PomModuleDescriptorBuilder, with minor changes: 1) Do not create artifact for empty classifier. (Previously did so for all non-null
- * classifiers)
+ * This file was originally a copy of org.apache.ivy.plugins.parser.m2.PomModuleDescriptorBuilder, but has since been significantly modified.
  */
 public class GradlePomModuleDescriptorBuilder {
     public static final ImmutableMap<String, Configuration> MAVEN2_CONFIGURATIONS = ImmutableMap.<String, Configuration>builder()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyModuleDescriptorConverter.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 
 public class IvyModuleDescriptorConverter {
-    private static final IvyArtifactName WILDARD_ARTIFACT = new DefaultIvyArtifactName(PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION, PatternMatchers.ANY_EXPRESSION);
 
     private static final String CLASSIFIER = "classifier";
     private static final Field DEPENDENCY_CONFIG_FIELD;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.NamespaceId;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
@@ -56,7 +57,6 @@ import org.gradle.internal.component.external.model.maven.MavenDependencyDescrip
 import org.gradle.internal.component.external.model.maven.MavenDependencyType;
 import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -262,11 +262,7 @@ public class ModuleMetadataSerializer {
         private void writeArtifacts(List<Artifact> artifacts) throws IOException {
             writeCount(artifacts.size());
             for (Artifact artifact : artifacts) {
-                IvyArtifactName artifactName = artifact.getArtifactName();
-                writeString(artifactName.getName());
-                writeString(artifactName.getType());
-                writeNullableString(artifactName.getExtension());
-                writeNullableString(artifactName.getClassifier());
+                IvyArtifactNameSerializer.INSTANCE.write(encoder, artifact.getArtifactName());
                 writeStringSet(artifact.getConfigurations());
             }
         }
@@ -338,10 +334,7 @@ public class ModuleMetadataSerializer {
                 writeBoolean(false);
             } else {
                 writeBoolean(true);
-                writeString(artifact.getName());
-                writeString(artifact.getType());
-                writeNullableString(artifact.getExtension());
-                writeNullableString(artifact.getClassifier());
+                IvyArtifactNameSerializer.INSTANCE.write(encoder, artifact);
             }
         }
 
@@ -484,7 +477,7 @@ public class ModuleMetadataSerializer {
                 String reason = decoder.readNullableString();
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
                 boolean endorsing = decoder.readBoolean();
-                IvyArtifactName dependencyArtifact = readNullableArtifact();
+                IvyArtifactName dependencyArtifact = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
                 variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, (ImmutableAttributes) selector.getAttributes(), selector.getRequestedCapabilities(), endorsing, dependencyArtifact);
             }
         }
@@ -587,7 +580,7 @@ public class ModuleMetadataSerializer {
             int size = readCount();
             List<Artifact> result = Lists.newArrayListWithCapacity(size);
             for (int i = 0; i < size; i++) {
-                IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(readString(), readString(), readNullableString(), readNullableString());
+                IvyArtifactName ivyArtifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
                 result.add(new Artifact(ivyArtifactName, readStringSet()));
             }
             return result;
@@ -629,7 +622,7 @@ public class ModuleMetadataSerializer {
             int size = readCount();
             List<Artifact> result = Lists.newArrayListWithCapacity(size);
             for (int i = 0; i < size; i++) {
-                IvyArtifactName ivyArtifactName = new DefaultIvyArtifactName(readString(), readString(), readNullableString(), readNullableString());
+                IvyArtifactName ivyArtifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
                 result.add(new Artifact(ivyArtifactName, readStringSet()));
             }
             return result;
@@ -657,23 +650,10 @@ public class ModuleMetadataSerializer {
         private DefaultExclude readExcludeRule() throws IOException {
             String moduleOrg = readString();
             String moduleName = readString();
-            IvyArtifactName artifactName = readNullableArtifact();
+            IvyArtifactName artifactName = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
             String[] confs = readStringArray();
             String matcher = readNullableString();
             return new DefaultExclude(moduleIdentifierFactory.module(moduleOrg, moduleName), artifactName, confs, matcher);
-        }
-
-        private IvyArtifactName readNullableArtifact() throws IOException {
-            boolean hasArtifact = readBoolean();
-            IvyArtifactName artifactName = null;
-            if (hasArtifact) {
-                String artifact = readString();
-                String type = readString();
-                String ext = readNullableString();
-                String classifier = readNullableString();
-                artifactName = new DefaultIvyArtifactName(artifact, type, ext, classifier);
-            }
-            return artifactName;
         }
 
         private List<MavenDependencyDescriptor> readMavenDependencies(Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
@@ -689,7 +669,7 @@ public class ModuleMetadataSerializer {
             int mapping = decoder.readSmallInt();
             if (mapping == deduplicationDependencyCache.size()) {
                 ModuleComponentSelector requested = componentSelectorSerializer.read(decoder);
-                IvyArtifactName artifactName = readNullableArtifact();
+                IvyArtifactName artifactName = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
                 List<ExcludeMetadata> mavenExcludes = readMavenDependencyExcludes();
                 MavenScope scope = MavenScope.values()[decoder.readSmallInt()];
                 MavenDependencyType type = MavenDependencyType.values()[decoder.readSmallInt()];

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultIvyPatternMatcherExcludeRuleSpec.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/simple/DefaultIvyPatternMatcherExcludeRuleSpec.java
@@ -74,6 +74,12 @@ final class DefaultIvyPatternMatcherExcludeRuleSpec implements IvyPatternMatcher
     }
 
     private boolean matches(String expression, String input) {
+        if (expression == null && input == null) {
+            return true;
+        }
+        if (expression == null || input == null) {
+            return false;
+        }
         return matcher.getMatcher(expression).matches(input);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/IvyArtifactNameSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/IvyArtifactNameSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
+
+import org.gradle.internal.component.model.DefaultIvyArtifactName;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.serialize.AbstractSerializer;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Serializes and de-serializes {@link IvyArtifactName}s.
+ */
+public class IvyArtifactNameSerializer extends AbstractSerializer<IvyArtifactName>  {
+
+    public static final IvyArtifactNameSerializer INSTANCE = new IvyArtifactNameSerializer();
+    private IvyArtifactNameSerializer() {
+        // Private to enforce singleton.
+    }
+
+    @Override
+    public IvyArtifactName read(Decoder decoder) throws IOException {
+        String artifactName = decoder.readString();
+        String type = decoder.readString();
+        String extension = decoder.readNullableString();
+        String classifier = decoder.readNullableString();
+        return new DefaultIvyArtifactName(artifactName, type, extension, classifier);
+    }
+
+    @Override
+    public void write(Encoder encoder, IvyArtifactName value) throws IOException {
+        encoder.writeString(value.getName());
+        encoder.writeString(value.getType());
+        encoder.writeNullableString(value.getExtension());
+        encoder.writeNullableString(value.getClassifier());
+    }
+
+    public void writeNullable(Encoder encoder, @Nullable IvyArtifactName value) throws IOException {
+        if (value == null) {
+            encoder.writeBoolean(false);
+        } else {
+            encoder.writeBoolean(true);
+            write(encoder, value);
+        }
+    }
+
+    @Nullable
+    public IvyArtifactName readNullable(Decoder decoder) throws IOException {
+        boolean hasArtifact = decoder.readBoolean();
+        if (hasArtifact) {
+            return read(decoder);
+        }
+        return null;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactIdentifierSerializer.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.metadata;
 
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.serialize.Decoder;
@@ -29,20 +30,13 @@ public class ComponentArtifactIdentifierSerializer implements Serializer<Default
     @Override
     public void write(Encoder encoder, DefaultModuleComponentArtifactIdentifier value) throws Exception {
         componentIdentifierSerializer.write(encoder, value.getComponentIdentifier());
-        IvyArtifactName ivyArtifactName = value.getName();
-        encoder.writeString(ivyArtifactName.getName());
-        encoder.writeString(ivyArtifactName.getType());
-        encoder.writeNullableString(ivyArtifactName.getExtension());
-        encoder.writeNullableString(ivyArtifactName.getClassifier());
+        IvyArtifactNameSerializer.INSTANCE.write(encoder, value.getName());
     }
 
     @Override
     public DefaultModuleComponentArtifactIdentifier read(Decoder decoder) throws Exception {
         ModuleComponentIdentifier componentIdentifier = (ModuleComponentIdentifier) componentIdentifierSerializer.read(decoder);
-        String artifactName = decoder.readString();
-        String type = decoder.readString();
-        String extension = decoder.readNullableString();
-        String classifier = decoder.readNullableString();
-        return new DefaultModuleComponentArtifactIdentifier(componentIdentifier, artifactName, type, extension, classifier);
+        IvyArtifactName name = IvyArtifactNameSerializer.INSTANCE.read(decoder);
+        return new DefaultModuleComponentArtifactIdentifier(componentIdentifier, name);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentArtifactMetadataSerializer.java
@@ -18,10 +18,10 @@ package org.gradle.api.internal.artifacts.metadata;
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
@@ -35,11 +35,7 @@ public class ComponentArtifactMetadataSerializer extends AbstractSerializer<Comp
         if (value instanceof ModuleComponentArtifactMetadata) {
             ModuleComponentArtifactMetadata moduleComponentArtifactMetadata = (ModuleComponentArtifactMetadata) value;
             componentIdentifierSerializer.write(encoder, moduleComponentArtifactMetadata.getComponentId());
-            IvyArtifactName ivyArtifactName = moduleComponentArtifactMetadata.getName();
-            encoder.writeString(ivyArtifactName.getName());
-            encoder.writeString(ivyArtifactName.getType());
-            encoder.writeNullableString(ivyArtifactName.getExtension());
-            encoder.writeNullableString(ivyArtifactName.getClassifier());
+            IvyArtifactNameSerializer.INSTANCE.write(encoder,  moduleComponentArtifactMetadata.getName());
         } else {
             throw new IllegalArgumentException("Unknown artifact metadata type.");
         }
@@ -48,11 +44,8 @@ public class ComponentArtifactMetadataSerializer extends AbstractSerializer<Comp
     @Override
     public ComponentArtifactMetadata read(Decoder decoder) throws Exception {
         ModuleComponentIdentifier componentIdentifier = (ModuleComponentIdentifier) componentIdentifierSerializer.read(decoder);
-        String artifactName = decoder.readString();
-        String type = decoder.readString();
-        String extension = decoder.readNullableString();
-        String classifier = decoder.readNullableString();
-        return new DefaultModuleComponentArtifactMetadata(componentIdentifier, new DefaultIvyArtifactName(artifactName, type, extension, classifier));
+        IvyArtifactName name = IvyArtifactNameSerializer.INSTANCE.read(decoder);
+        return new DefaultModuleComponentArtifactMetadata(componentIdentifier, name);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -28,17 +28,16 @@ import org.gradle.api.internal.artifacts.ModuleComponentSelectorSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.internal.component.external.descriptor.DefaultExclude;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
-import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -129,7 +128,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         boolean endorsing = decoder.readBoolean();
         boolean force = decoder.readBoolean();
         String reason = decoder.readNullableString();
-        IvyArtifactName artifact = readNullableArtifact(decoder);
+        IvyArtifactName artifact = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
         return new GradleDependencyMetadata(selector, excludes, constraint, endorsing, reason, force, artifact);
     }
 
@@ -137,10 +136,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         ImmutableList.Builder<ModuleComponentArtifactMetadata> artifacts = new ImmutableList.Builder<>();
         int artifactsCount = decoder.readSmallInt();
         for (int i = 0; i < artifactsCount; i++) {
-            String name = decoder.readString();
-            String type = decoder.readString();
-            String extension = decoder.readNullableString();
-            String classifier = decoder.readNullableString();
+            IvyArtifactName artifactName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
             String timestamp = decoder.readNullableString();
 
             String version;
@@ -151,24 +147,20 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
             }
 
             boolean alternativeArtifact = decoder.readBoolean();
-            DefaultIvyArtifactName alternative = null;
+            IvyArtifactName alternative = null;
             if (alternativeArtifact) {
-                String altName = decoder.readString();
-                String altType = decoder.readString();
-                String altExtension = decoder.readNullableString();
-                String altClassifier = decoder.readNullableString();
-                alternative = new DefaultIvyArtifactName(altName, altType, altExtension, altClassifier);
+                alternative = IvyArtifactNameSerializer.INSTANCE.read(decoder);
             }
             boolean optional = decoder.readBoolean();
 
             if (optional) {
-                artifacts.add(new ModuleComponentOptionalArtifactMetadata(cid, new DefaultIvyArtifactName(name, type, extension, classifier)));
+                artifacts.add(new ModuleComponentOptionalArtifactMetadata(cid, artifactName));
             } else {
                 if (alternativeArtifact) {
-                    artifacts.add(new DefaultModuleComponentArtifactMetadata(cid, new DefaultIvyArtifactName(name, type, extension, classifier),
+                    artifacts.add(new DefaultModuleComponentArtifactMetadata(cid, artifactName,
                             new DefaultModuleComponentArtifactMetadata(cid, alternative)));
                 } else {
-                    artifacts.add(new DefaultModuleComponentArtifactMetadata(cid, new DefaultIvyArtifactName(name, type, extension, classifier)));
+                    artifacts.add(new DefaultModuleComponentArtifactMetadata(cid, artifactName));
                 }
             }
         }
@@ -212,8 +204,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         encoder.writeSmallInt(ivyArtifactsCount);
         for (ComponentArtifactMetadata artifact : artifacts) {
             if (!(artifact instanceof UrlBackedArtifactMetadata)) {
-                IvyArtifactName artifactName = artifact.getName();
-                writeIvyArtifactName(encoder, artifactName);
+                IvyArtifactNameSerializer.INSTANCE.write(encoder, artifact.getName());
                 ComponentIdentifier componentId = artifact.getComponentId();
                 if (componentId instanceof MavenUniqueSnapshotComponentIdentifier) {
                     MavenUniqueSnapshotComponentIdentifier uid = (MavenUniqueSnapshotComponentIdentifier) componentId;
@@ -224,7 +215,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
                 }
                 encoder.writeBoolean(artifact.getAlternativeArtifact().isPresent());
                 if (artifact.getAlternativeArtifact().isPresent()) {
-                    writeIvyArtifactName(encoder, artifact.getAlternativeArtifact().get().getName());
+                    IvyArtifactNameSerializer.INSTANCE.write(encoder, artifact.getAlternativeArtifact().get().getName());
                 }
                 encoder.writeBoolean(artifact.isOptionalArtifact());
             }
@@ -236,13 +227,6 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
                 encoder.writeString(((UrlBackedArtifactMetadata) file).getRelativeUrl());
             }
         }
-    }
-
-    private void writeIvyArtifactName(Encoder encoder, IvyArtifactName artifactName) throws IOException {
-        encoder.writeString(artifactName.getName());
-        encoder.writeString(artifactName.getType());
-        encoder.writeNullableString(artifactName.getExtension());
-        encoder.writeNullableString(artifactName.getClassifier());
     }
 
     protected abstract void writeDependencies(Encoder encoder, ConfigurationMetadata configuration, Map<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache) throws IOException;
@@ -272,7 +256,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         encoder.writeBoolean(dependencyMetadata.isEndorsingStrictVersions());
         encoder.writeBoolean(dependencyMetadata.isForce());
         encoder.writeNullableString(dependencyMetadata.getReason());
-        writeNullableArtifact(encoder,  dependencyMetadata.getDependencyArtifact());
+        IvyArtifactNameSerializer.INSTANCE.writeNullable(encoder, dependencyMetadata.getDependencyArtifact());
     }
 
     protected void writeMavenExcludeRules(Encoder encoder, List<ExcludeMetadata> excludes) throws IOException {
@@ -283,33 +267,10 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         }
     }
 
-    @Nullable
-    protected IvyArtifactName readNullableArtifact(Decoder decoder) throws IOException {
-        boolean hasArtifact = decoder.readBoolean();
-        IvyArtifactName artifactName = null;
-        if (hasArtifact) {
-            String artifact = decoder.readString();
-            String type = decoder.readString();
-            String ext = decoder.readNullableString();
-            String classifier = decoder.readNullableString();
-            artifactName = new DefaultIvyArtifactName(artifact, type, ext, classifier);
-        }
-        return artifactName;
-    }
-
-    protected void writeNullableArtifact(Encoder encoder, @Nullable IvyArtifactName artifact) throws IOException {
-        if (artifact == null) {
-            encoder.writeBoolean(false);
-        } else {
-            encoder.writeBoolean(true);
-            writeIvyArtifactName(encoder, artifact);
-        }
-    }
-
     protected DefaultExclude readExcludeRule(Decoder decoder) throws IOException {
         String moduleOrg = decoder.readString();
         String moduleName = decoder.readString();
-        IvyArtifactName artifactName = readNullableArtifact(decoder);
+        IvyArtifactName artifactName = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
         String[] confs = readStringSet(decoder).toArray(new String[0]);
         String matcher = decoder.readNullableString();
         return new DefaultExclude(moduleIdentifierFactory.module(moduleOrg, moduleName), artifactName, confs, matcher);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentArtifactIdentifier.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.component.external.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.IvyArtifactName;
-import org.gradle.util.internal.GUtil;
 
 import javax.annotation.Nullable;
 
@@ -45,8 +45,8 @@ public class DefaultModuleComponentArtifactIdentifier implements ModuleComponent
 
     @Override
     public String getFileName() {
-        String classifier = GUtil.isTrue(name.getClassifier()) ? "-" + name.getClassifier() : "";
-        String extension = GUtil.isTrue(name.getExtension()) ? "." + name.getExtension() : "";
+        String classifier = StringUtils.isNotEmpty(name.getClassifier()) ? "-" + name.getClassifier() : "";
+        String extension = StringUtils.isNotEmpty(name.getExtension()) ? "." + name.getExtension() : "";
         return name.getName() + "-" + componentIdentifier.getVersion() + classifier + extension;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.descriptor.MavenScope;
@@ -231,7 +232,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         int mapping = decoder.readSmallInt();
         if (mapping == deduplicationDependencyCache.size()) {
             ModuleComponentSelector requested = getComponentSelectorSerializer().read(decoder);
-            IvyArtifactName artifactName = readNullableArtifact(decoder);
+            IvyArtifactName artifactName = IvyArtifactNameSerializer.INSTANCE.readNullable(decoder);
             List<ExcludeMetadata> mavenExcludes = readMavenExcludes(decoder);
             MavenScope scope = MavenScope.values()[decoder.readSmallInt()];
             MavenDependencyType type = MavenDependencyType.values()[decoder.readSmallInt()];
@@ -253,7 +254,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         } else {
             encoder.writeSmallInt(nextMapping);
             getComponentSelectorSerializer().write(encoder, mavenDependency.getSelector());
-            writeNullableArtifact(encoder, mavenDependency.getDependencyArtifact());
+            IvyArtifactNameSerializer.INSTANCE.writeNullable(encoder, mavenDependency.getDependencyArtifact());
             writeMavenExcludeRules(encoder, mavenDependency.getAllExcludes());
             encoder.writeSmallInt(mavenDependency.getScope().ordinal());
             encoder.writeSmallInt(mavenDependency.getType().ordinal());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentOverrideMetadata.java
@@ -19,7 +19,6 @@ package org.gradle.internal.component.model;
 import org.gradle.api.artifacts.ClientModule;
 
 import javax.annotation.Nullable;
-import java.util.List;
 
 /**
  * Metadata about a component that will override the information obtained when resolving, typically specified by a dependency descriptor.
@@ -29,9 +28,10 @@ import java.util.List;
 public interface ComponentOverrideMetadata {
 
     /**
-     * If the dependency declared artifacts for the component, return them. Empty otherwise.
+     * If the dependency declared an artifact for the component, return it.
      */
-    List<IvyArtifactName> getArtifacts();
+    @Nullable
+    IvyArtifactName getArtifact();
 
     /**
      * If the request originated from a ClientModule, return it. Null otherwise.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultComponentOverrideMetadata.java
@@ -16,20 +16,17 @@
 
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.internal.component.local.model.DslOriginDependencyMetadata;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.List;
 
 public class DefaultComponentOverrideMetadata implements ComponentOverrideMetadata {
-    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata(false, (IvyArtifactName) null, null);
+    public static final ComponentOverrideMetadata EMPTY = new DefaultComponentOverrideMetadata(false, null, null);
 
     private final boolean changing;
-    private final List<IvyArtifactName> artifacts;
+    private final IvyArtifactName artifact;
     private final ClientModule clientModule;
 
     public static ComponentOverrideMetadata forDependency(boolean changing, @Nullable IvyArtifactName mainArtifact, @Nullable ClientModule clientModule) {
@@ -40,12 +37,8 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
     }
 
     private DefaultComponentOverrideMetadata(boolean changing, @Nullable IvyArtifactName artifact, @Nullable ClientModule clientModule) {
-        this(changing, artifact == null ? Collections.emptyList() : ImmutableList.of(artifact), clientModule);
-    }
-
-    private DefaultComponentOverrideMetadata(boolean changing, List<IvyArtifactName> artifacts, @Nullable ClientModule clientModule) {
         this.changing = changing;
-        this.artifacts = artifacts;
+        this.artifact = artifact;
         this.clientModule = clientModule;
     }
 
@@ -62,12 +55,13 @@ public class DefaultComponentOverrideMetadata implements ComponentOverrideMetada
 
     @Override
     public ComponentOverrideMetadata withChanging() {
-        return new DefaultComponentOverrideMetadata(true, artifacts, clientModule);
+        return new DefaultComponentOverrideMetadata(true, artifact, clientModule);
     }
 
+    @Nullable
     @Override
-    public List<IvyArtifactName> getArtifacts() {
-        return artifacts;
+    public IvyArtifactName getArtifact() {
+        return artifact;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleDependencyDescriptorFactoryTest.groovy
@@ -55,11 +55,10 @@ class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDependencyDe
         selector.versionConstraint.preferredVersion == ""
     }
 
-    def testCreateFromModuleDependency() {
+    def "test create from module dependency"() {
         when:
-        boolean withArtifacts = true
-        DefaultExternalModuleDependency moduleDependency = new DefaultExternalModuleDependency("org.gradle",
-                "gradle-core", "1.0", null)
+        def configuration = withArtifacts ? null : TEST_DEP_CONF
+        DefaultExternalModuleDependency moduleDependency = new DefaultExternalModuleDependency("org.gradle", "gradle-core", "1.0", configuration)
         setUpDependency(moduleDependency, withArtifacts)
 
         LocalOriginDependencyMetadata dependencyMetaData = externalModuleDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, moduleDependency)
@@ -72,24 +71,8 @@ class ExternalModuleDependencyDescriptorFactoryTest extends AbstractDependencyDe
         moduleDependency.version == dependencyMetaData.selector.version
         ((VersionConstraintInternal) moduleDependency.getVersionConstraint()).asImmutable() == dependencyMetaData.selector.versionConstraint
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)
-    }
 
-    def testCreateFromModuleDependencyWithoutArtifacts() {
-        when:
-        boolean withArtifacts = false
-        DefaultExternalModuleDependency moduleDependency = new DefaultExternalModuleDependency("org.gradle",
-            "gradle-core", "1.0", TEST_DEP_CONF)
-        setUpDependency(moduleDependency, withArtifacts)
-
-        LocalOriginDependencyMetadata dependencyMetaData = externalModuleDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, moduleDependency)
-
-        then:
-        moduleDependency.changing == dependencyMetaData.changing
-        moduleDependency.force == dependencyMetaData.force
-        moduleDependency.group == dependencyMetaData.selector.group
-        moduleDependency.name == dependencyMetaData.selector.module
-        moduleDependency.version == dependencyMetaData.selector.version
-        ((VersionConstraintInternal) moduleDependency.getVersionConstraint()).asImmutable() == dependencyMetaData.selector.versionConstraint
-        assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)
+        where:
+        withArtifacts << [true, false]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -48,10 +48,10 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
         !projectDependencyDescriptorFactory.canConvert(Mock(ExternalModuleDependency))
     }
 
-    def testCreateFromProjectDependency() {
+    def "test create from project dependency"() {
         when:
-        boolean withArtifacts = true
-        ProjectDependency projectDependency = createProjectDependency(null)
+        def configuration = withArtifacts ? null : TEST_DEP_CONF
+        ProjectDependency projectDependency = createProjectDependency(configuration)
         setUpDependency(projectDependency, withArtifacts)
         LocalOriginDependencyMetadata dependencyMetaData = projectDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, projectDependency)
 
@@ -61,21 +61,9 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
         !dependencyMetaData.force
         dependencyMetaData.selector == new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root", ImmutableAttributes.EMPTY, [])
         projectDependency == dependencyMetaData.source
-    }
 
-    def testCreateFromProjectDependencyWithoutArtifacts() {
-        when:
-        boolean withArtifacts = false
-        ProjectDependency projectDependency = createProjectDependency(TEST_DEP_CONF)
-        setUpDependency(projectDependency, withArtifacts)
-        LocalOriginDependencyMetadata dependencyMetaData = projectDependencyDescriptorFactory.createDependencyDescriptor(componentId, TEST_CONF, null, projectDependency)
-
-        then:
-        assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData, withArtifacts)
-        !dependencyMetaData.changing
-        !dependencyMetaData.force
-        dependencyMetaData.selector == new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root", ImmutableAttributes.EMPTY, [])
-        projectDependency == dependencyMetaData.source
+        where:
+        withArtifacts << [true, false]
     }
 
     private ProjectDependency createProjectDependency(String dependencyConfiguration) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolverTest.groovy
@@ -139,9 +139,11 @@ class ExternalResourceResolverTest extends Specification {
     def "tries to fetch artifact when module metadata file is missing and legacy mode is active"() {
         given:
         def id = Stub(ModuleComponentIdentifier)
+        def metadata = Stub(ComponentOverrideMetadata)
+        metadata.artifact >> null
 
         when:
-        resolver.remoteAccess.resolveComponentMetaData(id, Stub(ComponentOverrideMetadata), metadataResult)
+        resolver.remoteAccess.resolveComponentMetaData(id, metadata, metadataResult)
 
         then:
         1 * metadataSources.sources() >> ImmutableList.of(new DefaultArtifactMetadataSource(Mock(MutableModuleMetadataFactory)))


### PR DESCRIPTION
A clean-up PR to separate assorted code changes I found along the way of debugging #20696

* Create and use unified IvyArtifactNameSerializer to reduce duplicated encoder/decoder code
* Add missing @Nullable annotations all-around where they were prevously missing
* Update ComponentOverrideMetadata to hold only a single IvyArtifactName since it only ever held a single one
* Update outdated javadoc, fix grammar
* Reworked logic in DefaultArtifactMetadataSource
* Avoid potential NPE in DefaultIvyPatternMatcherExcludeRuleSpec
* Replace GUtil.isTrue with StringUtils.isNotEmpty
* Simplify testing code by consolidating/parameterizing some tests, removing unused code, make methods static