### PR TITLE
Change Java formatting rules to keep empty bodies on one line

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -48,6 +48,9 @@
     <codeStyleSettings language="JAVA">
       <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
       <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
       <option name="IF_BRACE_FORCE" value="3" />
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
The current Java formatting rules used in the Gradle project will always format the code with empty bodies moving the closing curly bracket on the next line. This applies to classes with empty bodies, methods/constructors and lambdas.

```java
public class TestLambdas {
    
    private TestLambdas() {
    }

    public static Action<?> createUntrackableLambda() {
        return arg -> {
        };
    }

    public interface SerializableConsumer extends Consumer<Object>, Serializable {
    }

    private static void testMethod(Object arg) {
    }
}
```

The suggestion in this PR is to revise this formatting in favor of the more concise one:

```java
public class TestLambdas {

    private TestLambdas() {}

    public static Action<?> createUntrackableLambda() {
        return arg -> {};
    }

    public interface SerializableConsumer extends Consumer<Object>, Serializable {}

    private static void testMethod(Object arg) {}
}
```

Some arguments in favor of the new style:
* Lambdas standout the most, because even in the production code there could be a need to pass a do-nothing lambda as an argument, and there is no reason to make it multiline. In the test code empty lambdas are seen even more often. In Groovy (not covered in this PR) we even write the actual do-something lambdas in one line.
* Methods with empty bodies are encountered in both production and test code most often as do-nothing overrides in regular or anonymous classes. A wall of do-nothing methods overrides looks nicer when they are all one-liners. One other use-case for empty-bodies methods is a private constructor that overrides a generated public one.
* Classes or interfaces with empty bodies are also present in the code base, including but not limited to marker interfaces or classes that exist solely to bring multiple parents together (e.g. `SerializableAction`).

One important note about this style change in the persisted project settings is that **existing files with pre-PR formatting will not get autoformatted** even if the reformat action is applied in the IDE. Instead, the current IDE behavior is only to preserve single-lines when they are explicitly introduced in the new or changed code. In this regard this formatting change is "safe" -- it will not go reformatting all files you touch.