### PR TITLE
Fix hashing for known implementation snapshots

### DIFF
--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
@@ -33,7 +33,7 @@ public class ClassImplementationSnapshot extends ImplementationSnapshot {
 
     @Override
     public void appendToHasher(Hasher hasher) {
-        hasher.putString(ImplementationSnapshot.class.getName());
+        hasher.putString(ClassImplementationSnapshot.class.getName());
         hasher.putString(typeName);
         hasher.putHash(classLoaderHash);
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
@@ -65,7 +65,7 @@ public class LambdaImplementationSnapshot extends ImplementationSnapshot {
 
     @Override
     public void appendToHasher(Hasher hasher) {
-        hasher.putString(ImplementationSnapshot.class.getName());
+        hasher.putString(LambdaImplementationSnapshot.class.getName());
         hasher.putString(typeName);
         hasher.putHash(classLoaderHash);
         hasher.putString(functionalInterfaceClass);


### PR DESCRIPTION
Hashing for know implementation snapshots (classes and lambdas) currently uses the parent class name during append to a hasher. However, we should differentiate between them.

This would also avoid a potential problem if another known implementation snapshot gets added that stores the same kinds of fields. Although, this is unlikely.

Related to #21054