### PR TITLE
Convert backslash to slash when printing file path

### DIFF
--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileTreeElement.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/DefaultFileTreeElement.java
@@ -48,7 +48,7 @@ public class DefaultFileTreeElement extends AbstractFileTreeElement {
 
     @Override
     public String getDisplayName() {
-        return "file '" + file + "'";
+        return "file '" + file.toString().replace('\\', '/') + "'";
     }
 
     @Override

--- a/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileTreeElementTest.groovy
+++ b/subprojects/file-collections/src/test/groovy/org/gradle/api/internal/file/DefaultFileTreeElementTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.file
 import org.gradle.api.file.FileTreeElement
 import org.gradle.internal.file.Chmod
 import org.gradle.internal.file.Stat
+import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
@@ -35,5 +36,14 @@ class DefaultFileTreeElementTest extends Specification {
 
         expect:
         e.mode == 0644
+    }
+
+    def "display name does not contains backslash"() {
+        def fileSystem = Mock(FileSystem)
+        def f = tmpDir.createFile("foo", "user", "bar")
+        FileTreeElement e = DefaultFileTreeElement.of(f, fileSystem)
+
+        expect:
+        !e.toString().contains('\\')
     }
 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #19752

### Context
The catalog code generator is broken on windows because the `file.separator` backslash. If the folder name starts with `u` then the `\u<something>` creates a compile error: `illegal unicode escape`

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
