### PR TITLE
Don't fail QuickFeedback/SmokeTest builds on SanityCheck failure

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -178,14 +178,18 @@ fun buildToolGradleParameters(daemon: Boolean = true, isContinue: Boolean = true
         if (isContinue) "--continue" else ""
     )
 
-fun Dependencies.compileAllDependency(compileAllId: String) {
-    // Compile All has to succeed before anything else is started
-    dependency(RelativeId(compileAllId)) {
+fun Dependencies.dependsOn(buildTypeId: RelativeId) {
+    dependency(buildTypeId) {
         snapshot {
             onDependencyFailure = FailureAction.FAIL_TO_START
             onDependencyCancel = FailureAction.FAIL_TO_START
         }
     }
+}
+
+fun Dependencies.compileAllDependency(compileAllId: String) {
+    // Compile All has to succeed before anything else is started
+    dependsOn(RelativeId(compileAllId))
     // Get the build receipt from sanity check to reuse the timestamp
     artifacts(RelativeId(compileAllId)) {
         id = "ARTIFACT_DEPENDENCY_$compileAllId"

--- a/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
+++ b/.teamcity/src/main/kotlin/configurations/FlakyTestQuarantine.kt
@@ -13,7 +13,7 @@ import common.killProcessStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import model.CIBuildModel
 import model.Stage
-import model.StageNames
+import model.StageName
 
 class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch = Arch.AMD64) : BaseGradleBuildType(stage = stage, init = {
     id("${model.projectId}_FlakyQuarantine_${os.asName()}_${arch.asName()}")
@@ -24,10 +24,10 @@ class FlakyTestQuarantine(model: CIBuildModel, stage: Stage, os: Os, arch: Arch 
 
     val testsWithOs = model.stages.filter {
         it.stageName in listOf(
-            StageNames.QUICK_FEEDBACK_LINUX_ONLY,
-            StageNames.QUICK_FEEDBACK,
-            StageNames.PULL_REQUEST_FEEDBACK,
-            StageNames.READY_FOR_NIGHTLY,
+            StageName.QUICK_FEEDBACK_LINUX_ONLY,
+            StageName.QUICK_FEEDBACK,
+            StageName.PULL_REQUEST_FEEDBACK,
+            StageName.READY_FOR_NIGHTLY,
         )
     }.flatMap { it.functionalTests }.filter { it.os == os }
 

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -9,20 +9,20 @@ import common.applyDefaultSettings
 import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.compileAllDependency
+import common.dependsOn
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
-import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.ProjectFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import model.CIBuildModel
-import model.StageNames
+import model.StageName
 
 val m2CleanScriptUnixLike = """
     REPO=%teamcity.agent.jvm.user.home%/.m2/repository
@@ -128,7 +128,7 @@ fun applyDefaults(
     model: CIBuildModel,
     buildType: BaseGradleBuildType,
     gradleTasks: String,
-    notQuick: Boolean = false,
+    dependsOnQuickFeedbackLinux: Boolean = false,
     os: Os = Os.LINUX,
     extraParameters: String = "",
     timeout: Int = 90,
@@ -145,14 +145,14 @@ fun applyDefaults(
         checkCleanM2AndAndroidUserHome(os)
     }
 
-    applyDefaultDependencies(model, buildType, notQuick)
+    applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
 }
 
 fun applyTestDefaults(
     model: CIBuildModel,
     buildType: BaseGradleBuildType,
     gradleTasks: String,
-    notQuick: Boolean = false,
+    dependsOnQuickFeedbackLinux: Boolean = false,
     buildJvm: Jvm = BuildToolBuildJvm,
     os: Os = Os.LINUX,
     arch: Arch = Arch.AMD64,
@@ -179,21 +179,16 @@ fun applyTestDefaults(
         checkCleanM2AndAndroidUserHome(os)
     }
 
-    applyDefaultDependencies(model, buildType, notQuick)
+    applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
 }
 
 fun buildScanTag(tag: String) = """"-Dscan.tag.$tag""""
 fun buildScanCustomValue(key: String, value: String) = """"-Dscan.value.$key=$value""""
-fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, notQuick: Boolean = false) {
-    if (notQuick) {
+fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, dependsOnQuickFeedbackLinux: Boolean) {
+    if (dependsOnQuickFeedbackLinux) {
         // wait for quick feedback phase to finish successfully
         buildType.dependencies {
-            dependency(RelativeId(stageTriggerId(model, StageNames.QUICK_FEEDBACK_LINUX_ONLY))) {
-                snapshot {
-                    onDependencyFailure = FailureAction.FAIL_TO_START
-                    onDependencyCancel = FailureAction.FAIL_TO_START
-                }
-            }
+            dependsOn(RelativeId(stageTriggerId(model, StageName.QUICK_FEEDBACK_LINUX_ONLY)))
         }
     }
     if (buildType !is CompileAllProduction) {

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -2,9 +2,11 @@ package configurations
 
 import common.buildToolGradleParameters
 import common.customGradle
+import common.dependsOn
 import common.gradleWrapper
 import common.requiresNoEc2Agent
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
+import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import model.CIBuildModel
@@ -32,6 +34,11 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
         javaCrash = false
     }
 
+    dependencies {
+        // If SanityCheck fails, Gradleception will definitely fail because the last build step is also sanityCheck
+        dependsOn(RelativeId(SanityCheck.buildTypeId(model)))
+    }
+
     /*
      To avoid unnecessary rerun, what we do here is a bit complicated:
 
@@ -55,7 +62,6 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
         model,
         this,
         ":distributions-full:install",
-        notQuick = true,
         extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType",
         extraSteps = {
             script {

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -31,7 +31,6 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
         this,
         ":smoke-test:$task",
         timeout = 120,
-        notQuick = true,
         extraParameters = buildScanTag("SmokeTests") +
             " -PtestJavaVersion=${testJava.version.major}" +
             " -PtestJavaVendor=${testJava.vendor.name}" +

--- a/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
+++ b/.teamcity/src/test/kotlin/CIConfigIntegrationTests.kt
@@ -16,7 +16,7 @@ import model.JsonBasedGradleSubprojectProvider
 import model.QUICK_CROSS_VERSION_BUCKETS
 import model.SmallSubprojectBucket
 import model.Stage
-import model.StageNames
+import model.StageName
 import model.TestCoverage
 import model.TestType
 import model.ignoredSubprojects
@@ -54,7 +54,7 @@ class CIConfigIntegrationTests {
 
     @Test
     fun macOSBuildsSubset() {
-        val readyForRelease = rootProject.subProjects.find { it.name.contains(StageNames.READY_FOR_RELEASE.stageName) }!!
+        val readyForRelease = rootProject.subProjects.find { it.name.contains(StageName.READY_FOR_RELEASE.stageName) }!!
         val macOS = readyForRelease.subProjects.find { it.name.contains("Macos") }!!
 
         macOS.buildTypes.forEach { buildType ->

--- a/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
+++ b/.teamcity/src/test/kotlin/PerformanceTestBuildTypeTest.kt
@@ -30,7 +30,7 @@ import model.PerformanceTestCoverage
 import model.PerformanceTestType
 import model.SpecificBuild
 import model.Stage
-import model.StageNames
+import model.StageName
 import model.TestCoverage
 import model.TestType
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -57,7 +57,7 @@ class PerformanceTestBuildTypeTest {
         val performanceTest = PerformanceTest(
             buildModel,
             Stage(
-                StageNames.PULL_REQUEST_FEEDBACK,
+                StageName.PULL_REQUEST_FEEDBACK,
                 specificBuilds = listOf(
                     SpecificBuild.BuildDistributions,
                     SpecificBuild.Gradleception,


### PR DESCRIPTION
Previously, if SanityCheck fails, almost all subsequent builds will
not start. We want the builds to reveal as many problems as possible.

This change removes the red solid line in the dependency graph (marked with "x").
![TeamCity Dependencies (3)](https://user-images.githubusercontent.com/12689835/180143769-efe9b979-c5f6-41b5-a930-ab3f3a8cfce6.jpg)

Before the change, when SanityCheck fails, the following tests will not run:

- QuickFeedback Windows builds
- Gradleception (because it depends on QuickFeedbackLinuxTrigger)
- Smoke tests (because it depends on QuickFeedbackLinuxTrigger)
- PlatformTest/ConfigCacheTest builds (because it depends on QuickFeedbackLinuxTrigger)

This change removes the dependencies on QuickFeedbackLinuxTrgger:

- ~QuickFeedback Windows builds~
- ~Gradleception~ (added dependency on SanityCheck)
- ~Smoke tests (because it depends on QuickFeedbackLinuxTrigger)~
- ~PlatformTest/ConfigCacheTest builds~
