### PR TITLE
Add missing @Nullable annotations on API types

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -47,6 +47,54 @@
             "changes": [
                 "Method has been removed"
             ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.DependencyArtifact",
+            "member": "Method org.gradle.api.artifacts.DependencyArtifact.getClassifier()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.DependencyArtifact",
+            "member": "Method org.gradle.api.artifacts.DependencyArtifact.getExtension()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.DependencyArtifact",
+            "member": "Method org.gradle.api.artifacts.DependencyArtifact.getUrl()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.ResolvedArtifact",
+            "member": "Method org.gradle.api.artifacts.ResolvedArtifact.getExtension()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.ArtifactIdentifier",
+            "member": "Method org.gradle.api.artifacts.ArtifactIdentifier.getClassifier()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.ArtifactIdentifier",
+            "member": "Method org.gradle.api.artifacts.ArtifactIdentifier.getExtension()",
+            "acceptation": "Method always could return null",
+            "changes": [
+                "From non-null returning to null returning breaking change"
+            ]
         }
     ]
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactIdentifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ArtifactIdentifier.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.artifacts;
 
+import javax.annotation.Nullable;
+
 /**
  * The identifier for a module artifact.
  */
@@ -45,11 +47,13 @@ public interface ArtifactIdentifier {
      *
      * @see #getType()
      */
+    @Nullable
     String getExtension();
 
     /**
      * Returns the classifier of this artifact, if any.
      */
+    @Nullable
     String getClassifier();
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/DependencyArtifact.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.artifacts;
 
+import javax.annotation.Nullable;
+
 /**
  * <p>An {@code Artifact} represents an artifact included in a {@link org.gradle.api.artifacts.Dependency}.</p>
  * An artifact is an (immutable) value object.
@@ -37,7 +39,7 @@ public interface DependencyArtifact {
      * but sometimes this is not the case. For example for an ivy XML module descriptor, the type is
      * <em>ivy</em> and the extension is <em>xml</em>.
      *
-     * @see #getExtension() 
+     * @see #getExtension()
      */
     String getType();
 
@@ -51,33 +53,36 @@ public interface DependencyArtifact {
      * but sometimes this is not the case. For example for an ivy XML module descriptor, the type is
      * <em>ivy</em> and the extension is <em>xml</em>.
      *
-     * @see #getType() 
+     * @see #getType()
      */
+    @Nullable
     String getExtension();
 
     /**
      * Sets the extension of this artifact.
      */
-    void setExtension(String extension);
+    void setExtension(@Nullable String extension);
 
     /**
      * Returns the classifier of this artifact.
      */
+    @Nullable
     String getClassifier();
 
     /**
      * Sets the classifier of this artifact.
      */
-    void setClassifier(String classifier);
+    void setClassifier(@Nullable String classifier);
 
     /**
-     * Returns an URL under which this artifact can be retrieved. If not
-     * specified the user repositories are used for retrieving. 
+     * Returns a URL under which this artifact can be retrieved. If not
+     * specified the user repositories are used for retrieving.
      */
+    @Nullable
     String getUrl();
 
     /**
      * Sets the URL for this artifact.
      */
-    void setUrl(String url);
+    void setUrl(@Nullable String url);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvedArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolvedArtifact.java
@@ -40,6 +40,7 @@ public interface ResolvedArtifact {
 
     String getType();
 
+    @Nullable
     String getExtension();
 
     @Nullable

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyArtifact.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.dependencies;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyArtifact;
 
+import javax.annotation.Nullable;
+
 public class DefaultDependencyArtifact implements DependencyArtifact {
     private String name;
     private String type;
@@ -28,7 +30,7 @@ public class DefaultDependencyArtifact implements DependencyArtifact {
     public DefaultDependencyArtifact() {
     }
 
-    public DefaultDependencyArtifact(String name, String type, String extension, String classifier, String url) {
+    public DefaultDependencyArtifact(String name, String type, @Nullable String extension, @Nullable String classifier, @Nullable String url) {
         this.name = name;
         this.type = type;
         this.extension = extension;
@@ -63,33 +65,36 @@ public class DefaultDependencyArtifact implements DependencyArtifact {
         this.type = type;
     }
 
+    @Nullable
     @Override
     public String getExtension() {
         return extension;
     }
 
     @Override
-    public void setExtension(String extension) {
+    public void setExtension(@Nullable String extension) {
         this.extension = extension;
     }
 
+    @Nullable
     @Override
     public String getClassifier() {
         return classifier;
     }
 
     @Override
-    public void setClassifier(String classifier) {
+    public void setClassifier(@Nullable String classifier) {
         this.classifier = classifier;
     }
 
+    @Nullable
     @Override
     public String getUrl() {
         return url;
     }
 
     @Override
-    public void setUrl(String url) {
+    public void setUrl(@Nullable String url) {
         this.url = url;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultArtifactIdentifier.java
@@ -55,11 +55,13 @@ public class DefaultArtifactIdentifier implements ArtifactIdentifier {
         return name.getType();
     }
 
+    @Nullable
     @Override
     public String getExtension() {
         return name.getExtension();
     }
 
+    @Nullable
     @Override
     public String getClassifier() {
         return name.getClassifier();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/PreResolvedResolvableArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/PreResolvedResolvableArtifact.java
@@ -130,6 +130,7 @@ public class PreResolvedResolvableArtifact implements ResolvableArtifact, Resolv
         return artifact.getType();
     }
 
+    @Nullable
     @Override
     public String getExtension() {
         return artifact.getExtension();


### PR DESCRIPTION
Some types were missing these annotations. 

Waiting for 8.0 since this breaks Kotlin source compatibility. 