### PR TITLE
Preserve identity of `OrdinalGroup` instances loaded from the config cache

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.execution.plan.ExecutionNodeAccessHierarchies
 import org.gradle.execution.plan.ExecutionPlan
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.NodeValidator
+import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.PlanExecutor
 import org.gradle.execution.plan.SelfExecutingNode
 import org.gradle.execution.plan.TaskDependencyResolver
@@ -197,7 +198,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
         def builder = Mock(BuildLifecycleController.WorkGraphBuilder)
         def nodeFactory = new TaskNodeFactory(Stub(GradleInternal), Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator))
         def hierarchies = new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_SENSITIVE, TestFiles.fileSystem())
-        def plan = new DefaultExecutionPlan(displayName, nodeFactory, Stub(TaskDependencyResolver), hierarchies.outputHierarchy, hierarchies.destroyableHierarchy, services.coordinationService)
+        def plan = new DefaultExecutionPlan(displayName, nodeFactory, new OrdinalGroupFactory(), Stub(TaskDependencyResolver), hierarchies.outputHierarchy, hierarchies.destroyableHierarchy, services.coordinationService)
         def workPlan = Stub(BuildWorkPlan) {
             _ * stop() >> { plan.close() }
         }

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheIntegrationTest.groovy
@@ -25,6 +25,24 @@ import spock.lang.Issue
 
 class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
 
