### PR TITLE
support for --export-keys without --write-verification-metadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/verification/DependencyVerificationSignatureWriteIntegTest.groovy
@@ -443,4 +443,39 @@ class DependencyVerificationSignatureWriteIntegTest extends AbstractSignatureVer
         keyringsAscii.size() == 1
         keyringsAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
     }
+
+    @Issue("https://github.com/gradle/gradle/issues/18567")
+    def "--export-keys can export keys even with without --write-verification-metadata"() {
+        def keyring = newKeyRing()
+        createMetadataFile {
+            keyServer(keyServerFixture.uri)
+            addTrustedKey("org:foo:1.0.0", SigningFixtures.validPublicKeyHexString)
+        }
+
+        given:
+        javaLibrary()
+        uncheckedModule("org", "foo", "1.0") {
+            withSignature {
+                keyring.sign(it, [(SigningFixtures.validSecretKey): SigningFixtures.validPassword])
+            }
+        }
+        buildFile << """
+            dependencies {
+                implementation "org:foo:1.0"
+            }
+        """
+
+        when:
+        serveValidKey()
+        keyServerFixture.registerPublicKey(keyring.publicKey)
+        succeeds "build", "--export-keys"
+
+        then:
+        outputContains("Exported 1 keys to")
+        def exportedKeyRingAscii = file("gradle/verification-keyring.keys")
+        exportedKeyRingAscii.exists()
+        def keyringsAscii = SecuritySupport.loadKeyRingFile(exportedKeyRingAscii)
+        keyringsAscii.size() == 1
+        keyringsAscii.find { it.publicKey.keyID == SigningFixtures.validPublicKey.keyID }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -104,7 +104,7 @@ public class StartParameterResolutionOverride {
                                                                          BuildCommencedTimeProvider timeProvider,
                                                                          Factory<GradleProperties> gradlePropertiesFactory) {
         List<String> checksums = startParameter.getWriteDependencyVerifications();
-        if (!checksums.isEmpty()) {
+        if (!checksums.isEmpty() || startParameter.isExportKeys()) {
             File verificationsFile = DependencyVerificationOverride.dependencyVerificationsFile(gradleDir);
             return DisablingVerificationOverride.of(
                 new WriteDependencyVerificationFile(verificationsFile, keyRing.get(), buildOperationExecutor, checksums, checksumService, signatureVerificationServiceFactory, startParameter.isDryRun(), startParameter.isExportKeys())

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -142,9 +142,15 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         this.isExportKeyring = exportKeyRing;
     }
 
+    private boolean isWriteVerificationFile() {
+        return !checksums.isEmpty();
+    }
+
     private void validateChecksums() {
-        assertSupportedChecksums();
-        warnAboutInsecureChecksums();
+        if (isWriteVerificationFile()) {
+            assertSupportedChecksums();
+            warnAboutInsecureChecksums();
+        }
     }
 
     private void assertSupportedChecksums() {
@@ -154,9 +160,6 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
                 // in the build and the user feedback isn't great ("cannot create service blah!")
                 LOGGER.warn("Invalid checksum type: '" + checksum + "'. You must choose one or more in " + SUPPORTED_CHECKSUMS);
             }
-        }
-        if (checksums.isEmpty()) {
-            throw new DependencyVerificationException("You must specify at least one checksum type to use. You must choose one or more in " + SUPPORTED_CHECKSUMS);
         }
         assertPgpHasChecksumFallback(checksums);
     }
@@ -218,10 +221,12 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             verificationsBuilder.setVerifySignatures(true);
         }
         DependencyVerifier verifier = verificationsBuilder.build();
-        DependencyVerificationsXmlWriter.serialize(
-            verifier,
-            new FileOutputStream(out)
-        );
+        if (isWriteVerificationFile()) {
+            DependencyVerificationsXmlWriter.serialize(
+                verifier,
+                new FileOutputStream(out)
+            );
+        }
         if (isExportKeyring) {
             exportKeys(signatureVerificationService, verifier);
         }

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -573,15 +573,17 @@ If you use git and use the binary version, make sure to make it treat this file 
 *.gpg           binary
 ----
 
-You can also ask Gradle to export all keys without updating the verification metadata file:
+====
+
+You can also ask Gradle to export all trusted keys without updating the verification metadata file:
 
 ----
 ./gradlew --export-keys
 ----
 
 [NOTE]
+====
 This command disables signature verification, similar to `--write-verification-metadata`.
-
 ====
 
 [[sec:bootstrapping-signature-verification]]

--- a/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/01-core-dependency-management/dependency_verification.adoc
@@ -572,6 +572,16 @@ If you use git and use the binary version, make sure to make it treat this file 
 ----
 *.gpg           binary
 ----
+
+You can also ask Gradle to export all keys without updating the verification metadata file:
+
+----
+./gradlew --export-keys
+----
+
+[NOTE]
+This command disables signature verification, similar to `--write-verification-metadata`.
+
 ====
 
 [[sec:bootstrapping-signature-verification]]


### PR DESCRIPTION
Fixes: #18567

Signed-off-by: Jeff Gaston <gastoj3@gmail.com>

### Context

When starting to use dependency verification, it had been confusing to us that --export-keys didn't have any effect without --write-verification-metadata

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
