### PR TITLE
Add property `host` to `JavaDebugOptions`: support debugging via network

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -16,8 +16,10 @@
 
 package org.gradle.process;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 /**
  * Contains a subset of the <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html">Java Debug Wire Protocol</a> properties.
@@ -30,6 +32,16 @@ public interface JavaDebugOptions {
      * Whether to attach a debug agent to the forked process.
      */
     @Input Property<Boolean> getEnabled();
+
+    /**
+     * The address of the debugger server.
+     * If the value is not set, then only the port will be passed in the debugger options.
+     *
+     * @since 7.6
+     */
+    @Incubating
+    @Optional
+    @Input Property<String> getHost();
 
     /**
      * The debug port.

--- a/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
+++ b/subprojects/core-api/src/main/java/org/gradle/process/JavaDebugOptions.java
@@ -34,8 +34,9 @@ public interface JavaDebugOptions {
     @Input Property<Boolean> getEnabled();
 
     /**
-     * The address of the debugger server.
-     * If the value is not set, then only the port will be passed in the debugger options.
+     * Host address to listen on or connect to when debug is enabled.
+     * In the server mode on Java 9 and above, passing `*` for the host will make the server listen on all network interfaces.
+     * By default, no host address is passed to JDWP, so on Java 9 and above, the loopback address is used, while earlier versions listen on all interfaces.
      *
      * @since 7.6
      */

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultJavaDebugOptions.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Optional;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.process.JavaDebugOptions;
 
@@ -27,6 +28,7 @@ import java.util.Objects;
 
 public class DefaultJavaDebugOptions implements JavaDebugOptions {
     private final Property<Boolean> enabled;
+    private final Property<String> host;
     private final Property<Integer> port;
     private final Property<Boolean> server;
     private final Property<Boolean> suspend;
@@ -34,6 +36,7 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
     @Inject
     public DefaultJavaDebugOptions(ObjectFactory objectFactory) {
         this.enabled = objectFactory.property(Boolean.class).convention(false);
+        this.host = objectFactory.property(String.class);
         this.port = objectFactory.property(Integer.class).convention(5005);
         this.server = objectFactory.property(Boolean.class).convention(true);
         this.suspend = objectFactory.property(Boolean.class).convention(true);
@@ -47,7 +50,7 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getEnabled().get(), getPort().get(), getServer().get(), getSuspend().get());
+        return Objects.hash(getEnabled().get(), getHost().getOrNull(), getPort().get(), getServer().get(), getSuspend().get());
     }
 
     @Override
@@ -60,14 +63,21 @@ public class DefaultJavaDebugOptions implements JavaDebugOptions {
         }
         DefaultJavaDebugOptions that = (DefaultJavaDebugOptions) o;
         return enabled.get() == that.enabled.get()
-                && port.get().equals(that.port.get())
-                && server.get()  == that.server.get()
-                && suspend.get()  == that.suspend.get();
+            && Objects.equals(host.getOrNull(), that.host.getOrNull())
+            && port.get().equals(that.port.get())
+            && server.get() == that.server.get()
+            && suspend.get() == that.suspend.get();
     }
 
     @Override
     public Property<Boolean> getEnabled() {
         return enabled;
+    }
+
+    @Override
+    @Optional
+    public Property<String> getHost() {
+        return host;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -150,7 +150,13 @@ public class JvmOptions {
             boolean server = debugOptions.getServer().get();
             boolean suspend = debugOptions.getSuspend().get();
             int port = debugOptions.getPort().get();
-            args.add("-agentlib:jdwp=transport=dt_socket,server=" + (server ? 'y' : 'n') + ",suspend=" + (suspend ? 'y' : 'n') + ",address=" + port);
+            String host = debugOptions.getHost().getOrNull();
+            String address = (host != null ? host + ":" : "") + port;
+            args.add("-agentlib:jdwp=transport=dt_socket," +
+                "server=" + (server ? 'y' : 'n') +
+                ",suspend=" + (suspend ? 'y' : 'n') +
+                ",address=" + address
+            );
         }
         return args;
     }
