### PR TITLE
Fix failing toolchain build

### DIFF
--- a/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/toolchain-task/groovy/build.gradle
@@ -39,6 +39,6 @@ tasks.register('showDefaultToolchain', CustomTaskUsingToolchains)
 
 tasks.register('showCustomToolchain', CustomTaskUsingToolchains) {
     launcher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(16)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }


### PR DESCRIPTION
Use Java 17 for test as Java 16 is out of date now.