### PR TITLE
Fix NPE when resolving module version from including build

### DIFF
--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
@@ -98,7 +98,14 @@ public class DefaultVariantVersionMappingStrategy implements VariantVersionMappi
                     if (selected != null) {
                         if (selected.getId() instanceof ProjectComponentIdentifier) {
                             ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) selected.getId();
-                            return projectResolver.resolve(ModuleVersionIdentifier.class, projectRegistry.getProject(projectId.getProjectPath()));
+                            ProjectInternal project = projectRegistry.getProject(projectId.getProjectPath());
+                            if (project != null) {
+                                // project might not be in projectRegistry, if the project to be resolved is in another included build.
+                                // E.g. build A includes builds B, B includes build C. C has some dependencies from B.
+                                // In that case, the projectRegistry does not know about those projects and returns null. But OTOH
+                                // 'selected' does have a valid module version.
+                                return projectResolver.resolve(ModuleVersionIdentifier.class, project);
+                            }
                         }
                         return selected.getModuleVersion();
                     }


### PR DESCRIPTION
`project` will not be in `projectRegistry`, if the project to be resolved is in another included build,
potentially the _including_ build.

E.g. build A includes builds B, B includes build C. C has some dependencies from B, which have been substituted to project references.

In that case, `projectRegistry` does not know about those projects and returns null.
OTOH, 'selected' does have a valid module version.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
