### PR TITLE
Add ability to use closure-like methods on props

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
@@ -26,7 +26,7 @@ class CallablePropertyIntegrationTest extends AbstractIntegrationSpec {
     }
 
     def "can call a property on a NDOC"() {
-        given:
+        when:
         buildFile << """
             class CallableItem {
                 def counter = 0
@@ -56,14 +56,11 @@ class CallablePropertyIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            println("The property was called " + container.foo.prop.counter + " times")
+            assert container.foo.prop.counter == 3
         """
 
-        when:
-        succeeds 'help'
-
         then:
-        outputContains("The property was called 3 times")
+        succeeds 'help'
     }
 
     def "cannot call a property on a NDOC with no call method (in #context)"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/internal/extensibility/CallablePropertyIntegrationTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.extensibility
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class CallablePropertyIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << "rootProject.name='callable-property-test'"
+    }
+
+    def "can call a property on a NDOC"() {
+        given:
+        buildFile << """
+            class CallableItem {
+                def counter = 0
+                void call() {
+                    counter++
+                }
+            }
+
+            abstract class NamedThing implements Named {
+                private final CallableItem prop = new CallableItem()
+
+                CallableItem getProp() {
+                    return prop
+                }
+            }
+
+            def container = objects.domainObjectContainer(NamedThing)
+            container.register("foo")
+
+            container.foo.prop()
+            configure(container.foo) {
+                prop()
+            }
+            container.configure {
+                foo {
+                    prop()
+                }
+            }
+
+            println("The property was called " + container.foo.prop.counter + " times")
+        """
+
+        when:
+        succeeds 'help'
+
+        then:
+        outputContains("The property was called 3 times")
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/MixInClosurePropertiesAsMethodsDynamicObject.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/MixInClosurePropertiesAsMethodsDynamicObject.java
@@ -22,6 +22,8 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.internal.metaobject.BeanDynamicObject;
 import org.gradle.internal.metaobject.CompositeDynamicObject;
 import org.gradle.internal.metaobject.DynamicInvokeResult;
+import org.gradle.internal.metaobject.DynamicObject;
+import org.gradle.internal.metaobject.DynamicObjectUtil;
 
 /**
  * Exposes methods for those properties whose value is a closure.
@@ -53,6 +55,8 @@ public abstract class MixInClosurePropertiesAsMethodsDynamicObject extends Compo
                 ((NamedDomainObjectContainer) property).configure((Closure) arguments[0]);
                 return DynamicInvokeResult.found();
             }
+            DynamicObject dynamicObject = DynamicObjectUtil.asDynamicObject(property);
+            return dynamicObject.tryInvokeMethod("call", arguments);
         }
         return DynamicInvokeResult.notFound();
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensibleDynamicObjectTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/extensibility/ExtensibleDynamicObjectTest.java
@@ -537,6 +537,17 @@ public class ExtensibleDynamicObjectTest {
     }
 
     @Test
+    public void canInvokeClosureLikePropertyAsAMethod() {
+        Bean bean = new Bean();
+        bean.defineProperty("someMethod", new Object() {
+            public String call(String param) {
+                return param.toLowerCase();
+            }
+        });
+        assertThat(bean.invokeMethod("someMethod", "Param"), equalTo("param"));
+    }
+
+    @Test
     public void invokeMethodFailsForUnknownMethod() {
         Bean bean = new Bean();
         try {


### PR DESCRIPTION
This aligns with Groovy's default behavior that will get a property and invoke `call` on it; i.e. for code like `foo()` it will get the value of `foo` property and invoke `call()` on it.

This is part of work on #21209 to allow the Groovy syntax to work properly.