### PR TITLE
Adds a command line argument which can be used to suppress all extra help messages if the build should fail with an exception

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/buildevents/BuildExceptionReporter.java
@@ -51,6 +51,8 @@ public class BuildExceptionReporter implements Action<Throwable> {
         NONE, FULL
     }
 
+    private boolean suppressHelpOnFailure = false;
+
     private final StyledTextOutputFactory textOutputFactory;
     private final LoggingConfiguration loggingConfiguration;
     private final BuildClientMetaData clientMetaData;
@@ -65,6 +67,10 @@ public class BuildExceptionReporter implements Action<Throwable> {
 
     public BuildExceptionReporter(StyledTextOutputFactory textOutputFactory, LoggingConfiguration loggingConfiguration, BuildClientMetaData clientMetaData) {
         this(textOutputFactory, loggingConfiguration, clientMetaData, null);
+    }
+
+    public void setSuppressHelpOnFailure(boolean suppressHelpOnFailure) {
+        this.suppressHelpOnFailure = suppressHelpOnFailure;
     }
 
     public void buildFinished(BuildResult result) {
@@ -100,14 +106,19 @@ public class BuildExceptionReporter implements Action<Throwable> {
             output.println();
             output.withStyle(Failure).format("%s: ", i + 1);
             details.summary.writeTo(output.withStyle(Failure));
-            output.println();
-            output.text("-----------");
 
-            writeFailureDetails(output, details);
+            if (!suppressHelpOnFailure) {
+                output.println();
+                output.text("-----------");
+                writeFailureDetails(output, details);
+                output.println("==============================================================================");
+            }
 
-            output.println("==============================================================================");
         }
-        writeGeneralTips(output);
+
+        if (!suppressHelpOnFailure) {
+            writeGeneralTips(output);
+        }
     }
 
     private void renderSingleBuildException(Throwable failure) {
@@ -119,9 +130,10 @@ public class BuildExceptionReporter implements Action<Throwable> {
         details.summary.writeTo(output.withStyle(Failure));
         output.println();
 
-        writeFailureDetails(output, details);
-
-        writeGeneralTips(output);
+        if (!suppressHelpOnFailure) {
+            writeFailureDetails(output, details);
+            writeGeneralTips(output);
+        }
     }
 
     private ExceptionStyle getShowStackTraceOption() {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -293,4 +293,16 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         ['-V']             | true                | 1
         ['--show-version'] | true                | 1
     }
+
+    def "sets suppressHelpOnFailure flag help if suppress flag is set"() {
+        when:
+        def commandLineExecution = factory.convert([option])
+        commandLineExecution.execute(executionListener)
+
+        then:
+        commandLineExecution.reporter.suppressHelpOnFailure == true
+
+        where:
+        option << ['-S', '--suppress-help']
+    }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #20964