### PR TITLE
Fix broken ChangesDuringTheBuildFileSystemWatchingIntegrationTest for M1

### DIFF
--- a/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
+++ b/subprojects/file-watching/src/integTest/groovy/org/gradle/internal/watch/ChangesDuringTheBuildFileSystemWatchingIntegrationTest.groovy
@@ -113,6 +113,8 @@ class ChangesDuringTheBuildFileSystemWatchingIntegrationTest extends AbstractFil
                 inputs.file(inputFile)
                 outputs.file(outputFile)
                 doLast {
+                    // Make sure the creation event for the build directory arrived
+                    Thread.sleep(40)
                     outputFile.text = inputFile.text
                 }
             }


### PR DESCRIPTION
The problem seems to be that the directory created event for the build directory comes in after we snapshotted the outputs of the consumer task. We don't ignore this event, since it is a parent of the output file. Though we could ignore `CREATED` events for directories if they are parents of already known things.

This may affect clean builds when you have real quick tasks. Though if the task is real quick, the saved state in the VFS is also not very "worthy".

This PR fixes the test by making the task run longer (introduce a sleep), causing the directory `CREATE` event to arrive before the task finishes executing.

Fixes https://github.com/gradle/gradle-private/issues/3537
