### PR TITLE
Update Kotlin examples for shared configuration of test suites to work with configuration cache enabled

### DIFF
--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/kotlin/build.gradle.kts
@@ -59,18 +59,22 @@ testing {
 // end::multi-configure[]
 
 val checkDependencies by tasks.registering {
-    dependsOn(
-        configurations.getByName("testRuntimeClasspath"),
-        configurations.getByName("integrationTestRuntimeClasspath"),
-        configurations.getByName("functionalTestRuntimeClasspath")
-    )
+    val testRuntimeClasspath = configurations.getByName("testRuntimeClasspath")
+    val integrationTestRuntimeClasspath = configurations.getByName("integrationTestRuntimeClasspath")
+    val functionalTestRuntimeClasspath = configurations.getByName("functionalTestRuntimeClasspath")
+
+    val testRuntimeClasspathFiles = testRuntimeClasspath.files
+    val integrationTestRuntimeClasspathFiles = integrationTestRuntimeClasspath.files
+    val functionalTestRuntimeClasspathFiles = functionalTestRuntimeClasspath.files
+
+    dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(configurations.getByName("testRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("testRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.size == 3)
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "junit-4.13.2.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "commons-lang3-3.11.jar" })
+        assert(testRuntimeClasspathFiles.size == 12)
+        assert(testRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(integrationTestRuntimeClasspathFiles.size == 12)
+        assert(integrationTestRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(functionalTestRuntimeClasspathFiles.size == 3)
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "junit-4.13.2.jar" })
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "commons-lang3-3.11.jar" })
     }
 }

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/kotlin/build.gradle.kts
@@ -46,18 +46,22 @@ testing {
 // end::multi-configure[]
 
 val checkDependencies by tasks.registering {
-    dependsOn(
-        configurations.getByName("testRuntimeClasspath"),
-        configurations.getByName("integrationTestRuntimeClasspath"),
-        configurations.getByName("functionalTestRuntimeClasspath")
-    )
+    val testRuntimeClasspath = configurations.getByName("testRuntimeClasspath")
+    val integrationTestRuntimeClasspath = configurations.getByName("integrationTestRuntimeClasspath")
+    val functionalTestRuntimeClasspath = configurations.getByName("functionalTestRuntimeClasspath")
+
+    val testRuntimeClasspathFiles = testRuntimeClasspath.files
+    val integrationTestRuntimeClasspathFiles = integrationTestRuntimeClasspath.files
+    val functionalTestRuntimeClasspathFiles = functionalTestRuntimeClasspath.files
+
+    dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(configurations.getByName("testRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("testRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.size == 3)
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "junit-4.13.2.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "commons-lang3-3.11.jar" })
+        assert(testRuntimeClasspathFiles.size == 12)
+        assert(testRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(integrationTestRuntimeClasspathFiles.size == 12)
+        assert(integrationTestRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(functionalTestRuntimeClasspathFiles.size == 3)
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "junit-4.13.2.jar" })
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "commons-lang3-3.11.jar" })
     }
 }

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
@@ -48,18 +48,22 @@ testing {
 // end::multi-configure[]
 
 val checkDependencies by tasks.registering {
-    dependsOn(
-        configurations.getByName("testRuntimeClasspath"),
-        configurations.getByName("integrationTestRuntimeClasspath"),
-        configurations.getByName("functionalTestRuntimeClasspath")
-    )
+    val testRuntimeClasspath = configurations.getByName("testRuntimeClasspath")
+    val integrationTestRuntimeClasspath = configurations.getByName("integrationTestRuntimeClasspath")
+    val functionalTestRuntimeClasspath = configurations.getByName("functionalTestRuntimeClasspath")
+
+    val testRuntimeClasspathFiles = testRuntimeClasspath.files
+    val integrationTestRuntimeClasspathFiles = integrationTestRuntimeClasspath.files
+    val functionalTestRuntimeClasspathFiles = functionalTestRuntimeClasspath.files
+
+    dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(configurations.getByName("testRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("testRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.size == 12)
-        assert(configurations.getByName("integrationTestRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.size == 13)
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(configurations.getByName("functionalTestRuntimeClasspath").files.any { it.name == "commons-lang3-3.11.jar" })
+        assert(testRuntimeClasspathFiles.size == 12)
+        assert(testRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(integrationTestRuntimeClasspathFiles.size == 12)
+        assert(integrationTestRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(functionalTestRuntimeClasspathFiles.size == 13)
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
+        assert(functionalTestRuntimeClasspathFiles.any { it.name == "commons-lang3-3.11.jar" })
     }
 }


### PR DESCRIPTION
Preemptively correcting some snippets which will fail when configuration caching is enabled for all snippets/samples.