### PR TITLE
Support serializable Lambdas as nested inputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements ValidationMessageChecker, DirectoryBuildCacheFixture, ExecutionOptimizationDeprecationFixture {
@@ -77,8 +76,7 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         """
     }
 
-    @ToBeFixedForConfigurationCache(because = "Non-serializable lambdas are not supported in configuration cache")
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/21104")
+    @ToBeFixedForConfigurationCache(because = "https://github.com/gradle/gradle/issues/21109")
     @ValidationTestFor(
         ValidationProblemId.UNKNOWN_IMPLEMENTATION
     )
@@ -172,8 +170,8 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         setupTaskClassWithActionProperty()
         def originalClassName = "LambdaOriginal"
         def changedClassName = "LambdaChanged"
-        file("buildSrc/src/main/java/${originalClassName}.java") << javaClass(originalClassName, serializableActionLambdaWritingFile("ACTION", "original"))
-        file("buildSrc/src/main/java/${changedClassName}.java") << javaClass(changedClassName, serializableActionLambdaWritingFile("ACTION", "changed"))
+        file("buildSrc/src/main/java/${originalClassName}.java") << javaClass(originalClassName, actionLambdaWritingFile("ACTION", "original"))
+        file("buildSrc/src/main/java/${changedClassName}.java") << javaClass(changedClassName, actionLambdaWritingFile("ACTION", "changed"))
         buildFile << """
             task myTask(type: TaskWithActionProperty) {
                 action = providers.gradleProperty("changed").isPresent()
@@ -206,7 +204,7 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         setupTaskClassWithActionProperty()
         def lambdaClassName = "LambdaAction"
         def anonymousClassName = "AnonymousAction"
-        file("buildSrc/src/main/java/${lambdaClassName}.java") << javaClass(lambdaClassName, serializableActionLambdaWritingFile("ACTION", "lambda"))
+        file("buildSrc/src/main/java/${lambdaClassName}.java") << javaClass(lambdaClassName, actionLambdaWritingFile("ACTION", "lambda"))
         file("buildSrc/src/main/java/${anonymousClassName}.java") << javaClass(anonymousClassName, anonymousClassWritingFile("ACTION", "anonymous"))
         buildFile << """
             task myTask(type: TaskWithActionProperty) {
@@ -503,7 +501,7 @@ ${classBody}
     /**
      * Configuration cache infrastructure makes sure that {@code Action} instances are always serializable.
      */
-    private static String serializableActionLambdaWritingFile(String constantName, String outputString) {
+    private static String actionLambdaWritingFile(String constantName, String outputString) {
         lambdaWritingFile("Action", constantName, outputString)
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/LambdaInputsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DirectoryBuildCacheFixture
 import org.gradle.integtests.fixtures.ExecutionOptimizationDeprecationFixture
+import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
@@ -75,6 +76,7 @@ class LambdaInputsIntegrationTest extends AbstractIntegrationSpec implements Val
         """
     }
 
+    @ToBeFixedForConfigurationCache(because = "Non-serializable lambdas are not supported in configuration cache")
     @ValidationTestFor(
         ValidationProblemId.UNKNOWN_IMPLEMENTATION
     )

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.internal.reflect.problems.ValidationProblemId
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 import org.gradle.internal.reflect.validation.ValidationTestFor
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
 class NestedInputIntegrationTest extends AbstractIntegrationSpec implements DirectoryBuildCacheFixture, ValidationMessageChecker, ExecutionOptimizationDeprecationFixture {
@@ -935,7 +934,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         output.contains "Implementation of input property 'bean.action' has changed for task ':myTask'"
     }
 
-    @ToBeImplemented("https://github.com/gradle/gradle/issues/11703")
+    @Issue("https://github.com/gradle/gradle/issues/11703")
     def "nested bean from closure can be used with the build cache"() {
         def project1 = file("project1").createDir()
         def project2 = file("project2").createDir()
@@ -973,18 +972,8 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec implements Dire
         withBuildCache().run 'myTask'
 
         then:
-        // TODO: Should be skipped(":myTask")
-        executedAndNotSkipped(':myTask')
+        skipped(':myTask')
         project2.file('build/tmp/myTask/output.txt').text == "hello"
-
-        // TODO: This can be removed when the above already worked
-        when:
-        executer.inDirectory(project2)
-        run 'clean'
-        executer.inDirectory(project2)
-        withBuildCache().run 'myTask'
-        then:
-        skipped(":myTask")
     }
 
     private TestFile nestedBeanWithAction(TestFile projectDir = temporaryFolder.testDirectory) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -77,7 +77,7 @@ import org.gradle.internal.logging.slf4j.DefaultContextAwareTaskLogger;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.SharedResource;
-import org.gradle.internal.scripts.ScriptOrigin;
+import org.gradle.internal.scripts.ScriptOriginUtil;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 import org.gradle.util.Path;
@@ -837,17 +837,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private static ImplementationSnapshot getActionImplementation(Object value, ClassLoaderHierarchyHasher hasher) {
         HashCode classLoaderHash = hasher.getClassLoaderHash(value.getClass().getClassLoader());
-        String actionClassName = AbstractTask.getActionClassName(value);
-        return ImplementationSnapshot.of(actionClassName, value, classLoaderHash);
-    }
-
-    private static String getActionClassName(Object action) {
-        if (action instanceof ScriptOrigin) {
-            ScriptOrigin origin = (ScriptOrigin) action;
-            return origin.getOriginalClassName() + "_" + origin.getContentHash();
-        } else {
-            return action.getClass().getName();
-        }
+        String actionClassIdentifier = ScriptOriginUtil.getOriginClassIdentifier(value);
+        return ImplementationSnapshot.of(actionClassIdentifier, value, classLoaderHash);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/SnapshotTaskInputsBuildOperationResult.java
@@ -366,7 +366,7 @@ public class SnapshotTaskInputsBuildOperationResult implements SnapshotTaskInput
             .map(BeforeExecutionState::getAdditionalImplementations)
             .filter(additionalImplementations -> !additionalImplementations.isEmpty())
             .map(additionalImplementations -> additionalImplementations.stream()
-                .map(ImplementationSnapshot::getTypeName)
+                .map(ImplementationSnapshot::getClassIdentifier)
                 .collect(Collectors.toList())
             )
             .orElse(null);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
@@ -23,6 +23,8 @@ import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
+import org.gradle.internal.scripts.ScriptOrigin;
+import org.gradle.internal.snapshot.impl.ImplementationValue;
 import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.ConfigureUtil;
 
@@ -42,42 +44,48 @@ class NestedRuntimeBeanNode extends AbstractNestedRuntimeBeanNode {
     }
 
     private void visitImplementation(PropertyVisitor visitor) {
-        visitor.visitInputProperty(getPropertyName(), new ImplementationPropertyValue(getImplementationClass(getBean())), false);
+        Object unwrapped = unwrapBean(getBean());
+        String className = unwrapped instanceof ScriptOrigin
+            ? ((ScriptOrigin) unwrapped).getOriginalClassName()
+            : unwrapped.getClass().getName();
+        visitor.visitInputProperty(
+            getPropertyName(),
+            new ImplementationPropertyValue(new ImplementationValue(className, unwrapped)),
+            false
+        );
     }
 
     @VisibleForTesting
-    static Class<?> getImplementationClass(Object bean) {
+    static Object unwrapBean(Object bean) {
         // When Groovy coerces a Closure into an SAM type, then it creates a Proxy which is backed by the Closure.
         // We want to track the implementation of the Closure, since the class name and classloader of the proxy will not change.
         // Java and Kotlin Lambdas are coerced to SAM types at compile time, so no unpacking is necessary there.
         if (Proxy.isProxyClass(bean.getClass())) {
             InvocationHandler invocationHandler = Proxy.getInvocationHandler(bean);
             if (invocationHandler instanceof ConvertedClosure) {
-                Object delegate = ((ConvertedClosure) invocationHandler).getDelegate();
-                return delegate.getClass();
+                return ((ConvertedClosure) invocationHandler).getDelegate();
             }
-            return invocationHandler.getClass();
+            return invocationHandler;
         }
 
         // Same as above, if we have wrapped a closure in a WrappedConfigureAction or a ClosureBackedAction, we want to
         // track the closure itself, not the action class.
         if (bean instanceof ConfigureUtil.WrappedConfigureAction) {
-            return ((ConfigureUtil.WrappedConfigureAction)bean).getConfigureClosure().getClass();
+            return ((ConfigureUtil.WrappedConfigureAction<?>) bean).getConfigureClosure();
         }
 
         if (bean instanceof ClosureBackedAction) {
-            return ((ClosureBackedAction)bean).getClosure().getClass();
+            return ((ClosureBackedAction<?>) bean).getClosure();
         }
-
-        return bean.getClass();
+        return bean;
     }
 
     private static class ImplementationPropertyValue implements PropertyValue {
 
-        private final Class<?> beanClass;
+        private final ImplementationValue implementationValue;
 
-        public ImplementationPropertyValue(Class<?> beanClass) {
-            this.beanClass = beanClass;
+        public ImplementationPropertyValue(ImplementationValue implementationValue) {
+            this.implementationValue = implementationValue;
         }
 
         @Override
@@ -87,7 +95,7 @@ class NestedRuntimeBeanNode extends AbstractNestedRuntimeBeanNode {
 
         @Override
         public Object getUnprocessedValue() {
-            return beanClass;
+            return implementationValue;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 import org.gradle.internal.reflect.validation.TypeValidationContext;
-import org.gradle.internal.scripts.ScriptOrigin;
+import org.gradle.internal.scripts.ScriptOriginUtil;
 import org.gradle.internal.snapshot.impl.ImplementationValue;
 import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.util.internal.ConfigureUtil;
@@ -45,12 +45,10 @@ class NestedRuntimeBeanNode extends AbstractNestedRuntimeBeanNode {
 
     private void visitImplementation(PropertyVisitor visitor) {
         Object unwrapped = unwrapBean(getBean());
-        String className = unwrapped instanceof ScriptOrigin
-            ? ((ScriptOrigin) unwrapped).getOriginalClassName()
-            : unwrapped.getClass().getName();
+        String classIdentifier = ScriptOriginUtil.getOriginClassIdentifier(unwrapped);
         visitor.visitInputProperty(
             getPropertyName(),
-            new ImplementationPropertyValue(new ImplementationValue(className, unwrapped)),
+            new ImplementationPropertyValue(new ImplementationValue(classIdentifier, unwrapped)),
             false
         );
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptOriginUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scripts/ScriptOriginUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.scripts;
+
+public class ScriptOriginUtil {
+
+    /**
+     * Extracts the class identifier of the value defined in a build script
+     * independent of its absolute path.
+     *
+     * The identifier depends on the original class name and the content hash of the script.
+     * As such it can be used for build caching between different locations.
+     */
+    public static String getOriginClassIdentifier(Object value) {
+        if (value instanceof ScriptOrigin) {
+            ScriptOrigin origin = (ScriptOrigin) value;
+            return origin.getOriginalClassName() + "_" + origin.getContentHash();
+        } else {
+            return value.getClass().getName();
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
@@ -63,7 +63,7 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
         1 * visitor.visitInputProperty('myProperty', { it.call() == 'myValue' }, false)
         1 * visitor.visitInputFileProperty('inputFile', _, _, _, _, _, _, _, InputFilePropertyType.FILE)
         1 * visitor.visitInputFileProperty('inputFiles', _, _, _, _, _, _, _, InputFilePropertyType.FILES)
-        1 * visitor.visitInputProperty('bean', { it.call() == NestedBean }, false)
+        1 * visitor.visitInputProperty('bean', { it.call().getImplementationClassName() == NestedBean.name }, false)
         1 * visitor.visitInputProperty('bean.nestedInput', { it.call() == 'nested' }, false)
         1 * visitor.visitInputFileProperty('bean.inputDir', _, _, _, _, _, _, _, InputFilePropertyType.DIRECTORY)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
@@ -63,7 +63,7 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
         1 * visitor.visitInputProperty('myProperty', { it.call() == 'myValue' }, false)
         1 * visitor.visitInputFileProperty('inputFile', _, _, _, _, _, _, _, InputFilePropertyType.FILE)
         1 * visitor.visitInputFileProperty('inputFiles', _, _, _, _, _, _, _, InputFilePropertyType.FILES)
-        1 * visitor.visitInputProperty('bean', { it.call().getImplementationClassName() == NestedBean.name }, false)
+        1 * visitor.visitInputProperty('bean', { it.call().implementationClassIdentifier == NestedBean.name }, false)
         1 * visitor.visitInputProperty('bean.nestedInput', { it.call() == 'nested' }, false)
         1 * visitor.visitInputFileProperty('bean.inputDir', _, _, _, _, _, _, _, InputFilePropertyType.DIRECTORY)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNodeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNodeTest.groovy
@@ -24,7 +24,7 @@ import spock.lang.Specification
 class NestedRuntimeBeanNodeTest extends Specification {
     def "correct implementation for #type coerced to Action is tracked"() {
         expect:
-        NestedRuntimeBeanNode.getImplementationClass(implementation as Action) == implementation.getClass()
+        NestedRuntimeBeanNode.unwrapBean(implementation as Action) == implementation
 
         where:
         type      | implementation
@@ -37,9 +37,9 @@ class NestedRuntimeBeanNodeTest extends Specification {
         def closure = { it }
 
         expect:
-        NestedRuntimeBeanNode.getImplementationClass(ConfigureUtil.configureUsing(closure)) == closure.getClass()
+        NestedRuntimeBeanNode.unwrapBean(ConfigureUtil.configureUsing(closure)) == closure
 
         and:
-        NestedRuntimeBeanNode.getImplementationClass(ClosureBackedAction.of(closure)) == closure.getClass()
+        NestedRuntimeBeanNode.unwrapBean(ClosureBackedAction.of(closure)) == closure
     }
 }

--- a/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting/validation_problems.adoc
@@ -362,14 +362,14 @@ Gradle considers the implementation of the following classes as inputs to a task
 
 There are two reasons why Gradle cannot track the implementation of a class:
 
-- a Java lambda was used to implement the class,
+- a non-serializable Java lambda was used to implement the class,
 - or the class has been loaded by a classloader unknown to Gradle.
 
 Using a Java lambda means that the bytecode uses invoke-dynamic instead of creating an actual sub-class.
-The class for the invoke-dynamic instruction is generated at JVM runtime and Gradle cannot uniquely identify this class across different JVMs.
+The class for the invoke-dynamic instruction is generated at JVM runtime and Gradle cannot uniquely identify this class across different JVMs if the target functional interface is not serializable.
 For task actions it is not a problem, because Gradle handles them in a special way.
-On the other hand, for classes of nested inputs implemented by a lambda Gradle does not support tracking.
-As a workaround you can convert the lambda to an anonymous inner class.
+On the other hand, for classes of nested inputs implemented by a non-serializable lambda Gradle does not support tracking.
+As a workaround you can convert the lambda to an anonymous inner class or make the target functional interface serializable.
 
 For the case where Gradle cannot track the implementation because it was loaded by a classloader unknown to Gradle, you can use Gradle's built-in ways to load the class.
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ImplementationChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/ImplementationChanges.java
@@ -45,9 +45,9 @@ public class ImplementationChanges implements ChangeContainer {
 
     @Override
     public boolean accept(ChangeVisitor visitor) {
-        if (!currentImplementation.getTypeName().equals(previousImplementation.getTypeName())) {
+        if (!currentImplementation.getClassIdentifier().equals(previousImplementation.getClassIdentifier())) {
             return visitor.visitChange(new DescriptiveChange("The type of %s has changed from '%s' to '%s'.",
-                executable.getDisplayName(), previousImplementation.getTypeName(), currentImplementation.getTypeName()));
+                executable.getDisplayName(), previousImplementation.getClassIdentifier(), currentImplementation.getClassIdentifier()));
         }
 
         if (previousImplementation instanceof UnknownImplementationSnapshot) {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -141,6 +141,10 @@ abstract class AbstractValueProcessor {
         if (value instanceof HashCode) {
             return visitor.hashCode((HashCode) value);
         }
+        if (value instanceof ImplementationValue) {
+            ImplementationValue implementationValue = (ImplementationValue) value;
+            return visitor.implementationValue(implementationValue.getImplementationClassName(), implementationValue.getValue());
+        }
 
         // Pluggable serialization
         for (ValueSnapshotterSerializerRegistry registry : valueSnapshotterSerializerRegistryList) {
@@ -194,6 +198,8 @@ abstract class AbstractValueProcessor {
         T enumValue(Enum value);
 
         T classValue(Class<?> value);
+
+        T implementationValue(String implementationClassName, Object implementation);
 
         T fileValue(File value);
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractValueProcessor.java
@@ -102,7 +102,7 @@ abstract class AbstractValueProcessor {
             Map<?, ?> map = (Map<?, ?>) value;
             ImmutableList.Builder<MapEntrySnapshot<T>> builder = ImmutableList.builderWithExpectedSize(map.size());
             for (Map.Entry<?, ?> entry : map.entrySet()) {
-                builder.add(new MapEntrySnapshot<T>(processValue(entry.getKey(), visitor), processValue(entry.getValue(), visitor)));
+                builder.add(new MapEntrySnapshot<>(processValue(entry.getKey(), visitor), processValue(entry.getValue(), visitor)));
             }
             if (value instanceof Properties) {
                 return visitor.properties(builder.build());
@@ -143,7 +143,7 @@ abstract class AbstractValueProcessor {
         }
         if (value instanceof ImplementationValue) {
             ImplementationValue implementationValue = (ImplementationValue) value;
-            return visitor.implementationValue(implementationValue.getImplementationClassName(), implementationValue.getValue());
+            return visitor.implementationValue(implementationValue.getImplementationClassIdentifier(), implementationValue.getValue());
         }
 
         // Pluggable serialization
@@ -199,7 +199,7 @@ abstract class AbstractValueProcessor {
 
         T classValue(Class<?> value);
 
-        T implementationValue(String implementationClassName, Object implementation);
+        T implementationValue(String implementationClassIdentifier, Object implementation);
 
         T fileValue(File value);
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
@@ -107,6 +107,11 @@ public class DefaultIsolatableFactory extends AbstractValueProcessor implements 
         }
 
         @Override
+        public Isolatable<?> implementationValue(String implementationClassName, Object implementation) {
+            throw new IsolationException(implementationClassName);
+        }
+
+        @Override
         public Isolatable<?> fileValue(File value) {
             return new FileValueSnapshot(value);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultIsolatableFactory.java
@@ -107,8 +107,8 @@ public class DefaultIsolatableFactory extends AbstractValueProcessor implements 
         }
 
         @Override
-        public Isolatable<?> implementationValue(String implementationClassName, Object implementation) {
-            throw new IsolationException(implementationClassName);
+        public Isolatable<?> implementationValue(String implementationClassIdentifier, Object implementation) {
+            throw new IsolationException(implementationClassIdentifier);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -105,6 +105,14 @@ public class DefaultValueSnapshotter extends AbstractValueProcessor implements V
         }
 
         @Override
+        public ValueSnapshot implementationValue(String implementationClassName, Object implementation) {
+            return ImplementationSnapshot.of(
+                implementationClassName,
+                implementation,
+                classLoaderHasher.getClassLoaderHash(implementation.getClass().getClassLoader()));
+        }
+
+        @Override
         public ValueSnapshot fileValue(File value) {
             return new FileValueSnapshot(value);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/DefaultValueSnapshotter.java
@@ -105,9 +105,9 @@ public class DefaultValueSnapshotter extends AbstractValueProcessor implements V
         }
 
         @Override
-        public ValueSnapshot implementationValue(String implementationClassName, Object implementation) {
+        public ValueSnapshot implementationValue(String implementationClassIdentifier, Object implementation) {
             return ImplementationSnapshot.of(
-                implementationClassName,
+                implementationClassIdentifier,
                 implementation,
                 classLoaderHasher.getClassLoaderHash(implementation.getClass().getClassLoader()));
         }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationSnapshotSerializer.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationSnapshotSerializer.java
@@ -27,9 +27,9 @@ public class ImplementationSnapshotSerializer implements Serializer<Implementati
     private enum Impl implements Serializer<ImplementationSnapshot> {
         CLASS {
             @Override
-            protected ImplementationSnapshot readAdditionalData(String typeName, Decoder decoder) throws Exception {
+            protected ImplementationSnapshot readAdditionalData(String classIdentifier, Decoder decoder) throws Exception {
                 HashCode classLoaderHash = hashCodeSerializer.read(decoder);
-                return new ClassImplementationSnapshot(typeName, classLoaderHash);
+                return new ClassImplementationSnapshot(classIdentifier, classLoaderHash);
             }
 
             @Override
@@ -39,7 +39,7 @@ public class ImplementationSnapshotSerializer implements Serializer<Implementati
         },
         LAMBDA {
             @Override
-            protected ImplementationSnapshot readAdditionalData(String typeName, Decoder decoder) throws Exception {
+            protected ImplementationSnapshot readAdditionalData(String classIdentifier, Decoder decoder) throws Exception {
                 HashCode classLoaderHash = hashCodeSerializer.read(decoder);
                 String functionalInterfaceClass = decoder.readString();
                 String implClass = decoder.readString();
@@ -47,7 +47,7 @@ public class ImplementationSnapshotSerializer implements Serializer<Implementati
                 String implMethodSignature = decoder.readString();
                 int implMethodKind = decoder.readSmallInt();
                 return new LambdaImplementationSnapshot(
-                    typeName,
+                    classIdentifier,
                     classLoaderHash,
                     functionalInterfaceClass,
                     implClass,
@@ -70,9 +70,9 @@ public class ImplementationSnapshotSerializer implements Serializer<Implementati
         },
         UNKNOWN {
             @Override
-            protected ImplementationSnapshot readAdditionalData(String typeName, Decoder decoder) throws Exception {
+            protected ImplementationSnapshot readAdditionalData(String classIdentifier, Decoder decoder) throws Exception {
                 UnknownImplementationSnapshot.UnknownReason unknownReason = UnknownImplementationSnapshot.UnknownReason.values()[decoder.readSmallInt()];
-                return new UnknownImplementationSnapshot(typeName, unknownReason);
+                return new UnknownImplementationSnapshot(classIdentifier, unknownReason);
             }
 
             @Override
@@ -84,19 +84,19 @@ public class ImplementationSnapshotSerializer implements Serializer<Implementati
 
         @Override
         public void write(Encoder encoder, ImplementationSnapshot implementationSnapshot) throws Exception {
-            encoder.writeString(implementationSnapshot.getTypeName());
+            encoder.writeString(implementationSnapshot.getClassIdentifier());
             writeAdditionalData(encoder, implementationSnapshot);
         }
 
         @Override
         public ImplementationSnapshot read(Decoder decoder) throws Exception {
-            String typeName = decoder.readString();
-            return readAdditionalData(typeName, decoder);
+            String classIdentifier = decoder.readString();
+            return readAdditionalData(classIdentifier, decoder);
         }
 
         protected final Serializer<HashCode> hashCodeSerializer = new HashCodeSerializer();
 
-        protected abstract ImplementationSnapshot readAdditionalData(String typeName, Decoder decoder) throws Exception;
+        protected abstract ImplementationSnapshot readAdditionalData(String classIdentifier, Decoder decoder) throws Exception;
 
         protected abstract void writeAdditionalData(Encoder encoder, ImplementationSnapshot implementationSnapshot) throws Exception;
     }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
@@ -17,16 +17,16 @@
 package org.gradle.internal.snapshot.impl;
 
 public class ImplementationValue {
-    private final String className;
+    private final String classIdentifier;
     private final Object value;
 
-    public ImplementationValue(String className, Object value) {
-        this.className = className;
+    public ImplementationValue(String classIdentifier, Object value) {
+        this.classIdentifier = classIdentifier;
         this.value = value;
     }
 
-    public String getImplementationClassName() {
-        return className;
+    public String getImplementationClassIdentifier() {
+        return classIdentifier;
     }
 
     public Object getValue() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+public class ImplementationValue {
+    private final String className;
+    private final Object value;
+
+    public ImplementationValue(String className, Object value) {
+        this.className = className;
+        this.value = value;
+    }
+
+    public String getImplementationClassName() {
+        return className;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/snapshot/impl/SnapshotSerializerTest.groovy
@@ -213,7 +213,7 @@ class SnapshotSerializerTest extends Specification {
 
         expect:
         ImplementationSnapshot copy = written as ImplementationSnapshot
-        copy.typeName == original.typeName
+        copy.classIdentifier == original.classIdentifier
         copy.classLoaderHash == null
         copy.unknownReason == UnknownImplementationSnapshot.UnknownReason.UNKNOWN_CLASSLOADER
     }
@@ -224,7 +224,7 @@ class SnapshotSerializerTest extends Specification {
 
         expect:
         ImplementationSnapshot copy = written as ImplementationSnapshot
-        copy.typeName == original.typeName
+        copy.classIdentifier == original.classIdentifier
         copy.classLoaderHash == null
         copy.unknownReason == UnknownImplementationSnapshot.UnknownReason.UNTRACKED_LAMBDA
     }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ClassImplementationSnapshot.java
@@ -26,15 +26,15 @@ import java.util.Objects;
 public class ClassImplementationSnapshot extends ImplementationSnapshot {
     private final HashCode classLoaderHash;
 
-    public ClassImplementationSnapshot(String typeName, HashCode classLoaderHash) {
-        super(typeName);
+    public ClassImplementationSnapshot(String classIdentifier, HashCode classLoaderHash) {
+        super(classIdentifier);
         this.classLoaderHash = classLoaderHash;
     }
 
     @Override
     public void appendToHasher(Hasher hasher) {
         hasher.putString(ClassImplementationSnapshot.class.getName());
-        hasher.putString(typeName);
+        hasher.putString(classIdentifier);
         hasher.putHash(classLoaderHash);
     }
 
@@ -59,17 +59,17 @@ public class ClassImplementationSnapshot extends ImplementationSnapshot {
         }
 
         ClassImplementationSnapshot that = (ClassImplementationSnapshot) o;
-        return typeName.equals(that.typeName) &&
+        return classIdentifier.equals(that.classIdentifier) &&
             classLoaderHash.equals(that.classLoaderHash);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName, classLoaderHash);
+        return Objects.hash(classIdentifier, classLoaderHash);
     }
 
     @Override
     public String toString() {
-        return typeName + "@" + classLoaderHash;
+        return classIdentifier + "@" + classLoaderHash;
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/ImplementationSnapshot.java
@@ -37,7 +37,7 @@ public abstract class ImplementationSnapshot implements ValueSnapshot {
 
     private static final String GENERATED_LAMBDA_CLASS_SUFFIX = "$$Lambda$";
 
-    protected final String typeName;
+    protected final String classIdentifier;
 
     public static ImplementationSnapshot of(Class<?> type, ClassLoaderHierarchyHasher classLoaderHasher) {
         String className = type.getName();
@@ -58,23 +58,23 @@ public abstract class ImplementationSnapshot implements ValueSnapshot {
     }
 
     private static ImplementationSnapshot of(
-        String typeName,
+        String classIdentifier,
         @Nullable HashCode classLoaderHash,
         boolean isLambda,
         @Nullable Object value
     ) {
         if (classLoaderHash == null) {
-            return new UnknownImplementationSnapshot(typeName, UnknownReason.UNKNOWN_CLASSLOADER);
+            return new UnknownImplementationSnapshot(classIdentifier, UnknownReason.UNKNOWN_CLASSLOADER);
         }
 
         if (isLambda) {
             return Optional.ofNullable(value)
                 .flatMap(ImplementationSnapshot::serializedLambdaFor)
                 .<ImplementationSnapshot>map(it -> new LambdaImplementationSnapshot(classLoaderHash, it))
-                .orElseGet(() -> new UnknownImplementationSnapshot(typeName, UnknownReason.UNTRACKED_LAMBDA));
+                .orElseGet(() -> new UnknownImplementationSnapshot(classIdentifier, UnknownReason.UNTRACKED_LAMBDA));
         }
 
-        return new ClassImplementationSnapshot(typeName, classLoaderHash);
+        return new ClassImplementationSnapshot(classIdentifier, classLoaderHash);
     }
 
     private static Optional<SerializedLambda> serializedLambdaFor(Object lambda) {
@@ -104,12 +104,12 @@ public abstract class ImplementationSnapshot implements ValueSnapshot {
         return className.contains(GENERATED_LAMBDA_CLASS_SUFFIX);
     }
 
-    protected ImplementationSnapshot(String typeName) {
-        this.typeName = typeName;
+    protected ImplementationSnapshot(String classIdentifier) {
+        this.classIdentifier = classIdentifier;
     }
 
-    public String getTypeName() {
-        return typeName;
+    public String getClassIdentifier() {
+        return classIdentifier;
     }
 
     @Nullable

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/LambdaImplementationSnapshot.java
@@ -66,7 +66,7 @@ public class LambdaImplementationSnapshot extends ImplementationSnapshot {
     @Override
     public void appendToHasher(Hasher hasher) {
         hasher.putString(LambdaImplementationSnapshot.class.getName());
-        hasher.putString(typeName);
+        hasher.putString(classIdentifier);
         hasher.putHash(classLoaderHash);
         hasher.putString(functionalInterfaceClass);
         hasher.putString(implClass);
@@ -116,7 +116,7 @@ public class LambdaImplementationSnapshot extends ImplementationSnapshot {
         }
 
         LambdaImplementationSnapshot that = (LambdaImplementationSnapshot) o;
-        return typeName.equals(that.typeName) &&
+        return classIdentifier.equals(that.classIdentifier) &&
             classLoaderHash.equals(that.classLoaderHash) &&
             functionalInterfaceClass.equals(that.functionalInterfaceClass) &&
             implClass.equals(that.implClass) &&
@@ -127,11 +127,11 @@ public class LambdaImplementationSnapshot extends ImplementationSnapshot {
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName, classLoaderHash, functionalInterfaceClass, implClass, implMethodName, implMethodSignature, implMethodKind);
+        return Objects.hash(classIdentifier, classLoaderHash, functionalInterfaceClass, implClass, implMethodName, implMethodSignature, implMethodKind);
     }
 
     @Override
     public String toString() {
-        return typeName + "::" + implMethodName + "@" + classLoaderHash;
+        return classIdentifier + "::" + implMethodName + "@" + classLoaderHash;
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/UnknownImplementationSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/UnknownImplementationSnapshot.java
@@ -70,7 +70,7 @@ public class UnknownImplementationSnapshot extends ImplementationSnapshot {
 
         UnknownImplementationSnapshot that = (UnknownImplementationSnapshot) o;
 
-        return typeName.equals(that.typeName) && unknownReason.equals(that.unknownReason);
+        return classIdentifier.equals(that.classIdentifier) && unknownReason.equals(that.unknownReason);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class UnknownImplementationSnapshot extends ImplementationSnapshot {
     }
 
     public String getProblemDescription() {
-        return String.format(unknownReason.descriptionTemplate, typeName);
+        return String.format(unknownReason.descriptionTemplate, classIdentifier);
     }
 
     public String getReasonDescription() {
@@ -101,11 +101,11 @@ public class UnknownImplementationSnapshot extends ImplementationSnapshot {
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeName, unknownReason);
+        return Objects.hash(classIdentifier, unknownReason);
     }
 
     @Override
     public String toString() {
-        return typeName + "@<" + unknownReason.name() + ">";
+        return classIdentifier + "@<" + unknownReason.name() + ">";
     }
 }


### PR DESCRIPTION
Serializable lambdas are now supported as nested inputs for a task.

Additionally, the problem with absolute path dependent script names is resolved, fixing the up-to-date checks in a location-independent manner.

Fixes #11703

Related to #21085


