### PR TITLE
Remove stripping of illegal access errors from all error output

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -42,11 +42,9 @@ public class LogContent {
     private final ImmutableList<String> lines;
     private final boolean definitelyNoDebugPrefix;
     private final boolean definitelyNoAnsiChars;
-    private final LogContent rawContent;
 
-    private LogContent(ImmutableList<String> lines, boolean definitelyNoDebugPrefix, boolean definitelyNoAnsiChars, LogContent rawContent) {
+    private LogContent(ImmutableList<String> lines, boolean definitelyNoDebugPrefix, boolean definitelyNoAnsiChars) {
         this.lines = lines;
-        this.rawContent = rawContent == null ? this : rawContent;
         this.definitelyNoDebugPrefix = definitelyNoDebugPrefix || lines.isEmpty();
         this.definitelyNoAnsiChars = definitelyNoAnsiChars || lines.isEmpty();
     }
@@ -55,8 +53,7 @@ public class LogContent {
      * Creates a new instance, from raw characters.
      */
     public static LogContent of(String chars) {
-        LogContent raw = new LogContent(toLines(chars), false, false, null);
-        return new LogContent(toLines(chars), false, false, raw);
+        return new LogContent(toLines(chars), false, false);
     }
 
     private static ImmutableList<String> toLines(String chars) {
@@ -88,11 +85,11 @@ public class LogContent {
      * Creates a new instance from a sequence of lines (without the line separators).
      */
     public static LogContent of(List<String> lines) {
-        return new LogContent(ImmutableList.copyOf(lines), false, false, null);
+        return new LogContent(ImmutableList.copyOf(lines), false, false);
     }
 
     public static LogContent empty() {
-        return new LogContent(ImmutableList.of(), true, true, null);
+        return new LogContent(ImmutableList.of(), true, true);
     }
 
     /**
@@ -147,8 +144,8 @@ public class LogContent {
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i);
             if (pattern.matcher(line).matches()) {
-                LogContent before = new LogContent(lines.subList(0, i), definitelyNoDebugPrefix, definitelyNoAnsiChars, rawContent);
-                LogContent after = new LogContent(lines.subList(i, lines.size()), definitelyNoDebugPrefix, definitelyNoAnsiChars, rawContent);
+                LogContent before = new LogContent(lines.subList(0, i), definitelyNoDebugPrefix, definitelyNoAnsiChars);
+                LogContent after = new LogContent(lines.subList(i, lines.size()), definitelyNoDebugPrefix, definitelyNoAnsiChars);
                 return Pair.of(before, after);
             }
         }
@@ -172,7 +169,7 @@ public class LogContent {
      * Drops the first n lines.
      */
     public LogContent drop(int i) {
-        return new LogContent(lines.subList(i, lines.size()), definitelyNoDebugPrefix, definitelyNoAnsiChars, rawContent);
+        return new LogContent(lines.subList(i, lines.size()), definitelyNoDebugPrefix, definitelyNoAnsiChars);
     }
 
     /**
@@ -191,7 +188,7 @@ public class LogContent {
                 result.add(line);
             }
         }
-        return new LogContent(ImmutableList.copyOf(result), true, definitelyNoAnsiChars, rawContent);
+        return new LogContent(ImmutableList.copyOf(result), true, definitelyNoAnsiChars);
     }
 
     /**
@@ -211,7 +208,7 @@ public class LogContent {
                     result.append("\n");
                 }
             });
-            return new LogContent(toLines(result.toString()), definitelyNoDebugPrefix, true, rawContent);
+            return new LogContent(toLines(result.toString()), definitelyNoDebugPrefix, true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -234,7 +231,7 @@ public class LogContent {
                 }
                 row.visit(diagnosticConsole);
             }
-            return new LogContent(toLines(diagnosticConsole.toString()), definitelyNoDebugPrefix, true, rawContent);
+            return new LogContent(toLines(diagnosticConsole.toString()), definitelyNoDebugPrefix, true);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -38,8 +38,6 @@ import java.util.regex.Pattern;
 public class LogContent {
     // see org.gradle.internal.logging.console.StyledTextOutputBackedRenderer.ISO_8601_DATE_TIME_FORMAT
     private final static Pattern DEBUG_PREFIX = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[-+]\\d{4} \\[\\w+] \\[.+?] ");
-    private final static Pattern JAVA_ILLEGAL_ACCESS_WARNING_PATTERN = Pattern.compile("(?ms)WARNING: An illegal reflective access operation has occurred$.+?"
-        + "^WARNING: All illegal access operations will be denied in a future release\r?\n");
 
     private final ImmutableList<String> lines;
     private final boolean definitelyNoDebugPrefix;
@@ -58,7 +56,7 @@ public class LogContent {
      */
     public static LogContent of(String chars) {
         LogContent raw = new LogContent(toLines(chars), false, false, null);
-        return new LogContent(toLines(stripJavaIllegalAccessWarnings(chars)), false, false, raw);
+        return new LogContent(toLines(chars), false, false, raw);
     }
 
     private static ImmutableList<String> toLines(String chars) {
@@ -254,9 +252,5 @@ public class LogContent {
         }
         writer.flush();
         return console;
-    }
-
-    public static String stripJavaIllegalAccessWarnings(String result) {
-        return JAVA_ILLEGAL_ACCESS_WARNING_PATTERN.matcher(result).replaceAll("");
     }
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionFailureTest.groovy
@@ -375,37 +375,6 @@ Some.Failure
         output << [rawOutput, debugOutput]
     }
 
-    def "ignores JDK warnings"() {
-        given:
-        def output = """
-FAILURE: broken
-
-* Where: WARNING: An illegal reflective access operation has occurred
-WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/home/tcagent1/agent/work/668602365d1521fc/subprojects/ivy/build/integ%20test/lib/groovy-all-2.4.12.jar) to method java.lang.Object.finalize()
-WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
-WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
-WARNING: All illegal access operations will be denied in a future release
-Build file 'build.gradle' line: 123
-
-* What went wrong:
-WARNING: An illegal reflective access operation has occurred
-WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/home/tcagent1/agent/work/668602365d1521fc/subprojects/ivy/build/integ%20test/lib/groovy-all-2.4.12.jar) to method java.lang.Object.finalize()
-WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
-WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
-WARNING: All illegal access operations will be denied in a future release
-  something bad
-* Try:
-  to fix it
-"""
-        when:
-        def failure = OutputScrapingExecutionFailure.from(output, "")
-
-        then:
-        failure.assertHasFileName("Build file 'build.gradle'")
-        failure.assertHasLineNumber(123)
-        failure.assertHasDescription("something bad")
-    }
-
     def static getRawOutput() {
         return """
 \u001B[1m<\u001B[0;32;1;0;39;1m-------------> 0% INITIALIZING [0s]\u001B[m\u001B[36D\u001B[1B\u001B[1m> Evaluating settings\u001B[m\u001B[21D\u001B[1B\u001B[2A\u001B[1m<\u001B[0;32;1;0;39;1m-------------> 0% INITIALIZING [0s]\u001B[m\u001B[36D\u001B[1B\u001B[1m> Evaluating settings\u001B[m\u001B[21D\u001B[1B\u001B[2A\u001B[1m<\u001B[0;32;1;0;39;1m-------------> 0% INITIALIZING [0s]\u001B[m\u001B[36D\u001B[1B\u001B[1m> Evaluating settings\u001B[m\u001B[21D\u001B[1B\u001B[2ASome sort of output\u001B[0K

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/jvm/AbstractConsoleJvmTestLoggingFunctionalTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.logging.console.jvm
 import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.ExecutionResult
-import org.gradle.integtests.fixtures.executer.LogContent
 
 abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractIntegrationSpec {
     private static final String TEST_TASK_NAME = 'test'
@@ -201,7 +200,7 @@ abstract class AbstractConsoleJvmTestLoggingFunctionalTest extends AbstractInteg
     }
 
     static String getTaskOutput(ExecutionResult result) {
-        LogContent.stripJavaIllegalAccessWarnings(result.groupedOutput.task(TEST_TASK_PATH).output).trim()
+        result.groupedOutput.task(TEST_TASK_PATH).output.trim()
     }
 
     static boolean matchesTaskOutput(String taskOutput, String regexToFind) {


### PR DESCRIPTION
This makes it impossible to assert that these errors occur in some tests.