### PR TITLE
Include generated sources into main jar for gradle-kotlin-dsl

### DIFF
--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
@@ -42,7 +42,8 @@ tasks {
     }
 
     processResources {
-        // Add generated sources to the main jar because `src` or any other Gradle distribution does not include them
+        // Add generated sources to the main jar because `src` or any other Gradle distribution does not include them.
+        // A more general solution is probably required: https://github.com/gradle/gradle/issues/21114
         from(apiExtensionsFileCollection)
     }
 

--- a/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
+++ b/build-logic/kotlin-dsl/src/main/kotlin/gradlebuild.kotlin-dsl-dependencies-embedded.gradle.kts
@@ -35,8 +35,15 @@ tasks {
         kotlinDslPluginsVersion.set(publishedKotlinDslPluginVersion)
     }
 
+    val apiExtensionsFileCollection = files(apiExtensionsOutputDir).builtBy(generateKotlinDependencyExtensions)
+
     sourceSets.main {
-        kotlin.srcDir(files(apiExtensionsOutputDir).builtBy(generateKotlinDependencyExtensions))
+        kotlin.srcDir(apiExtensionsFileCollection)
+    }
+
+    processResources {
+        // Add generated sources to the main jar because `src` or any other Gradle distribution does not include them
+        from(apiExtensionsFileCollection)
     }
 
 // -- Version manifest properties --------------------------------------

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.internal.AntUtil
+import org.gradle.util.internal.ToBeImplemented
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
 import static org.gradle.test.fixtures.server.http.MavenHttpPluginRepository.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
@@ -80,6 +81,26 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
         then:
         TestFile unpackedRoot = new TestFile(contentsDir.file('build/distributions/unzip').listFiles().first())
         unpackedRoot.file("bin/gradle").exists()
+    }
+
+    @ToBeImplemented("https://github.com/gradle/gradle/issues/21114")
+    @Requires(TestPrecondition.NOT_WINDOWS)
+    def "source distribution must contain generated sources"() {
+        given:
+        TestFile contentsDir = unpackDistribution()
+
+        when:
+        def generatedSourceName = "/org/gradle/kotlin/dsl/KotlinDependencyExtensions.kt"
+        def foundGeneratedSources = false
+        contentsDir.eachFileRecurse {
+            if (it.absolutePath.endsWith(generatedSourceName)) {
+                foundGeneratedSources = true
+            }
+        }
+
+        then:
+        // TODO: remove negation when fixed
+        !foundGeneratedSources
     }
 
 }


### PR DESCRIPTION
Includes the generated sources for `gradle-kotlin-dsl` into the main jar along the compiled code.

This is a temporary workaround to allow users see the generated sources and their docs of this particular module in the IDE.
It seems like a more general solution is required, which should be discussed in a [separate issue](https://github.com/gradle/gradle/issues/21114).

Fixes #20995