### PR TITLE
Fix flakiness in `ConfigurationCacheCompositeBuildsIntegrationTest`

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheCompositeBuildsIntegrationTest.groovy
@@ -278,7 +278,7 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
             settingsFile "includeBuild '$it'\n"
         }
         buildFile '''
-            ['clean', 'jar'].each { name ->
+            ['clean', 'compileJava'].each { name ->
                 tasks.register(name) {
                     gradle.includedBuilds.each { build ->
                         dependsOn(build.task(':' + name))
@@ -307,19 +307,19 @@ class ConfigurationCacheCompositeBuildsIntegrationTest extends AbstractConfigura
         def configurationCache = newConfigurationCacheFixture()
 
         when:
-        configurationCacheRun 'clean', 'jar'
+        configurationCacheRun 'clean', 'compileJava'
 
         then:
         configurationCache.assertStateStored()
 
         when:
-        configurationCacheRun 'clean', 'jar'
+        configurationCacheRun 'clean', 'compileJava'
 
         then:
         configurationCache.assertStateLoaded()
 
         and:
-        result.assertTaskOrder(':lib:jar', ':util:jar', ':jar')
+        result.assertTaskOrder(':lib:compileJava', ':util:compileJava', ':compileJava')
 
         where:
         order << ['lib', 'util'].permutations()


### PR DESCRIPTION
By using `compileJava` instead of `jar` since artifact dependencies between projects from different builds don't imply a `jar` dependency but certainly imply a `compileJava` dependency.