### PR TITLE
Update nightly version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220513164305+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20220622230534+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Verify our own build doesn't need additional changes given the removal of --add-opens for tests.