### PR TITLE
Rename gradle --show-version command line flag to --show-gradle-version

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -264,9 +264,9 @@ The [`Groovydoc`](dsl/org.gradle.api.tasks.javadoc.Groovydoc.html) task now expo
 
 These defaults are the same as what was previously used, so there should be no changes to the default behavior.
 
-### --show-gradle-version (-V) flag
+### Show Gradle version information in console output (`--show-gradle-version`/`-V`)
 
-The `-V` flag (long form `--show-gradle-version`) instructs Gradle to first print version information and then continue executing any requested tasks.  This is in contrast to the pre-existing `-v` (long form `--version`) flag which prints version information and then immediately exits.
+The `-V` flag (long form `--show-gradle-version`) instructs Gradle to print version information and continue executing any requested tasks.  This is in contrast to the pre-existing `-v` (long form `--version`) flag which prints version information and then immediately exits.
 
 This flag may be useful in CI environments to record Gradle version information in the log as part of a single Gradle execution.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -264,9 +264,9 @@ The [`Groovydoc`](dsl/org.gradle.api.tasks.javadoc.Groovydoc.html) task now expo
 
 These defaults are the same as what was previously used, so there should be no changes to the default behavior.
 
-### --show-version (-V) flag
+### --show-gradle-version (-V) flag
 
-The `-V` flag (long form `--show-version`) instructs Gradle to first print version information and then continue executing any requested tasks.  This is in contrast to the pre-existing `-v` (long form `--version`) flag which prints version information and then immediately exits.
+The `-V` flag (long form `--show-gradle-version`) instructs Gradle to first print version information and then continue executing any requested tasks.  This is in contrast to the pre-existing `-v` (long form `--version`) flag which prints version information and then immediately exits.
 
 This flag may be useful in CI environments to record Gradle version information in the log as part of a single Gradle execution.
 
@@ -289,7 +289,7 @@ See the [documentation](userguide/pmd_plugin.html#sec:pmd_conf_threads) for more
 
 ### Better test compatibility with Java 9+
 
-When running on Java 9+, Gradle no longer opens the `java.base/java.util` and `java.base/java.lang` JDK modules for all `Test` tasks. In some cases, this would cause code to pass during testing but fail at runtime.  
+When running on Java 9+, Gradle no longer opens the `java.base/java.util` and `java.base/java.lang` JDK modules for all `Test` tasks. In some cases, this would cause code to pass during testing but fail at runtime.
 
 This change may cause new test failures and warnings. When running on Java 16+, code performing reflection on JDK internals will now fail tests. When running on Java 9-15, illegal access warnings will appear in logs. While this change may break some existing builds, most failures are likely to uncover suppressed issues which would have only been detected at runtime.
 

--- a/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/reference/command_line_interface.adoc
@@ -348,7 +348,7 @@ Shows a help message with all available CLI options.
 `-v`, `--version`::
 Prints Gradle, Groovy, Ant, JVM, and operating system version information and exit without executing any tasks.
 
-`-V`, `--show-version`::
+`-V`, `--show-gradle-version`::
 Prints Gradle, Groovy, Ant, JVM, and operating system version information and continue execution of specified tasks.
 
 `-S`, `--full-stacktrace`::

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/DefaultCommandLineActionFactory.java
@@ -124,7 +124,7 @@ public class DefaultCommandLineActionFactory implements CommandLineActionFactory
         public void configureCommandLineParser(CommandLineParser parser) {
             parser.option(HELP, "?", "help").hasDescription("Shows this help message.");
             parser.option(VERSION, "version").hasDescription("Print version info and exit.");
-            parser.option(VERSION_CONTINUE, "show-version").hasDescription("Print version info and continue.");
+            parser.option(VERSION_CONTINUE, "show-gradle-version").hasDescription("Print version info and continue.");
         }
 
         @Override

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/DefaultCommandLineActionFactoryTest.groovy
@@ -41,11 +41,11 @@ import spock.lang.Specification
 
 class DefaultCommandLineActionFactoryTest extends Specification {
     @Rule
-    public final RedirectStdOutAndErr outputs = new RedirectStdOutAndErr();
+    public final RedirectStdOutAndErr outputs = new RedirectStdOutAndErr()
     @Rule
-    public final SetSystemProperties sysProperties = new SetSystemProperties();
+    public final SetSystemProperties sysProperties = new SetSystemProperties()
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass());
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider(getClass())
     final ExecutionListener executionListener = Mock()
     final LoggingServiceRegistry loggingServices = Mock()
     final LoggingManagerInternal loggingManager = Mock()
@@ -111,11 +111,11 @@ class DefaultCommandLineActionFactoryTest extends Specification {
 
     def "reports command-line parse failure"() {
         when:
-        def commandLineExecution = factory.convert(['--broken'])
+        def commandLineExecution = factory.convert([badOption])
         commandLineExecution.execute(executionListener)
 
         then:
-        outputs.stdErr.contains('--broken')
+        outputs.stdErr.contains("Unknown command-line option '" + badOption + "'.")
         outputs.stdErr.contains('USAGE: gradle [option...] [task...]')
         outputs.stdErr.contains('--help')
         outputs.stdErr.contains('--some-option')
@@ -124,6 +124,9 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         1 * actionFactory1.configureCommandLineParser(!null) >> {CommandLineParser parser -> parser.option('some-option')}
         1 * executionListener.onFailure({it instanceof CommandLineArgumentException})
         0 * executionListener._
+
+        where:
+        badOption << ['--broken', '--show-version']
     }
 
     def "reports failure to build action due to command-line parse failure"() {
@@ -198,7 +201,7 @@ class DefaultCommandLineActionFactoryTest extends Specification {
     }
 
     def "uses system property for application name"() {
-        System.setProperty("org.gradle.appname", "gradle-app");
+        System.setProperty("org.gradle.appname", "gradle-app")
 
         when:
         def commandLineExecution = factory.convert(['-?'])
@@ -287,8 +290,8 @@ class DefaultCommandLineActionFactoryTest extends Specification {
         where:
         options            | action1Intermediary | action2Called
         ['-V']             | false               | 0
-        ['--show-version'] | false               | 0
+        ['--show-gradle-version'] | false               | 0
         ['-V']             | true                | 1
-        ['--show-version'] | true                | 1
+        ['--show-gradle-version'] | true                | 1
     }
 }


### PR DESCRIPTION
- Add test to ensure --show-version throws an error.

<!--- The issue this PR addresses -->
Fixes #21152 