### PR TITLE
Let the Tooling API control system properties contributed from the client-side

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -407,6 +407,11 @@ testLauncher.withTestsFor(spec -> {
 }).run();
 ```
 
+#### Added support for passing system properties to the build with the Tooling API
+
+Before 7.6, the Tooling API started builds with the system properties from the host JVM. This leaked configuration from the IDE to the build.
+Starting in Gradle 7.6, `LongRunningOperation.withSystemProperties(Map)` provides an isolated set of build system properties.
+For more information, see [`LongRunningOperation`](javadoc/org/gradle/tooling/LongRunningOperation.html#withSystemProperties-java.util.Map-).
 
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ADD RELEASE FEATURES ABOVE

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -149,9 +149,16 @@ public class DaemonParameters {
 
     public Map<String, String> getEffectiveSystemProperties() {
         Map<String, String> systemProperties = new HashMap<String, String>();
+        GUtil.addToMap(systemProperties, System.getProperties());
         GUtil.addToMap(systemProperties, jvmOptions.getMutableSystemProperties());
         GUtil.addToMap(systemProperties, jvmOptions.getImmutableDaemonProperties());
-        GUtil.addToMap(systemProperties, System.getProperties());
+        return systemProperties;
+    }
+
+    public Map<String, String> getMutableAndImmutableSystemProperties() {
+        Map<String, String> systemProperties = new HashMap<String, String>();
+        GUtil.addToMap(systemProperties, jvmOptions.getMutableSystemProperties());
+        GUtil.addToMap(systemProperties, jvmOptions.getImmutableDaemonProperties());
         return systemProperties;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionOperationParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ConnectionOperationParameters.java
@@ -19,17 +19,25 @@ package org.gradle.tooling.internal.provider;
 import org.gradle.launcher.daemon.configuration.DaemonParameters;
 import org.gradle.tooling.internal.provider.connection.ProviderOperationParameters;
 
+import java.util.Map;
+
 public class ConnectionOperationParameters {
     private final DaemonParameters daemonParameters;
+    private final Map<String, String> tapiSystemProperties;
     private final ProviderOperationParameters operationParameters;
 
-    public ConnectionOperationParameters(DaemonParameters daemonParameters, ProviderOperationParameters operationParameters) {
+    public ConnectionOperationParameters(DaemonParameters daemonParameters, Map<String, String> tapiSystemProperties, ProviderOperationParameters operationParameters) {
         this.daemonParameters = daemonParameters;
+        this.tapiSystemProperties = tapiSystemProperties;
         this.operationParameters = operationParameters;
     }
 
     public DaemonParameters getDaemonParameters() {
         return daemonParameters;
+    }
+
+    public Map<String, String> getTapiSystemProperties() {
+        return tapiSystemProperties;
     }
 
     public ProviderOperationParameters getOperationParameters() {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DaemonBuildActionExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/DaemonBuildActionExecuter.java
@@ -40,7 +40,7 @@ public class DaemonBuildActionExecuter implements BuildActionExecuter<Connection
         ClassPath classPath = DefaultClassPath.of(operationParameters.getInjectedPluginClasspath());
 
         DaemonParameters daemonParameters = parameters.getDaemonParameters();
-        BuildActionParameters actionParameters = new DefaultBuildActionParameters(daemonParameters.getEffectiveSystemProperties(), daemonParameters.getEnvironmentVariables(), SystemProperties.getInstance().getCurrentDir(), operationParameters.getBuildLogLevel(), daemonParameters.isEnabled(), classPath);
+        BuildActionParameters actionParameters = new DefaultBuildActionParameters(parameters.getTapiSystemProperties(), daemonParameters.getEnvironmentVariables(), SystemProperties.getInstance().getCurrentDir(), operationParameters.getBuildLogLevel(), daemonParameters.isEnabled(), classPath);
         return executer.execute(action, actionParameters, buildRequestContext);
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -79,6 +79,7 @@ import org.gradle.tooling.internal.provider.serialization.SerializedPayload;
 import org.gradle.tooling.internal.provider.test.ProviderInternalTestExecutionRequest;
 import org.gradle.tooling.model.build.BuildEnvironment;
 import org.gradle.util.GradleVersion;
+import org.gradle.util.internal.GUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +87,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -219,7 +221,7 @@ public class ProviderConnection {
             BuildActionExecuter<ConnectionOperationParameters, BuildRequestContext> executer = createExecuter(providerParameters, parameters);
             boolean interactive = providerParameters.getStandardInput() != null;
             BuildRequestContext buildRequestContext = new DefaultBuildRequestContext(new DefaultBuildRequestMetaData(providerParameters.getStartTime(), interactive), cancellationToken, buildEventConsumer);
-            BuildActionResult result = executer.execute(action, new ConnectionOperationParameters(parameters.daemonParams, providerParameters), buildRequestContext);
+            BuildActionResult result = executer.execute(action, new ConnectionOperationParameters(parameters.daemonParams, parameters.tapiSystemProperties, providerParameters), buildRequestContext);
             throwFailure(result);
             return payloadSerializer.deserialize(result.getResult());
         } finally {
@@ -261,7 +263,7 @@ public class ProviderConnection {
         if (Boolean.TRUE.equals(operationParameters.isEmbedded())) {
             loggingManager = sharedServices.getFactory(LoggingManagerInternal.class).create();
             loggingManager.captureSystemSources();
-            executer = new StdInSwapExecuter(standardInput, embeddedExecutor);
+            executer = new SystemPropertySetterExecuter(new StdInSwapExecuter(standardInput, embeddedExecutor));
         } else {
             LoggingServiceRegistry loggingServices = LoggingServiceRegistry.newNestedLogging();
             loggingManager = loggingServices.getFactory(LoggingManagerInternal.class).create();
@@ -324,18 +326,29 @@ public class ProviderConnection {
             daemonParams.setIdleTimeout(idleTimeout);
         }
 
-        return new Parameters(daemonParams, buildLayoutResult, properties);
+        Map<String, String> effectiveSystemProperties = new HashMap<>();
+        Map<String, String> operationParametersSystemProperties = operationParameters.getSystemProperties(null);
+        if (operationParametersSystemProperties != null) {
+            effectiveSystemProperties.putAll(operationParametersSystemProperties);
+            effectiveSystemProperties.putAll(daemonParams.getMutableAndImmutableSystemProperties());
+        } else {
+            GUtil.addToMap(effectiveSystemProperties, System.getProperties());
+            effectiveSystemProperties.putAll(daemonParams.getMutableAndImmutableSystemProperties());
+        }
+        return new Parameters(daemonParams, buildLayoutResult, properties, effectiveSystemProperties);
     }
 
     private static class Parameters {
         final DaemonParameters daemonParams;
         final BuildLayoutResult buildLayout;
         final AllProperties properties;
+        final Map<String, String> tapiSystemProperties;
 
-        public Parameters(DaemonParameters daemonParams, BuildLayoutResult buildLayout, AllProperties properties) {
+        public Parameters(DaemonParameters daemonParams, BuildLayoutResult buildLayout, AllProperties properties, Map<String, String> tapiSystemProperties) {
             this.daemonParams = daemonParams;
             this.buildLayout = buildLayout;
             this.properties = properties;
+            this.tapiSystemProperties = tapiSystemProperties;
         }
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SystemPropertySetterExecuter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/SystemPropertySetterExecuter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider;
+
+import org.gradle.initialization.BuildRequestContext;
+import org.gradle.internal.invocation.BuildAction;
+import org.gradle.launcher.exec.BuildActionExecuter;
+import org.gradle.launcher.exec.BuildActionParameters;
+import org.gradle.launcher.exec.BuildActionResult;
+
+import java.util.Properties;
+
+public class SystemPropertySetterExecuter implements BuildActionExecuter<BuildActionParameters, BuildRequestContext> {
+
+    private final BuildActionExecuter<BuildActionParameters, BuildRequestContext> delegate;
+
+    public SystemPropertySetterExecuter(BuildActionExecuter<BuildActionParameters, BuildRequestContext> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BuildActionResult execute(BuildAction action, BuildActionParameters actionParameters, BuildRequestContext buildRequestContext) {
+        Properties originalProperties = System.getProperties();
+        Properties updatedProperties = new Properties();
+        updatedProperties.putAll(originalProperties);
+        updatedProperties.putAll(actionParameters.getSystemProperties());
+        System.setProperties(updatedProperties);
+        try {
+            return delegate.execute(action, actionParameters, buildRequestContext);
+        } finally {
+            System.setProperties(originalProperties);
+        }
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/connection/ProviderOperationParameters.java
@@ -171,4 +171,10 @@ public interface ProviderOperationParameters {
      * @since 2.8-rc-1
      */
     List<File> getInjectedPluginClasspath();
+
+    /**
+     * @return Additional system properties defined by the client to be available in the build.
+     * @since 7.6
+     */
+    Map<String, String> getSystemProperties(Map<String, String> defaultValue);
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/SystemPropertyPropagationCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/SystemPropertyPropagationCrossVersionTest.groovy
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r76
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildLauncher
+import org.gradle.util.GradleVersion
+
+@ToolingApiVersion('>=7.6')
+@TargetGradleVersion('>=7.6')
+class SystemPropertyPropagationCrossVersionTest extends ToolingApiSpecification {
+
+    OutputStream out
+
+    def setup() {
+        out = new ByteArrayOutputStream()
+        System.setProperty('mySystemProperty', 'defined in the client JVM')
+        buildFile << '''
+            tasks.register('printSystemProperty') {
+                doLast {
+                    System.properties.each { k, v ->
+                        println("$k=$v")
+                    }
+                }
+            }
+        '''
+    }
+
+    @TargetGradleVersion(">=2.6 <7.6")
+    def "Custom system properties are ignored in older Gradle versions"() {
+        setup:
+        if (targetDist.version < GradleVersion.version('4.9') ) {
+            buildFile.text = buildFile.text.replace('tasks.register', 'tasks.create')
+        }
+
+        when:
+        runTask { withSystemProperties('mySystemProperty' : 'ignored') }
+
+        then:
+        hasSystemProperty('mySystemProperty', 'defined in the client JVM')
+    }
+
+    def "Client JVM system properties appear in the build if withSystemProperties() is not called"() {
+        when:
+        runTask()
+
+        then:
+        hasSystemProperty('mySystemProperty', 'defined in the client JVM')
+    }
+
+    def "Client JVM system properties do not appear in the build if withSystemProperties() is called"() {
+        setup:
+        toolingApi.requireDaemons() // no separate daemon JVM -> all client JVM system properties are expected to be visible
+
+        when:
+        runTask { withSystemProperties('unrelated' : 'value') }
+
+        then:
+        hasNoSystemProperty('mySystemProperty')
+    }
+
+    def "Calling withSystemProperties(null) resets to default behavior"() {
+        when:
+        runTask {
+            withSystemProperties('unrelated' : 'value')
+            withSystemProperties(null)
+        }
+
+        then:
+        hasSystemProperty('mySystemProperty', 'defined in the client JVM')
+    }
+
+    def "Passing an empty map to withSystemProperties() hides all client system properties"() {
+        setup:
+        toolingApi.requireDaemons() // no separate daemon JVM -> all client JVM system properties are expected to be visible
+
+        when:
+        runTask { withSystemProperties([:]) }
+
+        then:
+        hasNoSystemProperty('mySystemProperty')
+    }
+
+    def "Can define new system property"() {
+        when:
+        runTask { withSystemProperties('customKey' : 'customValue') }
+
+        then:
+        hasSystemProperty('customKey', 'customValue')
+    }
+
+    def "Can override existing system properties"() {
+        when:
+        runTask { withSystemProperties('mySystemProperty' : 'newValue') }
+
+        then:
+        hasSystemProperty('mySystemProperty', 'newValue')
+    }
+
+    def "JVM arguments have precedence over system properties"() {
+        when:
+        runTask {
+            withSystemProperties('customKey' : 'syspropValue')
+            addJvmArguments('-DcustomKey=jvmargValue')
+        }
+
+        then:
+        hasSystemProperty('customKey', 'jvmargValue')
+    }
+
+    def "Cannot modify immutable system properties"() {
+        setup:
+        toolingApi.requireDaemons() // no separate daemon JVM -> no immutable system properties
+
+        when:
+        String customTmpDir = System.getProperty('java.io.tmpdir') + System.getProperty('path.separator') + 'custom'
+        runTask {
+            withSystemProperties('java.io.tmpdir' : customTmpDir)
+        }
+
+        then:
+        hasNoSystemProperty('java.io.tmpdir', customTmpDir)
+    }
+
+    private void runTask(@DelegatesTo(value = BuildLauncher, strategy = Closure.DELEGATE_ONLY) Closure<?> launcherSpec = {}) {
+        withConnection {
+            def launcher = newBuild().forTasks('printSystemProperty')
+            launcherSpec.delegate = launcher
+            launcherSpec()
+            launcher.setStandardOutput(out)
+            launcher.run()
+        }
+    }
+
+    private boolean hasNoSystemProperty(String key, String value = null) {
+        !out.toString().contains("$key=${value ?: ""}")
+    }
+
+    private boolean hasSystemProperty(String key, String value) {
+        out.toString().contains("$key=$value")
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/ConfigurableLauncher.java
@@ -117,6 +117,13 @@ public interface ConfigurableLauncher<T extends ConfigurableLauncher<T>> extends
 
     /**
      * {@inheritDoc}
+     * @since 7.6
+     */
+    @Override
+    T withSystemProperties(Map<String, String> systemProperties);
+
+    /**
+     * {@inheritDoc}
      * @since 5.0
      */
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/LongRunningOperation.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.tooling;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationType;
 
 import javax.annotation.Nullable;
@@ -119,6 +120,28 @@ public interface LongRunningOperation {
      * @since 5.0
      */
     LongRunningOperation addJvmArguments(String... jvmArguments);
+
+    /**
+     * Sets system properties to pass to the build.
+     * <p>
+     * By default, the Tooling API passes all system properties defined in the client to the build. If called, this method limits the system properties that are passed to the build, except for
+     * immutable system properties that need to match on both sides.
+     * <p>
+     * System properties can be also defined in the build scripts (and in the gradle.properties file), or with a JVM argument. In case of an overlapping system property definition the precedence is as follows:
+     * <ul>
+     *     <li>{@code withSystemProperties()} (highest)</li>
+     *     <li>{@code withJvmArguments()}</li>
+     *     <li>build scripts</li>
+     * </ul>
+     * <p>
+     * Note: this method has "setter" behavior, so the last invocation will overwrite previously set values.
+     *
+     * @param systemProperties the system properties add to the Gradle process. Passing {@code null} resets to the default behavior.
+     * @return this
+     * @since 7.6
+     */
+    @Incubating
+    LongRunningOperation withSystemProperties(Map<String, String> systemProperties);
 
     /**
      * Appends Java VM arguments to the existing list.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
@@ -127,6 +127,12 @@ public abstract class AbstractLongRunningOperation<T extends AbstractLongRunning
     }
 
     @Override
+    public T withSystemProperties(Map<String, String> systemProperties) {
+        operationParamsBuilder.setSystemProperties(systemProperties);
+        return getThis();
+    }
+
+    @Override
     public T addJvmArguments(Iterable<String> jvmArguments) {
         operationParamsBuilder.addJvmArguments(CollectionUtils.toList(Preconditions.checkNotNull(jvmArguments)));
         return getThis();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
@@ -71,6 +71,7 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
         private List<String> tasks;
         private List<InternalLaunchable> launchables;
         private ClassPath injectedPluginClasspath = ClassPath.EMPTY;
+        private Map<String, String> systemProperties;
 
         private Builder() {
         }
@@ -182,6 +183,11 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
             return this;
         }
 
+        public Builder setSystemProperties(Map<String, String> systemProperties) {
+            this.systemProperties = systemProperties;
+            return this;
+        }
+
         public void addProgressListener(org.gradle.tooling.ProgressListener listener) {
             legacyProgressListeners.add(listener);
         }
@@ -208,7 +214,7 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
             }
 
             return new ConsumerOperationParameters(entryPoint, parameters, stdout, stderr, colorOutput, stdin, javaHome, jvmArguments, envVariables, arguments, tasks, launchables, injectedPluginClasspath,
-                legacyProgressListeners, progressListeners, cancellationToken);
+                legacyProgressListeners, progressListeners, cancellationToken, systemProperties);
         }
 
         public void copyFrom(ConsumerOperationParameters operationParameters) {
@@ -226,6 +232,7 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
             colorOutput = operationParameters.colorOutput;
             javaHome = operationParameters.javaHome;
             injectedPluginClasspath = operationParameters.injectedPluginClasspath;
+            systemProperties = operationParameters.systemProperties;
         }
     }
 
@@ -252,9 +259,12 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
     private final List<org.gradle.tooling.ProgressListener> legacyProgressListeners;
     private final Map<OperationType, List<ProgressListener>> progressListeners;
 
+    private final Map<String, String> systemProperties;
+
     private ConsumerOperationParameters(String entryPointName, ConnectionParameters parameters, OutputStream stdout, OutputStream stderr, Boolean colorOutput, InputStream stdin,
                                         File javaHome, List<String> jvmArguments,  Map<String, String> envVariables, List<String> arguments, List<String> tasks, List<InternalLaunchable> launchables, ClassPath injectedPluginClasspath,
-                                        List<org.gradle.tooling.ProgressListener> legacyProgressListeners, Map<OperationType, List<ProgressListener>> progressListeners, CancellationToken cancellationToken) {
+                                        List<org.gradle.tooling.ProgressListener> legacyProgressListeners, Map<OperationType, List<ProgressListener>> progressListeners, CancellationToken cancellationToken,
+                                        Map<String, String> systemProperties) {
         this.entryPointName = entryPointName;
         this.parameters = parameters;
         this.stdout = stdout;
@@ -271,6 +281,7 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
         this.cancellationToken = cancellationToken;
         this.legacyProgressListeners = legacyProgressListeners;
         this.progressListeners = progressListeners;
+        this.systemProperties = systemProperties;
 
         // create the listener adapters right when the ConsumerOperationParameters are instantiated but no earlier,
         // this ensures that when multiple requests are issued that are built from the same builder, such requests do not share any state kept in the listener adapters
@@ -440,6 +451,13 @@ public class ConsumerOperationParameters implements org.gradle.tooling.internal.
 
     public BuildCancellationToken getCancellationToken() {
         return ((CancellationTokenInternal) cancellationToken).getToken();
+    }
+
+    /**
+     * @since 7.6
+     */
+    public  Map<String, ?> getSystemProperties() {
+        return systemProperties;
     }
 
 }


### PR DESCRIPTION
Fixes #17745
Spec: https://docs.google.com/document/d/1eM8E_fajrCF_O-5R-_1VyCuPk4kpW5LJshqcrYZFoxo/edit#

When a client executes a Gradle build invocation via the Tooling API, [all system properties](https://github.com/gradle/gradle/blob/master/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java#L154) from the client JVM are passed to the daemon. This is not desired, especially for IntelliJ IDEA, as it uses a large number of system properties that could potentially break the build (e.g. `java.system.class.loader`).

This pull request introduces `LongRunningOperation.withSystemProperties(Map)` to let the TAPI client control what system properties are available for the target build from the client JVM. The exact behavior is defined in [SystemPropertyPropagationCrossVersionTest](https://github.com/gradle/gradle/pull/21223/files#diff-67f55edd35e95eb55dbb8d746cfe62d9ea174edc8e271dea9c7428abcda76132).

The new API has an effect only if the target Gradle version is >=7.6.

