### PR TITLE
Let configuration cache support composite builds with builds included in any order

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.scan.config.fixtures.ApplyGradleEnterprisePluginFixture
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
 
 import java.util.regex.Pattern
 
@@ -268,6 +269,60 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
             withUniqueProblems(expectedProblem)
             withProblemsWithStackTraceCount(0)
         }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/20945")
+    def "composite build with dependency substitution can include builds in any order"() {
+        given:
+        order.each {
+            settingsFile "includeBuild '$it'\n"
+        }
+        buildFile '''
+            ['clean', 'build'].each { name ->
+                tasks.register(name) {
+                    gradle.includedBuilds.each { build ->
+                        dependsOn(build.task(':' + name))
+                    }
+                }
+            }
+        '''
+        createDir('lib') {
+            file('settings.gradle') << 'rootProject.name = "lib"'
+            file('build.gradle') << '''
+                plugins { id 'java-library' }
+                group = 'com.example'
+                version = '1.0'
+            '''
+        }
+        createDir('util') {
+            file('settings.gradle') << 'rootProject.name = "util"'
+            file('build.gradle') << '''
+                plugins { id 'java-library' }
+                dependencies {
+                    api 'com.example:lib:1.0'
+                }
+            '''
+        }
+
+        def configurationCache = newConfigurationCacheFixture()
+
+        when:
+        configurationCacheRun 'clean', 'build'
+
+        then:
+        configurationCache.assertStateStored()
+
+        when:
+        configurationCacheRun 'clean', 'build'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        result.assertTaskOrder(':lib:build', ':util:build', ':build')
+
+        where:
+        order << ['lib', 'util'].permutations()
     }
 
     private static withEnterprisePlugin(TestFile settingsDir) {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/TaskInAnotherBuildCodec.kt
@@ -39,7 +39,7 @@ class TaskInAnotherBuildCodec(
     override suspend fun ReadContext.decode(): TaskInAnotherBuild {
         val taskPath = readString()
         val targetBuild = readNonNull<BuildIdentifier>()
-        return TaskInAnotherBuild.of(
+        return TaskInAnotherBuild.lazy(
             taskPath,
             targetBuild,
             includedTaskGraph

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.NodeExecutionContext;
 import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.composite.internal.IncludedBuildTaskResource;
 import org.gradle.composite.internal.TaskIdentifier;
+import org.gradle.internal.lazy.Lazy;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
 
@@ -32,7 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
+public abstract class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     public static TaskInAnotherBuild of(
         TaskInternal task,
         BuildTreeWorkGraphController taskGraph
@@ -40,31 +41,50 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
         BuildIdentifier targetBuild = buildIdentifierOf(task);
         TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, task);
         IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
-        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild, taskResource);
+        return new TaskInAnotherBuild(task.getIdentityPath(), task.getPath(), targetBuild) {
+            @Override
+            protected IncludedBuildTaskResource getTarget() {
+                return taskResource;
+            }
+        };
     }
 
-    public static TaskInAnotherBuild of(
+    /**
+     * Creates a lazy reference to a task in another build.
+     *
+     * The task will be located on-demand to allow for cycles between builds stored to
+     * the configuration cache.
+     *
+     * @param taskPath the path to the task relative to its build
+     * @param targetBuild the build containing the task
+     * @param taskGraph the task graph where the task should be located
+     * @return a lazy reference to the given task.
+     */
+    public static TaskInAnotherBuild lazy(
         String taskPath,
         BuildIdentifier targetBuild,
         BuildTreeWorkGraphController taskGraph
     ) {
         TaskIdentifier taskIdentifier = TaskIdentifier.of(targetBuild, taskPath);
-        IncludedBuildTaskResource taskResource = taskGraph.locateTask(taskIdentifier);
         Path taskIdentityPath = Path.path(targetBuild.getName()).append(Path.path(taskPath));
-        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild, taskResource);
+        Lazy<IncludedBuildTaskResource> target = Lazy.unsafe().of(() -> taskGraph.locateTask(taskIdentifier));
+        return new TaskInAnotherBuild(taskIdentityPath, taskPath, targetBuild) {
+            @Override
+            protected IncludedBuildTaskResource getTarget() {
+                return target.get();
+            }
+        };
     }
 
     private IncludedBuildTaskResource.State taskState = IncludedBuildTaskResource.State.Waiting;
     private final Path taskIdentityPath;
     private final String taskPath;
     private final BuildIdentifier targetBuild;
-    private final IncludedBuildTaskResource target;
 
-    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild, IncludedBuildTaskResource target) {
+    protected TaskInAnotherBuild(Path taskIdentityPath, String taskPath, BuildIdentifier targetBuild) {
         this.taskIdentityPath = taskIdentityPath;
         this.taskPath = taskPath;
         this.targetBuild = targetBuild;
-        this.target = target;
     }
 
     public BuildIdentifier getTargetBuild() {
@@ -81,7 +101,7 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
 
     @Override
     public TaskInternal getTask() {
-        return target.getTask();
+        return getTarget().getTask();
     }
 
     @Override
@@ -98,6 +118,7 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
 
     @Override
     public void prepareForExecution(Action<Node> monitor) {
+        IncludedBuildTaskResource target = getTarget();
         target.queueForExecution();
         target.onComplete(() -> monitor.execute(this));
     }
@@ -140,7 +161,7 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
 
         // This node is ready to "execute" when the task in the other build has completed
         if (!taskState.isComplete()) {
-            taskState = target.getTaskState();
+            taskState = getTarget().getTaskState();
         }
         switch (taskState) {
             case Waiting:
@@ -161,7 +182,7 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
 
     @Override
     protected String nodeSpecificHealthDiagnostics() {
-        return "taskState=" + taskState + ", " + target.healthDiagnostics();
+        return "taskState=" + taskState + ", " + getTarget().healthDiagnostics();
     }
 
     @Override
@@ -172,4 +193,6 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
     private static BuildIdentifier buildIdentifierOf(TaskInternal task) {
         return ((ProjectInternal) task.getProject()).getOwner().getOwner().getBuildIdentifier();
     }
+
+    protected abstract IncludedBuildTaskResource getTarget();
 }


### PR DESCRIPTION
By lazily locating tasks from another build after all builds have been loaded.

Fixes #20945
