### PR TITLE
Fix Groovy JDK 15 compatibility for test coverage

### DIFF
--- a/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -67,7 +67,7 @@ class GroovyCoverage {
 
         allVersions.addAll(FUTURE)
 
-        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_16)) {
+        if (javaVersion.isCompatibleWith(JavaVersion.VERSION_15)) {
             return versionsAbove(allVersions, '3.0.0')
         } else if (javaVersion.isCompatibleWith(JavaVersion.VERSION_14)) {
             return versionsBetween(allVersions, '2.2.2', '2.5.10')


### PR DESCRIPTION
We've been testing with the wrong Groovy versions. For Java 15 it should have been > 3.0.0.