### PR TITLE
Fix potential deadlocks scheduling the dependencies of a finalizer

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -23,7 +23,6 @@ import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.decodePreservingIdentity
 import org.gradle.configurationcache.serialization.encodePreservingIdentityOf
 import org.gradle.configurationcache.serialization.readCollectionInto
-import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.readNonNull
 import org.gradle.configurationcache.serialization.withGradleIsolate
 import org.gradle.configurationcache.serialization.writeCollection
@@ -116,10 +115,6 @@ class WorkNodeCodec(
                 is FinalizerGroup -> {
                     writeSmallInt(1)
                     writeSmallInt(nodesById.getValue(group.node))
-                    val ownedNodeIds = group.ownedMembers.mapNotNull { node -> nodesById[node] }
-                    writeCollection(ownedNodeIds) {
-                        writeSmallInt(it)
-                    }
                     writeNodeGroup(group.delegate, nodesById)
                 }
                 is CompositeNodeGroup -> {
@@ -147,9 +142,8 @@ class WorkNodeCodec(
                 }
                 1 -> {
                     val finalizerNode = nodesById.getValue(readSmallInt()) as TaskNode
-                    val ownedNodes = readList { nodesById.getValue(readSmallInt()) }
                     val delegate = readNodeGroup(nodesById)
-                    FinalizerGroup(finalizerNode, delegate, ownedNodes)
+                    FinalizerGroup(finalizerNode, delegate)
                 }
                 2 -> {
                     val ordinalGroup = readNodeGroup(nodesById)

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
@@ -33,6 +33,11 @@ public class CompositeNodeGroup extends HasFinalizers {
         this.reachableFromEntryPoint = reachableFromEntryPoint();
     }
 
+    @Override
+    public String toString() {
+        return "composite group, entry point: " + isReachableFromEntryPoint() + " groups: " + finalizerGroups;
+    }
+
     @Nullable
     @Override
     public OrdinalGroup asOrdinal() {
@@ -85,20 +90,6 @@ public class CompositeNodeGroup extends HasFinalizers {
     }
 
     @Override
-    public void maybeAddToOwnedMembers(Node node) {
-        // Intentionally empty.
-        // Trying to add a node here means that this node is already owned by some
-        // FinalizerGroup or is a part of the OrdinalGroup.
-    }
-
-    @Override
-    public void removeFromOwnedMembers(Node node) {
-        for (FinalizerGroup group : finalizerGroups) {
-            group.removeFromOwnedMembers(node);
-        }
-    }
-
-    @Override
     public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
         if (ordinalGroup.isReachableFromEntryPoint()) {
             // Reachable from entry point node, can run at any time
@@ -119,4 +110,5 @@ public class CompositeNodeGroup extends HasFinalizers {
         // No finalizer group is ready to run, and either all of them have failed or some are not yet complete
         return state;
     }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -19,10 +19,11 @@ package org.gradle.execution.plan;
 import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -33,16 +34,10 @@ public class FinalizerGroup extends HasFinalizers {
     private final TaskNode node;
     private final NodeGroup delegate;
     private final Set<Node> members = new LinkedHashSet<>();
-    /**
-     * A collection of Nodes owned by this group. Only a single FinalizerGroup may own a node.
-     * The owned nodes can still be members of other finalizer groups though.
-     * The important distinction is how these members are handled when they are finalized by this group.
-     * They aren't considered the group successors but only successors to the finalizer node itself.
-     * This prevents deadlocks and false cycles when a dependency of a finalizer is finalized by it.
-     */
-    private final Set<Node> ownedMembers = new HashSet<>();
     @Nullable
     private OrdinalGroup ordinal;
+    @Nullable
+    private ElementSuccessors successors;
 
     public FinalizerGroup(TaskNode node, NodeGroup delegate) {
         this.ordinal = delegate.asOrdinal();
@@ -50,14 +45,9 @@ public class FinalizerGroup extends HasFinalizers {
         this.delegate = delegate;
     }
 
-    public FinalizerGroup(TaskNode node, NodeGroup delegate, Collection<Node> ownedMembers) {
-        this(node, delegate);
-        this.ownedMembers.addAll(ownedMembers);
-    }
-
     @Override
     public String toString() {
-        return "finalizer in " + ordinal;
+        return "finalizer " + node + " in " + ordinal;
     }
 
     public TaskNode getNode() {
@@ -86,10 +76,6 @@ public class FinalizerGroup extends HasFinalizers {
         return node.getFinalizingSuccessors();
     }
 
-    private Set<Node> getFinalizedNodesInReverseOrder() {
-        return node.getFinalizingSuccessorsInReverseOrder();
-    }
-
     @Nullable
     @Override
     public OrdinalGroup asOrdinal() {
@@ -110,35 +96,30 @@ public class FinalizerGroup extends HasFinalizers {
     @Override
     public Collection<Node> getSuccessorsFor(Node node) {
         assert members.contains(node) : "Node " + node + " is not part of the finalizer group of " + this.node;
-        Set<Node> successors = getFinalizedNodes();
-        if (!isFinalizerNode(node)) {
-            successors = filterSuccessorsForFinalizerDependency(successors);
+        if (successors == null) {
+            successors = createSuccessors();
         }
-        return successors;
+        return successors.successorsFor(node);
     }
 
     @Override
     public Collection<Node> getSuccessorsInReverseOrderFor(Node node) {
-        assert members.contains(node) : "Node " + node + " is not part of the finalizer group of " + this.node;
-        Set<Node> successors = getFinalizedNodesInReverseOrder();
-        if (!isFinalizerNode(node)) {
-            successors = filterSuccessorsForFinalizerDependency(successors);
-        }
+        List<Node> successors = new ArrayList<>(getSuccessorsFor(node));
+        Collections.reverse(successors);
         return successors;
     }
 
-    private Set<Node> filterSuccessorsForFinalizerDependency(Set<Node> successors) {
-        // The nodes that are dependencies of the finalizer can have a smaller set of successors.
-        // Owned nodes finalized by this finalizer that are also dependencies of the finalizer are not considered
-        // successors to finalizer dependencies (but they are successors to the finalizer).
-        // This prevents deadlocks and false cycles when two unrelated finalizer's dependencies finalized by this
-        // finalizer are considered each other's successors.
-        // Such nodes are still successors to other finalized nodes, like non-members and not-owned members.
-        // Not owned members are expected to be scheduled by their other group. Typically, it is a node reachable
-        // from the entry point, but a dependency of some other finalizer can also be an example.
-        Set<Node> filteredSuccessors = new LinkedHashSet<>(successors);
-        filteredSuccessors.removeIf(ownedMembers::contains);
-        return filteredSuccessors;
+    private ElementSuccessors createSuccessors() {
+        for (Node finalizedNode : getFinalizedNodes()) {
+            if (members.contains(finalizedNode)) {
+                return new FinalizesMembers();
+            }
+        }
+        return new DoesNotFinalizeMembers();
+    }
+
+    private static boolean memberCanStartAtAnyTime(Node node) {
+        return node.getGroup().isReachableFromEntryPoint();
     }
 
     @Override
@@ -147,29 +128,17 @@ public class FinalizerGroup extends HasFinalizers {
     }
 
     @Override
-    public void maybeAddToOwnedMembers(Node node) {
-        ownedMembers.add(node);
-    }
-
-    @Override
-    public void removeFromOwnedMembers(Node node) {
-        ownedMembers.remove(node);
-    }
-
-    public Collection<Node> getOwnedMembers() {
-        return Collections.unmodifiableCollection(ownedMembers);
-    }
-
-    @Override
     public void addMember(Node node) {
         members.add(node);
         delegate.addMember(node);
+        successors = null;
     }
 
     @Override
     public void removeMember(Node node) {
         members.remove(node);
         delegate.removeMember(node);
+        successors = null;
     }
 
     public void visitAllMembers(Consumer<Node> visitor) {
@@ -180,19 +149,25 @@ public class FinalizerGroup extends HasFinalizers {
 
     @Override
     public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
-        // If this node is reachable from an entry point and is not the finalizer itself, then it can start at any time
-        if (delegate.isReachableFromEntryPoint() && !isFinalizerNode(node)) {
+        if (!isFinalizerNode(node) && memberCanStartAtAnyTime(node)) {
+            // Is not the finalizer and is reachable from an entry point, so can start
             return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
         }
 
-        // Otherwise, wait for (almost) all finalized nodes to complete with one exception.
+        // Wait for all finalized nodes, potentially excluding some finalized nodes that are also members of this group
+        Collection<Node> successors = getSuccessorsFor(node);
+        if (successors.isEmpty()) {
+            // All finalized nodes are also members and none can start early
+            return checkPeersCompleteFor(node);
+        }
         boolean isAnyExecuted = false;
-        for (Node finalized : getSuccessorsFor(node)) {
+        for (Node finalized : successors) {
             if (!finalized.isComplete()) {
                 return Node.DependenciesState.NOT_COMPLETE;
             }
             isAnyExecuted |= finalized.isExecuted();
         }
+        // All relevant finalized nodes have completed
         // Can run if any finalized node executed or if this node is reachable from an entry point
         if (isAnyExecuted || delegate.isReachableFromEntryPoint()) {
             return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
@@ -208,7 +183,96 @@ public class FinalizerGroup extends HasFinalizers {
         }
     }
 
+    /**
+     * Determines the state for a member node that is also a finalized node, in the case where all finalized nodes are also member nodes
+     * and none can start for some other reason.
+     *
+     * The approach is to defer execution until one of the member nodes is "activated", that is, it can start if its membership in this
+     * group is ignored.
+     */
+    private Node.DependenciesState checkPeersCompleteFor(Node node) {
+        // If some other member has already completed, then allow all other members to start.
+        for (Node member : members) {
+            if (member.isComplete()) {
+                return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+            }
+        }
+
+        HasFinalizers hasFinalizers = (HasFinalizers) node.getGroup();
+        for (FinalizerGroup group : hasFinalizers.getFinalizerGroups()) {
+            if (group == this) {
+                continue;
+            }
+            if (group.isActivated(node)) {
+                return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+            }
+        }
+
+        return Node.DependenciesState.NOT_COMPLETE;
+    }
+
+    private boolean isActivated(Node node) {
+        // A node is active when it is the finalizer of this group and is ready to start
+        if (node == this.node) {
+            return checkSuccessorsCompleteFor(node) == Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+        }
+        return false;
+    }
+
     private boolean isFinalizerNode(Node node) {
         return node == this.node;
     }
+
+    private abstract class ElementSuccessors {
+        public Set<Node> successorsFor(Node node) {
+            // If the node is the finalizer for this group, it should wait for all the finalized nodes
+            if (isFinalizerNode(node)) {
+                return getFinalizedNodes();
+            }
+
+            // If the node is reachable from an entry point, it can start at any time
+            if (memberCanStartAtAnyTime(node)) {
+                return Collections.emptySet();
+            }
+
+            return getFilteredSuccessorsFor(node);
+        }
+
+        protected abstract Set<Node> getFilteredSuccessorsFor(Node node);
+    }
+
+    private class DoesNotFinalizeMembers extends ElementSuccessors {
+        @Override
+        protected Set<Node> getFilteredSuccessorsFor(Node node) {
+            // None of the finalized nodes are members of the group -> so all members should wait for all the finalized nodes
+            return getFinalizedNodes();
+        }
+    }
+
+    private class FinalizesMembers extends ElementSuccessors {
+        private final Set<Node> finalizedNodesThatCanStartAtAnyTime;
+
+        public FinalizesMembers() {
+            Set<Node> successors = getFinalizedNodes();
+            finalizedNodesThatCanStartAtAnyTime = new LinkedHashSet<>(successors.size());
+            for (Node successor : successors) {
+                if (!members.contains(successor) || memberCanStartAtAnyTime(successor)) {
+                    finalizedNodesThatCanStartAtAnyTime.add(successor);
+                }
+            }
+        }
+
+        @Override
+        protected Set<Node> getFilteredSuccessorsFor(Node node) {
+            // If the node is not finalized by this group, it should wait for all the finalized nodes
+            Set<Node> successors = getFinalizedNodes();
+            if (!successors.contains(node)) {
+                return successors;
+            }
+
+            // The node is also finalized by this group, so it should wait for those finalized nodes that can start at any time
+            return finalizedNodesThatCanStartAtAnyTime;
+        }
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
@@ -22,27 +22,4 @@ abstract class HasFinalizers extends NodeGroup {
     public abstract NodeGroup getOrdinalGroup();
 
     public abstract Set<FinalizerGroup> getFinalizerGroups();
-
-    /**
-     * Tries to add the node to the set of exclusive nodes of this group. If this group doesn't support
-     * exclusive nodes, e.g. it is a CompositeNodeGroup, then does nothing.
-     *
-     * The node should be an exclusive node of a single {@link FinalizerGroup} (though it can be non-exclusive member of multiple groups still),
-     * see that class' documentation for details.
-     *
-     * @param node the node to add to the set of exclusive nodes
-     */
-    public abstract void maybeAddToOwnedMembers(Node node);
-
-    /**
-     * Removes the node from the list of owned nodes of a finalizer group.
-     * Unlike {@link #maybeAddToOwnedMembers(Node)}, the removal affects all finalizer groups
-     * returned by {@link #getFinalizerGroups()}.
-     *
-     * The node should be an exclusive node of a single {@link FinalizerGroup} (though it can be non-exclusive member of multiple groups still),
-     * see that class' documentation for details.
-     *
-     * @param node the node
-     */
-    public abstract void removeFromOwnedMembers(Node node);
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -142,10 +142,7 @@ public abstract class Node implements Comparable<Node> {
         NodeGroup newGroup = group;
         for (Node predecessor : getDependencyPredecessors()) {
             if (predecessor.getGroup() instanceof HasFinalizers) {
-                HasFinalizers newGroupWithFinalizers = maybeInheritGroupAsFinalizerDependency((HasFinalizers) predecessor.getGroup(), newGroup);
-                // The first finalizer group to reach here would "own" this node if it isn't part of some ordinal group already.
-                newGroupWithFinalizers.maybeAddToOwnedMembers(this);
-                newGroup = newGroupWithFinalizers;
+                newGroup = maybeInheritGroupAsFinalizerDependency((HasFinalizers) predecessor.getGroup(), newGroup);
             }
         }
         if (newGroup != group) {
@@ -163,7 +160,7 @@ public abstract class Node implements Comparable<Node> {
         }
 
         HasFinalizers currentFinalizers = (HasFinalizers) current;
-        if (currentFinalizers.getFinalizerGroups().containsAll(finalizers.getFinalizerGroups())) {
+        if (currentFinalizers.isReachableFromEntryPoint() == finalizers.isReachableFromEntryPoint() && currentFinalizers.getFinalizerGroups().containsAll(finalizers.getFinalizerGroups())) {
             return currentFinalizers;
         }
 
@@ -476,7 +473,7 @@ public abstract class Node implements Comparable<Node> {
 
     @OverridingMethodsMustInvokeSuper
     public Iterable<Node> getAllSuccessors() {
-        return dependencySuccessors;
+        return getHardSuccessors();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskInAnotherBuild.java
@@ -161,7 +161,7 @@ public class TaskInAnotherBuild extends TaskNode implements SelfExecutingNode {
 
     @Override
     public String toString() {
-        return taskIdentityPath.toString();
+        return "other build task " + taskIdentityPath;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -71,10 +71,6 @@ public abstract class TaskNode extends Node {
         return finalizingSuccessors;
     }
 
-    public Set<Node> getFinalizingSuccessorsInReverseOrder() {
-        return finalizingSuccessors.descendingSet();
-    }
-
     public Set<Node> getShouldSuccessors() {
         return shouldSuccessors;
     }
@@ -156,12 +152,6 @@ public abstract class TaskNode extends Node {
         if (!getFinalizingSuccessors().isEmpty()) {
             // This node is a finalizer, decorate the current group to add finalizer behaviour
             NodeGroup oldGroup = getGroup();
-            if (oldGroup instanceof HasFinalizers) {
-                // The finalizer has its own scheduling logic. Its execution moment is determined by the node it finalizes.
-                // The other finalizer groups containing this node (as a dependency of the finalizer) should always consider it
-                // as a hard successor for group elements.
-                ((HasFinalizers) oldGroup).removeFromOwnedMembers(this);
-            }
             FinalizerGroup finalizerGroup = new FinalizerGroup(this, oldGroup);
             setGroup(finalizerGroup);
         }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -515,6 +515,28 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assertAllWorkComplete()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/21125")
+    def "finalizer dependency runs in parallel with finalized task when that dependency is also a dependency of a later entry point task"() {
+        given:
+        Task finalizer = createTask("finalizer")
+        Task finalizerDep = task("finalizerDep", type: Async)
+        Task a = task("a", type: Async, finalizedBy: [finalizer])
+        // Note: this task must be "ordered" greater than the finalizer to trigger the issue
+        Task b = task("zz", type: Async, dependsOn: [finalizerDep])
+        relationships(finalizer, dependsOn: [finalizerDep, b])
+
+        when:
+        addToGraphAndPopulate(a, b)
+
+        then:
+        executionPlan.tasks as List == [a, finalizerDep, b, finalizer]
+        assertTaskReady(a)
+        assertTaskReady(finalizerDep)
+        assertTaskReady(b)
+        assertTaskReadyAndNoMoreToStart(finalizer)
+        assertAllWorkComplete()
+    }
+
     def "finalizer dependency runs even when finalizer does not run when dependency is also an entry point task"() {
         given:
         Task finalizerDepDep = task("finalizerDepDep", type: Async)
@@ -615,6 +637,26 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assertAllWorkComplete()
     }
 
+    def "finalizer can have overlapping finalized nodes and dependencies"() {
+        given:
+        TaskInternal finalizer = createTask("finalizer")
+        TaskInternal finalizerDepA = task("finalizerDepA", type: Async, finalizedBy: [finalizer])
+        TaskInternal finalizerDepB = task("finalizerDepB", type: Async)
+        relationships(finalizer, dependsOn: [finalizerDepA, finalizerDepB])
+        TaskInternal entryPoint = task("entryPoint", type: Async, finalizedBy: [finalizer])
+
+        when:
+        addToGraphAndPopulate(entryPoint)
+
+        then:
+        executionPlan.tasks as List == [entryPoint, finalizerDepA, finalizerDepB, finalizer]
+        assertTaskReady(entryPoint)
+        assertTaskReady(finalizerDepA)
+        assertTaskReady(finalizerDepB)
+        assertTaskReadyAndNoMoreToStart(finalizer)
+        assertAllWorkComplete()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/21000")
     def "dependency of finalizers finalizing other finalizer do not start before the latter"() {
         given:
@@ -639,7 +681,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21000")
-    def "dependency of finalizers finalizing dependency of other finalizer do not start before this dependecy"() {
+    def "dependency of finalizers finalizing dependency of other finalizer do not start before this dependency"() {
         given:
         TaskInternal finalizerA = createTask("finalizerA", project, Async)
         TaskInternal finalizerB = createTask("finalizerB", project, Async)
@@ -663,6 +705,37 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assertAllWorkComplete()
     }
 
+    def "dependency of finalizers in chain of finalizers are deferred"() {
+        given:
+        TaskInternal finalizerA = createTask("finalizerA", project, Async)
+        TaskInternal finalizerB = createTask("finalizerB", project, Async)
+        TaskInternal finalizerC = createTask("finalizerC", project, Async)
+        TaskInternal finalizerD = createTask("finalizerD", project, Async)
+        TaskInternal finalizerDepA = task("finalizerDepA", type: Async, finalizedBy: [finalizerA, finalizerB])
+        TaskInternal finalizerDepB = task("finalizerDepB", type: Async, finalizedBy: [finalizerB, finalizerC])
+        TaskInternal finalizerDepC = task("finalizerDepC", type: Async, finalizedBy: [finalizerC, finalizerD])
+        TaskInternal finalizerDepD = task("finalizerDepD", type: Async, finalizedBy: [finalizerD])
+        relationships(finalizerA, dependsOn: [finalizerDepA])
+        relationships(finalizerB, dependsOn: [finalizerDepA, finalizerDepB])
+        relationships(finalizerC, dependsOn: [finalizerDepB, finalizerDepC])
+        relationships(finalizerD, dependsOn: [finalizerDepC, finalizerDepD])
+        TaskInternal entryPoint = task("entryPoint", type: Async, finalizedBy: [finalizerA])
+
+        when:
+        addToGraphAndPopulate(entryPoint)
+
+        then:
+        // TODO - finalizers are incorrectly ordered
+        executionPlan.tasks as List == [entryPoint, finalizerDepA, finalizerDepB, finalizerDepC, finalizerDepD, finalizerD, finalizerC, finalizerB, finalizerA]
+        assertTaskReady(entryPoint)
+        assertTaskReady(finalizerDepA)
+        assertTasksReady(finalizerDepB, finalizerA)
+        assertTasksReady(finalizerDepC, finalizerB)
+        assertTasksReady(finalizerDepD, finalizerC)
+        assertTaskReadyAndNoMoreToStart(finalizerD)
+        assertAllWorkComplete()
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/21000")
     def "finalizer dependencies reachable from entry point and finalized by the finalizer can run in parallel"() {
         TaskInternal finalizer = createTask("finalizer", project, Async)
@@ -678,6 +751,28 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         executionPlan.tasks as List == [finalizerDepA, finalizerDepB, finalizer, entryPoint]
         assertTasksReady(finalizerDepA, finalizerDepB)
         assertTasksReadyAndNoMoreToStart(finalizer, entryPoint)
+        assertAllWorkComplete()
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/21125")
+    def "multiple finalizers can depend on a task that they all finalize"() {
+        TaskInternal finalizerA = createTask("finalizerA", project, Async)
+        TaskInternal finalizerB = createTask("finalizerB", project, Async)
+        TaskInternal finalizerDepDep = task("finalizerDepDep", type: Async, finalizedBy: [finalizerA, finalizerB])
+        TaskInternal finalizerDep = task("finalizerDep", type: Async, dependsOn: [finalizerDepDep])
+        relationships(finalizerA, dependsOn: [finalizerDep])
+        relationships(finalizerB, dependsOn: [finalizerDep])
+        TaskInternal entryPoint = task("entryPoint", type: Async, finalizedBy: [finalizerA, finalizerB])
+
+        when:
+        addToGraphAndPopulate(entryPoint)
+
+        then:
+        executionPlan.tasks as List == [entryPoint, finalizerDepDep, finalizerDep, finalizerB, finalizerA]
+        assertTaskReady(entryPoint)
+        assertTaskReady(finalizerDepDep)
+        assertTaskReady(finalizerDep)
+        assertTasksReadyAndNoMoreToStart(finalizerB, finalizerA)
         assertAllWorkComplete()
     }
 


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context

Fixes a couple of cases:

- When a node is a dependency of and finalized by multiple independent finalizers.
- When a node is a dependency of a finalizer via multiple paths and one of those paths includes an entry point task

Reworks the scheduling of the members of a finalizer group so that:

- Finalized nodes that are not members, or that are members but reachable from an entry point, can start at any time.
- Member nodes that are also finalized wait until the previous nodes complete.
- Member nodes that are not finalized wait until the previous nodes complete.
- When the first set of nodes is empty (that is all finalized nodes are also members), then the second set of nodes wait for the first member to be able to start due to some other criteria other than its membership in the group.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
