### PR TITLE
Improve dependencies/constraints generated by 'init' for Kotlin projects

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
@@ -201,10 +201,6 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
             String groovyAllCoordinates = groovyGroupName(groovyVersion) + ":" + (constraintsDefined ? "groovy-all" : "groovy-all:" + groovyVersion);
             buildScriptBuilder.implementationDependency("Use the latest Groovy version for building this library", groovyAllCoordinates);
         }
-        if (getLanguage() == Language.KOTLIN) {
-            buildScriptBuilder.dependencies().platformDependency("implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom");
-            buildScriptBuilder.implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8");
-        }
         if (getLanguage() == Language.SCALA) {
             String scalaVersion = libraryVersionProvider.getVersion("scala");
             String scalaLibraryVersion = libraryVersionProvider.getVersion("scala-library");
@@ -219,10 +215,6 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
 
         if (getLanguage() == Language.GROOVY) {
             buildScriptBuilder.implementationDependencyConstraint(null, groovyModuleDependency("groovy-all", libraryVersionProvider.getVersion("groovy")));
-        }
-        if (getLanguage() == Language.KOTLIN) {
-            buildScriptBuilder.dependencies().platformDependency("implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom");
-            buildScriptBuilder.implementationDependencyConstraint(null, "org.jetbrains.kotlin:kotlin-stdlib-jdk8");
         }
         if (getLanguage() == Language.SCALA) {
             String scalaLibraryVersion = libraryVersionProvider.getVersion("scala-library");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinGradlePluginProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinGradlePluginProjectInitDescriptor.java
@@ -57,11 +57,6 @@ public class KotlinGradlePluginProjectInitDescriptor extends JvmGradlePluginProj
 
         String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
         buildScriptBuilder.plugin("Apply the Kotlin JVM plugin to add support for Kotlin.", "org.jetbrains.kotlin.jvm", kotlinVersion);
-        buildScriptBuilder.dependencies().platformDependency(
-            "implementation", "Align versions of all Kotlin components", "org.jetbrains.kotlin:kotlin-bom"
-        );
-        buildScriptBuilder.
-            implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8");
 
         if (!settings.isUseTestSuites()) {
             buildScriptBuilder.testImplementationDependency("Use the Kotlin JUnit 5 integration.", "org.jetbrains.kotlin:kotlin-test-junit5");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageSpecificAdaptor.java
@@ -133,11 +133,7 @@ public class LanguageSpecificAdaptor implements ProjectGenerator {
         BuildScriptBuilder buildSrcScriptBuilder = scriptBuilderFactory.scriptForNewProjects(settings.getDsl(), "buildSrc/build", settings.isUseIncubatingAPIs());
         buildSrcScriptBuilder.conventionPluginSupport("Support convention plugins written in " + settings.getDsl().toString() + ". Convention plugins are build scripts in 'src/main' that automatically become available as plugins in the main build.");
         if (getLanguage() == Language.KOTLIN) {
-            String kotlinPluginCoordinates = "org.jetbrains.kotlin:kotlin-gradle-plugin";
-            if (settings.getDsl() == BuildInitDsl.GROOVY) {
-                // we don't get a Kotlin version from context without the 'kotlin-dsl' plugin
-                kotlinPluginCoordinates = kotlinPluginCoordinates + ":" + libraryVersionProvider.getVersion("kotlin");
-            }
+            String kotlinPluginCoordinates = "org.jetbrains.kotlin:kotlin-gradle-plugin:" + libraryVersionProvider.getVersion("kotlin");
             buildSrcScriptBuilder.implementationDependency(null, kotlinPluginCoordinates);
         }
         return buildSrcScriptBuilder;


### PR DESCRIPTION

### Context

[This sample](https://docs.gradle.org/current/samples/sample_building_kotlin_applications_multi_project.html), and in general what `gradle init` generates for Kotlin projects in terms of dependency declarations, is confusing. In particular, it makes it unclear where to configure the Kotlin version in the sample when using Kotlin DSL.

- The Kotlin JVM plugin automatically adds the standard library and BOM nowadays. It makes little sense to add the dependencies (without version) again. It makes no sense at all to add constraints without versions. This PR removes these.
- The version of Kotlin you are building against is controlled by the version of the Kotlin plugin you apply. In a setup with a convention plugin, this should be reflected in the dependency to `org.jetbrains.kotlin:kotlin-gradle-plugin:VERSION`. So even if it works without version (when you use Kotlin DSL), a version should be defined here. For plain Kotlin projects, you are not limited by the Kotlin version embedded in Gradle and thus these projects should not suggest to just rely on this version (which may change if you upgrade Gradle). This PR adds a version to `org.jetbrains.kotlin:kotlin-gradle-plugin` even if _kotlin-dsl_ is used.

Once this is integrated, the Kotlin samples published to the docs will be automatically upgraded as it is produced with `gradle init`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- ~[ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- ~[ ] Provide unit tests (under `<subproject>/src/test`) to verify logic~
- ~[ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
