### PR TITLE
Add equals/hashCode to OrdinalGroup

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
@@ -52,4 +52,23 @@ public class OrdinalGroup extends NodeGroup {
     public int getOrdinal() {
         return ordinal;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        OrdinalGroup that = (OrdinalGroup) o;
+
+        return ordinal == that.ordinal;
+    }
+
+    @Override
+    public int hashCode() {
+        return ordinal;
+    }
 }


### PR DESCRIPTION
When loading the execution graph (nodes) from the configuration cache, then new node groups are created for the ordinals. Since those didn't have an equals/hashCode implementation, we ended up having to different OrdinalGroups in OrdinalNodeAccess for the destroyer tasks, although them having the same ordinal.

This caused clean tasks to run after the producer tasks when loading from the configuration cache even though the command line task order was different.

This can be seen by looking at `[org.gradle.execution.taskgraph.ParallelTaskExecutionIntegrationTest.tasks are not run in parallel if destroy files overlap with input files (destroy first)](https://ge.gradle.org/scans/tests?search.relativeStartTime=P90D&search.tags=not:performanceTest,ci&search.timeZoneId=Europe/Berlin&tests.container=org.gradle.execution.taskgraph.ParallelTaskExecutionIntegrationTest&tests.sortField=FLAKY&tests.test=tasks%20are%20not%20run%20in%20parallel%20if%20destroy%20files%20overlap%20with%20input%20files%20(destroy%20first)).

We were able to reproduce the failure by adding a sleep for `destroyerPing` in `LocalTaskNode.resolveMutations`:

```diff
Index: subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
===================================================================
diff --git a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java	(revision 490710bd385b4c7e2dc5735a3417edc6253b8dad)
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java	(date 1654260386977)
@@ -221,6 +221,14 @@
         final LocalTaskNode taskNode = this;
         final TaskInternal task = getTask();
         final MutationInfo mutations = getMutationInfo();
+        if (task.getName().equals("destroyerPing")) {
+            System.out.println("destroyerPing");
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
         ProjectInternal project = (ProjectInternal) task.getProject();
         ServiceRegistry serviceRegistry = project.getServices();
         final FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
```

The fix adds `equals`/`hashCode` to `OrdinalGroup`, so the maps are again consistent. Another fix would be to make sure we create unique `OrdinalGroup`s when loading from the configuration cache in https://github.com/gradle/gradle/blob/ceef737add6b6a84019f69b478fb2f8342f30d35/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt#L139-L142.

We didn't find any usage of `==` on `OrdinalGroup`, those would need to be replace by `equals` to ensure correctness.

Fixes #20897