### PR TITLE
Fix list-arrow margin for release notes

### DIFF
--- a/subprojects/docs/src/docs/css/release-notes.css
+++ b/subprojects/docs/src/docs/css/release-notes.css
@@ -16,6 +16,7 @@
   float: left;
   font: 14px bold sans-serif;
   margin-left: -1em;
+  margin-top: 0.12em;
   line-height: 25px;
 }
 


### PR DESCRIPTION
### Context

Current styling of the custom sign used for list items in release notes is off.
The arrow seemingly points to the bottom of the text it is related to.
This makes it awkward to quickly skim or even read the lists.

Current styling:
![image](https://user-images.githubusercontent.com/2759152/173845622-f5fc0d47-7c03-4d75-bb9a-758201f42734.png)

Updated styling:
![image](https://user-images.githubusercontent.com/2759152/173845774-d1511af1-6797-4311-8248-b9d0914f81d6.png)


