### PR TITLE
Fix flaky TaskExecutionIntegrationTest

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskExecutionIntegrationTest.groovy
@@ -164,7 +164,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             // An action attached to built-in task
             task a { doLast { assert Thread.currentThread().contextClassLoader == getClass().classLoader } }
-        
+
             // An action defined by a custom task
             task b(type: CustomTask)
             class CustomTask extends DefaultTask {
@@ -172,7 +172,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
                     assert Thread.currentThread().contextClassLoader == getClass().classLoader
                 }
             }
-        
+
             // An action implementation
             task c
             class DoLast implements Action<Task> {
@@ -181,7 +181,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
             c.doLast new DoLast()
-        
+
             // The following is NOT compatible with the configuration cache because anonymous inner classes
             // in a groovy script always capture the script object reference:
             //   c.doLast new Action<Task>() {
@@ -332,7 +332,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
             task c(dependsOn: ['a', 'b'])
             task d
             c.mustRunAfter d
-        
+
         """
         expect:
         2.times {
@@ -603,7 +603,7 @@ class TaskExecutionIntegrationTest extends AbstractIntegrationSpec {
         expect:
         2.times {
             succeeds ':build'
-            result.assertTasksExecutedInOrder ':b:jar', ':a:compileJava', any(':a:compileFinalizer', ':a:jar'), ':build'
+            result.assertTasksExecutedInOrder ':b:jar', ':a:compileJava', any(':a:compileFinalizer', ':a:jar', ':build')
         }
     }
 


### PR DESCRIPTION
Because `:build` can be executed before `:a:compileFinalizer`. 

Example: https://ge.gradle.org/s/76ielnow6gjc2/tests/:integ-test:configCacheIntegTest/org.gradle.integtests.TaskExecutionIntegrationTest/executes%20finalizer%20task%20as%20soon%20as%20possible%20after%20finalized%20task?expanded-stacktrace=WyIwLTEiXQ&top-execution=1
