### PR TITLE
Refine Historical Performance Test

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTest.kt
@@ -27,6 +27,7 @@ import common.performanceTestCommandLine
 import common.removeSubstDirOnWindows
 import common.substDirOnWindows
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import model.CIBuildModel
 import model.PerformanceTestBuildSpec
 import model.PerformanceTestType
@@ -55,7 +56,13 @@ class PerformanceTest(
         artifactRules = individualPerformanceTestArtifactRules
 
         params {
-            param("performance.baselines", type.defaultBaselines)
+            text(
+                "performance.baselines",
+                type.defaultBaselines,
+                display = ParameterDisplay.PROMPT,
+                allowEmpty = false,
+                description = "The baselines you want to run performance tests against."
+            )
             param("performance.channel", performanceTestBuildSpec.channel())
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             when (os) {

--- a/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
+++ b/.teamcity/src/main/kotlin/configurations/PerformanceTestsPass.kt
@@ -18,6 +18,7 @@ package configurations
 
 import common.Os
 import common.applyDefaultSettings
+import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.ReuseBuilds
 import model.CIBuildModel
 import model.PerformanceTestType
@@ -35,6 +36,13 @@ class PerformanceTestsPass(model: CIBuildModel, performanceTestProject: Performa
 
         applyDefaultSettings(os)
         params {
+            text(
+                "reverse.dep.*.performance.baselines",
+                type.defaultBaselines,
+                display = ParameterDisplay.PROMPT,
+                allowEmpty = false,
+                description = "The baselines you want to run performance tests against."
+            )
             param("env.PERFORMANCE_DB_PASSWORD_TCAGENT", "%performance.db.password.tcagent%")
             param("performance.db.username", "tcagent")
             param("performance.channel", performanceTestSpec.channel())

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -328,9 +328,9 @@ enum class PerformanceTestType(
     historical(
         displayName = "Historical Performance Test",
         timeout = 2280,
-        defaultBaselines = "3.5.1,4.10.3,5.6.4,6.9.1,last",
+        defaultBaselines = "last",
         channel = "historical",
-        extraParameters = "--checks none"
+        extraParameters = "--checks none --cross-version-only"
     ),
     adHoc(
         displayName = "AdHoc Performance Test",

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
@@ -41,10 +41,11 @@ class ReleasedVersionsDetails(currentBaseVersion: GradleVersion, releasedVersion
         }
 
         val latestFinalRelease = releasedVersions.finalReleases.first()
-        val latestRelease = listOf(releasedVersions.latestReleaseSnapshot, releasedVersions.latestRc).filter { it.gradleVersion() > latestFinalRelease.gradleVersion() }.maxByOrNull { it.buildTimeStamp() } ?: latestFinalRelease
+        val latestRelease = listOf(releasedVersions.latestReleaseSnapshot, releasedVersions.latestRc).filter { it.gradleVersion() > latestFinalRelease.gradleVersion() }.maxByOrNull { it.buildTimeStamp() }
+            ?: latestFinalRelease
         val previousVersions = (listOf(latestRelease) + releasedVersions.finalReleases).filter { it.gradleVersion() >= lowestInterestingVersion && it.gradleVersion().baseVersion < currentBaseVersion }.distinct()
         allPreviousVersions = previousVersions.map { it.gradleVersion() }
-        mostRecentRelease = previousVersions.first().gradleVersion()
+        mostRecentRelease = (listOf(releasedVersions.latestRc) + releasedVersions.finalReleases).first().gradleVersion()
         mostRecentSnapshot = releasedVersions.latestReleaseSnapshot.gradleVersion()
 
         val testedVersions = previousVersions.filter { it.gradleVersion() >= lowestTestedVersion }

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ReleasedVersionsDetails.kt
@@ -41,11 +41,10 @@ class ReleasedVersionsDetails(currentBaseVersion: GradleVersion, releasedVersion
         }
 
         val latestFinalRelease = releasedVersions.finalReleases.first()
-        val latestRelease = listOf(releasedVersions.latestReleaseSnapshot, releasedVersions.latestRc).filter { it.gradleVersion() > latestFinalRelease.gradleVersion() }.maxByOrNull { it.buildTimeStamp() }
-            ?: latestFinalRelease
+        val latestRelease = listOf(releasedVersions.latestReleaseSnapshot, releasedVersions.latestRc).filter { it.gradleVersion() > latestFinalRelease.gradleVersion() }.maxByOrNull { it.buildTimeStamp() } ?: latestFinalRelease
         val previousVersions = (listOf(latestRelease) + releasedVersions.finalReleases).filter { it.gradleVersion() >= lowestInterestingVersion && it.gradleVersion().baseVersion < currentBaseVersion }.distinct()
         allPreviousVersions = previousVersions.map { it.gradleVersion() }
-        mostRecentRelease = (listOf(releasedVersions.latestRc) + releasedVersions.finalReleases).first().gradleVersion()
+        mostRecentRelease = previousVersions.first().gradleVersion()
         mostRecentSnapshot = releasedVersions.latestReleaseSnapshot.gradleVersion()
 
         val testedVersions = previousVersions.filter { it.gradleVersion() >= lowestTestedVersion }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild/performance/tasks/PerformanceTest.groovy
@@ -245,6 +245,10 @@ abstract class PerformanceTest extends DistributionTest {
     @Input
     abstract Property<String> getProfiler()
 
+    @Option(option = "cross-version-only", description = "Only run cross version performance tests")
+    @Input
+    final Property<Boolean> crossVersionOnly = project.objects.property(Boolean.class).convention(false)
+
     @Optional
     @Input
     String getDatabaseUrl() {
@@ -316,6 +320,7 @@ abstract class PerformanceTest extends DistributionTest {
             addSystemPropertyIfExist(result, "org.gradle.performance.scenarios", scenarios)
             addSystemPropertyIfExist(result, "org.gradle.performance.testProject", getTestProjectName().getOrNull())
             addSystemPropertyIfExist(result, "org.gradle.performance.baselines", baselines.getOrNull())
+            addSystemPropertyIfExist(result, "org.gradle.performance.crossVersionOnly", crossVersionOnly.get())
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.warmups", warmups)
             addSystemPropertyIfExist(result, "org.gradle.performance.execution.runs", runs)
             addSystemPropertyIfExist(result, "org.gradle.performance.regression.checks", checks)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractCrossBuildPerformanceTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.CrossBuildResultsStore
 import org.gradle.performance.results.WritableResultsStore
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.junit.Assume
 import org.junit.Rule
 
 import static org.gradle.performance.results.ResultsStoreHelper.createResultsStoreWhenDatabaseAvailable
@@ -36,6 +37,7 @@ import static org.gradle.performance.results.ResultsStoreHelper.createResultsSto
 @CompileStatic
 @AllFeaturesShouldBeAnnotated
 class AbstractCrossBuildPerformanceTest extends AbstractPerformanceTest {
+    private static final String CROSS_VERSION_ONLY_PROPERTY_NAME = "org.gradle.performance.crossVersionOnly"
     private static final WritableResultsStore<CrossBuildPerformanceResults> RESULTS_STORE = createResultsStoreWhenDatabaseAvailable { new CrossBuildResultsStore() }
 
     protected final IntegrationTestBuildContext buildContext = new IntegrationTestBuildContext()
@@ -49,6 +51,7 @@ class AbstractCrossBuildPerformanceTest extends AbstractPerformanceTest {
     CrossBuildPerformanceTestRunner runner
 
     def setup() {
+        Assume.assumeFalse(Boolean.getBoolean(CROSS_VERSION_ONLY_PROPERTY_NAME))
         runner = new CrossBuildPerformanceTestRunner(
                 new GradleBuildExperimentRunner(gradleProfilerReporter, outputDirSelector),
                 RESULTS_STORE.reportAlso(dataReporter),


### PR DESCRIPTION
In the past, we run "Historical Performance Test" against a lot of baselines: `3.5.1,4.10.3,5.6.4,6.9.1,last`. Unfortunately, this slow historical performance test didn't bring us much value - nobody looked at the reports.

This PR does:

- Only keep `last` as the baseline.
- Support setting a version as baseline so you can get a plain report displaying the performance difference of all scenarios.
- Polish the performance test report so people can see the performance difference against last released version, see [here](https://builds.gradle.org/repository/download/Gradle_Experimental_Check_PerformanceTestHistoricalLinux_Trigger/53342690:id/performance-test-results.zip!/report/index.html) for an example.
- Don't run cross build performance tests because they make no sense.

<img width="1718" alt="image" src="https://user-images.githubusercontent.com/12689835/176102127-568788be-c799-423f-aedc-feb8a44dc4d1.png">
