### PR TITLE
Fix `Manifest.from(Object...)` to accept any Manifest object

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -9,6 +9,7 @@ Include only their name, impactful features should be called out separately belo
  THiS LIST SHOULD BE ALPHABETIZED BY [PERSON NAME] - the docs:updateContributorsInReleaseNotes task will enforce this ordering, which is case-insensitive.
 -->
 We would like to thank the following community members for their contributions to this release of Gradle:
+[BJ Hargrave](https://github.com/bjhargrave),
 [altrisi](https://github.com/altrisi),
 [aSemy](https://github.com/aSemy),
 [Ashwin Pankaj](https://github.com/ashwinpankaj),

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
@@ -62,12 +62,14 @@ public class CustomManifestInternalWrapper implements ManifestInternal {
 
     @Override
     public Manifest attributes(Map<String, ?> attributes) throws ManifestException {
-        return delegate.attributes(attributes);
+        delegate.attributes(attributes);
+        return this;
     }
 
     @Override
     public Manifest attributes(Map<String, ?> attributes, String sectionName) throws ManifestException {
-        return delegate.attributes(attributes, sectionName);
+        delegate.attributes(attributes, sectionName);
+        return this;
     }
 
     @Override
@@ -77,21 +79,25 @@ public class CustomManifestInternalWrapper implements ManifestInternal {
 
     @Override
     public Manifest writeTo(Object path) {
-        return delegate.writeTo(path);
+        delegate.writeTo(path);
+        return this;
     }
 
     @Override
     public Manifest from(Object... mergePath) {
-        return delegate.from(mergePath);
+        delegate.from(mergePath);
+        return this;
     }
 
     @Override
     public Manifest from(Object mergePath, Closure<?> closure) {
-        return delegate.from(mergePath, closure);
+        delegate.from(mergePath, closure);
+        return this;
     }
 
     @Override
     public Manifest from(Object mergePath, Action<ManifestMergeSpec> action) {
-        return delegate.from(mergePath, action);
+        delegate.from(mergePath, action);
+        return this;
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifestMergeSpec.java
@@ -81,13 +81,13 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
         mergedManifest.getAttributes().putAll(baseManifest.getAttributes());
         mergedManifest.getSections().putAll(baseManifest.getSections());
         for (Object mergePath : mergePaths) {
-            DefaultManifest manifestToMerge = createManifest(mergePath, fileResolver, contentCharset);
+            Manifest manifestToMerge = createManifest(mergePath, fileResolver, contentCharset);
             mergedManifest = mergeManifest(mergedManifest, manifestToMerge, fileResolver);
         }
         return mergedManifest;
     }
 
-    private DefaultManifest mergeManifest(DefaultManifest baseManifest, DefaultManifest toMergeManifest, PathToFileResolver fileResolver) {
+    private DefaultManifest mergeManifest(Manifest baseManifest, Manifest toMergeManifest, PathToFileResolver fileResolver) {
         DefaultManifest mergedManifest = new DefaultManifest(fileResolver);
         mergeSection(null, mergedManifest, baseManifest.getAttributes(), toMergeManifest.getAttributes());
         Set<String> allSections = Sets.union(baseManifest.getSections().keySet(), toMergeManifest.getSections().keySet());
@@ -99,7 +99,7 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
         return mergedManifest;
     }
 
-    private void mergeSection(String section, DefaultManifest mergedManifest, Attributes baseAttributes, Attributes mergeAttributes) {
+    private void mergeSection(String section, Manifest mergedManifest, Attributes baseAttributes, Attributes mergeAttributes) {
         Map<String, Object> mergeOnlyAttributes = new LinkedHashMap<String, Object>(mergeAttributes);
         Set<DefaultManifestMergeDetails> mergeDetailsSet = new LinkedHashSet<DefaultManifestMergeDetails>();
 
@@ -138,7 +138,7 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
         }
     }
 
-    private void addMergeDetailToManifest(String section, DefaultManifest mergedManifest, DefaultManifestMergeDetails mergeDetails) {
+    private void addMergeDetailToManifest(String section, Manifest mergedManifest, DefaultManifestMergeDetails mergeDetails) {
         if (!mergeDetails.isExcluded()) {
             if (section == null) {
                 mergedManifest.attributes(WrapUtil.toMap(mergeDetails.getKey(), mergeDetails.getValue()));
@@ -148,9 +148,9 @@ public class DefaultManifestMergeSpec implements ManifestMergeSpec {
         }
     }
 
-    private DefaultManifest createManifest(Object mergePath, PathToFileResolver fileResolver, String contentCharset) {
-        if (mergePath instanceof DefaultManifest) {
-            return ((DefaultManifest) mergePath).getEffectiveManifest();
+    private Manifest createManifest(Object mergePath, PathToFileResolver fileResolver, String contentCharset) {
+        if (mergePath instanceof Manifest) {
+            return ((Manifest) mergePath).getEffectiveManifest();
         }
         return new DefaultManifest(mergePath, fileResolver, contentCharset);
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestMergeSpecTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestMergeSpecTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.java.archives.internal
 
 import org.gradle.api.Action
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.java.archives.Manifest
 import org.gradle.api.java.archives.ManifestMergeDetails
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -124,6 +125,16 @@ class DefaultManifestMergeSpecTest extends Specification {
 
         expect:
         mergeSpec.merge(baseManifest, Mock(FileResolver)).sections.section == [key2: 'mergeValue2']
+    }
+
+    def mergeWithForeignManifest() {
+        DefaultManifest baseManifest = new DefaultManifest(Mock(FileResolver))
+        baseManifest.attributes key1: 'value1'
+        Manifest foreign = new CustomManifestInternalWrapper(new DefaultManifest(Mock(FileResolver)).attributes( key2: 'value2'))
+        mergeSpec.from(foreign)
+
+        expect:
+        mergeSpec.merge(baseManifest, Mock(FileResolver)).attributes == [key1: 'value1', key2: 'value2'] + MANIFEST_VERSION_MAP
     }
 
     def mergeShouldWinByDefault() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #20928

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

One should be able to pass an implementation of `org.gradle.api.java.archives.Manifest` to `Manifest.from(Object...)` to get the argument manifest merged into the receiver manifest.

The [javadoc](https://github.com/gradle/gradle/blob/270f942676177479a8e389cdd734a18771bc4982/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/Manifest.java#L84-L85) indicates this is supported.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
