### PR TITLE
Use IDataDriver for MultiVersionTests

### DIFF
--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -22,6 +22,7 @@ val googleApiVersion = "1.25.0" // See usage before attempting to upgrade
 val jacksonVersion = "2.13.3"
 val jaxbVersion = "3.0.0"
 val jettyVersion = "9.4.36.v20210114"
+val junit5Version = "5.8.2"
 val mavenVersion = "3.6.3"
 val nativePlatformVersion = "0.22-milestone-23"
 val slf4jVersion = "1.7.30"
@@ -34,7 +35,7 @@ val bytebuddyVersion = "1.10.20"
 javaPlatform.allowDependencies()
 
 dependencies {
-    api(platform("org.junit:junit-bom:5.8.2!!"))
+    api(platform("org.junit:junit-bom:${junit5Version}!!"))
 
     constraints {
         api(libs.ansiControlSequenceUtil) { version { strictly("0.3") }}
@@ -110,6 +111,9 @@ dependencies {
         api(libs.jsr305)                { version { strictly("3.0.2") }}
         api(libs.julToSlf4j)            { version { strictly(slf4jVersion) }}
         api(libs.junit)                 { version { strictly("4.13.2") }}
+        api(libs.junit5JupiterApi)      { version { strictly(junit5Version) }}
+        api(libs.junit5Vintage)         { version { strictly(junit5Version) }}
+        api(libs.junitPlatform)         { version { strictly("1.8.2") }}
         api(libs.jzlib)                 { version { strictly("1.1.3") }}
         api(libs.kryo)                  { version { strictly("2.24.0") }}
         api(libs.log4jToSlf4j)          { version { strictly(slf4jVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -175,8 +175,8 @@ dependencies {
         api(libs.samplesCheck)          { version { strictly("1.0.0") }}
         api(libs.snappy)                { version { strictly("0.4") }}
         api(libs.socksProxy)            { version { strictly("2.0.0") }}
-        api(libs.spock)                 { version { strictly("2.2-M3-groovy-3.0") }}
-        api(libs.spockJUnit4)           { version { strictly("2.2-M3-groovy-3.0") }}
+        api(libs.spock)                 { version { strictly("2.2-M2-groovy-3.0") }}
+        api(libs.spockJUnit4)           { version { strictly("2.2-M2-groovy-3.0") }}
         api(libs.sshdCore)              { version { strictly(sshdVersion) }}
         api(libs.sshdScp)               { version { strictly(sshdVersion) }}
         api(libs.sshdSftp)              { version { strictly(sshdVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -22,6 +22,7 @@ val googleApiVersion = "1.25.0" // See usage before attempting to upgrade
 val jacksonVersion = "2.13.3"
 val jaxbVersion = "3.0.0"
 val jettyVersion = "9.4.36.v20210114"
+val junitPlatformVersion = "1.8.2"
 val mavenVersion = "3.6.3"
 val nativePlatformVersion = "0.22-milestone-23"
 val slf4jVersion = "1.7.30"
@@ -29,6 +30,11 @@ val sshdVersion = "2.0.0" // Upgrade requires changes in package names and tests
 val tomljVersion = "1.0.0"
 
 val bytebuddyVersion = "1.10.20"
+
+// Those two versions are managed by the junit bom, which is pulled in by Spock.
+// In order to downgrade, we need to add a constraint here.
+val junitPlatformCommons = "org.junit.platform:junit-platform-commons"
+val junitPlatformEngine = "org.junit.platform:junit-platform-engine"
 
 dependencies {
     constraints {
@@ -107,7 +113,9 @@ dependencies {
         api(libs.junit)                 { version { strictly("4.13.2") }}
         api(libs.junit5JupiterApi)      { version { strictly("5.8.2") }}
         api(libs.junit5Vintage)         { version { strictly("5.8.2") }}
-        api(libs.junitPlatform)         { version { strictly("1.8.2") }}
+        api(libs.junitPlatform)         { version { strictly(junitPlatformVersion) }}
+        api(junitPlatformCommons)       { version { strictly(junitPlatformVersion) }}
+        api(junitPlatformEngine)        { version { strictly(junitPlatformVersion) }}
         api(libs.jzlib)                 { version { strictly("1.1.3") }}
         api(libs.kryo)                  { version { strictly("2.24.0") }}
         api(libs.log4jToSlf4j)          { version { strictly(slf4jVersion) }}
@@ -169,8 +177,8 @@ dependencies {
         api(libs.samplesCheck)          { version { strictly("1.0.0") }}
         api(libs.snappy)                { version { strictly("0.4") }}
         api(libs.socksProxy)            { version { strictly("2.0.0") }}
-        api(libs.spock)                 { version { strictly("2.1-groovy-3.0") }}
-        api(libs.spockJUnit4)           { version { strictly("2.1-groovy-3.0") }}
+        api(libs.spock)                 { version { strictly("2.2-M3-groovy-3.0") }}
+        api(libs.spockJUnit4)           { version { strictly("2.2-M3-groovy-3.0") }}
         api(libs.sshdCore)              { version { strictly(sshdVersion) }}
         api(libs.sshdScp)               { version { strictly(sshdVersion) }}
         api(libs.sshdSftp)              { version { strictly(sshdVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -22,8 +22,6 @@ val googleApiVersion = "1.25.0" // See usage before attempting to upgrade
 val jacksonVersion = "2.13.3"
 val jaxbVersion = "3.0.0"
 val jettyVersion = "9.4.36.v20210114"
-val junitJupiterVersion = "5.8.2"
-val junitPlatformVersion = "1.8.2"
 val mavenVersion = "3.6.3"
 val nativePlatformVersion = "0.22-milestone-23"
 val slf4jVersion = "1.7.30"
@@ -32,15 +30,12 @@ val tomljVersion = "1.0.0"
 
 val bytebuddyVersion = "1.10.20"
 
-// Those two versions are managed by the junit bom, which is pulled in by Spock.
-// In order to downgrade, we need to add a constraint here.
-val junitPlatformCommons = "org.junit.platform:junit-platform-commons"
-val junitPlatformEngine = "org.junit.platform:junit-platform-engine"
-val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine"
-val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params"
-val junitJupiter = "org.junit.jupiter:junit-jupiter"
+// For the junit-bom
+javaPlatform.allowDependencies()
 
 dependencies {
+    api(platform("org.junit:junit-bom:5.8.2!!"))
+
     constraints {
         api(libs.ansiControlSequenceUtil) { version { strictly("0.3") }}
         api(libs.ant)                   { version { strictly(antVersion) }}
@@ -115,14 +110,6 @@ dependencies {
         api(libs.jsr305)                { version { strictly("3.0.2") }}
         api(libs.julToSlf4j)            { version { strictly(slf4jVersion) }}
         api(libs.junit)                 { version { strictly("4.13.2") }}
-        api(libs.junit5JupiterApi)      { version { strictly(junitJupiterVersion) }}
-        api(junitJupiter)               { version { strictly(junitJupiterVersion) }}
-        api(junitJupiterEngine)         { version { strictly(junitJupiterVersion) }}
-        api(junitJupiterParams)         { version { strictly(junitJupiterVersion) }}
-        api(libs.junit5Vintage)         { version { strictly(junitJupiterVersion) }}
-        api(libs.junitPlatform)         { version { strictly(junitPlatformVersion) }}
-        api(junitPlatformCommons)       { version { strictly(junitPlatformVersion) }}
-        api(junitPlatformEngine)        { version { strictly(junitPlatformVersion) }}
         api(libs.jzlib)                 { version { strictly("1.1.3") }}
         api(libs.kryo)                  { version { strictly("2.24.0") }}
         api(libs.log4jToSlf4j)          { version { strictly(slf4jVersion) }}

--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -22,6 +22,7 @@ val googleApiVersion = "1.25.0" // See usage before attempting to upgrade
 val jacksonVersion = "2.13.3"
 val jaxbVersion = "3.0.0"
 val jettyVersion = "9.4.36.v20210114"
+val junitJupiterVersion = "5.8.2"
 val junitPlatformVersion = "1.8.2"
 val mavenVersion = "3.6.3"
 val nativePlatformVersion = "0.22-milestone-23"
@@ -35,6 +36,9 @@ val bytebuddyVersion = "1.10.20"
 // In order to downgrade, we need to add a constraint here.
 val junitPlatformCommons = "org.junit.platform:junit-platform-commons"
 val junitPlatformEngine = "org.junit.platform:junit-platform-engine"
+val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine"
+val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params"
+val junitJupiter = "org.junit.jupiter:junit-jupiter"
 
 dependencies {
     constraints {
@@ -111,8 +115,11 @@ dependencies {
         api(libs.jsr305)                { version { strictly("3.0.2") }}
         api(libs.julToSlf4j)            { version { strictly(slf4jVersion) }}
         api(libs.junit)                 { version { strictly("4.13.2") }}
-        api(libs.junit5JupiterApi)      { version { strictly("5.8.2") }}
-        api(libs.junit5Vintage)         { version { strictly("5.8.2") }}
+        api(libs.junit5JupiterApi)      { version { strictly(junitJupiterVersion) }}
+        api(junitJupiter)               { version { strictly(junitJupiterVersion) }}
+        api(junitJupiterEngine)         { version { strictly(junitJupiterVersion) }}
+        api(junitJupiterParams)         { version { strictly(junitJupiterVersion) }}
+        api(libs.junit5Vintage)         { version { strictly(junitJupiterVersion) }}
         api(libs.junitPlatform)         { version { strictly(junitPlatformVersion) }}
         api(junitPlatformCommons)       { version { strictly(junitPlatformVersion) }}
         api(junitPlatformEngine)        { version { strictly(junitPlatformVersion) }}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/AbstractMultiTestInterceptor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/AbstractMultiTestInterceptor.java
@@ -104,7 +104,7 @@ public abstract class AbstractMultiTestInterceptor extends AbstractMethodInterce
 
     private void parameterizeFeature(FeatureInfo feature) {
         if (feature.getDataProcessorMethod() == null) {
-            MethodInfo dataProcessor = new MethodInfo(new ConstantInvoker(new Object[]{"data"})) {
+            MethodInfo dataProcessor = new SyntheticMethodInfo(new Object[]{"data"}) {
                 @Override
                 public <ANN extends Annotation> ANN getAnnotation(Class<ANN> clazz) {
                     if (clazz.equals(DataProcessorMetadata.class)) {
@@ -127,7 +127,7 @@ public abstract class AbstractMultiTestInterceptor extends AbstractMethodInterce
             dataProcessor.setName("internalDataProcessor");
             dataProcessor.setKind(MethodKind.DATA_PROCESSOR);
 
-            MethodInfo dataProviderMethod = new MethodInfo(new ConstantInvoker(Collections.singleton("data")));
+            MethodInfo dataProviderMethod = new SyntheticMethodInfo(Collections.singleton("data"));
             feature.setDataProcessorMethod(dataProcessor);
             DataProviderInfo dataProvider = new DataProviderInfo();
             dataProvider.setParent(feature);
@@ -227,6 +227,17 @@ public abstract class AbstractMultiTestInterceptor extends AbstractMethodInterce
             currentExecution.before(invocation);
             invocation.proceed();
             currentExecution.after();
+        }
+    }
+
+    public static class SyntheticMethodInfo extends MethodInfo {
+        public SyntheticMethodInfo(Object value) {
+            super(new ConstantInvoker(value));
+        }
+
+        @Override
+        public boolean hasBytecodeName(String name) {
+            return false;
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/AbstractMultiTestInterceptor.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/AbstractMultiTestInterceptor.java
@@ -102,6 +102,9 @@ public abstract class AbstractMultiTestInterceptor extends AbstractMethodInterce
         feature.getIterationInterceptors().add(0, new ParameterizedFeatureMultiVersionInterceptor());
     }
 
+    /**
+     * Parameterizes a feature running one iteration with 0 parameters.
+     */
     private void parameterizeFeature(FeatureInfo feature) {
         if (feature.getDataProcessorMethod() == null) {
             MethodInfo dataProcessor = new SyntheticMethodInfo(new Object[]{"data"}) {
@@ -231,10 +234,16 @@ public abstract class AbstractMultiTestInterceptor extends AbstractMethodInterce
     }
 
     public static class SyntheticMethodInfo extends MethodInfo {
-        public SyntheticMethodInfo(Object value) {
-            super(new ConstantInvoker(value));
+        public SyntheticMethodInfo(Object returnValue) {
+            super(new ConstantInvoker(returnValue));
         }
 
+        /**
+         * This method is called when Spock sanitizes the stacktrace.
+         *
+         * The default implementation would fail here, so we always return false,
+         * since this method never will be in the bytecode.
+         */
         @Override
         public boolean hasBytecodeName(String name) {
             return false;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/MultiTestExtension.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/extensions/MultiTestExtension.java
@@ -28,7 +28,6 @@ public abstract class MultiTestExtension<T extends Annotation> implements IAnnot
     public void visitSpecAnnotation(T annotation, SpecInfo spec) {
         if (!spec.getFeatures().isEmpty()) {
             AbstractMultiTestInterceptor interceptor = makeInterceptor(spec.getBottomSpec().getReflection());
-            spec.addInitializerInterceptor(interceptor);
             for (FeatureInfo feature : spec.getFeatures()) {
                 interceptor.interceptFeature(feature);
             }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
@@ -98,6 +98,8 @@ class MultiTestLifecycleSpec extends Specification {
     static class SampleRule extends ExternalResource {
         private final String name
 
+        // We add a constructor parameter here, so this class can't be instantiated by the default constructor.
+        // This way we can test if the class has been initialized correctly by Spock.
         SampleRule(String name) {
             this.name = name
         }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures.extensions
 
 
+import org.gradle.integtests.fixtures.RequiredFeature
 import org.junit.Rule
 import org.junit.rules.ExternalResource
 import spock.lang.Specification
@@ -27,7 +28,7 @@ class MultiTestLifecycleSpec extends Specification {
     private static final Lifecycle LIFECYCLE = new Lifecycle()
 
     @Rule
-    public final SampleRule rule = new SampleRule()
+    public final SampleRule rule = new SampleRule("myName")
 
     def setupSpec() {
         LIFECYCLE.pushEvent("setup spec")
@@ -41,7 +42,12 @@ class MultiTestLifecycleSpec extends Specification {
             "rule before", "setup", "unrolled test: 1: isFluid: false", "cleanup", "rule after",
             "rule before", "setup", "unrolled test: 1: isFluid: true", "cleanup", "rule after",
             "rule before", "setup", "unrolled test: 2: isFluid: false", "cleanup", "rule after",
-            "rule before", "setup", "unrolled test: 2: isFluid: true", "cleanup", "rule after"
+            "rule before", "setup", "unrolled test: 2: isFluid: true", "cleanup", "rule after",
+            "rule before", "setup", "unrolled test: 3: isFluid: false", "cleanup", "rule after",
+            "rule before", "setup", "unrolled test: 3: isFluid: true", "cleanup", "rule after",
+            "rule before", "setup", "unrolled test with required: 1: isFluid: true", "cleanup", "rule after",
+            "rule before", "setup", "unrolled test with required: 2: isFluid: true", "cleanup", "rule after",
+            "rule before", "setup", "unrolled test with required: 3: isFluid: true", "cleanup", "rule after"
         ])
     }
 
@@ -59,16 +65,32 @@ class MultiTestLifecycleSpec extends Specification {
         true
     }
 
-    def unrolled() {
+    def "unrolled foo: #foo"() {
         LIFECYCLE.pushEvent("unrolled test: $foo: isFluid: ${FluidDependenciesResolveInterceptor.isFluid()}")
         expect:
         true
 
         where:
-        foo << [1, 2]
+        foo << [1, 2, 3]
+    }
+
+    @RequiredFeature(feature = FluidDependenciesResolveInterceptor.ASSUME_FLUID_DEPENDENCIES, value = "true")
+    def "unrolled foo with required: #foo"() {
+        LIFECYCLE.pushEvent("unrolled test with required: $foo: isFluid: ${FluidDependenciesResolveInterceptor.isFluid()}")
+        expect:
+        true
+
+        where:
+        foo << [1, 2, 3]
     }
 
     static class SampleRule extends ExternalResource {
+        private final String name
+
+        SampleRule(String name) {
+            this.name = name
+        }
+
         @Override
         protected void before() throws Throwable {
             LIFECYCLE.pushEvent("rule before")

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/extensions/MultiTestLifecycleSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures.extensions
 
 
 import org.gradle.integtests.fixtures.RequiredFeature
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.ExternalResource
 import spock.lang.Specification
@@ -47,7 +48,9 @@ class MultiTestLifecycleSpec extends Specification {
             "rule before", "setup", "unrolled test: 3: isFluid: true", "cleanup", "rule after",
             "rule before", "setup", "unrolled test with required: 1: isFluid: true", "cleanup", "rule after",
             "rule before", "setup", "unrolled test with required: 2: isFluid: true", "cleanup", "rule after",
-            "rule before", "setup", "unrolled test with required: 3: isFluid: true", "cleanup", "rule after"
+            "rule before", "setup", "unrolled test with required: 3: isFluid: true", "cleanup", "rule after",
+            "rule before", "setup", "skipped test: isFluid: false", "cleanup", "rule after",
+            "rule before", "setup", "skipped test: isFluid: true", "cleanup", "rule after"
         ])
     }
 
@@ -82,6 +85,14 @@ class MultiTestLifecycleSpec extends Specification {
 
         where:
         foo << [1, 2, 3]
+    }
+
+    def "skipped test"() {
+        LIFECYCLE.pushEvent("skipped test: isFluid: ${FluidDependenciesResolveInterceptor.isFluid()}")
+        Assume.assumeTrue("can skip test", false)
+
+        expect:
+        false
     }
 
     static class SampleRule extends ExternalResource {


### PR DESCRIPTION
Instead of using our home-grown solution for running multi-version tests, it is now possible to use Spock's `IDataDriver` which has been introduced in Spock 2.2-M3 to create additional iterations for tests. This is better, since we don't need to rely on our code trying to re-do Spock's test setup, which is pretty brittle and didn't support all cases. An other big advantage is that we now have unrolled tests - one per each version - instead of one test which had a list of the versions in its name. Compare
[Old](https://ge.gradle.org/s/it47mludb4auk/tests/overview?class=org.gradle.integtests.resolve.api.ArtifactCollectionIntegrationTest):
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/423186/179400870-9acc8733-d0ba-4a51-a986-dd92d640cef4.png">

[New](https://ge.gradle.org/s/ge24hjnpynzkc/tests/overview?class=org.gradle.integtests.resolve.api.ArtifactCollectionIntegrationTest):
<img width="883" alt="image" src="https://user-images.githubusercontent.com/423186/179400917-d5590dfd-8506-4a51-b65a-7d84eb8347f3.png">