### PR TITLE
Fix lazy task configuration docs to recommend named(String, Action)

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
@@ -239,7 +239,7 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      *
      * @param name The object's name
      * @return A {@link Provider} that will return the object when queried. The object may be created and configured at this point, if not already.
-     * @throws UnknownDomainObjectException If a object with the given name is not defined.
+     * @throws UnknownDomainObjectException If an object with the given name is not defined.
      * @since 5.0
      */
     NamedDomainObjectProvider<T> named(String name, Action<? super T> configurationAction) throws UnknownDomainObjectException;
@@ -250,7 +250,7 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @param name The object's name
      * @param type The object's type
      * @return A {@link Provider} that will return the object when queried. The object may be created and configured at this point, if not already.
-     * @throws UnknownDomainObjectException If a object with the given name is not defined.
+     * @throws UnknownDomainObjectException If an object with the given name is not defined.
      * @since 5.0
      */
     <S extends T> NamedDomainObjectProvider<S> named(String name, Class<S> type) throws UnknownDomainObjectException;
@@ -263,7 +263,7 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @param type The object's type
      * @param configurationAction The action to use to configure the object.
      * @return A {@link Provider} that will return the object when queried. The object may be created and configured at this point, if not already.
-     * @throws UnknownDomainObjectException If a object with the given name is not defined.
+     * @throws UnknownDomainObjectException If an object with the given name is not defined.
      * @since 5.0
      */
     <S extends T> NamedDomainObjectProvider<S> named(String name, Class<S> type, Action<? super S> configurationAction) throws UnknownDomainObjectException;

--- a/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
+++ b/subprojects/docs/src/docs/userguide/extending-gradle/task_configuration_avoidance.adoc
@@ -196,7 +196,7 @@ This will cause your build to eagerly create fewer tasks that are registered by 
 
 2. **Migrate tasks configured by name.**
 Similar to the previous point, this will cause your build to eagerly create fewer tasks that are registered by plugins.
-For example, logic that uses `TaskContainer#getByName(String, Closure/Action)` should be converted to `TaskContainer#named(String).configure(Closure/Action)`.
+For example, logic that uses `TaskContainer#getByName(String, Closure)` should be converted to `TaskContainer#named(String, Action)`.
 This also includes <<#task_configuration_avoidance_pitfalls_hidden_eager_task_realization, task configuration via DSL blocks>>.
 
 3. **Migrate tasks creation to `register(...)`.**
@@ -247,7 +247,7 @@ image::taskConfigurationAvoidance-performance-annotated.png[]
 === Pitfalls
 
 * [[task_configuration_avoidance_pitfalls_hidden_eager_task_realization]] **Beware of the hidden eager task realization.**
-There are many ways that a task can be configured eagerly.  For example, configuring a task using the task name and a DSL block will cause the task to immediately be created:
+There are many ways that a task can be configured eagerly.  For example, configuring a task using the task name and a DSL block will cause the task to immediately be created when using the Groovy DSL:
 +
 [source,groovy]
 ----
@@ -264,7 +264,7 @@ Instead use the `named()` method to acquire a reference to the task and configur
 +
 [source,groovy]
 ----
-tasks.named("someTask").configure {
+tasks.named("someTask") {
     // ...
     // Beware of the pitfalls here
 }
@@ -424,7 +424,7 @@ It is highly recommended to have cross-version test coverage using <<test_kit.ad
 
 | Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskCollection.html#getByName-java.lang.String-groovy.lang.Closure-[TaskCollection.getByName(java.lang.String, groovy.lang.Closure)]
 .2+| This returns a `TaskProvider` instead of a `Task`.
-| Use: `named(java.lang.String).configure(Action)`
+| Use: `named(java.lang.String, Action)`
 
 | Instead of: link:{javadocPath}/org/gradle/api/tasks/TaskContainer.html#getByPath-java.lang.String-[TaskContainer.getByPath(java.lang.String)]
 .2+| Accessing tasks from another project requires a specific ordering of project evaluation.


### PR DESCRIPTION
We originally only supported named(String).configure(Action) as an idiom
