### PR TITLE
Polish commit distribution build

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -140,9 +140,10 @@ abstract class BuildCommitDistribution @Inject internal constructor(
                     this["distributionUrl"] = "https://services.gradle.org/$repository/gradle-${closestReleasedVersion.version}-bin.zip"
                 }
                 wrapperProperties.store(wrapperPropertiesFile.outputStream(), "Modified by `BuildCommitDistribution` task")
+                println("First attempt to build commit distribution failed: \n\n$outputString\n\nTrying again with ${closestReleasedVersion.version}")
                 runDistributionBuild(checkoutDir, System.out)
             } else {
-                println(output.toByteArray().decodeToString())
+                println("Failed to build commit distribution:\n\n${output.toByteArray().decodeToString()}")
                 throw e
             }
         }
@@ -160,6 +161,7 @@ abstract class BuildCommitDistribution @Inject internal constructor(
             "--no-configuration-cache",
             "clean",
             ":distributions-full:install",
+            "-Dscan.tag.BuildCommitDistribution",
             "-Pgradle_installPath=" + commitDistributionHome.get().asFile.absolutePath,
             ":tooling-api:installToolingApiShadedJar",
             "-PtoolingApiShadedJarInstallPath=" + commitDistributionToolingApiJar.get().asFile.absolutePath,


### PR DESCRIPTION
- Add a build scan tag to that build.
- Clearly log no matter commit distribution build fails or succeeds.
