### PR TITLE
[WIP] Running the docs tests with the CC enabled

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -122,6 +122,7 @@ object BuildParams {
     const val AUTO_DOWNLOAD_ANDROID_STUDIO = "autoDownloadAndroidStudio"
     const val RUN_ANDROID_STUDIO_IN_HEADLESS_MODE = "runAndroidStudioInHeadlessMode"
     const val STUDIO_HOME = "studioHome"
+    const val CONFIGURATION_CACHE_FOR_DOCS_TESTS_ENABLED = "enableConfigurationCacheForDocsTests"
 
     internal
     val VENDOR_MAPPING = mapOf("oracle" to JvmVendorSpec.ORACLE, "openjdk" to JvmVendorSpec.ADOPTIUM)

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -1,3 +1,4 @@
+import gradlebuild.basics.BuildParams
 import gradlebuild.integrationtests.model.GradleDistribution
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.docs.internal.tasks.CheckLinks
@@ -60,6 +61,7 @@ dependencies {
     docsTestImplementation project(":logging")
     docsTestImplementation libs.junit5Vintage
     docsTestImplementation libs.junit
+    docsTestImplementation libs.guava
 
     integTestDistributionRuntimeOnly project(":distributions-full")
 }
@@ -571,6 +573,10 @@ tasks.withType(InstallSample).configureEach {
     }
 }
 
