### PR TITLE
Detect wrapper configuration changes between TAPI build invocations

### DIFF
--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -297,6 +297,11 @@ project.description = text
             o.completed()
             return delegate.getToolingImplementationClasspath(progressLoggerFactory, progressListener, connectionParameters, cancellationToken)
         }
+
+        @Override
+        Distribution checkChangesInConfiguration() {
+            return this
+        }
     }
 
     def "receives progress and logging while the model is building"() {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/Distribution.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/Distribution.java
@@ -25,4 +25,11 @@ public interface Distribution {
 
     ClassPath getToolingImplementationClasspath(
         ProgressLoggerFactory progressLoggerFactory, InternalBuildProgressListener progressListener, ConnectionParameters connectionParameters, BuildCancellationToken cancellationToken);
+
+    /**
+     * Checks the distribution's configuration and creates a new instance if there is a change.
+     *
+     * @return A new distribution instance with the updated configuration, or {@code this} of no changes were detected.
+     */
+    Distribution checkChangesInConfiguration();
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import spock.lang.Specification
 
 class LazyConsumerActionExecutorTest extends Specification {
-    final Distribution distribution = Mock()
+    final Distribution distribution = Stub()
     final ToolingImplementationLoader implementationLoader = Mock()
     final ConsumerOperationParameters params = Mock()
     final ConsumerAction<String> action = Mock()
@@ -37,8 +37,11 @@ class LazyConsumerActionExecutorTest extends Specification {
     final ProgressLoggerFactory progressLoggerFactory = Mock()
     final FailsafeBuildProgressListenerAdapter buildProgressListener = Mock()
     final BuildCancellationToken cancellationToken = Mock()
-
     final LazyConsumerActionExecutor connection = new LazyConsumerActionExecutor(distribution, implementationLoader, loggingProvider, connectionParams)
+
+    def setup() {
+        distribution.checkChangesInConfiguration() >> distribution
+    }
 
     def createsConnectionOnDemandToBuildModel() {
         when:

--- a/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/wrapper/WrapperConfiguration.java
@@ -81,4 +81,48 @@ public class WrapperConfiguration {
     public void setNetworkTimeout(int networkTimeout) {
         this.networkTimeout = networkTimeout;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WrapperConfiguration that = (WrapperConfiguration) o;
+
+        if (networkTimeout != that.networkTimeout) {
+            return false;
+        }
+        if (distribution != null ? !distribution.equals(that.distribution) : that.distribution != null) {
+            return false;
+        }
+        if (distributionBase != null ? !distributionBase.equals(that.distributionBase) : that.distributionBase != null) {
+            return false;
+        }
+        if (distributionPath != null ? !distributionPath.equals(that.distributionPath) : that.distributionPath != null) {
+            return false;
+        }
+        if (distributionSha256Sum != null ? !distributionSha256Sum.equals(that.distributionSha256Sum) : that.distributionSha256Sum != null) {
+            return false;
+        }
+        if (zipBase != null ? !zipBase.equals(that.zipBase) : that.zipBase != null) {
+            return false;
+        }
+        return zipPath != null ? zipPath.equals(that.zipPath) : that.zipPath == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = distribution != null ? distribution.hashCode() : 0;
+        result = 31 * result + (distributionBase != null ? distributionBase.hashCode() : 0);
+        result = 31 * result + (distributionPath != null ? distributionPath.hashCode() : 0);
+        result = 31 * result + (distributionSha256Sum != null ? distributionSha256Sum.hashCode() : 0);
+        result = 31 * result + (zipBase != null ? zipBase.hashCode() : 0);
+        result = 31 * result + (zipPath != null ? zipPath.hashCode() : 0);
+        result = 31 * result + networkTimeout;
+        return result;
+    }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -54,7 +54,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 60 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 64 * 1024
     }
 
     def "generated wrapper scripts for given version from command-line"() {
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("53018fb29b1af30cb2776fd1ddfede2d1a60bb541d00750cbbb0e40e7c61226b")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("44af88e551e5e6a995e9571cda381311b36bfb6c8379a9af0398d4497136718d")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #21137

IDEA users reported that builds sometimes are running with an unexpected Gradle version. A typical reproducer is to:
- check out a project from git, import it into IDEA, and run a task using the Gradle wrapper
- switch to a different branch that uses a different wrapper version
- run the same build

IDEA and other IDEs reuse `ProjectConnection` instances between build invocations (i.e. running tasks, executing tests, etc.) to save resources by avoiding shutting down and re-creating daemon processes. The internal implementation for `ProjectConnection` caches the configuration of the target Gradle distribution when invoking a build for the first time. 

This PR fixes the issue by re-reading the `gradle-wrapper.properties` file and creating a new internal connection to the target Gradle version if there is a change in the properties.
