### PR TITLE
Allow adding testFixtures dependencies directly to Test Suites

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
@@ -18,7 +18,10 @@ package org.gradle.api.plugins.jvm;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 
 /**
  * This DSL element is used to add dependencies to a component, like {@link JvmTestSuite}.
@@ -116,4 +119,28 @@ public interface JvmComponentDependencies {
      * @since 7.5
      */
     void annotationProcessor(Object dependencyNotation, Action<? super Dependency> configuration);
+
+    /**
+     * Declares a dependency on the test fixtures of a project.
+     * @param project the project upon which to add a test fixtures dependency
+     *
+     * @since 7.6
+     */
+    Dependency testFixtures(Project project);
+
+    /**
+     * Declares a dependency on the test fixtures of a project.
+     * @param projectDependency the project dependency for a project upon which to add a test fixtures dependency
+     *
+     * @since 7.6
+     */
+    Dependency testFixtures(ProjectDependency projectDependency);
+
+    /**
+     * Declares a dependency on the test fixtures of a component.
+     * @param moduleDependency the module upon which to add a test fixtures dependency
+     *
+     * @since 7.6
+     */
+    Dependency testFixtures(ModuleDependency moduleDependency);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
@@ -18,10 +18,13 @@ package org.gradle.api.plugins.jvm.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.MinimalExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.internal.catalog.DependencyBundleValueSource;
 import org.gradle.api.internal.provider.DefaultValueSourceProviderFactory;
