### PR TITLE
Fix flakiness of `ConfigurationCacheCompositeBuildsIntegrationTest`

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -278,7 +278,7 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
             settingsFile "includeBuild '$it'\n"
         }
         buildFile '''
-            ['clean', 'build'].each { name ->
+            ['clean', 'jar'].each { name ->
                 tasks.register(name) {
                     gradle.includedBuilds.each { build ->
                         dependsOn(build.task(':' + name))
@@ -307,19 +307,19 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
         def configurationCache = newConfigurationCacheFixture()
 
         when:
-        configurationCacheRun 'clean', 'build'
+        configurationCacheRun 'clean', 'jar'
 
         then:
         configurationCache.assertStateStored()
 
         when:
-        configurationCacheRun 'clean', 'build'
+        configurationCacheRun 'clean', 'jar'
 
         then:
         configurationCache.assertStateLoaded()
 
         and:
-        result.assertTaskOrder(':lib:build', ':util:build', ':build')
+        result.assertTaskOrder(':lib:jar', ':util:jar', ':jar')
 
         where:
         order << ['lib', 'util'].permutations()


### PR DESCRIPTION
By running the `jar` task instead of the `build` task for deterministic ordering between `:util:jar` and `:lib:jar` since `util` has an `api` dependency on `lib`.