### PR TITLE
Fix cycle detection error involving finalized dependencies of finalizer

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -26,7 +26,29 @@ import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.exact
 
 class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/21000")
+    def "finalizer can indirectly depend on the entry point finalized by it"() {
+        given:
+        buildFile '''
+            task finalizer {
+                dependsOn 'finalized'
+            }
+            task finalized {
+                dependsOn 'entryPoint'
+                finalizedBy 'finalizer'
+            }
+            task entryPoint {
+                finalizedBy 'finalizer'
+            }
+        '''
+
+        expect:
+        2.times {
+            succeeds 'entryPoint'
+            result.assertTaskOrder ':entryPoint', ':finalized', ':finalizer'
+        }
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/21000")
     def "finalizer task can depend on finalized task"() {
         given:
         buildFile '''
@@ -42,17 +64,36 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         expect:
-        fails 'entryPoint'
+        2.times {
+            succeeds 'entryPoint'
+            result.assertTaskOrder ':entryPoint', ':finalized', ':finalizer'
+        }
 
-        and:
-        failureDescriptionContains 'Misdetected cycle between :finalized and :finalized.'
+    }
 
-        // TODO: should be
-//        expect:
-//        succeeds 'entryPoint'
-//
-//        and:
-//        result.assertTaskOrder ':entryPoint', ':finalized', ':finalizer'
+    @Issue("https://github.com/gradle/gradle/issues/21000")
+    def "finalizer task can depend on multiple finalized tasks"() {
+        given:
+        buildFile '''
+            task finalizer {
+                dependsOn 'finalized1', 'finalized2'
+            }
+            task finalized1 {
+                finalizedBy 'finalizer'
+            }
+            task finalized2 {
+                finalizedBy 'finalizer'
+            }
+            task entryPoint {
+                finalizedBy 'finalizer'
+            }
+        '''
+
+        expect:
+        2.times {
+            succeeds 'entryPoint'
+            result.assertTaskOrder ':entryPoint', any(':finalized1', ':finalized2'), ':finalizer'
+        }
     }
 
     void 'finalizer tasks are scheduled as expected (#requestedTasks)'() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -26,6 +26,35 @@ import static org.gradle.integtests.fixtures.executer.TaskOrderSpecs.exact
 
 class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
 
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/21000")
+    def "finalizer task can depend on finalized task"() {
+        given:
+        buildFile '''
+            task finalizer {
+                dependsOn 'finalized'
+            }
+            task finalized {
+                finalizedBy 'finalizer'
+            }
+            task entryPoint {
+                finalizedBy 'finalizer'
+            }
+        '''
+
+        expect:
+        fails 'entryPoint'
+
+        and:
+        failureDescriptionContains 'Misdetected cycle between :finalized and :finalized.'
+
+        // TODO: should be
+//        expect:
+//        succeeds 'entryPoint'
+//
+//        and:
+//        result.assertTaskOrder ':entryPoint', ':finalized', ':finalizer'
+    }
+
     void 'finalizer tasks are scheduled as expected (#requestedTasks)'() {
         given:
         setupProject()

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
@@ -85,6 +85,20 @@ public class CompositeNodeGroup extends HasFinalizers {
     }
 
     @Override
+    public void maybeAddToOwnedMembers(Node node) {
+        // Intentionally empty.
+        // Trying to add a node here means that this node is already owned by some
+        // FinalizerGroup or is a part of the OrdinalGroup.
+    }
+
+    @Override
+    public void removeFromOwnedMembers(Node node) {
+        for (FinalizerGroup group : finalizerGroups) {
+            group.removeFromOwnedMembers(node);
+        }
+    }
+
+    @Override
     public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
         if (ordinalGroup.isReachableFromEntryPoint()) {
             // Reachable from entry point node, can run at any time

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -486,12 +486,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
 
     private void onOrderingCycle(Node successor, Node currentNode) {
         CachingDirectedGraphWalker<Node, Void> graphWalker = new CachingDirectedGraphWalker<>((node, values, connectedNodes) -> {
-            connectedNodes.addAll(node.getDependencySuccessors());
-            if (node instanceof TaskNode) {
-                TaskNode taskNode = (TaskNode) node;
-                connectedNodes.addAll(taskNode.getMustSuccessors());
-                connectedNodes.addAll(taskNode.getFinalizingSuccessors());
-            }
+            node.getHardSuccessors().forEach(connectedNodes::add);
         });
         graphWalker.add(successor);
 
@@ -507,8 +502,9 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
         DirectedGraphRenderer<Node> graphRenderer = new DirectedGraphRenderer<>(
             (it, output) -> output.withStyle(StyledTextOutput.Style.Identifier).text(it),
             (it, values, connectedNodes) -> {
+                Set<Node> successors = Sets.newHashSet(it.getHardSuccessors());
                 for (Node dependency : firstCycle) {
-                    if (it.hasHardSuccessor(dependency)) {
+                    if (dependency instanceof TaskNode && successors.contains(dependency)) {
                         connectedNodes.add(dependency);
                     }
                 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -1238,5 +1238,21 @@ public class DefaultExecutionPlan implements ExecutionPlan, WorkSource<Node> {
                 pos++;
             }
         }
+
+        @Override
+        public String toString() {
+            StringBuilder str = new StringBuilder("ExecutionQueue[");
+            for (int i = 0; i < nodes.size(); ++i) {
+                if (i > 0) {
+                    str.append(", ");
+                }
+                if (i == pos) {
+                    str.append('*');
+                }
+                str.append(nodes.get(i));
+            }
+            str.append("]");
+            return str.toString();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -31,6 +33,14 @@ public class FinalizerGroup extends HasFinalizers {
     private final TaskNode node;
     private final NodeGroup delegate;
     private final Set<Node> members = new LinkedHashSet<>();
+    /**
+     * A collection of Nodes owned by this group. Only a single FinalizerGroup may own a node.
+     * The owned nodes can still be members of other finalizer groups though.
+     * The important distinction is how these members are handled when they are finalized by this group.
+     * They aren't considered the group successors but only successors to the finalizer node itself.
+     * This prevents deadlocks and false cycles when a dependency of a finalizer is finalized by it.
+     */
+    private final Set<Node> ownedMembers = new HashSet<>();
     @Nullable
     private OrdinalGroup ordinal;
 
@@ -38,6 +48,11 @@ public class FinalizerGroup extends HasFinalizers {
         this.ordinal = delegate.asOrdinal();
         this.node = node;
         this.delegate = delegate;
+    }
+
+    public FinalizerGroup(TaskNode node, NodeGroup delegate, Collection<Node> ownedMembers) {
+        this(node, delegate);
+        this.ownedMembers.addAll(ownedMembers);
     }
 
     @Override
@@ -64,8 +79,15 @@ public class FinalizerGroup extends HasFinalizers {
         return delegate;
     }
 
-    public Collection<Node> getFinalizedNodes() {
+    /**
+     * Returns a set of nodes that are finalized by this group. The returned set might contain the nodes belonging to this group.
+     */
+    public Set<Node> getFinalizedNodes() {
         return node.getFinalizingSuccessors();
+    }
+
+    private Set<Node> getFinalizedNodesInReverseOrder() {
+        return node.getFinalizingSuccessorsInReverseOrder();
     }
 
     @Nullable
@@ -86,18 +108,56 @@ public class FinalizerGroup extends HasFinalizers {
     }
 
     @Override
-    public Collection<Node> getSuccessors() {
-        return node.getFinalizingSuccessors();
+    public Collection<Node> getSuccessorsFor(Node node) {
+        assert members.contains(node) : "Node " + node + " is not part of the finalizer group of " + this.node;
+        Set<Node> successors = getFinalizedNodes();
+        if (!isFinalizerNode(node)) {
+            successors = filterSuccessorsForFinalizerDependency(successors);
+        }
+        return successors;
     }
 
     @Override
-    public Collection<Node> getSuccessorsInReverseOrder() {
-        return node.getFinalizingSuccessorsInReverseOrder();
+    public Collection<Node> getSuccessorsInReverseOrderFor(Node node) {
+        assert members.contains(node) : "Node " + node + " is not part of the finalizer group of " + this.node;
+        Set<Node> successors = getFinalizedNodesInReverseOrder();
+        if (!isFinalizerNode(node)) {
+            successors = filterSuccessorsForFinalizerDependency(successors);
+        }
+        return successors;
+    }
+
+    private Set<Node> filterSuccessorsForFinalizerDependency(Set<Node> successors) {
+        // The nodes that are dependencies of the finalizer can have a smaller set of successors.
+        // Owned nodes finalized by this finalizer that are also dependencies of the finalizer are not considered
+        // successors to finalizer dependencies (but they are successors to the finalizer).
+        // This prevents deadlocks and false cycles when two unrelated finalizer's dependencies finalized by this
+        // finalizer are considered each other's successors.
+        // Such nodes are still successors to other finalized nodes, like non-members and not-owned members.
+        // Not owned members are expected to be scheduled by their other group. Typically, it is a node reachable
+        // from the entry point, but a dependency of some other finalizer can also be an example.
+        Set<Node> filteredSuccessors = new LinkedHashSet<>(successors);
+        filteredSuccessors.removeIf(ownedMembers::contains);
+        return filteredSuccessors;
     }
 
     @Override
     public Set<FinalizerGroup> getFinalizerGroups() {
         return ImmutableSet.of(this);
+    }
+
+    @Override
+    public void maybeAddToOwnedMembers(Node node) {
+        ownedMembers.add(node);
+    }
+
+    @Override
+    public void removeFromOwnedMembers(Node node) {
+        ownedMembers.remove(node);
+    }
+
+    public Collection<Node> getOwnedMembers() {
+        return Collections.unmodifiableCollection(ownedMembers);
     }
 
     @Override
@@ -121,13 +181,13 @@ public class FinalizerGroup extends HasFinalizers {
     @Override
     public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
         // If this node is reachable from an entry point and is not the finalizer itself, then it can start at any time
-        if (delegate.isReachableFromEntryPoint() && node != this.node) {
+        if (delegate.isReachableFromEntryPoint() && !isFinalizerNode(node)) {
             return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
         }
 
-        // Otherwise, wait for all finalized nodes to complete
+        // Otherwise, wait for (almost) all finalized nodes to complete with one exception.
         boolean isAnyExecuted = false;
-        for (Node finalized : getFinalizedNodes()) {
+        for (Node finalized : getSuccessorsFor(node)) {
             if (!finalized.isComplete()) {
                 return Node.DependenciesState.NOT_COMPLETE;
             }
@@ -146,5 +206,9 @@ public class FinalizerGroup extends HasFinalizers {
             // Can skip execution
             return Node.DependenciesState.COMPLETE_AND_CAN_SKIP;
         }
+    }
+
+    private boolean isFinalizerNode(Node node) {
+        return node == this.node;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
@@ -22,4 +22,27 @@ abstract class HasFinalizers extends NodeGroup {
     public abstract NodeGroup getOrdinalGroup();
 
     public abstract Set<FinalizerGroup> getFinalizerGroups();
+
+    /**
+     * Tries to add the node to the set of exclusive nodes of this group. If this group doesn't support
+     * exclusive nodes, e.g. it is a CompositeNodeGroup, then does nothing.
+     *
+     * The node should be an exclusive node of a single {@link FinalizerGroup} (though it can be non-exclusive member of multiple groups still),
+     * see that class' documentation for details.
+     *
+     * @param node the node to add to the set of exclusive nodes
+     */
+    public abstract void maybeAddToOwnedMembers(Node node);
+
+    /**
+     * Removes the node from the list of owned nodes of a finalizer group.
+     * Unlike {@link #maybeAddToOwnedMembers(Node)}, the removal affects all finalizer groups
+     * returned by {@link #getFinalizerGroups()}.
+     *
+     * The node should be an exclusive node of a single {@link FinalizerGroup} (though it can be non-exclusive member of multiple groups still),
+     * see that class' documentation for details.
+     *
+     * @param node the node
+     */
+    public abstract void removeFromOwnedMembers(Node node);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -106,7 +106,8 @@ public class LocalTaskNode extends TaskNode {
     public boolean isCanCancel() {
         FinalizerGroup finalizerGroup = getFinalizerGroup();
         if (finalizerGroup != null) {
-            for (Node node : finalizerGroup.getSuccessors()) {
+            // TODO(mlopatkin) what if this node is some dependency of a finalizer and its group is a CompositeNodeGroup and not just a FinalizerGroup?
+            for (Node node : finalizerGroup.getFinalizedNodes()) {
                 // Cannot cancel this node if something it finalizes has started
                 if (node.isExecuting() || node.isExecuted()) {
                     return false;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -494,14 +494,6 @@ public abstract class Node implements Comparable<Node> {
         return dependencySuccessors.descendingSet();
     }
 
-    /**
-     * Returns if the node has the given node as a hard successor, i.e. a non-removable relationship.
-     */
-    @OverridingMethodsMustInvokeSuper
-    public boolean hasHardSuccessor(Node successor) {
-        return dependencySuccessors.contains(successor);
-    }
-
     public Set<Node> getFinalizers() {
         return Collections.emptySet();
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
@@ -69,13 +69,27 @@ public abstract class NodeGroup {
     }
 
     /**
-     * Returns the set of nodes which must complete before any node in this group can start.
+     * Returns the sequence of nodes which must complete before the given node can start. The given node must belong to this group.
+     * The returned sequence is not exhaustive, i.e. it doesn't mean that the given node can start even if all nodes in it are
+     * completed.
+     *
+     * @param node the node to check successors for
      */
-    public Iterable<? extends Node> getSuccessors() {
+    public Iterable<? extends Node> getSuccessorsFor(Node node) {
         return Collections.emptyList();
     }
 
-    public Iterable<? extends Node> getSuccessorsInReverseOrder() {
+    /**
+     * Returns the sequence of nodes which must complete before the given node can start. The given node must belong to this group.
+     * The returned sequence is not exhaustive, i.e. it doesn't mean that the given node can start even if all nodes in it are
+     * completed.
+     *
+     * The returned sequence is a reverse of the result of {@link #getSuccessorsFor(Node)}.
+     *
+     * @param node the node to check successors for
+     * @see #getSuccessorsFor(Node)
+     */
+    public Iterable<? extends Node> getSuccessorsInReverseOrderFor(Node node) {
         return Collections.emptyList();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -139,18 +139,6 @@ public abstract class TaskNode extends Node {
         }
     }
 
-    @Override
-    public boolean hasHardSuccessor(Node successor) {
-        if (super.hasHardSuccessor(successor)) {
-            return true;
-        }
-        if (!(successor instanceof TaskNode)) {
-            return false;
-        }
-        return getMustSuccessors().contains(successor)
-            || getFinalizingSuccessors().contains(successor);
-    }
-
     public abstract TaskInternal getTask();
 
     protected void deprecateLifecycleHookReferencingNonLocalTask(String hookName, Node taskNode) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -99,6 +99,15 @@ abstract class AbstractExecutionPlanSpec extends Specification {
         return task
     }
 
+    protected void relationships(Map options, TaskInternal task) {
+        dependsOn(task, options.dependsOn ?: [])
+        task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
+        mustRunAfter(task, options.mustRunAfter ?: [])
+        shouldRunAfter(task, options.shouldRunAfter ?: [])
+        finalizedBy(task, options.finalizedBy ?: [])
+        task.getSharedResources() >> (options.resources ?: [])
+    }
+
     protected void dependsOn(TaskInternal task, List<Task> dependsOnTasks) {
         task.getTaskDependencies() >> taskDependencyResolvingTo(task, dependsOnTasks)
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -1125,15 +1125,6 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         return task
     }
 
-    private void relationships(Map options, TaskInternal task) {
-        dependsOn(task, options.dependsOn ?: [])
-        task.lifecycleDependencies >> taskDependencyResolvingTo(task, options.dependsOn ?: [])
-        mustRunAfter(task, options.mustRunAfter ?: [])
-        shouldRunAfter(task, options.shouldRunAfter ?: [])
-        finalizedBy(task, options.finalizedBy ?: [])
-        task.getSharedResources() >> (options.resources ?: [])
-    }
-
     private TaskInternal filteredTask(final String name) {
         def task = createTask(name)
         task.getTaskDependencies() >> brokenDependencies()

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -34,7 +34,7 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 159 * 1024 * 1024
+        return 161 * 1024 * 1024
     }
 
     def allZipContents() {


### PR DESCRIPTION
This is a tweaked version of the solution we discussed earlier. Removing all members from the list of the group's successors sometimes allows finalizer dependencies to execute earlier, potentially before the finalized task. The "ownedNodes" strives to resolve this by limiting the exclusion to nodes which are brought to live by this finalizer itself and not by entry point or some other finalizer.

This, however, doesn't solve all problems with the new implementation - it is possible to have false (or may be not false, but still undetectable in 7.4) cycles between nodes in different groups. I've added a test case for this, but don't have a solution yet.


Fixes #21000 .