### PR TITLE
Fix failing sample tests

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -592,8 +592,8 @@ tasks.named("docsTest") { task ->
         if (!OperatingSystem.current().macOsX) {
             excludeTestsMatching "org.gradle.docs.samples.*.building-swift-*.sample"
         }
-        // We don't maintain Java 7 on Windows
-        if (OperatingSystem.current().windows) {
+        // We don't maintain Java 7 on Windows and Mac
+        if (OperatingSystem.current().windows || OperatingSystem.current().macOsX) {
             excludeTestsMatching "*java7CrossCompilation.sample"
         }
         // Only execute Groovy sample tests on Java < 9 to avoid warnings in output

--- a/subprojects/docs/src/snippets/java/toolchain-task/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/toolchain-task/kotlin/build.gradle.kts
@@ -39,6 +39,6 @@ tasks.register<CustomTaskUsingToolchains>("showDefaultToolchain")
 
 tasks.register<CustomTaskUsingToolchains>("showCustomToolchain") {
     launcher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(16))
+        languageVersion.set(JavaLanguageVersion.of(17))
     })
 }


### PR DESCRIPTION
1. Don't run java7CrossCompilation on mac.
2. Use Java 17 in toolchainTask.

See the failure here: https://ge.gradle.org/s/ic4a5wkaou26e/tests/overview?outcome=failed