### PR TITLE
Support building commit distribution even when the nightly is missing

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -40,6 +40,9 @@ fun Directory.parentOrRoot(): Directory = if (this.file("version.txt").asFile.ex
 }
 
 
+fun Project.releasedVersionsFile() = repoRoot().file("released-versions.json")
+
+
 /**
  * We use command line Git instead of JGit, because JGit's [Repository.resolve] does not work with worktrees.
  */

--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild.update-versions.gradle.kts
@@ -1,4 +1,5 @@
 import com.google.gson.Gson
+import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.buildutils.tasks.UpdateAgpVersions
 import gradlebuild.buildutils.tasks.UpdateReleasedVersions
 import gradlebuild.buildutils.model.ReleasedVersion
@@ -6,7 +7,7 @@ import java.net.URL
 
 
 tasks.withType<UpdateReleasedVersions>().configureEach {
-    releasedVersionsFile.set(layout.projectDirectory.file("released-versions.json"))
+    releasedVersionsFile.set(releasedVersionsFile())
     group = "Versioning"
 }
 

--- a/build-logic/buildquality/src/main/kotlin/gradlebuild.incubation-report.gradle.kts
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild.incubation-report.gradle.kts
@@ -16,6 +16,7 @@
 
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.accessors.kotlin
+import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.incubation.tasks.IncubatingApiReportTask
 
