### PR TITLE
Re-enable `GradleBuildSanityCheckConfigurationCacheSmokeTest`

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class GradleBuildSanityCheckConfigurationCacheSmokeTest extends AbstractGradleBuildConfigurationCacheSmokeTest {
 
-    @spock.lang.Ignore
     def "can run Gradle sanityCheck with configuration cache enabled"() {
 
         given:

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
@@ -62,7 +62,7 @@ class GradleBuildSanityCheckConfigurationCacheSmokeTest extends AbstractGradleBu
         result.task(":configuration-cache:validatePlugins").outcome == TaskOutcome.FROM_CACHE
         result.task(":configuration-cache:codenarcIntegTest").outcome == TaskOutcome.FROM_CACHE
         result.task(":configuration-cache:checkstyleIntegTestGroovy").outcome == TaskOutcome.FROM_CACHE
-        result.task(":configuration-cache:classycleIntegTest").outcome == TaskOutcome.FROM_CACHE
+        result.task(":configuration-cache:archTest").outcome == TaskOutcome.FROM_CACHE
         result.task(":configuration-cache:codeQuality").outcome == TaskOutcome.UP_TO_DATE
         result.task(":docs:checkstyleApi").outcome == TaskOutcome.FROM_CACHE
         result.task(":internal-build-reports:allIncubationReportsZip").outcome == TaskOutcome.SUCCESS

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleBuildSanityCheckConfigurationCacheSmokeTest.groovy
@@ -21,12 +21,11 @@ import org.gradle.testkit.runner.TaskOutcome
 class GradleBuildSanityCheckConfigurationCacheSmokeTest extends AbstractGradleBuildConfigurationCacheSmokeTest {
 
     def "can run Gradle sanityCheck with configuration cache enabled"() {
-
         given:
         // This is an approximation, running the whole build lifecycle 'sanityCheck' is too expensive
         // See build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
         def tasks = [
-            ':configuration-cache:sanityCheck',
+            ":configuration-cache:sanityCheck",
             ":docs:checkstyleApi",
             ":internal-build-reports:allIncubationReportsZip",
             ":architecture-test:checkBinaryCompatibility",


### PR DESCRIPTION
This reverts commit bd40fa05f46e7f5d4acb0b8b04b6155fb2008ae7 since the underlying problem has been fixed.