### PR TITLE
Keep forked Java compilers around after a build

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -32,6 +32,8 @@ import org.gradle.workers.internal.KeepAliveMode;
 import java.io.File;
 
 public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> {
+
+    private static final String KEEP_DAEMON_ALIVE_PROPERTY = "org.gradle.internal.java.compile.daemon.keepAlive";
     private final Class<? extends Compiler<JavaCompileSpec>> compilerClass;
     private final Object[] compilerConstructorArguments;
     private final JavaForkOptionsFactory forkOptionsFactory;
@@ -68,10 +70,18 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         ClassPath compilerClasspath = classPathRegistry.getClassPath("JAVA-COMPILER");
         FlatClassLoaderStructure classLoaderStructure = new FlatClassLoaderStructure(new VisitableURLClassLoader.Spec("compiler", compilerClasspath.getAsURLs()));
 
+        String keepAliveModeStr = System.getProperty(KEEP_DAEMON_ALIVE_PROPERTY, KeepAliveMode.SESSION.name());
+        KeepAliveMode keepAliveMode;
+        try {
+            keepAliveMode = KeepAliveMode.valueOf(keepAliveModeStr);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid value for system property " + KEEP_DAEMON_ALIVE_PROPERTY + ": " + keepAliveModeStr);
+        }
+
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)
             .withClassLoaderStructure(classLoaderStructure)
-            .keepAliveMode(KeepAliveMode.DAEMON)
+            .keepAliveMode(keepAliveMode)
             .build();
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -71,7 +71,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)
             .withClassLoaderStructure(classLoaderStructure)
-            .keepAliveMode(KeepAliveMode.SESSION)
+            .keepAliveMode(KeepAliveMode.DAEMON)
             .build();
     }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/DaemonJavaCompiler.java
@@ -75,7 +75,7 @@ public class DaemonJavaCompiler extends AbstractDaemonCompiler<JavaCompileSpec> 
         try {
             keepAliveMode = KeepAliveMode.valueOf(keepAliveModeStr);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid value for system property " + KEEP_DAEMON_ALIVE_PROPERTY + ": " + keepAliveModeStr);
+            throw new IllegalStateException("Invalid value for system property " + KEEP_DAEMON_ALIVE_PROPERTY + ": " + keepAliveModeStr, e);
         }
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)


### PR DESCRIPTION
This results in significant performance improvements when repeatedly running builds by allowing us to re-use the JITed code from the already running `java` processes. A simple benchmark I ran locally using `largeJavaMultiProject` shows a 32% improvement on average for `abiChange`, and a 52% (!) improvement for `cleanAssemble`.

The benchmarks can be found attached, they were run on the latest nightly (7.6-20220615224043+0000) and this branch which was near the same commit as the nightly.

[benchmarks.zip](https://github.com/gradle/gradle/files/8922460/benchmarks.zip)

I would like to get a confirmation from the @gradle/bt-execution team that there are no known problems with this. Otherwise, this seems like a fairly straightforward performance win to me.