@@ -32,11 +35,15 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.internal.Cast;
+import org.gradle.internal.component.external.model.ImmutableCapability;
+import org.gradle.internal.component.external.model.ProjectTestFixtures;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;
 
 public class DefaultJvmComponentDependencies implements JvmComponentDependencies {
     private final Configuration implementation;
@@ -100,6 +107,26 @@ public class DefaultJvmComponentDependencies implements JvmComponentDependencies
     @Override
     public void annotationProcessor(Object dependency, @Nullable Action<? super Dependency> configuration) {
         doAdd(annotationProcessor, dependency, configuration);
+    }
+
+    @Override
+    public Dependency testFixtures(Project project) {
+        final ProjectDependency projectDependency = (ProjectDependency) getDependencyHandler().create(project);
+        return testFixtures(projectDependency);
+    }
+
+    @Override
+    public Dependency testFixtures(ProjectDependency projectDependency) {
+        projectDependency.capabilities(new ProjectTestFixtures(projectDependency.getDependencyProject()));
+        return projectDependency;
+    }
+
+    @Override
+    public Dependency testFixtures(ModuleDependency moduleDependency) {
+        moduleDependency.capabilities(capabilities -> {
+            capabilities.requireCapability(new ImmutableCapability(moduleDependency.getGroup(), moduleDependency.getName() + TEST_FIXTURES_CAPABILITY_APPENDIX, null));
+        });
+        return moduleDependency;
     }
 
     private void doAdd(Configuration bucket, Object dependency, @Nullable Action<? super Dependency> configuration) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesDependenciesIntegrationTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.testing.testsuites
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-
-
 class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
     private versionCatalog = file('gradle', 'libs.versions.toml')
 
@@ -603,5 +601,209 @@ class TestSuitesDependenciesIntegrationTest extends AbstractIntegrationSpec {
 
         expect: "tests using a class from that platform will succeed"
         succeeds('test')
+    }
+
+    def "can add testFixture dependency to the default test suite"() {
+        given: "a multi-project build with a consumer project that depends on the fixtures in a util project"
+        multiProjectBuild("root", ["consumer", "util"])
+        file("consumer/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        useJUnitJupiter()
+                        dependencies {
+                            implementation(testFixtures(project(':util')))
+                        }
+                    }
+                }
+            }
+        """
+        file("util/build.gradle") << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+        """
+
+        and: "containing a test which uses a fixture method"
+        file("consumer/src/test/java/org/test/MyTest.java") << """
+            package org.test;
+
+            import org.junit.jupiter.api.Assertions;
+            import org.junit.jupiter.api.Test;
+
+            public class MyTest {
+                @Test
+                public void testSomething() {
+                    Assertions.assertEquals(1, MyFixture.calculateSomething());
+                }
+            }
+        """
+        file("util/src/testFixtures/java/org/test/MyFixture.java") << """
+            package org.test;
+
+            public class MyFixture {
+                public static int calculateSomething() { return 1; }
+            }
+        """
+
+        expect: "test runs successfully"
+        succeeds( ":consumer:test")
+    }
+
+    def "can add testFixture dependency to the same project to the default test suite"() {
+        given: "a single-project build where a custom test suite depends on the fixtures in that project for its integration tests"
+        buildFile << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    test {
+                        useJUnitJupiter()
+                        dependencies {
+                            implementation(testFixtures(project))
+                        }
+                    }
+                }
+            }
+        """
+
+        and: "containing a test which uses a fixture method"
+        file("src/integrationTest/java/org/test/MyTest.java") << """
+            package org.test;
+
+            import org.junit.jupiter.api.Assertions;
+            import org.junit.jupiter.api.Test;
+
+            public class MyTest {
+                @Test
+                public void testSomething() {
+                    Assertions.assertEquals(1, MyFixture.calculateSomething());
+                }
+            }
+        """
+        file("src/testFixtures/java/org/test/MyFixture.java") << """
+            package org.test;
+
+            public class MyFixture {
+                public static int calculateSomething() { return 1; }
+            }
+        """
+
+        expect: "test runs successfully"
+        succeeds( ":test")
+    }
+
+    def "can add testFixture dependency to a custom test suite"() {
+        given: "a multi-project build with a consumer project that depends on the fixtures in a util project for its integration tests"
+        multiProjectBuild("root", ["consumer", "util"])
+        file("consumer/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    integrationTest(JvmTestSuite) {
+                        useJUnitJupiter()
+                        dependencies {
+                            implementation(testFixtures(project(':util')))
+                        }
+                    }
+                }
+            }
+        """
+        file("util/build.gradle") << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+        """
+
+        and: "containing a test which uses a fixture method"
+        file("consumer/src/integrationTest/java/org/test/MyTest.java") << """
+            package org.test;
+
+            import org.junit.jupiter.api.Assertions;
+            import org.junit.jupiter.api.Test;
+
+            public class MyTest {
+                @Test
+                public void testSomething() {
+                    Assertions.assertEquals(1, MyFixture.calculateSomething());
+                }
+            }
+        """
+        file("util/src/testFixtures/java/org/test/MyFixture.java") << """
+            package org.test;
+
+            public class MyFixture {
+                public static int calculateSomething() { return 1; }
+            }
+        """
+
+        expect: "test runs successfully"
+        succeeds( ":consumer:integrationTest")
+    }
+
+    def "can add testFixture dependency to the same project to a custom test suite"() {
+        given: "a single-project build where a custom test suite depends on the fixtures in that project for its integration tests"
+        buildFile << """
+            plugins {
+                id 'java-library'
+                id 'java-test-fixtures'
+            }
+
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    integrationTest(JvmTestSuite) {
+                        useJUnitJupiter()
+                        dependencies {
+                            implementation(testFixtures(project))
+                        }
+                    }
+                }
+            }
+        """
+
+        and: "containing a test which uses a fixture method"
+        file("src/integrationTest/java/org/test/MyTest.java") << """
+            package org.test;
+
+            import org.junit.jupiter.api.Assertions;
+            import org.junit.jupiter.api.Test;
+
+            public class MyTest {
+                @Test
+                public void testSomething() {
+                    Assertions.assertEquals(1, MyFixture.calculateSomething());
+                }
+            }
+        """
+        file("src/testFixtures/java/org/test/MyFixture.java") << """
+            package org.test;
+
+            public class MyFixture {
+                public static int calculateSomething() { return 1; }
+            }
+        """
+
+        expect: "test runs successfully"
+        succeeds( ":integrationTest")
     }
 }


### PR DESCRIPTION
Supercedes #19472.

Adds non-`Object` typed methods, in preparation for further Test Suites dependency handling work.