### PR TITLE
Use --cross-version-only for flakiness detection build

### DIFF
--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -320,7 +320,7 @@ enum class PerformanceTestType(
         timeout = 600,
         defaultBaselines = "flakiness-detection-commit",
         channel = "flakiness-detection",
-        extraParameters = "--checks none --rerun"
+        extraParameters = "--checks none --rerun --cross-version-only"
     ),
     historical(
         displayName = "Historical Performance Test",


### PR DESCRIPTION
To fix the error here: https://builds.gradle.org/viewLog.html?buildId=53727990&buildTypeId=Gradle_Master_Check_PerformanceTestFlakinessDetectionLinux_Trigger

Because `FlakinessReportGenerator` uses `CrossVersionResultsStore` to query the data and there is no data for cross build performance tests.