+def isConfigurationCacheEnabledForDocsTests() {
+    return Boolean.parseBoolean(providers.gradleProperty(BuildParams.CONFIGURATION_CACHE_FOR_DOCS_TESTS_ENABLED).getOrNull())
+}
+
 // TODO add some kind of test precondition support in sample test conf
 tasks.named("docsTest") { task ->
     maxParallelForks = 2
@@ -641,6 +647,232 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching "org.gradle.docs.samples.*.snippet-native*.sample"
             excludeTestsMatching "org.gradle.docs.samples.*.snippet-swift*.sample"
             excludeTestsMatching "org.gradle.docs.samples.*.building-swift*.sample"
+        }
+    }
+
+    if (isConfigurationCacheEnabledForDocsTests()) {
+        systemProperty("org.gradle.integtest.samples.withConfigurationCache", "true")
+        systemProperty("org.gradle.integtest.executer", "configCache")
+
+        filter {
+            // Configuration cache samples enable configuration cache explicitly.
+            excludeTestsMatching "org.gradle.docs.samples.*.snippet-configuration-cache-*.sample"
+
+            // Broken tests
+            [
+                // cannot serialize Gradle script object references
+                "snippet-dependency-management-customizing-resolution-attribute-substitution-rule_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-capability-substitution-rule_kotlin_capability_substitution.sample",
+                // Task `:lib:compileJava` of type `org.gradle.api.tasks.compile.JavaCompile`: value 'configuration ':lib:compileClasspath'' failed to visit file collection
+                "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_groovy_resolve.sample",
+                // Also cannot serialize Gradle script object references as these are not supported with the configuration cache.
+                "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_kotlin_resolve.sample",
+                // cannot serialize Gradle script object references
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFiles.sample",
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFilesLocal.sample",
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_kotlin_ivyComonentMetadataRule.sample",
+                "snippet-dependency-management-customizing-resolution-metadata-rule_kotlin_comonentMetadataRules.sample",
+                "snippet-dependency-management-defining-using-configurations-custom_kotlin_custom-configuration.sample",
+                "snippet-dependency-management-dependency-verification-disabling-verification_kotlin_disabling_verification.sample",
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-configuration_kotlin_exclude-transitive-for-configuration.sample",
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_kotlin_exclude-transitive-for-dependency.sample",
+                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_kotlin_accessingMetadataArtifact.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-artifacts_kotlin_iterating-artifacts.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",
+                // Task `:walkDependencyGraph` of type `DependencyGraphWalk`: cannot serialize object of type 'DefaultConfiguration$ConfigurationResolvableDependencies'
+                "snippet-dependency-management-working-with-dependencies-walk-graph_groovy_walking-dependency-graph.sample",
+                "snippet-dependency-management-working-with-dependencies-walk-graph_kotlin_walking-dependency-graph.sample",
+                // Plugin 'com.android.internal.application': registration of listener on 'TaskExecutionGraph.addTaskExecutionListener' is unsupported
+                "snippet-kotlin-dsl-android-build_kotlin_sanityCheck.sample",
+                "snippet-kotlin-dsl-android-single-build_kotlin_sanityCheck.sample",
+                // 4 problems were found storing the configuration cache, 3 of which seem unique.
+                //- Task `:domain:compileJava` of type `org.gradle.api.tasks.compile.JavaCompile`: value 'configuration ':domain:compileClasspath'' failed to visit file collection
+                //- Task `:domain:compileTestJava` of type `org.gradle.api.tasks.compile.JavaCompile`: value 'file collection' failed to visit file collection
+                //- Task `:domain:test` of type `org.gradle.api.tasks.testing.Test`: value 'file collection' failed to visit file collection
+                "snippet-kotlin-dsl-multi-project-build_kotlin_build.sample",
+                // cannot serialize Gradle script object references
+                "snippet-testing-test-suite-multi-configure-each-extracted_kotlin_checkTask.sample",
+                "snippet-testing-test-suite-multi-configure-each-matching_kotlin_checkTask.sample",
+                "snippet-testing-test-suite-multi-configure-each_kotlin_checkTask.sample",
+                "snippet-tutorial-ant-loadfile-with-method_kotlin_antLoadfileWithMethod.sample",
+                "snippet-tutorial-ant-loadfile_kotlin_antLoadfile.sample",
+
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-tutorial-configure-task-using-project-property_groovy_configureTaskUsingProjectProperty.sample",
+                "snippet-tutorial-configure-task-using-project-property_kotlin_configureTaskUsingProjectProperty.sample",
+                // cannot serialize Gradle script object references
+                "snippet-tutorial-extra-properties_kotlin_extraProperties.sample",
+                "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
+                "snippet-files-archive-naming_kotlin_archiveNaming.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-files-archives-changed-base-name_groovy_zipWithArchivesBaseName.sample",
+                "snippet-files-archives-changed-base-name_kotlin_zipWithArchivesBaseName.sample", // + cannot serialize Gradle script object references
+                // cannot serialize Gradle script object references
+                "snippet-files-file-collections_kotlin_fileCollectionsFiltering.sample",
+                "snippet-files-file-collections_kotlin_fileCollectionsUsage.sample",
+                "snippet-files-file-collections_kotlin_fileCollectionsWithClosure.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-java-cross-compilation_kotlin_java7CrossCompilation.sample",
+                "snippet-java-custom-dirs_groovy_javaCustomReportDirs.sample",
+                "snippet-java-custom-dirs_kotlin_javaCustomReportDirs.sample",  // + cannot serialize Gradle script object references
+
+                // cannot serialize Gradle script object references
+                "snippet-java-fixtures_kotlin_javaTestFixtures.sample",
+                "snippet-maven-publish-conditional-publishing_kotlin_publishingMavenConditionally.sample",
+                "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",
+                "snippet-tasks-custom-task-with-missing-file-property_kotlin_missingFileProperties.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-tasks-incremental-build-custom-task-class_groovy_customTaskClassWithInputOutputAnnotations.sample",
+                "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep.sample",  // + cannot serialize object of type 'org.example.ProcessTemplates'
+                "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep2.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_customTaskClassWithInputOutputAnnotations.sample",
+                // cannot serialize Gradle script object references
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_incrementalAdHocTask.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_incrementalAdHocTaskNoSource.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_inferredTaskDep.sample",  // + cannot serialize object of type 'org.example.ProcessTemplates'
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_inferredTaskDep2.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildCustomMethods.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildCustomMethodsWithTaskArg.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildInputFilesConfig.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildInputFilesConfigUsingTask.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildUpToDateWhen.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_inferredTaskDependencyWithBuiltBy.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildCustomMethods.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildCustomMethodsWithTaskArg.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildInputFilesConfig.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildInputFilesConfigUsingTask.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildUpToDateWhen.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_inferredTaskDependencyWithBuiltBy.sample",
+                // cannot serialize Gradle script object references
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskChangedProperty.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskFirstRun.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskNoChange.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskRemovedInput.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskRemovedOutput.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskUpdatedInputs.sample",
+                // ANT
+                "snippet-ant-add-behaviour-to-ant-target_groovy_addBehaviourToAntTarget.sample",
+                "snippet-ant-add-behaviour-to-ant-target_kotlin_addBehaviourToAntTarget.sample",
+                "snippet-ant-depends-on-ant-target_groovy_dependsOnAntTarget.sample",
+                "snippet-ant-depends-on-ant-target_kotlin_dependsOnAntTarget.sample",
+                "snippet-ant-depends-on-task_groovy_dependsOnTask.sample",
+                "snippet-ant-depends-on-task_kotlin_dependsOnTask.sample",
+                "snippet-ant-hello_groovy_antHello.sample",
+                "snippet-ant-hello_kotlin_antHello.sample",
+                "snippet-ant-rename-task_groovy_renameAntDelegate.sample",
+                "snippet-ant-rename-task_kotlin_renameAntDelegate.sample",
+                // cannot serialize Gradle script object references
+                "snippet-ant-use-external-ant-task-with-config_kotlin_useExternalAntTaskWithConfig.sample",
+                "snippet-artifacts-generated-file-dependencies_kotlin_generatedFileDependencies.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-build-cache-cacheable-bundle-task_groovy_cacheableBundleTask.sample",
+                "snippet-build-cache-cacheable-bundle-task_kotlin_cacheableBundleTask.sample",
+                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle-caching.sample",
+                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle.sample",
+                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle-caching.sample",
+                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle.sample", // + cannot serialize Gradle script object references
+                // cannot serialize object of type 'org.gradle.api.internal.project.DefaultProject'
+                "snippet-buildlifecycle-project-evaluate-events_groovy_projectEvaluateEvents.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-buildlifecycle-project-evaluate-events_kotlin_projectEvaluateEvents.sample",
+
+                // registration of listener on 'TaskExecutionGraph.afterTask'
+                "snippet-buildlifecycle-task-execution-events_groovy_sanityCheck.sample",
+                "snippet-buildlifecycle-task-execution-events_groovy_taskExecutionEvents.groovy.sample",
+                "snippet-buildlifecycle-task-execution-events_kotlin_sanityCheck.sample",
+                "snippet-buildlifecycle-task-execution-events_kotlin_taskExecutionEvents.kotlin.sample",
+                // invocation of 'Task.project' at execution time is unsupported
+                "snippet-custom-model-internal-views_groovy_softwareModelExtend-iv-model.sample",
+                "snippet-custom-model-language-type_groovy_softwareModelExtend-components.sample",
+
+                // ECLIPSE
+                "snippet-ide-eclipse_groovy_wtpWithXml.sample",
+                "snippet-ide-eclipse_kotlin_wtpWithXml.sample",
+                // IDEA
+                "snippet-ide-idea-additional-test-sources_groovy_ideaAdditionalTestSources.sample",
+                "snippet-ide-idea-additional-test-sources_kotlin_ideaAdditionalTestSources.sample",
+                "snippet-ide-idea_groovy_projectWithXml.sample",
+                "snippet-ide-idea_kotlin_projectWithXml.sample",
+                // cannot serialize Gradle script object references
+                "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
+                "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
+                // IVY-publish
+                // field 'onlyIfSpec' from type 'org.gradle.api.publish.tasks.GenerateModuleMetadata'
+                "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
+                // cannot serialize object of type 'org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublication'
+                "snippet-ivy-publish-descriptor-customization_groovy_publishingIvyGenerateDescriptor.sample",
+                "snippet-ivy-publish-descriptor-customization_kotlin_publishingIvyGenerateDescriptor.sample",
+                // field 'onlyIfSpec' from type 'org.gradle.api.publish.tasks.GenerateModuleMetadata'
+                "snippet-ivy-publish-java-multi-project_groovy_publish-multi-project.sample",
+                "snippet-ivy-publish-java-multi-project_kotlin_publish-multi-project.sample",
+                "snippet-ivy-publish-quickstart_groovy_publishingIvyPublishLifecycle.sample",
+                "snippet-ivy-publish-quickstart_groovy_publishingIvyPublishSingle.sample",
+                "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishLifecycle.sample",
+                "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishSingle.sample",
+                // Build Model
+                "snippet-model-rules-basic-rule-source-plugin_groovy_basicRuleSourcePlugin-all.sample",
+                // invocation of 'Task.project' at execution time is unsupported.
+                "snippet-model-rules-basic-rule-source-plugin_groovy_basicRuleSourcePlugin-model-task.sample",
+                // Build Model
+                "snippet-model-rules-configure-as-required_groovy_modelDslConfigureRuleRunWhenRequired.sample",
+                "snippet-model-rules-configure-elements-of-map_groovy_modelDslModelMapNestedAll.sample",
+                "snippet-model-rules-initialization-rule-runs-before-configuration-rules_groovy_modelDslInitializationRuleRunsBeforeConfigurationRule.sample",
+                // invocation of 'Task.project' at execution time is unsupported.
+                "snippet-native-binaries-cpp_groovy_nativeComponentReport.sample",
+                // Native C++
+                "snippet-native-binaries-cunit_groovy_assembleDependentComponents.sample",
+                // invocation of 'Task.project' at execution time is unsupported.
+                "snippet-native-binaries-cunit_groovy_assembleDependentComponentsReport.sample",
+                // Native C++
+                "snippet-native-binaries-cunit_groovy_buildDependentComponents.sample",
+                // invocation of 'Task.project' at execution time is unsupported.
+                "snippet-native-binaries-cunit_groovy_buildDependentComponentsReport.sample",
+                // Native C++
+                "snippet-native-binaries-cunit_groovy_completeCUnitExample.sample",
+                // invocation of 'Task.project' at execution time is unsupported.
+                "snippet-native-binaries-cunit_groovy_dependentComponentsReport.sample",
+                "snippet-native-binaries-cunit_groovy_dependentComponentsReportAll.sample",
+                // failed to unpack provider
+                "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
+                "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
+                // cannot serialize Gradle script object references
+                "snippet-providers-property-convention_kotlin_propertyConvention.sample",
+                // SIGNING
+                "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
+                "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",
+                "snippet-signing-maven-publish_groovy_publishingMavenSignAndPublish.sample",
+                "snippet-signing-maven-publish_groovy_signingPluginSignPublication.sample",
+                "snippet-signing-maven-publish_kotlin_publishingMavenSignAndPublish.sample",
+                "snippet-signing-maven-publish_kotlin_signingPluginSignPublication.sample",
+                "snippet-signing-tasks_groovy_signingTaskOutput.sample",
+                "snippet-signing-tasks_kotlin_signingTaskOutput.sample",
+                // field 'onlyIfSpec' from type 'org.gradle.api.publish.tasks.GenerateModuleMetadata'
+                "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
+
+                // C++
+                "building-cpp-applications_groovy_build.sample",
+                "building-cpp-applications_kotlin_build.sample",
+                "building-cpp-libraries_groovy_build.sample",
+                "building-cpp-libraries_kotlin_build.sample",
+                // field 'spec' from type 'org.gradle.api.publish.maven.tasks.PublishToMavenRepository'
+                "publishing-credentials_groovy_publishCommandLineCredentials.sample",
+                "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
+                // Kotlin Plugin
+                "structuring-software-projects_groovy_aggregate-reports.sample",
+                "structuring-software-projects_groovy_build-server-application.sample",
+                "structuring-software-projects_groovy_umbrella-build.sample",  // + Plugin 'com.android.internal.application': registration of listener on 'TaskExecutionGraph.addTaskExecutionListener'
+                "structuring-software-projects_kotlin_aggregate-reports.sample",
+                "structuring-software-projects_kotlin_build-server-application.sample",
+                "structuring-software-projects_kotlin_umbrella-build.sample",  // + Plugin 'com.android.internal.application': registration of listener on 'TaskExecutionGraph.addTaskExecutionListener'
+
+                // invocation of 'Task.project' at execution time is unsupported.
+                "task-with-arguments_groovy_projectInfoTask.sample",
+                "task-with-arguments_kotlin_projectInfoTask.sample",
+            ].forEach { testName ->
+                excludeTestsMatching "org.gradle.docs.samples.*.$testName"
+            }
         }
     }
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -45,7 +45,8 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
 })
 @SampleModifiers({
     SetMirrorsSampleModifier.class,
-    MoreMemorySampleModifier.class
+    MoreMemorySampleModifier.class,
+    OptionalConfigurationCacheOutputSampleModifier.class
 })
 /*
  * To run the samples tests:
@@ -61,4 +62,3 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
  */
 abstract class BaseSamplesTest {
 }
