### PR TITLE
Fix broken link in more_about_tasks.adoc

### DIFF
--- a/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/more_about_tasks.adoc
@@ -1210,7 +1210,7 @@ If you are writing your own task that always should run, then you can also use t
 Sometimes you want to integrate an external tool like Git or Npm, both of which do their own up-to-date checking.
 In that case it doesn't make much sense for Gradle to also do up-to-date checks.
 You can disable Gradle's up-to-date checks by using the `@link:{javadocPath}/org/gradle/api/tasks/UntrackedTask.html[UntrackedTask]` annotation on the task wrapping the tool.
-Alternatively, you can use the runtime API method `link:{groovyDslDoc}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()]`.
+Alternatively, you can use the runtime API method `link:{groovyDslPath}/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)[Task.doNotTrackState()]`.
 
 For example, let's say you want to implement a task which clones a Git repository.
 


### PR DESCRIPTION
This fixes the broken link on https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:untracked_external_tool in the following statement:
> Alternatively, you can use the runtime API method [Task.doNotTrackState()](https://docs.gradle.org/current/userguide/%7BgroovyDslDoc%7D/org.gradle.api.Task.html#org.gradle.api.Task:doNotTrackState(java.lang.String)).