### PR TITLE
Improve testability of DetermineBaselines task

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/PerformanceTestPlugin.kt
@@ -26,6 +26,7 @@ import gradlebuild.basics.androidStudioHome
 import gradlebuild.basics.autoDownloadAndroidStudio
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.buildCommitId
+import gradlebuild.basics.defaultPerformanceBaselines
 import gradlebuild.basics.includePerformanceTestScenarios
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.performanceBaselines
@@ -329,6 +330,8 @@ class PerformanceTestPlugin : Plugin<Project> {
 
         determineBaselines.configure {
             configuredBaselines.set(extension.baselines)
+            defaultBaselines.set(project.defaultPerformanceBaselines)
+            logicalBranch.set(project.logicalBranch)
         }
 
         buildCommitDistribution.configure {

--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/DetermineBaselines.kt
@@ -16,9 +16,7 @@
 
 package gradlebuild.performance.tasks
 
-import gradlebuild.basics.defaultPerformanceBaselines
 import gradlebuild.basics.kotlindsl.execAndGetStdout
-import gradlebuild.basics.logicalBranch
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
@@ -39,6 +37,12 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
     @get:Internal
     abstract val determinedBaselines: Property<String>
 
+    @get:Internal
+    abstract val defaultBaselines: Property<String>
+
+    @get:Internal
+    abstract val logicalBranch: Property<String>
+
     @TaskAction
     fun determineForkPointCommitBaseline() {
         if (configuredBaselines.getOrElse("") == flakinessDetectionCommitBaseline) {
@@ -48,7 +52,7 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
         } else if (!currentBranchIsMasterOrRelease()) {
             determinedBaselines.set(forkPointCommitBaseline())
         } else {
-            determinedBaselines.set(project.defaultPerformanceBaselines)
+            determinedBaselines.set(defaultBaselines)
         }
 
         println("Determined baseline is: ${determinedBaselines.get()}")
@@ -64,7 +68,7 @@ abstract class DetermineBaselines @Inject constructor(@get:Internal val distribu
     fun determineFlakinessDetectionBaseline() = if (distributed) flakinessDetectionCommitBaseline else currentCommitBaseline()
 
     private
-    fun currentBranchIsMasterOrRelease() = project.logicalBranch.get() in listOf("master", "release")
+    fun currentBranchIsMasterOrRelease() = logicalBranch.get() in listOf("master", "release")
 
     private
     fun currentCommitBaseline() = commitBaseline(project.execAndGetStdout("git", "rev-parse", "HEAD"))

--- a/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
+++ b/build-logic/performance-testing/src/test/kotlin/gradlebuild/performance/tasks/DetermineBaselinesTest.kt
@@ -22,16 +22,14 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.kotlin.dsl.*
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Assume
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
+import org.junit.jupiter.api.Assertions
 
 
-@Ignore
 class DetermineBaselinesTest {
     private
     val project = ProjectBuilder.builder().build()
@@ -45,7 +43,6 @@ class DetermineBaselinesTest {
 
     @Before
     fun setUp() {
-        project.extra["defaultPerformanceBaselines"] = defaultPerformanceBaselines
         project.file("version.txt").writeText("1.0")
 
         // mock project.execAndGetStdout
@@ -59,7 +56,7 @@ class DetermineBaselinesTest {
 
     @Test
     fun `keeps flakiness-detection-commit as it is in coordinator build`() {
-        verifyBaselineDetermination(true, flakinessDetectionCommitBaseline, flakinessDetectionCommitBaseline)
+        verifyBaselineDetermination("any", true, flakinessDetectionCommitBaseline, flakinessDetectionCommitBaseline)
     }
 
     @Test
@@ -70,13 +67,12 @@ class DetermineBaselinesTest {
         mockGitOperation(listOf("git", "rev-parse", "--short", "current"), "current")
 
         // then
-        verifyBaselineDetermination(false, flakinessDetectionCommitBaseline, "5.0-commit-current")
+        verifyBaselineDetermination("any", false, flakinessDetectionCommitBaseline, "5.0-commit-current")
     }
 
     @Test
     fun `determines fork point commit on feature branch and default configuration`() {
         // given
-        setCurrentBranch("my-branch")
         mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")
         mockGitOperation(listOf("git", "merge-base", "origin/master", "HEAD"), "master-fork-point")
         mockGitOperation(listOf("git", "merge-base", "origin/release", "HEAD"), "release-fork-point")
@@ -84,7 +80,7 @@ class DetermineBaselinesTest {
         mockGitOperation(listOf("git", "rev-parse", "--short", "master-fork-point"), "master-fork-point")
 
         // then
-        verifyBaselineDetermination(false, null, "5.1-commit-master-fork-point")
+        verifyBaselineDetermination("my-branch", false, null, "5.1-commit-master-fork-point")
     }
 
     @Test
@@ -92,7 +88,6 @@ class DetermineBaselinesTest {
         // Windows git complains "long path" so we don't build commit distribution on Windows
         Assume.assumeFalse(OperatingSystem.current().isWindows)
         // given
-        setCurrentBranch("my-branch")
         mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")
         mockGitOperation(listOf("git", "merge-base", "origin/master", "HEAD"), "master-fork-point")
         mockGitOperation(listOf("git", "merge-base", "origin/release", "HEAD"), "release-fork-point")
@@ -100,25 +95,17 @@ class DetermineBaselinesTest {
         mockGitOperation(listOf("git", "rev-parse", "--short", "master-fork-point"), "master-fork-point")
 
         // then
-        verifyBaselineDetermination(false, null, "5.1-commit-master-fork-point")
+        verifyBaselineDetermination("my-branch", false, null, "5.1-commit-master-fork-point")
     }
 
     @Test
     fun `uses configured version on master branch`() {
-        // given
-        setCurrentBranch("master")
-
-        // then
-        verifyBaselineDetermination(false, defaultPerformanceBaselines, defaultPerformanceBaselines)
+        verifyBaselineDetermination("master", false, defaultPerformanceBaselines, defaultPerformanceBaselines)
     }
 
     @Test
     fun `uses configured version when it is overwritten on feature branch`() {
-        // given
-        setCurrentBranch("my-branch")
-
-        // then
-        verifyBaselineDetermination(false, "any", "any")
+        verifyBaselineDetermination("my-branch", false, "any", "any")
     }
 
     private
@@ -135,15 +122,17 @@ class DetermineBaselinesTest {
     }
 
     private
-    fun verifyBaselineDetermination(isCoordinatorBuild: Boolean, configuredBaseline: String?, determinedBaseline: String) {
+    fun verifyBaselineDetermination(currentBranch: String, isCoordinatorBuild: Boolean, configuredBaseline: String?, determinedBaseline: String) {
         // given
         val determineBaselinesTask = createDetermineBaselinesTask(isCoordinatorBuild)
 
         // when
+        determineBaselinesTask.logicalBranch.set(currentBranch)
         determineBaselinesTask.configuredBaselines.set(configuredBaseline)
+        determineBaselinesTask.defaultBaselines.set(defaultPerformanceBaselines)
         determineBaselinesTask.determineForkPointCommitBaseline()
 
         // then
-        assert(determineBaselinesTask.determinedBaselines.get() == determinedBaseline)
+        Assertions.assertEquals(determinedBaseline, determineBaselinesTask.determinedBaselines.get())
     }
 }


### PR DESCRIPTION
Previously, `DetermineBaselines` task depends on two project properties
`project.defaultBaselines` and `project.buildBranch`, which makes
it a bit hard to test. Nowe we extract them to improve testability.
