### PR TITLE
Preserve "stored" compression level when instrumenting JARs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -141,7 +141,7 @@ public class ClasspathBuilder {
                 // See https://stackoverflow.com/q/1206970.
                 entry.setSize(contents.length);
                 entry.setCompressedSize(contents.length);
-                entry.setCrc(Hashing.crc32().hashBytes(contents).padToLong());
+                entry.setCrc(computeCrc32Of(contents));
             }
         }
 
@@ -151,6 +151,10 @@ public class ClasspathBuilder {
             // It isn't clear if storing them uncompressed too would bring a performance benefit,
             // as reading less from the disk may save more time than spent unpacking.
             return compressionMethod != CompressionMethod.STORED;
+        }
+
+        private static long computeCrc32Of(byte[] contents) {
+            return Hashing.crc32().hashBytes(contents).padToLong();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathBuilder.java
@@ -16,11 +16,13 @@
 
 package org.gradle.internal.classpath;
 
+import com.google.common.hash.Hashing;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.GradleException;
-import org.gradle.api.internal.file.temp.TemporaryFileProvider;
 import org.gradle.api.internal.file.archive.ZipCopyAction;
+import org.gradle.api.internal.file.temp.TemporaryFileProvider;
+import org.gradle.internal.classpath.ClasspathEntryVisitor.Entry.CompressionMethod;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
@@ -76,7 +78,10 @@ public class ClasspathBuilder {
     }
 
     public interface EntryBuilder {
-        void put(String name, byte[] content) throws IOException;
+        default void put(String name, byte[] content) throws IOException {
+            put(name, content, CompressionMethod.UNDEFINED);
+        }
+        void put(String name, byte[] content, CompressionMethod compressionMethod) throws IOException;
     }
 
     private static class ZipEntryBuilder implements EntryBuilder {
@@ -88,9 +93,10 @@ public class ClasspathBuilder {
         }
 
         @Override
-        public void put(String name, byte[] content) throws IOException {
+        public void put(String name, byte[] content, CompressionMethod compressionMethod) throws IOException {
             maybeAddParent(name);
             ZipEntry zipEntry = newZipEntryWithFixedTime(name);
+            configureCompression(zipEntry, compressionMethod, content);
             outputStream.setEncoding("UTF-8");
             outputStream.putNextEntry(zipEntry);
             outputStream.write(content);
@@ -124,6 +130,27 @@ public class ClasspathBuilder {
             ZipEntry entry = new ZipEntry(name);
             entry.setTime(ZipCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES);
             return entry;
+        }
+
+        private void configureCompression(ZipEntry entry, CompressionMethod compressionMethod, byte[] contents) {
+            if (shouldCompress(compressionMethod)) {
+                entry.setMethod(ZipEntry.DEFLATED);
+            } else {
+                entry.setMethod(ZipEntry.STORED);
+                // A stored ZipEntry requires setting size and CRC32 upfront.
+                // See https://stackoverflow.com/q/1206970.
+                entry.setSize(contents.length);
+                entry.setCompressedSize(contents.length);
+                entry.setCrc(Hashing.crc32().hashBytes(contents).padToLong());
+            }
+        }
+
+        private static boolean shouldCompress(CompressionMethod compressionMethod) {
+            // Stored files may be used for memory mapping, so it is important to store them uncompressed.
+            // All other files are fine being compressed to reduce on-disk size.
+            // It isn't clear if storing them uncompressed too would bring a performance benefit,
+            // as reading less from the disk may save more time than spent unpacking.
+            return compressionMethod != CompressionMethod.STORED;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathEntryVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathEntryVisitor.java
@@ -27,9 +27,26 @@ public interface ClasspathEntryVisitor {
     void visit(Entry entry) throws IOException;
 
     interface Entry {
+        enum CompressionMethod {
+            /**
+             * The entry is compressed with DEFLATE algorithm.
+             */
+            DEFLATED,
+            /**
+             * The entry is not compressed and stored as is.
+             */
+            STORED,
+            /**
+             * The entry is compressed with some other algorithm or the source doesn't support compression at all.
+             */
+            UNDEFINED,
+        }
+
         String getName();
 
         RelativePath getPath();
+
+        CompressionMethod getCompressionMethod();
 
         /**
          * Can be called at most once for a given entry. If not called, content is skipped.

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -156,9 +156,10 @@ public class ClasspathWalker {
 
         @Override
         public CompressionMethod getCompressionMethod() {
-            // Standalone files are somewhat STORED (not compressed), but this is more of an accident
-            // and not something that we'd want to expose. The clients may want to process STORED entries
-            // in a special way.
+            // One could argue that files have STORED as the compression method, as they obviously aren't compressed.
+            // However, this property is mostly an accident of the way this classpath entry was produced.
+            // Exposing it may put unnecessary burden on clients if, for example, they try to keep the compression method
+            // while repackaging entries.
             return CompressionMethod.UNDEFINED;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/ClasspathWalker.java
@@ -114,6 +114,20 @@ public class ClasspathWalker {
         public byte[] getContent() throws IOException {
             return entry.getContent();
         }
+
+        @Override
+        public CompressionMethod getCompressionMethod() {
+            switch (entry.getCompressionMethod()) {
+                case STORED:
+                    return CompressionMethod.STORED;
+                case DEFLATED:
+                    return CompressionMethod.DEFLATED;
+                default:
+                    // Zip entries can be in many formats but JARs are unlikely to have them as JVM doesn't
+                    // support exotic ones, and the clients mostly don't care.
+                    return CompressionMethod.UNDEFINED;
+            }
+        }
     }
 
     private static class FileEntry implements ClasspathEntryVisitor.Entry {
@@ -138,6 +152,14 @@ public class ClasspathWalker {
         @Override
         public byte[] getContent() throws IOException {
             return Files.readAllBytes(file.toPath());
+        }
+
+        @Override
+        public CompressionMethod getCompressionMethod() {
+            // Standalone files are somewhat STORED (not compressed), but this is more of an accident
+            // and not something that we'd want to expose. The clients may want to process STORED entries
+            // in a special way.
+            return CompressionMethod.UNDEFINED;
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/InstrumentingClasspathFileTransformer.java
@@ -153,9 +153,9 @@ class InstrumentingClasspathFileTransformer implements ClasspathFileTransformer 
                     Pair<RelativePath, ClassVisitor> chain = transform.apply(entry, classWriter);
                     reader.accept(chain.right, 0);
                     byte[] bytes = classWriter.toByteArray();
-                    builder.put(chain.left.getPathString(), bytes);
+                    builder.put(chain.left.getPathString(), bytes, entry.getCompressionMethod());
                 } else {
-                    builder.put(entry.getName(), entry.getContent());
+                    builder.put(entry.getName(), entry.getContent(), entry.getCompressionMethod());
                 }
             } catch (Throwable e) {
                 throw new IOException("Failed to process the entry '" + entry.getName() + "' from '" + source + "'", e);

--- a/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/classpath/DefaultCachedClasspathTransformerTest.groovy
@@ -403,6 +403,7 @@ class DefaultCachedClasspathTransformerTest extends ConcurrentSpec {
         1 * fileAccessTimeJournal.setLastAccessTime(cachedFile.parentFile, _)
         0 * _
     }
+
     def "transformation keeps the compression level of archive entries"() {
         given:
         def file = testDir.file("thing.jar")

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/archive/ZipEntry.java
@@ -22,6 +22,24 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public interface ZipEntry {
+    /**
+     * The compression method used for an entry
+     */
+    enum ZipCompressionMethod {
+        /**
+         * The entry is compressed with DEFLATE algorithm.
+         */
+        DEFLATED,
+
+        /**
+         * The entry is stored uncompressed.
+         */
+        STORED,
+        /**
+         * The entry is compressed with some other method (Zip spec declares about a dozen of these).
+         */
+        OTHER,
+    }
 
     boolean isDirectory();
 
@@ -53,4 +71,6 @@ public interface ZipEntry {
      * have already been read from it.
      */
     boolean canReopen();
+
+    ZipCompressionMethod getCompressionMethod();
 }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/archive/impl/AbstractZipEntry.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/archive/impl/AbstractZipEntry.java
@@ -65,4 +65,16 @@ abstract class AbstractZipEntry implements ZipEntry {
             }
         });
     }
+
+    @Override
+    public ZipCompressionMethod getCompressionMethod() {
+        switch (entry.getMethod()) {
+            case java.util.zip.ZipEntry.STORED:
+                return ZipCompressionMethod.STORED;
+            case java.util.zip.ZipEntry.DEFLATED:
+                return ZipCompressionMethod.DEFLATED;
+            default:
+                return ZipCompressionMethod.OTHER;
+        }
+    }
 }

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/FallbackHandlingResourceHasher.java
@@ -159,5 +159,10 @@ abstract class FallbackHandlingResourceHasher implements ResourceHasher {
         public boolean canReopen() {
             return true;
         }
+
+        @Override
+        public ZipCompressionMethod getCompressionMethod() {
+            return delegate.getCompressionMethod();
+        }
     }
 }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/LineEndingNormalizingResourceHasherTest.groovy
@@ -221,6 +221,11 @@ class LineEndingNormalizingResourceHasherTest extends Specification {
             boolean canReopen() {
                 return !unsafe
             }
+
+            @Override
+            ZipEntry.ZipCompressionMethod getCompressionMethod() {
+                return ZipEntry.ZipCompressionMethod.DEFLATED
+            }
         }
         return new DefaultZipEntryContext(zipEntry, file.path, "foo.zip")
     }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/MetaInfAwareClasspathResourceHasherTest.groovy
@@ -483,6 +483,11 @@ class MetaInfAwareClasspathResourceHasherTest extends Specification {
             boolean canReopen() {
                 return !unsafe
             }
+
+            @Override
+            ZipEntry.ZipCompressionMethod getCompressionMethod() {
+                return ZipEntry.ZipCompressionMethod.DEFLATED
+            }
         }
         return new DefaultZipEntryContext(zipEntry, path, "foo.zip")
     }

--- a/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
+++ b/subprojects/normalization-java/src/test/groovy/org/gradle/api/internal/changedetection/state/PropertiesFileAwareClasspathResourceHasherTest.groovy
@@ -381,6 +381,11 @@ class PropertiesFileAwareClasspathResourceHasherTest extends Specification {
             boolean canReopen() {
                 return !unsafe
             }
+
+            @Override
+            ZipEntry.ZipCompressionMethod getCompressionMethod() {
+                return ZipEntry.ZipCompressionMethod.DEFLATED
+            }
         }
         return new DefaultZipEntryContext(zipEntry, path, "foo.zip")
     }


### PR DESCRIPTION
The instrumentation rewrites buildscript classpath JARs, the rewritten
JARs are then used as runtime classpath. The user code sometimes tries
different tricks to find the location of these JARs and use them. One
of the use cases is to memory map a "stored" (uncompressed) resource.
The rewriting code was compressing all JARs content and was breaking
memory mapping. With this commit, stored files will be left stored in
the rewritten JARs as well.

In general, we suggest the users to use a separate configuration to
access non-instrumented JARs instead, but this fix is relatively simple,
so benefits outweigh the cost.

<!--- The issue this PR addresses -->
Fixes #20824 