@@ -346,6 +352,7 @@ public class JvmOptions {
     private void copyDebugOptionsTo(JavaDebugOptions otherOptions) {
         // This severs the connection between from this debugOptions to the other debugOptions
         otherOptions.getEnabled().set(debugOptions.getEnabled().get());
+        otherOptions.getHost().set(debugOptions.getHost().getOrNull());
         otherOptions.getPort().set(debugOptions.getPort().get());
         otherOptions.getServer().set(debugOptions.getServer().get());
         otherOptions.getSuspend().set(debugOptions.getSuspend().get());

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -279,10 +279,42 @@ class DefaultJavaForkOptionsTest extends Specification {
         when:
         options.debugOptions {
             it.port.set(2233)
+            it.host.set("*")
         }
 
         then:
         options.debugOptions.port.get() == 2233
+        options.debugOptions.host.get() == "*"
+    }
+
+    def "allJvmArgs includes debug options port"() {
+        when:
+        options.debugOptions {
+            it.enabled.set(true)
+            it.port.set(11111)
+        }
+
+        then:
+        '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=11111' in options.allJvmArgs
+    }
+
+    def "allJvmArgs includes debug options host if it is set"() {
+        when:
+        options.debugOptions {
+            it.enabled.set(true)
+            it.port.set(22222)
+            if (host != null) {
+                it.host.set(host)
+            }
+        }
+
+        then:
+        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$address".toString() in options.allJvmArgs
+
+        where:
+        host        | address
+        null        | "22222"
+        "127.0.0.1" | "127.0.0.1:22222"
     }
 
     def "can set bootstrapClasspath"() {

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -18,6 +18,7 @@
 package org.gradle.process.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.process.JavaDebugOptions
 import org.gradle.process.JavaForkOptions
 import spock.lang.Specification
 
@@ -142,6 +143,21 @@ class JvmOptionsTest extends Specification {
             it == new TreeMap(["file.encoding": "UTF-16"] + localeProperties())
         })
         1 * target.getDebugOptions() >> new DefaultJavaDebugOptions()
+    }
+
+    def "copyTo copies debugOptions"() {
+        JavaDebugOptions debugOptions = new DefaultJavaDebugOptions();
+        JavaForkOptions target = Mock(JavaForkOptions) { it.debugOptions >> debugOptions }
+        JvmOptions source = parse("-Dx=y")
+        source.debugOptions.host.set("*")
+        source.debugOptions.port.set(1234)
+
+        when:
+        source.copyTo(target)
+
+        then: "Target should have the debugOptions copied from source"
+        target.debugOptions.host.get() == "*"
+        target.debugOptions.port.get() == 1234
     }
 
     def "#propDescr is immutable system property"() {

--- a/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/java_testing.adoc
@@ -650,6 +650,7 @@ You can also enable debugging in the DSL, where you can also configure other pro
     test {
         debugOptions {
             enabled = true
+            host = 'localhost'
             port = 4455
             server = true
             suspend = true
@@ -657,6 +658,8 @@ You can also enable debugging in the DSL, where you can also configure other pro
     }
 
 With this configuration the test JVM will behave just like when passing the `--debug-jvm` argument but it will listen on port 4455.
+
+To debug the test process remotely via network,  the `host` needs to be set to the machine's IP address or `"*"` (listen on all interfaces).
 
 [[sec:java_test_fixtures]]
 == Using test fixtures

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -368,7 +368,7 @@ Debug Gradle client (non-Daemon) process. Gradle will wait for you to attach a d
 
 `-Dorg.gradle.debug.host=(host address)`::
 Specifies the host address to listen on or connect to when debug is enabled.
-In the server mode, passing `*` for the host will make the server listen on all network interfaces.
+In the server mode on Java 9 and above, passing `*` for the host will make the server listen on all network interfaces.
 By default, no host address is passed to JDWP, so on Java 9 and above, the loopback address is used, while earlier versions listen on all interfaces.
 
 `-Dorg.gradle.debug.port=(port number)`::

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -366,6 +366,11 @@ Create a https://gradle.com/build-scans[build scan] with fine-grained informatio
 `-Dorg.gradle.debug=true`::
 Debug Gradle client (non-Daemon) process. Gradle will wait for you to attach a debugger at `localhost:5005` by default.
 
+`-Dorg.gradle.debug.host=(host address)`::
+Specifies the host address to listen on or connect to when debug is enabled.
+In the server mode, passing `*` for the host will make the server listen on all network interfaces.
+By default, no host address is passed to JDWP, so on Java 9 and above, the loopback address is used, while earlier versions listen on all interfaces.
+
 `-Dorg.gradle.debug.port=(port number)`::
 Specifies the port number to listen on when debug is enabled. _Default is `5005`._
 

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -80,7 +80,7 @@ _Default is `false`._
 
 `org.gradle.debug.host=(host address)`::
 Specifies the host address to listen on or connect to when debug is enabled.
-In the server mode, passing `*` for the host will make the server listen on all network interfaces.
+In the server mode on Java 9 and above, passing `*` for the host will make the server listen on all network interfaces.
 By default, no host address is passed to JDWP, so on Java 9 and above, the loopback address is used, while earlier versions listen on all interfaces.
 
 `org.gradle.debug.port=(port number)`::

--- a/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/build_environment.adoc
@@ -78,6 +78,11 @@ _Default is `10800000` (3 hours)._
 When set to `true`, Gradle will run the build with remote debugging enabled, listening on port 5005. Note that this is the equivalent of adding `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005` to the JVM command line and will suspend the virtual machine until a debugger is attached.
 _Default is `false`._
 
+`org.gradle.debug.host=(host address)`::
+Specifies the host address to listen on or connect to when debug is enabled.
+In the server mode, passing `*` for the host will make the server listen on all network interfaces.
+By default, no host address is passed to JDWP, so on Java 9 and above, the loopback address is used, while earlier versions listen on all interfaces.
+
 `org.gradle.debug.port=(port number)`::
 Specifies the port number to listen on when debug is enabled.
 _Default is `5005`._

--- a/subprojects/docs/src/docs/userguide/troubleshooting.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting.adoc
@@ -98,7 +98,10 @@ Many tips are also covered in the Android Studio user guide link:https://develop
 
 === Attaching a debugger to your build
 
-You can set breakpoints and debug <<custom_plugins.adoc#sec:packaging_a_plugin,buildSrc and standalone plugins>> in your Gradle build itself by setting the `org.gradle.debug` property to “true” and then attaching a remote debugger to port 5005. You can change the port number by setting the `org.gradle.debug.port` property to the desired port number.
+You can set breakpoints and debug <<custom_plugins.adoc#sec:packaging_a_plugin,buildSrc and standalone plugins>> in your Gradle build itself by setting the `org.gradle.debug` property to “true” and then attaching a remote debugger to port 5005.
+You can change the port number by setting the `org.gradle.debug.port` property to the desired port number.
+
+To attach the debugger remotely via network, you need to set the `org.gradle.debug.host` property to the machine's IP address or `*` (listen on all interfaces).
 
 ----
 ❯ gradle help -Dorg.gradle.debug=true

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -47,6 +47,7 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         options.add(new JvmArgsOption());
         options.add(new JavaHomeOption());
         options.add(new DebugOption());
+        options.add(new DebugHostOption());
         options.add(new DebugPortOption());
         options.add(new DebugServerOption());
         options.add(new DebugSuspendOption());
@@ -160,6 +161,19 @@ public class DaemonBuildOptions extends BuildOptionSet<DaemonParameters> {
         @Override
         public void applyTo(boolean value, DaemonParameters settings, Origin origin) {
             settings.setDebug(value);
+        }
+    }
+
+    public static class DebugHostOption extends StringBuildOption<DaemonParameters> {
+        public static final String GRADLE_PROPERTY = "org.gradle.debug.host";
+
+        public DebugHostOption() {
+            super(GRADLE_PROPERTY);
+        }
+
+        @Override
+        public void applyTo(String value, DaemonParameters settings, Origin origin) {
+            settings.setDebugHost(value);
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -180,6 +180,10 @@ public class DaemonParameters {
         jvmOptions.getDebugOptions().getPort().set(debug);
     }
 
+    public void setDebugHost(String host) {
+        jvmOptions.getDebugOptions().getHost().set(host);
+    }
+
     public void setDebugSuspend(boolean suspend) {
         jvmOptions.getDebugOptions().getSuspend().set(suspend);
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecDebugIntegrationTest.groovy
@@ -19,9 +19,12 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.integtests.fixtures.jvm.JDWPUtil
+import org.gradle.internal.jvm.Jvm
 import org.gradle.test.fixtures.ConcurrentTestUtil
+import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Ignore
+import spock.lang.Issue
 
 class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
@@ -88,6 +91,50 @@ class JavaExecDebugIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         taskName << ['runJavaExec', 'runProjectJavaExec', 'runExecOperationsJavaExec', 'test']
+    }
+
+    @Issue("20644")
+    @UnsupportedWithConfigurationCache(iterationMatchers = ".* :runProjectJavaExec")
+    def "can debug Java exec with socket server debugger (server = true) on #hostKind host with task :#taskName"() {
+        def address = nonLoopbackAddress()
+        Assume.assumeNotNull(address)
+
+        debugClient.host = address
+
+        sampleProject """
+            debugOptions {
+                enabled = true
+                server = true
+                suspend = true
+                ${jdwpHost != null ? "host = '$jdwpHost'" : ""}
+                port = $debugClient.port
+            }
+        """
+
+        when:
+        def handle = executer.withTasks(taskName).start()
+        ConcurrentTestUtil.poll(60) {
+            assert handle.standardOutput.contains('Listening for transport dt_socket at address')
+        }
+
+        then:
+        debugClient.connect().dispose()
+
+        then:
+        handle.waitForFinish()
+
+        where:
+        taskName << ['runJavaExec', 'runProjectJavaExec', 'runExecOperationsJavaExec', 'test'].collectMany { [it] * 2 }
+        jdwpHost << [Jvm.current().javaVersion.isJava9Compatible() ? "*" : null, nonLoopbackAddress()] * 4
+        hostKind << [Jvm.current().javaVersion.isJava9Compatible() ? "star" : "default", "exact IP"] * 4
+    }
+
+    /** To test attaching the debugger via a non-loopback network interface, we need to choose an IP address of such an interface. */
+    private static final String nonLoopbackAddress() {
+        Collections.list(NetworkInterface.getNetworkInterfaces())
+            .collectMany { it.isLoopback() ? [] : Collections.list(it.inetAddresses) }
+            .find { it instanceof Inet4Address && !it.isLoopbackAddress() }
+            ?.hostAddress
     }
 
     @Ignore


### PR DESCRIPTION
In Java 9 and above, if the JDWP arguments only include the port and not the host name, the debugger server will only listen on the loopback network interface, and it won't accept connections via network.

Debugging remotely with explicitly specified host address was only possible by passing the JDWP arguments as a string, which is a UX issue.
Adding a property for specifying the host address to `JavaDebugOptions` fixes that.

Also add daemon parameter property `org.gradle.debug.host`. 
This simplifies running the daemon in a way that it is debuggable remotely via network, as opposed to the loopback interface.

Fixes #20644
