### PR TITLE
Remove environment variable capture in build-logic test

### DIFF
--- a/build-logic/performance-testing/build.gradle.kts
+++ b/build-logic/performance-testing/build.gradle.kts
@@ -43,11 +43,3 @@ tasks.compileGroovy.configure {
 tasks.compileKotlin.configure {
     classpath += files(tasks.compileGroovy)
 }
-
-tasks.withType<Test>().configureEach {
-    // PerformanceTestIntegrationTest needs a clean environment
-    val testEnv = System.getenv().toMutableMap()
-    testEnv.remove("BUILD_BRANCH")
-    testEnv.remove("BUILD_COMMIT_ID")
-    setEnvironment(testEnv)
-}


### PR DESCRIPTION
Because it may break configuration cache.
