### PR TITLE
Split AbstractMultiProjectJvmApplicationInitIntegrationTest

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectApplicationInitIntegrationTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.buildinit.plugins
+
+import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
+
+class MultiProjectApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
+    @Override
+    String subprojectName() {
+        return null
+    }
+
+
+    def "can explicitly configure application not to split projects with #dsl build scripts"() {
+        expect:
+        succeeds('init', '--type', "java-application", '--dsl', dsl.id)
+
+        where:
+        dsl << [BuildInitDsl.KOTLIN, BuildInitDsl.GROOVY]
+    }
+}

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl
+import org.gradle.buildinit.plugins.internal.modifiers.Language
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import spock.lang.Unroll
 
@@ -27,16 +28,17 @@ import static org.gradle.buildinit.plugins.internal.modifiers.Language.SCALA
 
 abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
     abstract BuildInitDsl getBuildDsl()
+    abstract Language getJvmLanguage()
 
     @Override
     String subprojectName() {
         return null
     }
 
-    @Unroll("creates multi-project application sample for #jvmLanguage with #scriptDsl build scripts, when incubating flag = #incubating")
+    @Unroll("creates multi-project application sample when incubating flag = #incubating")
     def "creates multi-project application sample"() {
         given:
-        def dsl = scriptDsl as BuildInitDsl
+        def dsl = buildDsl
         def language = jvmLanguage.name
         def ext = jvmLanguage.extension
         def settingsFile = dsl.fileNameFor('settings')
@@ -58,18 +60,18 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
         )
 
         def appFiles = [buildFile,
-            "src/main/${language}/some/thing/app/App.${ext}",
-            "src/main/${language}/some/thing/app/MessageUtils.${ext}",
-            "src/test/${language}/some/thing/app/MessageUtilsTest.${ext}",
-            "src/main/resources",
-            "src/test/resources"]
+                        "src/main/${language}/some/thing/app/App.${ext}",
+                        "src/main/${language}/some/thing/app/MessageUtils.${ext}",
+                        "src/test/${language}/some/thing/app/MessageUtilsTest.${ext}",
+                        "src/main/resources",
+                        "src/test/resources"]
         targetDir.file("app").assertHasDescendants(appFiles*.toString())
 
         def listFiles = [buildFile,
-            "src/main/${language}/some/thing/list/LinkedList.${ext}",
-            "src/test/${language}/some/thing/list/LinkedListTest.${ext}",
-            "src/main/resources",
-            "src/test/resources"]
+                         "src/main/${language}/some/thing/list/LinkedList.${ext}",
+                         "src/test/${language}/some/thing/list/LinkedListTest.${ext}",
+                         "src/main/resources",
+                         "src/test/resources"]
         targetDir.file("list").assertHasDescendants(listFiles*.toString())
 
         def utilFiles = [
@@ -99,23 +101,9 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
         outputContains("Hello World!")
 
         where:
-        [jvmLanguage, scriptDsl, incubating] << [
-                [JAVA, GROOVY, KOTLIN, SCALA],
-                [getBuildDsl()],
-                [true, false]
-        ].combinations()
+        incubating << [true, false]
     }
 
-    def "can explicitly configure application not to split projects with #scriptDsl build scripts"() {
-        given:
-        def dsl = scriptDsl as BuildInitDsl
-
-        expect:
-        succeeds('init', '--type', "java-application", '--dsl', dsl.id)
-
-        where:
-        scriptDsl << getBuildDsl()
-    }
 
     void assertTestPassed(String subprojectName, String className, String name) {
         def result = new DefaultTestExecutionResult(targetDir.file(subprojectName))
@@ -124,16 +112,99 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
     }
 }
 
-class GroovyDslMultiProjectJvmApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+class GroovyDslMultiProjectJavaApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
     @Override
     BuildInitDsl getBuildDsl() {
         return BuildInitDsl.GROOVY
     }
+
+    @Override
+    Language getJvmLanguage() {
+        return JAVA
+    }
 }
 
-class KotlinDslMultiProjectJvmApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+class GroovyDslMultiProjectGroovyApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.GROOVY
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return GROOVY
+    }
+}
+
+class GroovyDslMultiProjectKotlinApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.GROOVY
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return KOTLIN
+    }
+}
+
+class GroovyDslMultiProjectScalaApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.GROOVY
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return SCALA
+    }
+}
+
+
+class KotlinDslMultiProjectJavaApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
     @Override
     BuildInitDsl getBuildDsl() {
         return BuildInitDsl.KOTLIN
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return JAVA
+    }
+}
+
+class KotlinDslMultiProjectGroovyApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.KOTLIN
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return GROOVY
+    }
+}
+
+class KotlinDslMultiProjectKotlinApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.KOTLIN
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return KOTLIN
+    }
+}
+
+class KotlinDslMultiProjectScalaApplicationInitIntegrationTest extends AbstractMultiProjectJvmApplicationInitIntegrationTest {
+    @Override
+    BuildInitDsl getBuildDsl() {
+        return BuildInitDsl.KOTLIN
+    }
+
+    @Override
+    Language getJvmLanguage() {
+        return SCALA
     }
 }


### PR DESCRIPTION
This class seems to be quite slow because it contains 8 test cases,
and each test case can be as slow as 30s. Now let's further split them.
