### PR TITLE
Automatically disambiguate two variants with an attribute with null value and a single value matching the requested

### DIFF
--- a/build-logic/packaging/src/main/kotlin/gradlebuild.shaded-jar.gradle.kts
+++ b/build-logic/packaging/src/main/kotlin/gradlebuild.shaded-jar.gradle.kts
@@ -85,6 +85,7 @@ fun registerTransforms() {
 fun createConfigurationToShade() = configurations.create("jarsToShade") {
     attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
     attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
     isCanBeResolved = true
     isCanBeConsumed = false
     withDependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -186,7 +186,13 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category': 'library', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar'])
+                        variant('runtime', [
+                            'org.gradle.status': 'release',
+                            'org.gradle.category': 'library',
+                            'org.gradle.dependency.bundling': 'external',
+                            'org.gradle.usage': 'java-runtime',
+                            'org.gradle.libraryelements': 'jar'
+                        ])
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantsDependencySubstitutionRulesIntegrationTest.groovy
@@ -122,7 +122,8 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
                         'org.gradle.category': 'library',
                         'org.gradle.libraryelements': 'jar',
                         'org.gradle.status': 'release',
-                        'org.gradle.usage': 'java-runtime'
+                        'org.gradle.usage': 'java-runtime',
+                        'org.gradle.dependency.bundling': 'external',
                     ])
                     selectedByRule()
                 }
@@ -251,7 +252,8 @@ class VariantsDependencySubstitutionRulesIntegrationTest extends AbstractIntegra
                         'org.gradle.category': 'library',
                         'org.gradle.libraryelements': 'jar',
                         'org.gradle.status': 'release',