@@ -28,7 +29,7 @@ val reportTask = tasks.register<IncubatingApiReportTask>("incubationReport") {
     description = "Generates a report of incubating APIS"
     title.set(project.name)
     versionFile.set(repoRoot().file("version.txt"))
-    releasedVersionsFile.set(repoRoot().file("released-versions.json"))
+    releasedVersionsFile.set(releasedVersionsFile())
     sources.from(sourceSets.main.get().java.sourceDirectories)
     sources.from(sourceSets.main.get().groovy.sourceDirectories)
     htmlReportFile.set(file(layout.buildDirectory.file("reports/incubation/${project.name}.html")))

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -10,11 +10,13 @@ dependencies {
     implementation(project(":module-identity"))
     implementation(project(":integration-testing"))
     implementation(project(":cleanup"))
+    implementation(project(":build-update-utils"))
 
     implementation("org.openmbee.junit:junit-xml-parser") {
         exclude(module = "lombok") // don't need it at runtime
     }
     implementation("com.google.guava:guava")
+    implementation("com.google.code.gson:gson")
     implementation("commons-io:commons-io")
     implementation("javax.activation:activation")
     implementation("javax.xml.bind:jaxb-api")

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -341,6 +341,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         buildCommitDistribution.configure {
             dependsOn(determineBaselines)
+            releasedVersionsFile.set(project.rootProject.layout.projectDirectory.file("released-versions.json"))
             commitBaseline.set(determineBaselines.flatMap { it.determinedBaselines })
         }
 

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -30,6 +30,7 @@ import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
 import gradlebuild.basics.performanceTestVerbose
 import gradlebuild.basics.propertiesForPerformanceDb
+import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.runAndroidStudioInHeadlessMode
 import gradlebuild.identity.extension.ModuleIdentityExtension
@@ -341,7 +342,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         buildCommitDistribution.configure {
             dependsOn(determineBaselines)
-            releasedVersionsFile.set(project.rootProject.layout.projectDirectory.file("released-versions.json"))
+            releasedVersionsFile.set(project.releasedVersionsFile())
             commitBaseline.set(determineBaselines.flatMap { it.determinedBaselines })
         }
 

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -17,6 +17,7 @@
 package gradlebuild.performance.tasks
 
 import gradlebuild.basics.repoRoot
+import gradlebuild.identity.model.ReleasedVersions
 import gradlebuild.performance.generator.tasks.RemoteProject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -25,15 +26,21 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.caching.http.HttpBuildCache
+import org.gradle.internal.impldep.com.google.gson.Gson
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecOperations
+import org.gradle.util.GradleVersion
 import org.gradle.work.DisableCachingByDefault
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.OutputStream
+import java.util.Properties
 import javax.inject.Inject
 
 
@@ -42,11 +49,22 @@ private
 val commitVersionRegex = """(\d+(\.\d+)+)-commit-[a-f0-9]+""".toRegex()
 
 
+/*
+Downloading https://services.gradle.org/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
+Exception in thread "main" java.io.FileNotFoundException:
+https://downloads.gradle-dn.com/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
+ */
+private
+val oldWrapperMissingErrorRegex = """\Qjava.io.FileNotFoundException:\E.*/distributions-snapshots/gradle-([\d.]+)""".toRegex()
+
+
 @DisableCachingByDefault(because = "Child Gradle build will do its own caching")
 abstract class BuildCommitDistribution @Inject internal constructor(
     private val fsOps: FileSystemOperations,
     private val execOps: ExecOperations,
 ) : DefaultTask() {
+    @get:Internal
+    abstract val releasedVersionsFile: RegularFileProperty
 
     @get:Input
     @get:Optional
@@ -69,19 +87,67 @@ abstract class BuildCommitDistribution @Inject internal constructor(
         val rootProjectDir = project.repoRoot().asFile.absolutePath
         val commit = commitBaseline.map { it.substring(it.lastIndexOf('-') + 1) }
         val checkoutDir = RemoteProject.checkout(fsOps, execOps, rootProjectDir, commit.get(), temporaryDir)
+
+        fsOps.delete { delete(commitDistributionHome.get().asFile) }
         tryBuildDistribution(checkoutDir)
         println("Building the commit distribution succeeded, now the baseline is ${commitBaseline.get()}")
     }
 
+    /**
+     * Sometimes, the nightly might be cleaned up before GA comes out. If this happens, we fall back to latest RC version or nightly version.
+     */
     private
-    fun tryBuildDistribution(checkoutDir: File) {
-        fsOps.delete {
-            delete(commitDistributionHome.get().asFile)
+    fun determineClosestReleasedVersion(expectedBaseVersion: GradleVersion): GradleVersion {
+        val releasedVersions = releasedVersionsFile.asFile.get().reader().use {
+            Gson().fromJson(it, ReleasedVersions::class.java)
         }
+        if (releasedVersions.finalReleases.any { it.gradleVersion() == expectedBaseVersion }) {
+            return expectedBaseVersion
+        } else if (releasedVersions.latestRc.gradleVersion().baseVersion == expectedBaseVersion) {
+            return releasedVersions.latestRc.gradleVersion()
+        } else if (releasedVersions.latestReleaseSnapshot.gradleVersion().baseVersion == expectedBaseVersion) {
+            return releasedVersions.latestReleaseSnapshot.gradleVersion()
+        } else {
+            throw IllegalStateException("Expected version: $expectedBaseVersion but can't find it")
+        }
+    }
+
+    private
+    fun runDistributionBuild(checkoutDir: File, os: OutputStream) {
         execOps.exec {
             commandLine(*getBuildCommands())
             workingDir = checkoutDir
+            standardOutput = os
+            errorOutput = os
         }
+    }
+
+    private
+    fun tryBuildDistribution(checkoutDir: File) {
+        val output = ByteArrayOutputStream()
+        try {
+            runDistributionBuild(checkoutDir, output)
+        } catch (e: Exception) {
+            val outputString = output.toByteArray().decodeToString()
+            if (failedBecauseOldWrapperMissing(outputString)) {
+                val expectedWrapperVersion = oldWrapperMissingErrorRegex.find(outputString)!!.groups[1]!!.value
+                val closestReleasedVersion = determineClosestReleasedVersion(GradleVersion.version(expectedWrapperVersion)).version
+                val wrapperPropertiesFile = checkoutDir.resolve("gradle/wrapper/gradle-wrapper.properties")
+                val wrapperProperties = Properties().apply {
+                    load(wrapperPropertiesFile.inputStream())
+                    this["distributionUrl"] = "https://services.gradle.org/distributions/gradle-$closestReleasedVersion-bin.zip"
+                }
+                wrapperProperties.store(wrapperPropertiesFile.outputStream(), "Modified by `BuildCommitDistribution` task")
+                runDistributionBuild(checkoutDir, System.out)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private
+    fun failedBecauseOldWrapperMissing(buildOutput: String): Boolean {
+        return buildOutput.contains(oldWrapperMissingErrorRegex)
     }
 
     private

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -131,15 +131,17 @@ abstract class BuildCommitDistribution @Inject internal constructor(
             val outputString = output.toByteArray().decodeToString()
             if (failedBecauseOldWrapperMissing(outputString)) {
                 val expectedWrapperVersion = oldWrapperMissingErrorRegex.find(outputString)!!.groups[1]!!.value
-                val closestReleasedVersion = determineClosestReleasedVersion(GradleVersion.version(expectedWrapperVersion)).version
+                val closestReleasedVersion = determineClosestReleasedVersion(GradleVersion.version(expectedWrapperVersion))
+                val repository = if (closestReleasedVersion.isSnapshot) "distributions-snapshots" else "distributions"
                 val wrapperPropertiesFile = checkoutDir.resolve("gradle/wrapper/gradle-wrapper.properties")
                 val wrapperProperties = Properties().apply {
                     load(wrapperPropertiesFile.inputStream())
-                    this["distributionUrl"] = "https://services.gradle.org/distributions/gradle-$closestReleasedVersion-bin.zip"
+                    this["distributionUrl"] = "https://services.gradle.org/$repository/gradle-${closestReleasedVersion.version}-bin.zip"
                 }
                 wrapperProperties.store(wrapperPropertiesFile.outputStream(), "Modified by `BuildCommitDistribution` task")
                 runDistributionBuild(checkoutDir, System.out)
             } else {
+                println(output.toByteArray().decodeToString())
                 throw e
             }
         }

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -16,6 +16,7 @@
 
 package gradlebuild.performance.tasks
 
+import com.google.gson.Gson
 import gradlebuild.basics.repoRoot
 import gradlebuild.identity.model.ReleasedVersions
 import gradlebuild.performance.generator.tasks.RemoteProject
@@ -32,7 +33,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.caching.http.HttpBuildCache
-import org.gradle.internal.impldep.com.google.gson.Gson
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecOperations
 import org.gradle.util.GradleVersion
@@ -50,9 +50,10 @@ val commitVersionRegex = """(\d+(\.\d+)+)-commit-[a-f0-9]+""".toRegex()
 
 
 /*
-Downloading https://services.gradle.org/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
-Exception in thread "main" java.io.FileNotFoundException:
-https://downloads.gradle-dn.com/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
+The error output looks like this:
+
+    Downloading https://services.gradle.org/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
+    Exception in thread "main" java.io.FileNotFoundException: https://downloads.gradle-dn.com/distributions-snapshots/gradle-7.5-20220202183149+0000-bin.zip
  */
 private
 val oldWrapperMissingErrorRegex = """\Qjava.io.FileNotFoundException:\E.*/distributions-snapshots/gradle-([\d.]+)""".toRegex()


### PR DESCRIPTION
Previously, we can't build a commit if the nightly wrapper on that commit is missing.
Now we do a best-effort build by using closest final release or RC releases to build that commit.