+    def "configuration cache for help on empty project"() {
+        given:
+        settingsFile.createFile()
+        configurationCacheRun "help"
+        def firstRunOutput = removeVfsLogOutput(result.normalizedOutput)
+            .replaceAll(/Calculating task graph as no configuration cache is available for tasks: help\n/, '')
+            .replaceAll(/Configuration cache entry stored.\n/, '')
+
+        when:
+        configurationCacheRun "help"
+        def secondRunOutput = removeVfsLogOutput(result.normalizedOutput)
+            .replaceAll(/Reusing configuration cache.\n/, '')
+            .replaceAll(/Configuration cache entry reused.\n/, '')
+
+        then:
+        firstRunOutput == secondRunOutput
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/18064")
     def "can build plugin with project dependencies"() {
         given:
@@ -115,24 +133,6 @@ class ConfigurationCacheIntegrationTest extends AbstractConfigurationCacheIntegr
 
         then:
         configurationCache.assertStateLoaded()
-    }
-
-    def "configuration cache for help on empty project"() {
-        given:
-        settingsFile.createFile()
-        configurationCacheRun "help"
-        def firstRunOutput = removeVfsLogOutput(result.normalizedOutput)
-            .replaceAll(/Calculating task graph as no configuration cache is available for tasks: help\n/, '')
-            .replaceAll(/Configuration cache entry stored.\n/, '')
-
-        when:
-        configurationCacheRun "help"
-        def secondRunOutput = removeVfsLogOutput(result.normalizedOutput)
-            .replaceAll(/Reusing configuration cache.\n/, '')
-            .replaceAll(/Configuration cache entry reused.\n/, '')
-
-        then:
-        firstRunOutput == secondRunOutput
     }
 
     private static String removeVfsLogOutput(String normalizedOutput) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheIO.kt
@@ -306,6 +306,7 @@ class ConfigurationCacheIO internal constructor(
             instantiator = service(),
             listenerManager = service(),
             taskNodeFactory = service(),
+            ordinalGroupFactory = service(),
             inputFingerprinter = service(),
             buildOperationExecutor = service(),
             classLoaderHierarchyHasher = service(),

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -503,7 +503,7 @@ class ConfigurationCacheState(
         gradle.settings.buildCache.let { buildCache ->
             buildCache.local = readNonNull()
             buildCache.remote = read() as BuildCache?
-            buildCache.setRegistrations(readNonNull<MutableSet<BuildCacheServiceRegistration>>())
+            buildCache.registrations = readNonNull<MutableSet<BuildCacheServiceRegistration>>()
         }
         RootBuildCacheControllerSettingsProcessor.process(gradle)
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -37,7 +37,6 @@ import org.gradle.configurationcache.problems.DocumentationSection.NotYetImpleme
 import org.gradle.configurationcache.serialization.DefaultReadContext
 import org.gradle.configurationcache.serialization.DefaultWriteContext
 import org.gradle.configurationcache.serialization.codecs.Codecs
-import org.gradle.configurationcache.serialization.codecs.WorkNodeCodec
 import org.gradle.configurationcache.serialization.logNotImplemented
 import org.gradle.configurationcache.serialization.readCollection
 import org.gradle.configurationcache.serialization.readFile
@@ -252,16 +251,20 @@ class ConfigurationCacheState(
 
     private
     suspend fun DefaultWriteContext.writeWorkGraphOf(gradle: GradleInternal, scheduledNodes: List<Node>) {
-        WorkNodeCodec(gradle, internalTypesCodec).run {
+        workNodeCodec(gradle).run {
             writeWork(scheduledNodes)
         }
     }
 
     private
     suspend fun DefaultReadContext.readWorkGraph(gradle: GradleInternal) =
-        WorkNodeCodec(gradle, internalTypesCodec).run {
+        workNodeCodec(gradle).run {
             readWork()
         }
+
+    private
+    fun workNodeCodec(gradle: GradleInternal) =
+        codecs.workNodeCodecFor(gradle)
 
     private
     suspend fun DefaultWriteContext.writeRequiredBuildServicesOf(gradle: GradleInternal, buildTreeState: StoredBuildTreeState) {
@@ -622,10 +625,6 @@ class ConfigurationCacheState(
     private
     fun stateFileFor(buildDefinition: BuildDefinition) =
         stateFile.stateFileForIncludedBuild(buildDefinition)
-
-    private
-    val internalTypesCodec
-        get() = codecs.internalTypesCodec()
 
     private
     val userTypesCodec

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -17,6 +17,7 @@
 package org.gradle.configurationcache.serialization.codecs
 
 import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSetToFileCollectionFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.BuildIdentifierSerializer
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.CapabilitySerializer
@@ -54,6 +55,7 @@ import org.gradle.configurationcache.serialization.codecs.transform.TransformedE
 import org.gradle.configurationcache.serialization.codecs.transform.TransformedProjectArtifactSetCodec
 import org.gradle.configurationcache.serialization.reentrant
 import org.gradle.configurationcache.serialization.unsupported
+import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.TaskNodeFactory
 import org.gradle.internal.Factory
 import org.gradle.internal.build.BuildStateRegistry
@@ -95,6 +97,7 @@ class Codecs(
     instantiator: Instantiator,
     listenerManager: ListenerManager,
     val taskNodeFactory: TaskNodeFactory,
+    val ordinalGroupFactory: OrdinalGroupFactory,
     inputFingerprinter: InputFingerprinter,
     buildOperationExecutor: BuildOperationExecutor,
     classLoaderHierarchyHasher: ClassLoaderHierarchyHasher,
@@ -223,7 +226,7 @@ class Codecs(
         bind(TaskNodeCodec(userTypesCodec, taskNodeFactory))
         bind(DelegatingCodec<TransformationNode>(userTypesCodec))
         bind(ActionNodeCodec(userTypesCodec))
-        bind(OrdinalNodeCodec())
+        bind(OrdinalNodeCodec(ordinalGroupFactory))
 
         bind(NotImplementedCodec)
     }.build()
@@ -320,4 +323,7 @@ class Codecs(
 
         bind(BuildIdentifierSerializer())
     }
+
+    fun workNodeCodecFor(gradle: GradleInternal) =
+        WorkNodeCodec(gradle, internalTypesCodec(), ordinalGroupFactory)
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/OrdinalNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/OrdinalNodeCodec.kt
@@ -21,11 +21,13 @@ import org.gradle.configurationcache.serialization.ReadContext
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.readEnum
 import org.gradle.configurationcache.serialization.writeEnum
-import org.gradle.execution.plan.OrdinalGroup
+import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.OrdinalNode
 
 
-class OrdinalNodeCodec() : Codec<OrdinalNode> {
+class OrdinalNodeCodec(
+    private val ordinalGroups: OrdinalGroupFactory
+) : Codec<OrdinalNode> {
     override suspend fun WriteContext.encode(value: OrdinalNode) {
         writeEnum(value.type)
         writeInt(value.ordinalGroup.ordinal)
@@ -34,7 +36,6 @@ class OrdinalNodeCodec() : Codec<OrdinalNode> {
     override suspend fun ReadContext.decode(): OrdinalNode {
         val ordinalType = readEnum<OrdinalNode.Type>()
         val ordinal = readInt()
-
-        return OrdinalNode(ordinalType, OrdinalGroup(ordinal))
+        return OrdinalNode(ordinalType, ordinalGroups.group(ordinal))
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -31,6 +31,7 @@ import org.gradle.execution.plan.FinalizerGroup
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.NodeGroup
 import org.gradle.execution.plan.OrdinalGroup
+import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.TaskInAnotherBuild
 import org.gradle.execution.plan.TaskNode
 
@@ -38,7 +39,8 @@ import org.gradle.execution.plan.TaskNode
 internal
 class WorkNodeCodec(
     private val owner: GradleInternal,
-    private val internalTypesCodec: Codec<Any?>
+    private val internalTypesCodec: Codec<Any?>,
+    private val ordinalGroups: OrdinalGroupFactory
 ) {
 
     suspend fun WriteContext.writeWork(nodes: List<Node>) {
@@ -138,7 +140,7 @@ class WorkNodeCodec(
             when (readSmallInt()) {
                 0 -> {
                     val ordinal = readSmallInt()
-                    OrdinalGroup(ordinal)
+                    ordinalGroups.group(ordinal)
                 }
                 1 -> {
                     val finalizerNode = nodesById.getValue(readSmallInt()) as TaskNode

--- a/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
+++ b/subprojects/configuration-cache/src/test/kotlin/org/gradle/configurationcache/serialization/codecs/AbstractUserTypeCodecTest.kt
@@ -163,6 +163,7 @@ abstract class AbstractUserTypeCodecTest {
         instantiator = mock(),
         listenerManager = mock(),
         taskNodeFactory = mock(),
+        ordinalGroupFactory = mock(),
         inputFingerprinter = mock(),
         buildOperationExecutor = mock(),
         classLoaderHierarchyHasher = mock(),

--- a/subprojects/core/build.gradle.kts
+++ b/subprojects/core/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation(libs.groovyTest)
     implementation(libs.groovyXml)
     implementation(libs.ant)
+    implementation(libs.fastutil)
     implementation(libs.guava)
     implementation(libs.inject)
     implementation(libs.asm)

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -82,7 +82,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
     private final Set<Node> producedButNotYetConsumed = newIdentityHashSet();
     private final Map<Pair<Node, Node>, Boolean> reachableCache = new HashMap<>();
     private final Set<Node> finalizers = new LinkedHashSet<>();
-    private final OrdinalNodeAccess ordinalNodeAccess = new OrdinalNodeAccess();
+    private final OrdinalNodeAccess ordinalNodeAccess;
     private Consumer<LocalTaskNode> completionHandler = localTaskNode -> {
     };
 
@@ -99,6 +99,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
     public DefaultExecutionPlan(
         String displayName,
         TaskNodeFactory taskNodeFactory,
+        OrdinalGroupFactory ordinalGroupFactory,
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy,
@@ -110,6 +111,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
         this.lockCoordinator = lockCoordinator;
+        this.ordinalNodeAccess = new OrdinalNodeAccess(ordinalGroupFactory);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
@@ -92,7 +92,7 @@ class DetermineExecutionPlanAction {
         createOrdinalRelationships();
 
         ordinalNodeAccess.createInterNodeRelationships();
-        nodeMapping.addAll(ordinalNodeAccess.getAllNodes());
+        ordinalNodeAccess.getAllNodes().forEach(nodeMapping::add);
     }
 
     private void updateFinalizerGroups() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlanFactory.java
@@ -24,6 +24,7 @@ import org.gradle.internal.service.scopes.ServiceScope;
 public class ExecutionPlanFactory {
     private final String displayName;
     private final TaskNodeFactory taskNodeFactory;
+    private final OrdinalGroupFactory ordinalGroupFactory;
     private final TaskDependencyResolver dependencyResolver;
     private final ExecutionNodeAccessHierarchy outputHierarchy;
     private final ExecutionNodeAccessHierarchy destroyableHierarchy;
@@ -32,6 +33,7 @@ public class ExecutionPlanFactory {
     public ExecutionPlanFactory(
         String displayName,
         TaskNodeFactory taskNodeFactory,
+        OrdinalGroupFactory ordinalGroupFactory,
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchy outputHierarchy,
         ExecutionNodeAccessHierarchy destroyableHierarchy,
@@ -39,6 +41,7 @@ public class ExecutionPlanFactory {
     ) {
         this.displayName = displayName;
         this.taskNodeFactory = taskNodeFactory;
+        this.ordinalGroupFactory = ordinalGroupFactory;
         this.dependencyResolver = dependencyResolver;
         this.outputHierarchy = outputHierarchy;
         this.destroyableHierarchy = destroyableHierarchy;
@@ -46,6 +49,6 @@ public class ExecutionPlanFactory {
     }
 
     public ExecutionPlan createPlan() {
-        return new DefaultExecutionPlan(displayName, taskNodeFactory, dependencyResolver, outputHierarchy, destroyableHierarchy, lockCoordinationService);
+        return new DefaultExecutionPlan(displayName, taskNodeFactory, ordinalGroupFactory, dependencyResolver, outputHierarchy, destroyableHierarchy, lockCoordinationService);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroup.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 public class OrdinalGroup extends NodeGroup {
     private final int ordinal;
 
-    public OrdinalGroup(int ordinal) {
+    OrdinalGroup(int ordinal) {
         this.ordinal = ordinal;
     }
 
@@ -50,25 +50,6 @@ public class OrdinalGroup extends NodeGroup {
     }
 
     public int getOrdinal() {
-        return ordinal;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        OrdinalGroup that = (OrdinalGroup) o;
-
-        return ordinal == that.ordinal;
-    }
-
-    @Override
-    public int hashCode() {
         return ordinal;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroupFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalGroupFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution.plan;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.gradle.internal.service.scopes.Scopes;
+import org.gradle.internal.service.scopes.ServiceScope;
+
+/**
+ * Preserves identity of {@see OrdinalGroup} instances so there's a 1-to-1 mapping of ordinals to groups allowing groups
+ * to be freely compared by identity.
+ */
+@ServiceScope(Scopes.Build.class)
+public class OrdinalGroupFactory {
+
+    private final Int2ObjectOpenHashMap<OrdinalGroup> groups = new Int2ObjectOpenHashMap<>();
+
+    public final OrdinalGroup group(int ordinal) {
+        return groups.computeIfAbsent(ordinal, OrdinalGroup::new);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -16,11 +16,11 @@
 
 package org.gradle.execution.plan;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -29,8 +29,8 @@ import java.util.stream.Collectors;
  */
 public class OrdinalNodeAccess {
     private final OrdinalGroupFactory ordinalGroups;
-    private final Map<OrdinalGroup, OrdinalNode> destroyerLocationNodes = Maps.newHashMap();
-    private final Map<OrdinalGroup, OrdinalNode> producerLocationNodes = Maps.newHashMap();
+    private final IdentityHashMap<OrdinalGroup, OrdinalNode> destroyerLocationNodes = new IdentityHashMap<>();
+    private final IdentityHashMap<OrdinalGroup, OrdinalNode> producerLocationNodes = new IdentityHashMap<>();
 
     public OrdinalNodeAccess(OrdinalGroupFactory ordinalGroups) {
         this.ordinalGroups = ordinalGroups;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -28,9 +28,13 @@ import java.util.stream.Collectors;
  * A factory for creating and accessing ordinal nodes
  */
 public class OrdinalNodeAccess {
-    private final Map<Integer, OrdinalGroup> groups = Maps.newHashMap();
+    private final OrdinalGroupFactory ordinalGroups;
     private final Map<OrdinalGroup, OrdinalNode> destroyerLocationNodes = Maps.newHashMap();
     private final Map<OrdinalGroup, OrdinalNode> producerLocationNodes = Maps.newHashMap();
+
+    public OrdinalNodeAccess(OrdinalGroupFactory ordinalGroups) {
+        this.ordinalGroups = ordinalGroups;
+    }
 
     OrdinalNode getOrCreateDestroyableLocationNode(OrdinalGroup ordinal) {
         return destroyerLocationNodes.computeIfAbsent(ordinal, i -> createDestroyerLocationNode(ordinal));
@@ -80,7 +84,7 @@ public class OrdinalNodeAccess {
     }
 
     public OrdinalGroup group(int ordinal) {
-        return groups.computeIfAbsent(ordinal, integer -> new OrdinalGroup(ordinal));
+        return ordinalGroups.group(ordinal);
     }
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/OrdinalNodeAccess.java
@@ -16,13 +16,12 @@
 
 package org.gradle.execution.plan;
 
-import com.google.common.collect.Streams;
-
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.Streams.concat;
 
 /**
  * A factory for creating and accessing ordinal nodes
@@ -37,15 +36,15 @@ public class OrdinalNodeAccess {
     }
 
     OrdinalNode getOrCreateDestroyableLocationNode(OrdinalGroup ordinal) {
-        return destroyerLocationNodes.computeIfAbsent(ordinal, i -> createDestroyerLocationNode(ordinal));
+        return destroyerLocationNodes.computeIfAbsent(ordinal, this::createDestroyerLocationNode);
     }
 
     OrdinalNode getOrCreateOutputLocationNode(OrdinalGroup ordinal) {
-        return producerLocationNodes.computeIfAbsent(ordinal, i -> createProducerLocationNode(ordinal));
+        return producerLocationNodes.computeIfAbsent(ordinal, this::createProducerLocationNode);
     }
 
-    List<OrdinalNode> getAllNodes() {
-        return Streams.concat(destroyerLocationNodes.values().stream(), producerLocationNodes.values().stream()).collect(Collectors.toList());
+    Stream<OrdinalNode> getAllNodes() {
+        return concat(destroyerLocationNodes.values().stream(), producerLocationNodes.values().stream());
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -105,6 +105,7 @@ import org.gradle.execution.TaskSelector;
 import org.gradle.execution.plan.DefaultNodeValidator;
 import org.gradle.execution.plan.ExecutionNodeAccessHierarchies;
 import org.gradle.execution.plan.ExecutionPlanFactory;
+import org.gradle.execution.plan.OrdinalGroupFactory;
 import org.gradle.execution.plan.TaskDependencyResolver;
 import org.gradle.execution.plan.TaskNodeDependencyResolver;
 import org.gradle.execution.plan.TaskNodeFactory;
@@ -240,9 +241,14 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         });
     }
 
+    OrdinalGroupFactory createOrdinalGroupFactory() {
+        return new OrdinalGroupFactory();
+    }
+
     ExecutionPlanFactory createExecutionPlanFactory(
         GradleInternal gradleInternal,
         TaskNodeFactory taskNodeFactory,
+        OrdinalGroupFactory ordinalGroupFactory,
         TaskDependencyResolver dependencyResolver,
         ExecutionNodeAccessHierarchies executionNodeAccessHierarchies,
         ResourceLockCoordinationService lockCoordinationService
@@ -250,6 +256,7 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new ExecutionPlanFactory(
             gradleInternal.getIdentityPath().toString(),
             taskNodeFactory,
+            ordinalGroupFactory,
             dependencyResolver,
             executionNodeAccessHierarchies.getOutputHierarchy(),
             executionNodeAccessHierarchies.getDestroyableHierarchy(),

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -55,7 +55,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     def setup() {
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
-        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), coordinator)
+        executionPlan = new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, fs), coordinator)
     }
 
     Node priorityNode(Map<String, ?> options = [:]) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -49,7 +49,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
 
     private DefaultExecutionPlan newExecutionPlan() {
         executionPlan?.close()
-        new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
+        new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
     }
 
     def "schedules tasks in dependency order"() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -46,6 +46,7 @@ import org.gradle.execution.plan.ExecutionNodeAccessHierarchy
 import org.gradle.execution.plan.LocalTaskNode
 import org.gradle.execution.plan.Node
 import org.gradle.execution.plan.NodeExecutor
+import org.gradle.execution.plan.OrdinalGroupFactory
 import org.gradle.execution.plan.PlanExecutor
 import org.gradle.execution.plan.SelfExecutingNode
 import org.gradle.execution.plan.TaskDependencyResolver
@@ -610,7 +611,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     }
 
     private DefaultExecutionPlan newExecutionPlan() {
-        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
+        return new DefaultExecutionPlan(Path.ROOT.toString(), taskNodeFactory, new OrdinalGroupFactory(), dependencyResolver, new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), new ExecutionNodeAccessHierarchy(CASE_SENSITIVE, Stub(Stat)), coordinator)
     }
 
     def task(String name, Task... dependsOn = []) {


### PR DESCRIPTION
As groups are compared by identity in many places.

Followup to #20921