-

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/OptionalConfigurationCacheOutputSampleModifier.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/OptionalConfigurationCacheOutputSampleModifier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.docs.samples;
+
+
+import com.google.common.base.Splitter;
+import org.gradle.exemplar.model.Command;
+import org.gradle.exemplar.model.Sample;
+import org.gradle.exemplar.test.runner.SampleModifier;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class OptionalConfigurationCacheOutputSampleModifier implements SampleModifier {
+    private static final String ENABLE_CONFIGURATION_CACHE_OUTPUT = "org.gradle.integtest.samples.withConfigurationCache";
+    private static final String OPTIONAL_LINE_PREFIX = "?? ";
+
+    @Override
+    public Sample modify(Sample sampleIn) {
+        if (!hasOutput(sampleIn)) {
+            return sampleIn;
+        }
+        boolean shouldUseOptionalOutput = Boolean.parseBoolean(System.getProperty(ENABLE_CONFIGURATION_CACHE_OUTPUT));
+        Function<Command, Command> commandTransformer = shouldUseOptionalOutput ? this::useOptionalConfigurationCacheOutput : this::stripOptionalConfigurationCacheOutput;
+
+        return new Sample(
+            sampleIn.getId(),
+            sampleIn.getProjectDir(),
+            sampleIn.getCommands().stream().map(commandTransformer).collect(Collectors.toList()));
+    }
+
+    private boolean hasOutput(Sample sample) {
+        for (Command command : sample.getCommands()) {
+            if (command.getExpectedOutput() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Command stripOptionalConfigurationCacheOutput(Command cmd) {
+        return toCommandWithTransformedOutput(cmd, line -> null);
+    }
+
+    private Command useOptionalConfigurationCacheOutput(Command cmd) {
+        return toCommandWithTransformedOutput(cmd, line -> line);
+    }
+
+    private Command toCommandWithTransformedOutput(Command cmdIn, Function<String, String> optionalOutputLineTransformer) {
+        String expectedOutput = cmdIn.getExpectedOutput();
+        if (expectedOutput == null) {
+            // No output is specified for this command, no transformation is necessary, use it as is
+            return cmdIn;
+        }
+        Splitter lineSplitter = Splitter.on('\n');
+        return cmdIn.toBuilder().setExpectedOutput(lineSplitter.splitToStream(expectedOutput).map(line -> {
+            if (line.startsWith(OPTIONAL_LINE_PREFIX)) {
+                return optionalOutputLineTransformer.apply(line.substring(OPTIONAL_LINE_PREFIX.length()));
+            }
+            return line;
+        }).filter(Objects::nonNull).collect(Collectors.joining("\n"))).build();
+    }
+}

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/base-dependency-insight.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/base-dependency-insight.out
@@ -158,3 +158,4 @@ A web-based, searchable dependency report is available by adding the --scan opti
 
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed
+?? Configuration cache entry stored.

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/fixed-dependency-insight.out
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-consistentResolution/tests/fixed-dependency-insight.out
@@ -162,3 +162,4 @@ A web-based, searchable dependency report is available by adding the --scan opti
 
 BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed
+?? Configuration cache entry stored.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheOutputNormalizer.groovy
@@ -19,12 +19,17 @@ package org.gradle.integtests.fixtures.logging
 import org.gradle.exemplar.executor.ExecutionMetadata
 import org.gradle.exemplar.test.normalizer.OutputNormalizer
 
+import java.util.regex.Pattern
+
 class ConfigurationCacheOutputNormalizer implements OutputNormalizer {
     @Override
     String normalize(String output, ExecutionMetadata executionMetadata) {
         return output.replaceAll(
             "configuration-cache/.*/configuration-cache-report",
             "configuration-cache/<hash>/configuration-cache-report"
-        )
+        ).replaceAll("Configuration cache entry stored\\.(\\n)?", "")
+        .replaceAll("\\d+ problem(s)? were found storing the configuration cache\\.(\\n)(\\n)", "")
+        .replaceAll("See the complete report at file:///home/user/gradle/samples/build/reports/configuration-cache/<hash>/configuration-cache-report.html(\\n)(\\n)", "")
+
     }
 }


### PR DESCRIPTION
New behavior is enabled in docs:docsTest with a global build flag. It
changes the executor to the one with configuration cache enabled and
toggles the golden output preprocessor mode. The flag is inevitable,
as the docsTest cannot be cloned easily (lots of non-trivial
configuration comes from the binary guides plugin).

The golden output preprocessor allow to add "?? " prefixed lines to
golden outputs. Without CC these lines are removed before the test.
With CC these lines are stripped of prefix and used for the
verification. The approach has its problems though, when the output
is included into the docs. An option could be to use asciidoctor's
tags to strip out this lines from the docs too. Or maybe a custom
include processor that understands "?? " properly could help. There
is also an output normalizer that strips all configuration cache from
the output.

The necessary level of strictness is still unclear: can we just have
"allow unmatched lines" enabled everywhere? Do we care about the CC output?
Do we need to show CC output in the docs.

There is an ignorelist of tests broken because of something other than
output too.
