### PR TITLE
Use java-gradle-plugin in tests

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/CustomPluginIntegrationTest.groovy
@@ -17,8 +17,6 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ArtifactBuilder
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
-import spock.lang.IgnoreIf
 
 class CustomPluginIntegrationTest extends AbstractIntegrationSpec {
     void "can reference plugin in buildSrc by id"() {
@@ -122,126 +120,6 @@ buildscript {
 }
 task test
 '''
-
-        expect:
-        succeeds('test')
-    }
-
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
-    def "can integration test plugin"() {
-        given:
-        file('src/main/groovy/CustomPlugin.groovy') << """
-import org.gradle.api.Project
-import org.gradle.api.Plugin
-class CustomPlugin implements Plugin<Project> {
-    void apply(Project project) {
-        project.ext.custom = 'value'
-    }
-}
-        """
-
-        file("src/main/resources/META-INF/gradle-plugins/custom.properties") << """
-implementation-class=CustomPlugin
-"""
-
-        file('src/test/groovy/CustomPluginTest.groovy') << """
-import org.junit.Test
-import org.gradle.testfixtures.ProjectBuilder
-class CustomPluginTest {
-    @Test
-    public void test() {
-        def project = ProjectBuilder.builder().build()
-
-        project.apply plugin: 'custom'
-
-        assert project.custom == 'value'
-    }
-}
-"""
-
-        buildFile << """
-apply plugin: 'groovy'
-${mavenCentralRepository()}
-dependencies {
-    implementation gradleApi()
-    implementation localGroovy()
-    testImplementation 'junit:junit:4.13'
-}
-// Needed when using ProjectBuilder
-class AddOpensArgProvider implements CommandLineArgumentProvider {
-    private final Test test;
-    public AddOpensArgProvider(Test test) {
-        this.test = test;
-    }
-    @Override
-    Iterable<String> asArguments() {
-        return test.javaVersion.isCompatibleWith(JavaVersion.VERSION_1_9)
-            ? ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
-            : []
-    }
-}
-tasks.withType(Test).configureEach {
-    jvmArgumentProviders.add(new AddOpensArgProvider(it))
-}
-"""
-
-        expect:
-        succeeds('test')
-    }
-
-    @IgnoreIf({ GradleContextualExecuter.embedded }) // Requires a Gradle distribution on the test-under-test classpath, but gradleApi() does not offer the full distribution
-    def "can use java plugin from custom plugin and its integration tests"() {
-        given:
-        file('src/main/groovy/CustomPlugin.groovy') << """
-import org.gradle.api.Project
-import org.gradle.api.Plugin
-class CustomPlugin implements Plugin<Project> {
-    void apply(Project project) {
-        project.apply plugin: 'java'
-    }
-}
-        """
-
-        file('src/test/groovy/CustomPluginTest.groovy') << """
-import org.junit.Test
-import org.gradle.testfixtures.ProjectBuilder
-class CustomPluginTest {
-    @Test
-    public void test() {
-        def project = ProjectBuilder.builder().build()
-
-        project.apply plugin: 'java'
-
-        assert project.sourceSets
-    }
-}
-"""
-
-        buildFile << """
-apply plugin: 'groovy'
-${mavenCentralRepository()}
-dependencies {
-    implementation gradleApi()
-    implementation localGroovy()
-    testImplementation 'junit:junit:4.13'
-}
-// Needed when using ProjectBuilder
-class AddOpensArgProvider implements CommandLineArgumentProvider {
-    private final Test test;
-    public AddOpensArgProvider(Test test) {
-        this.test = test;
-    }
-    @Override
-    Iterable<String> asArguments() {
-        return test.javaVersion.isCompatibleWith(JavaVersion.VERSION_1_9)
-            ? ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
-            : []
-    }
-}
-tasks.withType(Test).configureEach {
-    jvmArgumentProviders.add(new AddOpensArgProvider(it))
-}
-"""
 
         expect:
         succeeds('test')

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -17,7 +17,6 @@ package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -81,7 +80,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -180,6 +178,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     private final List<String> expectedDeprecationWarnings = new ArrayList<>();
     private boolean eagerClassLoaderCreationChecksOn = true;
     private boolean stackTraceChecksOn = true;
+    private boolean jdkWarningChecksOn = false;
 
     private final MutableActionSet<GradleExecuter> beforeExecute = new MutableActionSet<>();
     private ImmutableActionSet<GradleExecuter> afterExecute = ImmutableActionSet.empty();
@@ -253,6 +252,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         expectedGenericDeprecationWarnings = 0;
         expectedDeprecationWarnings.clear();
         stackTraceChecksOn = true;
+        jdkWarningChecksOn = false;
         renderWelcomeMessage = false;
         disableToolchainDownload = true;
         disableToolchainDetection = true;
@@ -387,6 +387,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
         }
         if (!stackTraceChecksOn) {
             executer.withStackTraceChecksDisabled();
+        }
+        if (jdkWarningChecksOn) {
+            executer.withJdkWarningChecksEnabled();
         }
         if (useOwnUserHomeServices) {
             executer.withOwnUserHomeServices();
@@ -1273,160 +1276,165 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     }
 
     protected Action<ExecutionResult> getResultAssertion() {
-        return new Action<ExecutionResult>() {
-            private int expectedGenericDeprecationWarnings = AbstractGradleExecuter.this.expectedGenericDeprecationWarnings;
-            private final List<String> expectedDeprecationWarnings = new ArrayList<>(AbstractGradleExecuter.this.expectedDeprecationWarnings);
-            private final boolean expectStackTraces = !AbstractGradleExecuter.this.stackTraceChecksOn;
-            private final boolean checkDeprecations = AbstractGradleExecuter.this.checkDeprecations;
+        return new ResultAssertion(
+            expectedGenericDeprecationWarnings, expectedDeprecationWarnings,
+            !stackTraceChecksOn, checkDeprecations, jdkWarningChecksOn
+        );
+    }
 
-            @Override
-            public void execute(ExecutionResult executionResult) {
-                String normalizedOutput = executionResult.getNormalizedOutput();
-                String error = executionResult.getError();
-                boolean executionFailure = isExecutionFailure(executionResult);
+    private static class ResultAssertion implements Action<ExecutionResult> {
+        private int expectedGenericDeprecationWarnings;
+        private final List<String> expectedDeprecationWarnings;
+        private final boolean expectStackTraces;
+        private final boolean checkDeprecations;
+        private final boolean checkJdkWarnings;
 
-                // for tests using rich console standard out and error are combined in output of execution result
-                if (executionFailure) {
-                    normalizedOutput = removeExceptionStackTraceForFailedExecution(normalizedOutput);
-                }
+        private ResultAssertion(
+            int expectedGenericDeprecationWarnings, List<String> expectedDeprecationWarnings,
+            boolean expectStackTraces, boolean checkDeprecations, boolean checkJdkWarnings
+        ) {
+            this.expectedGenericDeprecationWarnings = expectedGenericDeprecationWarnings;
+            this.expectedDeprecationWarnings = new ArrayList<>(expectedDeprecationWarnings);
+            this.expectStackTraces = expectStackTraces;
+            this.checkDeprecations = checkDeprecations;
+            this.checkJdkWarnings = checkJdkWarnings;
+        }
 
-                validate(normalizedOutput, "Standard output");
+        @Override
+        public void execute(ExecutionResult executionResult) {
+            String normalizedOutput = executionResult.getNormalizedOutput();
+            String error = executionResult.getError();
+            boolean executionFailure = executionResult instanceof ExecutionFailure;
 
-                if (executionFailure) {
-                    error = removeExceptionStackTraceForFailedExecution(error);
-                }
-
-                validate(error, "Standard error");
-
-                if (!expectedDeprecationWarnings.isEmpty()) {
-                    throw new AssertionError(String.format("Expected the following deprecation warnings:%n%s",
-                        expectedDeprecationWarnings.stream()
-                            .map(warning -> " - " + warning)
-                            .collect(joining("\n"))));
-                }
-                if (expectedGenericDeprecationWarnings > 0) {
-                    throw new AssertionError(String.format("Expected %d more deprecation warnings", expectedGenericDeprecationWarnings));
-                }
+            // for tests using rich console standard out and error are combined in output of execution result
+            if (executionFailure) {
+                normalizedOutput = removeExceptionStackTraceForFailedExecution(normalizedOutput);
             }
 
-            private boolean isErrorOutEmpty(String error) {
-                //remove SLF4J error out like 'Class path contains multiple SLF4J bindings.'
-                //See: https://github.com/gradle/performance/issues/375#issuecomment-315103861
-                return Strings.isNullOrEmpty(error.replaceAll("(?m)^SLF4J: .*", "").trim());
+            validate(normalizedOutput, "Standard output");
+
+            if (executionFailure) {
+                error = removeExceptionStackTraceForFailedExecution(error);
             }
 
-            private boolean isExecutionFailure(ExecutionResult executionResult) {
-                return executionResult instanceof ExecutionFailure;
-            }
+            validate(error, "Standard error");
 
-            // Axe everything after the expected exception
-            private String removeExceptionStackTraceForFailedExecution(String text) {
-                int pos = text.indexOf("* Exception is:");
-                if (pos >= 0) {
-                    text = text.substring(0, pos);
+            if (!expectedDeprecationWarnings.isEmpty()) {
+                throw new AssertionError(String.format("Expected the following deprecation warnings:%n%s",
+                    expectedDeprecationWarnings.stream()
+                        .map(warning -> " - " + warning)
+                        .collect(joining("\n"))));
+            }
+            if (expectedGenericDeprecationWarnings > 0) {
+                throw new AssertionError(String.format("Expected %d more deprecation warnings", expectedGenericDeprecationWarnings));
+            }
+        }
+
+        // Axe everything after the expected exception
+        private String removeExceptionStackTraceForFailedExecution(String text) {
+            int pos = text.indexOf("* Exception is:");
+            if (pos >= 0) {
+                text = text.substring(0, pos);
+            }
+            return text;
+        }
+
+        private void validate(String output, String displayName) {
+            List<String> lines;
+            try {
+                lines = CharSource.wrap(output).readLines();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            int i = 0;
+            boolean insideVariantDescriptionBlock = false;
+            boolean insideKotlinCompilerFlakyStacktrace = false;
+            boolean sawVmPluginLoadFailure = false;
+            while (i < lines.size()) {
+                String line = lines.get(i);
+                if (insideVariantDescriptionBlock && line.contains("]")) {
+                    insideVariantDescriptionBlock = false;
+                } else if (!insideVariantDescriptionBlock && line.contains("variant \"")) {
+                    insideVariantDescriptionBlock = true;
                 }
-                return text;
-            }
 
-            private void validate(String output, String displayName) {
-                List<String> lines;
-                try {
-                    lines = CharSource.wrap(output).readLines();
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-                int i = 0;
-                boolean insideVariantDescriptionBlock = false;
-                boolean insideKotlinCompilerFlakyStacktrace = false;
-                boolean sawVmPluginLoadFailure = false;
-                while (i < lines.size()) {
-                    String line = lines.get(i);
-                    if (insideVariantDescriptionBlock && line.contains("]")) {
-                        insideVariantDescriptionBlock = false;
-                    } else if (!insideVariantDescriptionBlock && line.contains("variant \"")) {
-                        insideVariantDescriptionBlock = true;
+                // https://youtrack.jetbrains.com/issue/KT-29546
+                if (line.contains("Compilation with Kotlin compile daemon was not successful")) {
+                    insideKotlinCompilerFlakyStacktrace = true;
+                    i++;
+                } else if (line.contains("Trying to create VM plugin `org.codehaus.groovy.vmplugin.v9.Java9` by checking `java.lang.Module`")) {
+                    // a groovy warning when running on Java < 9
+                    // https://issues.apache.org/jira/browse/GROOVY-9933
+                    i++; // full stracktrace skipped in next branch
+                    sawVmPluginLoadFailure = true;
+                } else if (line.contains("java.lang.ClassNotFoundException: java.lang.Module") && sawVmPluginLoadFailure) {
+                    // a groovy warning when running on Java < 9
+                    // https://issues.apache.org/jira/browse/GROOVY-9933
+                    i++;
+                    i = skipStackTrace(lines, i);
+                } else if (insideKotlinCompilerFlakyStacktrace &&
+                    (line.contains("java.rmi.UnmarshalException") ||
+                        line.contains("java.io.EOFException")) ||
+                    // Verbose logging by Jetty when connector is shutdown
+                    // https://github.com/eclipse/jetty.project/issues/3529
+                    line.contains("java.nio.channels.CancelledKeyException")) {
+                    i++;
+                    i = skipStackTrace(lines, i);
+                } else if (line.contains("com.amazonaws.http.IdleConnectionReaper")) {
+                    /*
+                    2021-01-05T08:15:51.329+0100 [DEBUG] [com.amazonaws.http.IdleConnectionReaper] Reaper thread:
+                    java.lang.InterruptedException: sleep interrupted
+                        at java.base/java.lang.Thread.sleep(Native Method)
+                        at com.amazonaws.http.IdleConnectionReaper.run(IdleConnectionReaper.java:188)
+                     */
+                    i += 2;
+                    i = skipStackTrace(lines, i);
+                } else if (line.matches(".*use(s)? or override(s)? a deprecated API\\.")) {
+                    // A javac warning, ignore
+                    i++;
+                } else if (line.matches(".*w: .* is deprecated\\..*")) {
+                    // A kotlinc warning, ignore
+                    i++;
+                } else if (isDeprecationMessageInHelpDescription(line)) {
+                    i++;
+                } else if (removeFirstExpectedDeprecationWarning(line)) {
+                    // Deprecation warning is expected
+                    i++;
+                    i = skipStackTrace(lines, i);
+                } else if (line.matches(".*\\s+deprecated.*")) {
+                    if (checkDeprecations && expectedGenericDeprecationWarnings <= 0) {
+                        throw new AssertionError(String.format("%s line %d contains a deprecation warning: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
                     }
-
-                    // https://youtrack.jetbrains.com/issue/KT-29546
-                    if (line.contains("Compilation with Kotlin compile daemon was not successful")) {
-                        insideKotlinCompilerFlakyStacktrace = true;
-                        i++;
-                    } else if (line.contains("Trying to create VM plugin `org.codehaus.groovy.vmplugin.v9.Java9` by checking `java.lang.Module`")) {
-                        // a groovy warning when running on Java < 9
-                        // https://issues.apache.org/jira/browse/GROOVY-9933
-                        i++; // full stracktrace skipped in next branch
-                        sawVmPluginLoadFailure = true;
-                    } else if (line.contains("java.lang.ClassNotFoundException: java.lang.Module") && sawVmPluginLoadFailure) {
-                        // a groovy warning when running on Java < 9
-                        // https://issues.apache.org/jira/browse/GROOVY-9933
-                        i++;
-                        i = skipStackTrace(lines, i);
-                    } else if (insideKotlinCompilerFlakyStacktrace &&
-                        (line.contains("java.rmi.UnmarshalException") ||
-                            line.contains("java.io.EOFException")) ||
-                        // Verbose logging by Jetty when connector is shutdown
-                        // https://github.com/eclipse/jetty.project/issues/3529
-                        line.contains("java.nio.channels.CancelledKeyException")) {
-                        i++;
-                        i = skipStackTrace(lines, i);
-                    } else if (line.contains("com.amazonaws.http.IdleConnectionReaper")) {
-                        /*
-                        2021-01-05T08:15:51.329+0100 [DEBUG] [com.amazonaws.http.IdleConnectionReaper] Reaper thread:
-                        java.lang.InterruptedException: sleep interrupted
-                            at java.base/java.lang.Thread.sleep(Native Method)
-                            at com.amazonaws.http.IdleConnectionReaper.run(IdleConnectionReaper.java:188)
-                         */
-                        i += 2;
-                        i = skipStackTrace(lines, i);
-                    } else if (line.matches(".*use(s)? or override(s)? a deprecated API\\.")) {
-                        // A javac warning, ignore
-                        i++;
-                    } else if (line.matches(".*w: .* is deprecated\\..*")) {
-                        // A kotlinc warning, ignore
-                        i++;
-                    } else if (isDeprecationMessageInHelpDescription(line)) {
-                        i++;
-                    } else if (removeFirstExpectedDeprecationWarning(warning -> line.contains(warning))) {
-                        // Deprecation warning is expected
-                        i++;
-                        i = skipStackTrace(lines, i);
-                    } else if (line.matches(".*\\s+deprecated.*")) {
-                        if (checkDeprecations && expectedGenericDeprecationWarnings <= 0) {
-                            throw new AssertionError(String.format("%s line %d contains a deprecation warning: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
-                        }
-                        expectedGenericDeprecationWarnings--;
-                        // skip over stack trace
-                        i++;
-                        i = skipStackTrace(lines, i);
-                    } else if (!expectStackTraces && !insideVariantDescriptionBlock && STACK_TRACE_ELEMENT.matcher(line).matches() && i < lines.size() - 1 && STACK_TRACE_ELEMENT.matcher(lines.get(i + 1)).matches()) {
-                        // 2 or more lines that look like stack trace elements
-                        throw new AssertionError(String.format("%s line %d contains an unexpected stack trace: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
-                    } else {
-                        i++;
-                    }
-                }
-            }
-
-            private boolean removeFirstExpectedDeprecationWarning(final Predicate<String> condition) {
-                final Optional<String> firstMatch = expectedDeprecationWarnings.stream().filter(condition).findFirst();
-                if (firstMatch.isPresent()) {
-                    return expectedDeprecationWarnings.remove(firstMatch.get());
+                    expectedGenericDeprecationWarnings--;
+                    // skip over stack trace
+                    i++;
+                    i = skipStackTrace(lines, i);
+                } else if (!expectStackTraces && !insideVariantDescriptionBlock && STACK_TRACE_ELEMENT.matcher(line).matches() && i < lines.size() - 1 && STACK_TRACE_ELEMENT.matcher(lines.get(i + 1)).matches()) {
+                    // 2 or more lines that look like stack trace elements
+                    throw new AssertionError(String.format("%s line %d contains an unexpected stack trace: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
+                } else if (checkJdkWarnings && line.matches("\\s*WARNING:.*")) {
+                    throw new AssertionError(String.format("%s line %d contains unexpected JDK warning: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
                 } else {
-                    return false;
-                }
-            }
-
-            private int skipStackTrace(List<String> lines, int i) {
-                while (i < lines.size() && STACK_TRACE_ELEMENT.matcher(lines.get(i)).matches()) {
                     i++;
                 }
-                return i;
             }
+        }
 
-            private boolean isDeprecationMessageInHelpDescription(String s) {
-                return s.matches(".*\\[deprecated.*]");
+        private boolean removeFirstExpectedDeprecationWarning(String line) {
+            return expectedDeprecationWarnings.stream().filter(line::contains).findFirst()
+                .map(expectedDeprecationWarnings::remove).orElse(false);
+        }
+
+        private static int skipStackTrace(List<String> lines, int i) {
+            while (i < lines.size() && STACK_TRACE_ELEMENT.matcher(lines.get(i)).matches()) {
+                i++;
             }
-        };
+            return i;
+        }
+
+        private boolean isDeprecationMessageInHelpDescription(String s) {
+            return s.matches(".*\\[deprecated.*]");
+        }
     }
 
     @Override
@@ -1480,6 +1488,11 @@ public abstract class AbstractGradleExecuter implements GradleExecuter, Resettab
     @Override
     public GradleExecuter withStackTraceChecksDisabled() {
         stackTraceChecksOn = false;
+        return this;
+    }
+    @Override
+    public GradleExecuter withJdkWarningChecksEnabled() {
+        jdkWarningChecksOn = true;
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -373,6 +373,11 @@ public interface GradleExecuter extends Stoppable {
     GradleExecuter withStackTraceChecksDisabled();
 
     /**
+     * Enables checks for warnings emitted by the JDK itself. Including illegal access warnings.
+     */
+    GradleExecuter withJdkWarningChecksEnabled();
+
+    /**
      * An executer may decide to implicitly bump the logging level, unless this is called.
      */
     GradleExecuter noExtraLogging();

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsTestCodeIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsTestCodeIntegrationTest.groovy
@@ -21,12 +21,11 @@ import org.gradle.test.fixtures.file.TestFile
 class BaseGradleImplDepsTestCodeIntegrationTest extends BaseGradleImplDepsIntegrationTest  {
 
     protected TestFile productionCode() {
-        file("src/main/java/org/acme/TestPlugin.java") << """
-        package org.acme;
+        file("src/main/java/MyPlugin.java") << """
         import org.gradle.api.Project;
         import org.gradle.api.Plugin;
 
-        public class TestPlugin implements Plugin<Project> {
+        public class MyPlugin implements Plugin<Project> {
             public void apply(Project p) {}
         }
         """
@@ -38,16 +37,16 @@ class BaseGradleImplDepsTestCodeIntegrationTest extends BaseGradleImplDepsIntegr
         import org.gradle.testkit.runner.GradleRunner;
         import org.junit.Test;
         import static org.junit.Assert.assertTrue;
-        
+
         public abstract class BaseTestPluginTest {
             GradleRunner runner() {
                 return GradleRunner.create();
             }
 
-            @Test 
+            @Test
             void commonTest() {
                 assertTrue(true);
-            }         
+            }
         }
         """
     }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsShadingIssuesIntegrationTest.groovy
@@ -28,7 +28,7 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
     def "doesn't fail when using Ivy in a plugin"() {
 
         when:
-        buildFile << testablePluginProjectWithAddOpens()
+        buildFile << testablePluginProject()
         file('src/main/groovy/MyPlugin.groovy') << """
             import org.gradle.api.Plugin
             import org.gradle.api.Project
@@ -68,7 +68,7 @@ class GradleImplDepsShadingIssuesIntegrationTest extends BaseGradleImplDepsInteg
     def "can read resources both with relative and absolute path in relocated and original path"() {
 
         when:
-        buildFile << testablePluginProjectWithAddOpens()
+        buildFile << testablePluginProject()
         file('src/main/groovy/MyPlugin.groovy') << '''
             import org.gradle.api.Plugin
             import org.gradle.api.Project

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsVisibilityIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsVisibilityIntegrationTest.groovy
@@ -106,7 +106,7 @@ class GradleImplDepsVisibilityIntegrationTest extends BaseGradleImplDepsIntegrat
 
     def "can use ProjectBuilder to unit test a plugin"() {
         when:
-        buildFile << testablePluginProjectWithAddOpens()
+        buildFile << testablePluginProject()
 
         file('src/main/groovy/MyPlugin.groovy') << customGroovyPlugin()
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -28,7 +28,7 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsTestCodeInt
 
     def setup() {
         executer.requireOwnGradleUserHomeDir()
-        buildFile << testablePluginProject(applyJavaPlugin())
+        buildFile << testablePluginProject(['java-gradle-plugin'])
     }
 
     def "gradle api jar is generated only when requested"() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java
@@ -414,7 +414,7 @@ public class JavaGradlePluginPlugin implements Plugin<Project> {
 
         @Override
         public Iterable<String> asArguments() {
-            return test.getJavaVersion().isCompatibleWith(JavaVersion.VERSION_16)
+            return test.getJavaVersion().isCompatibleWith(JavaVersion.VERSION_1_9)
                 ? Collections.singletonList("--add-opens=java.base/java.lang=ALL-UNNAMED")
                 : Collections.emptyList();
         }


### PR DESCRIPTION
Some tests were creating and testing plugins without the java-gradle-plugin. Update
those tests to use java-gradle plugin.

* Removes need to add --add-opens flag manually in tests
* Update java-gradle-plugin to add --add-opens for java versions > 9 instead of > 16 to avoid stderr warning