-                        'org.gradle.usage': 'java-runtime'
+                        'org.gradle.usage': 'java-runtime',
+                        'org.gradle.dependency.bundling': 'external',
                     ])
                     selectedByRule()
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -175,7 +175,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                     noArtifacts()
                 }
                 module("group:bom:1.0") {
-                    variant("runtime", ['org.gradle.category': 'library', 'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar'])
+                    variant("runtime", ['org.gradle.category': 'library', 'org.gradle.status': 'release', 'org.gradle.usage': 'java-runtime', 'org.gradle.libraryelements': 'jar', 'org.gradle.dependency.bundling': 'external'])
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -72,6 +72,7 @@ public enum CacheLayout {
         .changedTo(96, "6.4-rc-1")
         .changedTo(97, "6.8-rc-1")
         .changedTo(99, "7.5-rc-1")
+        .changedTo(1001234555, "7.6-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -87,6 +87,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
             result = concat(result, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
             result = concat(result, FORMAT_ATTRIBUTE, new CoercingStringValueSnapshot(LibraryElements.JAR, objectInstantiator));
             result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.LIBRARY, objectInstantiator));
+            result = concat(result, Bundling.BUNDLING_ATTRIBUTE, objectInstantiator.named(Bundling.class, Bundling.EXTERNAL));
             return result;
         });
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -53,7 +53,7 @@ class CacheLayoutTest extends Specification {
         CacheLayout cacheLayout = CacheLayout.META_DATA
 
         then:
-        def expectedVersion = 99
+        def expectedVersion = 1001234555
         cacheLayout.name == 'metadata'
         cacheLayout.key == "metadata-2.${expectedVersion}"
         cacheLayout.version == CacheVersion.parse("2.${expectedVersion}")

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -148,12 +148,13 @@ No dependencies matching given input were found in configuration ':conf'
         outputContains """
 org:leaf2:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf2:1.0
 +--- org:middle:1.0
@@ -204,12 +205,13 @@ org:leaf2:1.0
 Task :dependencyInsight
 org:leaf2:2.5
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - By conflict resolution: between versions 2.5, 1.5 and 1.0
 
@@ -262,12 +264,13 @@ org:leaf2:1.5 -> 2.5
         outputContains """
 org:leaf:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 +--- org:a:1.0
@@ -286,12 +289,13 @@ org:leaf:1.0
         outputContains """
 org:leaf:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 \\--- org:a:1.0
@@ -344,12 +348,13 @@ org:leaf:1.0
 
 org:leaf2:2.5
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - By conflict resolution: between versions 2.5, 1.5 and 1.0
 
@@ -419,12 +424,13 @@ org:leaf2:1.5 -> 2.5
 
 org:leaf2:2.5
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - By conflict resolution: between versions 2.5, 1.5 and 1.0
 
@@ -593,12 +599,13 @@ org:foo:1.+ FAILED
         outputContains """
 org:leaf:1.0 (forced)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 \\--- org:foo:1.0
@@ -616,12 +623,13 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:1.0 (selected by rule)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 \\--- org:foo:1.0
@@ -662,12 +670,13 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Was requested: didn't match version 3 because testing stuff
       - Forced
@@ -779,12 +788,13 @@ org:leaf:latest.integration -> 1.0
         outputContains """
 org:bar:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Forced
       - Selected by rule
@@ -845,12 +855,13 @@ org:foo:1.0 -> org:bar:2.0
         outputContains """
 org.test:bar:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Selected by rule: why not?
 
@@ -859,24 +870,26 @@ org:bar:1.0 -> org.test:bar:2.0
 
 org:baz:1.0 (selected by rule)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:baz:1.0
 \\--- conf
 
 org:foo:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Selected by rule: because I am in control
 
@@ -922,24 +935,26 @@ org:foo:1.0 -> 2.0
         outputContains """
 org:baz:2.0 (selected by rule)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:baz:1.1 -> 2.0
 \\--- conf
 
 org:bar:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Selected by rule: foo superseded by bar
 
@@ -984,12 +999,13 @@ org:foo:1.0 -> org:bar:1.0
         outputContains """
 org:new-leaf:77 (selected by rule)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0 -> org:new-leaf:77
 \\--- org:foo:2.0
@@ -1036,12 +1052,13 @@ org:leaf:2.0 -> org:new-leaf:77
         then:
         outputContains """org:bar:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Selected by rule: I am not sure I want to explain
 
@@ -1050,12 +1067,13 @@ org:bar:1.0 -> 2.0
 
 org:foo:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Selected by rule: I want to
 
@@ -1148,12 +1166,13 @@ org:leaf:latest.integration -> 1.6
         outputContains """
 org:leaf:2.0 (forced)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:2.0
 \\--- org:bar:1.0
@@ -1199,12 +1218,13 @@ org:leaf:1.0 -> 2.0
         outputContains """
 org:leaf:1.5 (forced)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0 -> 1.5
 \\--- org:foo:1.0
@@ -1252,12 +1272,13 @@ org:leaf:2.0 -> 1.5
         outputContains """
 org:leaf:1.0 (forced)
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 +--- conf
@@ -1303,12 +1324,13 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
    Selection reasons:
       - Forced
       - By constraint
@@ -1680,12 +1702,13 @@ project :C FAILED
         outputContains """
 org:leaf2:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf2:1.0
 \\--- org:leaf1:1.0
@@ -1796,9 +1819,9 @@ org:leaf2:1.0
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | ${jvmVersion.padRight("java-runtime".length())} |
 
@@ -1907,9 +1930,9 @@ org:leaf4:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -1946,9 +1969,9 @@ org:leaf1:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -1967,9 +1990,9 @@ org:leaf2:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -2124,9 +2147,9 @@ org:leaf3:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -2175,24 +2198,26 @@ org:leaf3:1.0
         then:
         result.groupedOutput.task(":dependencyInsight").output.contains("""foo:bar:2.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 foo:bar:2.0
 \\--- compile
 
 foo:foo:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 foo:foo:1.0
 \\--- compile""")
@@ -2235,9 +2260,9 @@ foo:foo:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2291,9 +2316,9 @@ org:foo -> $selected
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2344,9 +2369,9 @@ org:foo -> $selected
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2395,9 +2420,9 @@ org:foo:${displayVersion} -> $selected
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2452,9 +2477,9 @@ org:foo:[1.1,1.3] -> 1.3
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2469,9 +2494,9 @@ org:foo:1.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2530,9 +2555,9 @@ org:bar:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2548,9 +2573,9 @@ org:foo:1.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2593,9 +2618,9 @@ org:leaf:1.0 (by constraint)
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -2646,9 +2671,9 @@ org.test:leaf:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2693,12 +2718,13 @@ org.test:leaf:1.0
         outputContains """
 org:leaf2:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf2:1.0
 +--- org:middle:1.0
@@ -2832,9 +2858,9 @@ org:foo:1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2888,9 +2914,9 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -2954,9 +2980,9 @@ org:foo:1.0
     | org.gradle.status              | release  |              |
     | color                          | blue     | blue         |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -3036,9 +3062,9 @@ planet:mercury:1.0.2
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -3068,9 +3094,9 @@ planet:venus:2.0.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:
@@ -3100,9 +3126,9 @@ planet:pluto:1.0.0
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
 
@@ -3150,9 +3176,9 @@ org:foo:1.5
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | ${jvmVersion.padRight("standard-jvm".length())} |
    Selection reasons:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -439,12 +439,13 @@ org:middle:1.0 FAILED
         output.contains """
 org:leaf:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
 
 org:leaf:1.0
 \\--- org:top:1.0
@@ -482,13 +483,14 @@ org:leaf:1.0
         then:
         output.contains """org:leaf:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
-    | usage                      |              | dummy     |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
+    | usage                          |              | dummy     |
 
 org:leaf:1.0
 \\--- org:top:1.0
@@ -545,26 +547,28 @@ org:leaf:1.0
         outputContains """
 org:testA:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
-    | custom                     | dep_value    | dep_value |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
+    | custom                         | dep_value    | dep_value |
 
 org:testA:1.0
 \\--- conf
 
 org:testB:1.0
   Variant runtime:
-    | Attribute Name             | Provided     | Requested |
-    |----------------------------|--------------|-----------|
-    | org.gradle.category        | library      |           |
-    | org.gradle.libraryelements | jar          |           |
-    | org.gradle.status          | release      |           |
-    | org.gradle.usage           | java-runtime |           |
-    | custom                     | dep_value    | dep_value |
+    | Attribute Name                 | Provided     | Requested |
+    |--------------------------------|--------------|-----------|
+    | org.gradle.category            | library      |           |
+    | org.gradle.dependency.bundling | external     |           |
+    | org.gradle.libraryelements     | jar          |           |
+    | org.gradle.status              | release      |           |
+    | org.gradle.usage               | java-runtime |           |
+    | custom                         | dep_value    | dep_value |
 
 org:testB:+ -> 1.0
 \\--- conf

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/base-dependency-insight.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/base-dependency-insight.out
@@ -6,9 +6,9 @@ io.vertx:vertx-lang-groovy:3.9.4
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -21,9 +21,9 @@ io.vertx:vertx-lang-groovy-gen:3.9.4
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -37,9 +37,9 @@ org.codehaus.groovy:groovy:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
    Selection reasons:
@@ -70,9 +70,9 @@ org.codehaus.groovy:groovy-console:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -87,9 +87,9 @@ org.codehaus.groovy:groovy-json:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -103,9 +103,9 @@ org.codehaus.groovy:groovy-swing:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -121,9 +121,9 @@ org.codehaus.groovy:groovy-templates:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -139,9 +139,9 @@ org.codehaus.groovy:groovy-xml:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/fixed-dependency-insight.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/fixed-dependency-insight.out
@@ -6,9 +6,9 @@ io.vertx:vertx-lang-groovy:3.9.4
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -21,9 +21,9 @@ io.vertx:vertx-lang-groovy-gen:3.9.4
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -37,9 +37,9 @@ org.codehaus.groovy:groovy:3.0.1
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
    Selection reasons:
@@ -74,9 +74,9 @@ org.codehaus.groovy:groovy-console:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -91,9 +91,9 @@ org.codehaus.groovy:groovy-json:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -107,9 +107,9 @@ org.codehaus.groovy:groovy-swing:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -125,9 +125,9 @@ org.codehaus.groovy:groovy-templates:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -143,9 +143,9 @@ org.codehaus.groovy:groovy-xml:3.0.2
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-metadataRule/tests/failRuntimeClasspathResolve.out
@@ -7,25 +7,22 @@ Execution failed for task ':failRuntimeClasspathResolve'.
           - natives-windows-runtime
           - natives-windows-x86-runtime
         All of them match the consumer attributes:
-          - Variant 'natives-windows-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows':
+          - Variant 'natives-windows-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows':
               - Unmatched attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Provides attribute 'org.gradle.native.architecture' with value 'x86-64' but the consumer didn't ask for it
                   - Provides release status but the consumer didn't ask for it
-          - Variant 'natives-windows-x86-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows':
+          - Variant 'natives-windows-x86-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows':
               - Unmatched attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Provides attribute 'org.gradle.native.architecture' with value 'x86' but the consumer didn't ask for it
                   - Provides release status but the consumer didn't ask for it
         The following variants were also considered but didn't match the requested attributes:
-          - Variant 'compile' capability org.lwjgl:lwjgl:3.2.3 declares a library, packaged as a jar:
+          - Variant 'compile' capability org.lwjgl:lwjgl:3.2.3 declares a library, packaged as a jar, and its dependencies declared externally:
               - Incompatible because this component declares an API of a component and the consumer needed a runtime of a component
               - Other compatible attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')
@@ -52,22 +49,19 @@ Execution failed for task ':failRuntimeClasspathResolve'.
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Doesn't say anything about its elements (required them packaged as a jar)
                   - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')
-          - Variant 'natives-linux-arm32-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar:
+          - Variant 'natives-linux-arm32-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
               - Incompatible because this component declares a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'linux' and the consumer needed a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'
               - Other compatible attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
-          - Variant 'natives-linux-arm64-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar:
+          - Variant 'natives-linux-arm64-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
               - Incompatible because this component declares a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'linux' and the consumer needed a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'
               - Other compatible attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
-          - Variant 'natives-macos-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar:
+          - Variant 'natives-macos-runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
               - Incompatible because this component declares a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'macos' and the consumer needed a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'
               - Other compatible attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
           - Variant 'platform-compile' capability org.lwjgl:lwjgl-derived-platform:3.2.3:
@@ -86,10 +80,9 @@ Execution failed for task ':failRuntimeClasspathResolve'.
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
                   - Doesn't say anything about its elements (required them packaged as a jar)
                   - Doesn't say anything about org.gradle.native.operatingSystem (required 'windows')
-          - Variant 'runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar:
+          - Variant 'runtime' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
               - Incompatible because this component declares a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'none' and the consumer needed a component, as well as attribute 'org.gradle.native.operatingSystem' with value 'windows'
               - Other compatible attributes:
-                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                   - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                   - Doesn't say anything about its target Java version (required compatibility with Java 11)
           - Variant 'sources' capability org.lwjgl:lwjgl:3.2.3 declares a runtime of a component, and its dependencies declared externally:

--- a/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/inspectingDependencies-dependencyReason/tests/dependencyReasonReport.out
@@ -4,9 +4,9 @@ org.ow2.asm:asm:7.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | 11           |
    Selection reasons:

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReport.out
@@ -23,9 +23,9 @@ org.slf4j:slf4j-log4j12:1.6.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | 11           |
 

--- a/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReportReplaced.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/managingTransitiveDependencies-declaringCapabilities/tests/dependencyReportReplaced.out
@@ -4,9 +4,9 @@ org.slf4j:log4j-over-slf4j:1.7.10
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | 11           |
    Selection reasons:
@@ -25,9 +25,9 @@ org.slf4j:slf4j-log4j12:1.6.1
     |--------------------------------|----------|--------------|
     | org.gradle.status              | release  |              |
     | org.gradle.category            | library  | library      |
+    | org.gradle.dependency.bundling | external | external     |
     | org.gradle.libraryelements     | jar      | classes      |
     | org.gradle.usage               | java-api | java-api     |
-    | org.gradle.dependency.bundling |          | external     |
     | org.gradle.jvm.environment     |          | standard-jvm |
     | org.gradle.jvm.version         |          | 11           |
 

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/tests/runtimeClasspath.out
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features-external/tests/runtimeClasspath.out
@@ -6,9 +6,9 @@ org.mongodb:bson:3.9.1
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -25,9 +25,9 @@ org.mongodb:mongodb-driver-core:3.9.1
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 
@@ -42,9 +42,9 @@ org.mongodb:mongodb-driver-sync:3.9.1
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 

--- a/subprojects/docs/src/snippets/java-feature-variant/requiring-features/tests/runtimeClasspath.out
+++ b/subprojects/docs/src/snippets/java-feature-variant/requiring-features/tests/runtimeClasspath.out
@@ -6,9 +6,9 @@ mysql:mysql-connector-java:8.0.14
     |--------------------------------|--------------|--------------|
     | org.gradle.status              | release      |              |
     | org.gradle.category            | library      | library      |
+    | org.gradle.dependency.bundling | external     | external     |
     | org.gradle.libraryelements     | jar          | jar          |
     | org.gradle.usage               | java-runtime | java-runtime |
-    | org.gradle.dependency.bundling |              | external     |
     | org.gradle.jvm.environment     |              | standard-jvm |
     | org.gradle.jvm.version         |              | 11           |
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/variants/GradlePluginWithVariantsPublicationIntegrationTest.groovy
@@ -17,19 +17,97 @@
 package org.gradle.plugin.devel.variants
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+// older Gradle version 6.7.1 is used in test
+@Requires(TestPrecondition.JDK15_OR_EARLIER)
 class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegrationSpec {
 
-    @Requires(TestPrecondition.JDK15_OR_EARLIER) // older Gradle version 6.7.1 is used in test
     def "can publish and use Gradle plugin with multiple variants"() {
         given:
+        publishGradlePluginWithVariants()
+
+        and:
+        settingsFile """
+            pluginManagement {
+                repositories {
+                    maven { url = '${mavenRepo.uri}' }
+                }
+            }
+        """
+        buildFile """
+            plugins {
+                id('com.example.greeting') version '1.0'
+            }
+        """
+
+        when:
+        succeeds 'greet'
+
+        then:
+        outputContains("Hello from Gradle 7.0+")
+
+        when:
+        def gradle6Result = runWithGradle6('greet')
+
+        then:
+        gradle6Result.assertOutputContains("Hello from Gradle <7.0")
+    }
+
+    def "can publish and compile against Gradle plugin with multiple variants in buildSrc"() {
+        given:
+        publishGradlePluginWithVariants()
+
+        and:
+        file('buildSrc/settings.gradle') << ''
+        file('buildSrc/build.gradle') << """
+            plugins {
+                id('groovy-gradle-plugin')
+            }
+            dependencies {
+                implementation('com.example:producer:1.0')
+            }
+            repositories {
+                maven { url = '${mavenRepo.uri}' }
+            }
+        """
+        file('buildSrc/src/main/groovy/my-plugin.gradle') << '''
+            plugins {
+                id('com.example.greeting')
+            }
+        '''
+
+        and:
+        settingsFile ""
+        buildFile """
+            plugins {
+                id('my-plugin')
+            }
+        """
+
+        when:
+        succeeds 'greet'
+
+        then:
+        outputContains("Hello from Gradle 7.0+")
+
+        when:
+        def gradle6Result = runWithGradle6('greet')
+
+        then:
+        gradle6Result.assertOutputContains("Hello from Gradle <7.0")
+    }
+
+    private void publishGradlePluginWithVariants() {
+
+        // given:
         def producer = file('producer')
-        def consumer = file('consumer')
         def pluginModule = mavenRepo.module('com.example', 'producer', '1.0')
         def pluginMarker = mavenRepo.module('com.example.greeting', 'com.example.greeting.gradle.plugin', '1.0')
 
+        // and:
         producer.file('settings.gradle') << ''
         producer.file('build.gradle') << """
             plugins {
@@ -82,53 +160,37 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
         producer.file('src/main/java/example/plugin/GreetingPlugin.java') << pluginImplementation('<7.0')
         producer.file('src/gradle7/java/example/plugin/GreetingPlugin.java') << pluginImplementation('7.0+')
 
-        consumer.file('settings.gradle') << """
-            pluginManagement {
-                repositories {
-                    maven { url = '${mavenRepo.uri}' }
-                }
-            }
-        """
-        consumer.file('build.gradle') << """
-            plugins {
-                id('com.example.greeting') version '1.0'
-            }
-        """
-
-        when:
+        // when:
         projectDir(producer)
         succeeds 'publish'
 
-        then:
+        // then:
         pluginModule.assertPublished()
         pluginMarker.assertPublished()
         pluginModule.artifact().assertPublished()
         pluginModule.artifact(classifier: 'gradle7').assertPublished()
 
+        // and:
         def variants = pluginModule.parsedModuleMetadata.variants
-        variants.size() == 4
-        variants[0].name == "apiElements"
-        !variants[0].attributes.containsKey('org.gradle.plugin.api-version')
-        variants[1].name == "runtimeElements"
-        !variants[1].attributes.containsKey('org.gradle.plugin.api-version')
-        variants[2].name == "gradle7ApiElements"
-        variants[2].attributes['org.gradle.plugin.api-version'] == '7.0'
-        variants[3].name == "gradle7RuntimeElements"
-        variants[3].attributes['org.gradle.plugin.api-version'] == '7.0'
+        assert variants.size() == 4
+        assert variants[0].name == "apiElements"
+        assert !variants[0].attributes.containsKey('org.gradle.plugin.api-version')
+        assert variants[1].name == "runtimeElements"
+        assert !variants[1].attributes.containsKey('org.gradle.plugin.api-version')
+        assert variants[2].name == "gradle7ApiElements"
+        assert variants[2].attributes['org.gradle.plugin.api-version'] == '7.0'
+        assert variants[3].name == "gradle7RuntimeElements"
+        assert variants[3].attributes['org.gradle.plugin.api-version'] == '7.0'
 
-        and:
-        projectDir(consumer)
-        succeeds 'greet'
+        // cleanup:
+        projectDir(testDirectory)
+    }
 
-        then:
-        outputContains("Hello from Gradle 7.0+")
-
-        and:
-        def gradle6Executer = buildContext.distribution("6.7.1").executer(temporaryFolder, buildContext)
-        def gradle6Result = gradle6Executer.usingProjectDirectory(consumer).withTasks('greet').run()
-
-        then:
-        gradle6Result.assertOutputContains("Hello from Gradle <7.0")
+    private ExecutionResult runWithGradle6(String... tasks) {
+        return buildContext.distribution("6.7.1")
+            .executer(temporaryFolder, buildContext)
+            .withTasks('greet')
+            .run()
     }
 
     private static String pluginImplementation(String gradleVersion) {
@@ -154,5 +216,4 @@ class GradlePluginWithVariantsPublicationIntegrationTest extends AbstractIntegra
             }
         """
     }
-
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -99,7 +99,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
@@ -174,7 +174,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
 
@@ -237,7 +237,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}")
         outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}")
     }
@@ -277,7 +277,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}")
         outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}")
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -103,7 +103,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
     }
@@ -141,8 +141,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, api-1.0.jar, compile-only-api-1.0.jar]")
         outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-api}")
-        outputContains("api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}")
-        outputContains("compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}")
+        outputContains("api-1.0.jar (test:api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}")
+        outputContains("compile-only-api-1.0.jar (test:compile-only-api:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-api}")
     }
 
     def "provides runtime variant - format: #format"() {
@@ -181,7 +181,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
         outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
 
@@ -244,7 +244,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":java:compileJava", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}")
         outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=classes, org.gradle.usage=java-runtime}")
     }
@@ -284,7 +284,7 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:processResources", ":java:processResources", ":consumer:resolve")
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}")
-        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
+        outputContains("compile-1.0.jar (test:compile:1.0) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=jar, org.gradle.status=release, org.gradle.usage=java-runtime}")
         outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}")
         outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.libraryelements=resources, org.gradle.usage=java-runtime}")
     }


### PR DESCRIPTION
The Kotlin Gradle Plugin 1.7.0 is published with two variants targeting different Gradle versions, distinguished by the `GradlePluginApiVersion` attribute. The first variant, for Gradle versions < 7.0 doesn't have the attribute, the second variant, for Gradle versions > 7.0 has the attribute with a value of `7.0`.

Consuming it for compilation, e.g. in `buildSrc` or a plugin build fails on Gradle 7.6 because the dependency resolution engine cannot disambiguate.

This PR fixes the disambiguation algorithm to automatically disambiguate two variants with an attribute with null value and a single value matching the requested.

Along the way this PR also adds the `Bundling.EXTERNAL` attribute to libraries derived from Maven metadata.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
