### PR TITLE
Relax requirement on finalizing successors being task nodes

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -188,9 +188,6 @@ class WorkNodeCodec(
                     node.addMustSuccessor(it)
                 }
                 readSuccessorReferences(nodesById) {
-                    require(it is TaskNode) {
-                        "Expecting a TaskNode as a finalizing successor of `$node`, got `$it`."
-                    }
                     node.addFinalizingSuccessor(it)
                 }
                 val lifecycleSuccessors = mutableSetOf<Node>()


### PR DESCRIPTION
As it is no longer required by the internal API.