### PR TITLE
Optimize and simplify buildBranch and buildCommitId in build-logic

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildEnvironment.kt
@@ -20,14 +20,28 @@ import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.*
 
 
-fun Project.repoRoot() = layout.projectDirectory.parentOrRoot()
+abstract class BuildEnvironmentExtension {
+    abstract val gitCommitId: Property<String>
+    abstract val gitBranch: Property<String>
+    abstract val repoRoot: DirectoryProperty
+}
 
 
+// `generatePrecompiledScriptPluginAccessors` task invokes this method without `gradle.build-environment` applied
 private
+fun Project.getBuildEnvironmentExtension(): BuildEnvironmentExtension? = rootProject.extensions.findByType(BuildEnvironmentExtension::class.java)
+
+
+fun Project.repoRoot(): Directory = getBuildEnvironmentExtension()?.repoRoot?.get() ?: layout.projectDirectory.parentOrRoot()
+
+
 fun Directory.parentOrRoot(): Directory = if (this.file("version.txt").asFile.exists()) {
     this
 } else {
@@ -46,35 +60,25 @@ fun Project.releasedVersionsFile() = repoRoot().file("released-versions.json")
 /**
  * We use command line Git instead of JGit, because JGit's [Repository.resolve] does not work with worktrees.
  */
-fun Project.currentGitBranch() = git(layout.projectDirectory, "rev-parse", "--abbrev-ref", "HEAD")
+fun Project.currentGitBranchViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtension()?.gitBranch ?: objects.property(String::class.java)
 
 
-fun Project.currentGitCommit() = git(layout.projectDirectory, "rev-parse", "HEAD")
+fun Project.currentGitCommitViaFileSystemQuery(): Provider<String> = getBuildEnvironmentExtension()?.gitCommitId ?: objects.property(String::class.java)
 
 
 @Suppress("UnstableApiUsage")
-private
-fun Project.git(checkoutDir: Directory, vararg args: String): Provider<String> {
+fun Project.git(vararg args: String): String {
+    val projectDir = layout.projectDirectory.asFile
     val execOutput = providers.exec {
-        workingDir = checkoutDir.asFile
+        workingDir = projectDir
         isIgnoreExitValue = true
         commandLine = listOf("git", *args)
         if (OperatingSystem.current().isWindows) {
             commandLine = listOf("cmd", "/c") + commandLine
         }
     }
-    return execOutput.result.zip(execOutput.standardOutput.asBytes) { execResult, output ->
-        when {
-            execResult.exitValue == 0 -> String(output).trim()
-            checkoutDir.asFile.resolve(".git/HEAD").exists() -> {
-                // Read commit id directly from filesystem
-                val headRef = checkoutDir.asFile.resolve(".git/HEAD").readText()
-                    .replace("ref: ", "").trim()
-                checkoutDir.asFile.resolve(".git/$headRef").readText().trim()
-            }
-            else -> "<unknown>" // It's a source distribution, we don't know.
-        }
-    }
+    return if (execOutput.result.get().exitValue == 0) execOutput.standardOutput.asText.get().trim()
+    else "<unknown>" // It's a source distribution, we don't know.
 }
 
 

--- a/build-logic/build-platform/build.gradle.kts
+++ b/build-logic/build-platform/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
         }
         api("commons-io:commons-io:2.8.0")
         api("commons-lang:commons-lang:2.6")
-        api("io.mockk:mockk:1.10.6")
+        api("io.mockk:mockk:1.12.4")
         api("javax.activation:activation:1.1.1")
         api("javax.xml.bind:jaxb-api:2.3.1")
         api("com.sun.xml.bind:jaxb-core:2.2.11")

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import gradlebuild.basics.buildBranch
-import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.buildFinalRelease
 import gradlebuild.basics.buildMilestoneNumber
 import gradlebuild.basics.buildRcNumber
@@ -23,6 +21,7 @@ import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.buildTimestamp
 import gradlebuild.basics.buildVersionQualifier
 import gradlebuild.basics.ignoreIncomingBuildReceipt
+import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.identity.extension.ModuleIdentityExtension
 import gradlebuild.identity.extension.ReleasedVersionsDetails
@@ -85,14 +84,11 @@ fun Project.collectVersionDetails(moduleIdentity: ModuleIdentityExtension): Stri
     moduleIdentity.buildTimestamp.convention(buildTimestamp)
     moduleIdentity.promotionBuild.convention(isPromotionBuild())
 
-    moduleIdentity.gradleBuildBranch.convention(buildBranch)
-    moduleIdentity.gradleBuildCommitId.convention(buildCommitId)
-
     moduleIdentity.releasedVersions.set(
         provider {
             ReleasedVersionsDetails(
                 moduleIdentity.version.get().baseVersion,
-                repoRoot().file("released-versions.json")
+                releasedVersionsFile()
             )
         }
     )

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild/identity/extension/ModuleIdentityExtension.kt
@@ -16,13 +16,12 @@
 
 package gradlebuild.identity.extension
 
-import gradlebuild.basics.toPreTestedCommitBaseBranch
+import gradlebuild.basics.buildCommitId
 import gradlebuild.identity.tasks.BuildReceipt
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.*
 import org.gradle.util.GradleVersion
 
@@ -37,23 +36,6 @@ abstract class ModuleIdentityExtension(val tasks: TaskContainer, val objects: Ob
     abstract val snapshot: Property<Boolean>
     abstract val promotionBuild: Property<Boolean>
 
-    /**
-     * The actual build branch.
-     */
-    abstract val gradleBuildBranch: Property<String>
-
-    /**
-     * The logical branch.
-     * For non-pre-tested commit branches this is the same as {@link #gradleBuildBranch}.
-     * For pre-tested commit branches, this is the branch which will be forwarded to the state on this branch when
-     * pre-tested commit passes.
-     *
-     * For example, for the pre-tested commit branch "pre-test/master/queue/alice/personal-branch" the logical branch is "master".
-     */
-    val logicalBranch: Provider<String> = gradleBuildBranch.map(::toPreTestedCommitBaseBranch)
-
-    abstract val gradleBuildCommitId: Property<String>
-
     abstract val releasedVersions: Property<ReleasedVersionsDetails>
 
     fun createBuildReceipt() {
@@ -63,7 +45,7 @@ abstract class ModuleIdentityExtension(val tasks: TaskContainer, val objects: Ob
             this.snapshot.set(this@ModuleIdentityExtension.snapshot)
             this.promotionBuild.set(this@ModuleIdentityExtension.promotionBuild)
             this.buildTimestampFrom(this@ModuleIdentityExtension.buildTimestamp)
-            this.commitId.set(this@ModuleIdentityExtension.gradleBuildCommitId)
+            this.commitId.set(project.buildCommitId)
             this.receiptFolder.set(project.layout.buildDirectory.dir("generated-resources/build-receipt"))
         }
         tasks.named<Jar>("jar").configure {

--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -45,7 +45,9 @@ tasks.compileKotlin.configure {
 }
 
 tasks.withType<Test>().configureEach {
-    // This is required for the PerformanceTestIntegrationTest
-    environment("BUILD_BRANCH", "myBranch")
-    environment("BUILD_COMMIT_ID", "myCommitId")
+    // PerformanceTestIntegrationTest needs a clean environment
+    val testEnv = System.getenv().toMutableMap()
+    testEnv.remove("BUILD_BRANCH")
+    testEnv.remove("BUILD_COMMIT_ID")
+    setEnvironment(testEnv)
 }

--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -25,11 +25,12 @@ import gradlebuild.performance.generator.tasks.NativeProjectWithDepsGeneratorTas
 import gradlebuild.performance.generator.tasks.RemoteProject
 
 import static gradlebuild.basics.BuildEnvironmentKt.repoRoot
+import static gradlebuild.basics.BuildParamsKt.getBuildCommitId
 
 // === Gradle Build ===
 performanceTest.registerTestProject("gradleBuildCurrent", RemoteProject) {
     remoteUri = repoRoot(project).asFile.absolutePath
-    ref = moduleIdentity.gradleBuildCommitId
+    ref = getBuildCommitId(project)
 }
 
 performanceTest.registerTestProject("gradleBuildBaseline", RemoteProject) {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -24,7 +24,10 @@ import gradlebuild.basics.BuildEnvironment.isWindows
 import gradlebuild.basics.accessors.groovy
 import gradlebuild.basics.androidStudioHome
 import gradlebuild.basics.autoDownloadAndroidStudio
+import gradlebuild.basics.buildBranch
+import gradlebuild.basics.buildCommitId
 import gradlebuild.basics.includePerformanceTestScenarios
+import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.performanceBaselines
 import gradlebuild.basics.performanceDependencyBuildIds
 import gradlebuild.basics.performanceGeneratorMaxProjects
@@ -33,7 +36,6 @@ import gradlebuild.basics.propertiesForPerformanceDb
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.basics.runAndroidStudioInHeadlessMode
-import gradlebuild.identity.extension.ModuleIdentityExtension
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.performance.Config.androidStudioVersion
 import gradlebuild.performance.Config.defaultAndroidStudioJvmArgs
@@ -186,12 +188,11 @@ class PerformanceTestPlugin : Plugin<Project> {
             performanceResultsDirectory.set(repoRoot().dir("perf-results"))
             reportDir.set(project.layout.buildDirectory.dir(this@configureEach.name))
             databaseParameters.set(project.propertiesForPerformanceDb)
-            val moduleIdentity = project.the<ModuleIdentityExtension>()
-            branchName.set(moduleIdentity.gradleBuildBranch)
+            branchName.set(buildBranch)
             channel.convention(branchName.map { "commits-$it" })
-            channelPatterns.add(moduleIdentity.logicalBranch)
-            channelPatterns.add(moduleIdentity.logicalBranch.map { "commits-pre-test/$it/%" })
-            commitId.set(moduleIdentity.gradleBuildCommitId)
+            channelPatterns.add(logicalBranch)
+            channelPatterns.add(logicalBranch.map { "commits-pre-test/$it/%" })
+            commitId.set(buildCommitId)
             projectName.set(project.name)
         }
 
@@ -484,10 +485,9 @@ class PerformanceTestExtension(
             testProjectName.set(generatorTask.name)
             testProjectFiles.from(generatorTask)
 
-            val identityExtension = project.the<ModuleIdentityExtension>()
-            val gradleBuildBranch = identityExtension.gradleBuildBranch.get()
+            val gradleBuildBranch = project.buildBranch.get()
             branchName = gradleBuildBranch
-            commitId.set(identityExtension.gradleBuildCommitId)
+            commitId.set(project.buildCommitId)
 
             reportGeneratorClass.set("org.gradle.performance.results.report.DefaultReportGenerator")
 

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -17,13 +17,12 @@
 package gradlebuild.performance.tasks
 
 import gradlebuild.basics.kotlindsl.execAndGetStdout
-import gradlebuild.identity.extension.ModuleIdentityExtension
+import gradlebuild.basics.logicalBranch
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.kotlin.dsl.*
 import org.gradle.work.DisableCachingByDefault
 import javax.inject.Inject
 
@@ -70,7 +69,7 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
     fun determineFlakinessDetectionBaseline() = if (distributed) flakinessDetectionCommitBaseline else currentCommitBaseline()
 
     private
-    fun currentBranchIsMasterOrRelease() = project.the<ModuleIdentityExtension>().logicalBranch.get() in listOf("master", "release")
+    fun currentBranchIsMasterOrRelease() = project.logicalBranch.get() in listOf("master", "release")
 
     private
     fun Property<String>.isDefaultValue() = !isPresent || get() in listOf("", defaultBaseline)

--- a/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -16,13 +16,12 @@
 
 package gradlebuild.performance.tasks
 
+import gradlebuild.basics.BuildEnvironmentExtension
 import gradlebuild.basics.kotlindsl.execAndGetStdout
-import gradlebuild.identity.extension.ModuleIdentityExtension
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.kotlin.dsl.*
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Assume
@@ -34,10 +33,12 @@ class DetermineBaselinesTest {
     private
     val project = ProjectBuilder.builder().build()
 
+    private
+    val buildEnvironmentExtension = project.extensions.create("buildEnvironment", BuildEnvironmentExtension::class.java)
+
     @Before
     fun setUp() {
         project.file("version.txt").writeText("1.0")
-        project.apply(plugin = "gradlebuild.module-identity")
 
         // mock project.execAndGetStdout
         mockkStatic("gradlebuild.basics.kotlindsl.Kotlin_dsl_upstream_candidatesKt")
@@ -129,7 +130,7 @@ class DetermineBaselinesTest {
 
     private
     fun setCurrentBranch(branch: String) {
-        project.the<ModuleIdentityExtension>().gradleBuildBranch.set(branch)
+        buildEnvironmentExtension.gitBranch.set(branch)
     }
 
     private

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -19,13 +19,14 @@ import gradlebuild.basics.BuildEnvironment.isCiServer
 import gradlebuild.basics.BuildEnvironment.isCodeQl
 import gradlebuild.basics.BuildEnvironment.isGhActions
 import gradlebuild.basics.BuildEnvironment.isTravis
+import gradlebuild.basics.buildBranch
 import gradlebuild.basics.environmentVariable
 import gradlebuild.basics.kotlindsl.execAndGetStdout
+import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.predictiveTestSelectionEnabled
 import gradlebuild.basics.testDistributionEnabled
 import gradlebuild.buildscan.tasks.ExtractCheckstyleBuildScanData
 import gradlebuild.buildscan.tasks.ExtractCodeNarcBuildScanData
-import gradlebuild.identity.extension.ModuleIdentityExtension
 import org.gradle.api.internal.BuildType
 import org.gradle.api.internal.GradleInternal
 import org.gradle.internal.operations.BuildOperationDescriptor
@@ -64,7 +65,7 @@ if (project.testDistributionEnabled) {
     buildScan?.tag("TEST_DISTRIBUTION")
 }
 
-if (project.predictiveTestSelectionEnabled.get()) {
+if (project.predictiveTestSelectionEnabled.orNull == true) {
     buildScan?.tag("PTS")
 }
 
@@ -72,10 +73,8 @@ extractCheckstyleAndCodenarcData()
 
 extractWatchFsData()
 
-project.the<ModuleIdentityExtension>().apply {
-    if (logicalBranch.get() != gradleBuildBranch.get()) {
-        buildScan?.tag("PRE_TESTED_COMMIT")
-    }
+if (logicalBranch.orNull != buildBranch.orNull) {
+    buildScan?.tag("PRE_TESTED_COMMIT")
 }
 
 if ((project.gradle as GradleInternal).services.get(BuildType::class.java) != BuildType.TASKS) {

--- a/build-logic/root-build/build.gradle.kts
+++ b/build-logic/root-build/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Provides plugins that configures the root Gradle project"
 
 dependencies {
     implementation(project(":idea"))
+    implementation(project(":basics"))
     implementation(project(":profiling"))
 
     implementation(project(":cleanup")) {

--- a/build-logic/root-build/src/main/kotlin/gradlebuild.build-environment.gradle.kts
+++ b/build-logic/root-build/src/main/kotlin/gradlebuild.build-environment.gradle.kts
@@ -1,0 +1,25 @@
+import gradlebuild.basics.BuildEnvironmentExtension
+import gradlebuild.basics.git
+import gradlebuild.basics.parentOrRoot
+
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+val buildEnvironmentExtension = extensions.create("buildEnvironment", BuildEnvironmentExtension::class)
+buildEnvironmentExtension.gitCommitId.set(git("rev-parse", "HEAD"))
+buildEnvironmentExtension.gitBranch.set(git("rev-parse", "--abbrev-ref", "HEAD"))
+buildEnvironmentExtension.repoRoot.set(layout.projectDirectory.parentOrRoot())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("gradlebuild.build-environment")
     id("gradlebuild.root-build")
 
     id("gradlebuild.lifecycle")                  // CI: Add lifecycle tasks to for the CI pipeline (currently needs to be applied early as it might modify global properties)

--- a/subprojects/distributions-integ-tests/build.gradle.kts
+++ b/subprojects/distributions-integ-tests/build.gradle.kts
@@ -1,3 +1,6 @@
+import gradlebuild.basics.buildBranch
+import gradlebuild.basics.buildCommitId
+
 plugins {
     id("gradlebuild.internal.java")
 }
@@ -22,6 +25,6 @@ dependencies {
 }
 
 tasks.forkingIntegTest {
-    systemProperty("gradleBuildBranch", moduleIdentity.gradleBuildBranch.get())
-    systemProperty("gradleBuildCommitId", moduleIdentity.gradleBuildCommitId.get())
+    systemProperty("gradleBuildBranch", buildBranch.get())
+    systemProperty("gradleBuildCommitId", buildCommitId.get())
 }

--- a/subprojects/smoke-test/build.gradle.kts
+++ b/subprojects/smoke-test/build.gradle.kts
@@ -3,6 +3,7 @@ import gradlebuild.basics.accessors.groovy
 import gradlebuild.integrationtests.addDependenciesAndConfigurations
 import gradlebuild.integrationtests.tasks.SmokeTest
 import gradlebuild.performance.generator.tasks.RemoteProject
+import gradlebuild.basics.buildCommitId
 
 plugins {
     id("gradlebuild.internal.java")
@@ -61,7 +62,7 @@ tasks {
 
     val gradleBuildCurrent by registering(RemoteProject::class) {
         remoteUri.set(rootDir.absolutePath)
-        ref.set(moduleIdentity.gradleBuildCommitId)
+        ref.set(buildCommitId)
     }
 
     val remoteProjects = arrayOf(santaTracker, gradleBuildCurrent)


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-private/issues/3543

Previously, a local build runs hundreds of git operations, which is
unnecessary. This PR introduces an extension to cache necessary information
like build branch and commit id. Also, the duplicate properties
in `ModuleIdentityExtension` are removed to simplify the build.
