### PR TITLE
Extend JVM installation metadata with additional properties

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -193,7 +193,7 @@ public abstract class AvailableJavaHomes {
     }
 
     private static Jvm jvmFromMetadata(JvmInstallationMetadata metadata) {
-        return Jvm.discovered(metadata.getJavaHome().toFile(), metadata.getImplementationVersion(), metadata.getLanguageVersion());
+        return Jvm.discovered(metadata.getJavaHome().toFile(), metadata.getJavaVersion(), metadata.getLanguageVersion());
     }
 
     private static List<JvmInstallationMetadata> getJvms() {
@@ -215,7 +215,7 @@ public abstract class AvailableJavaHomes {
 
         System.out.println("Found the following JVMs:");
         for (JvmInstallationMetadata jvm : jvms) {
-            String name = jvm.getDisplayName() + " " + jvm.getImplementationVersion() + " ";
+            String name = jvm.getDisplayName() + " " + jvm.getJavaVersion() + " ";
             System.out.println("    " + name + " - " + jvm.getJavaHome());
         }
         return jvms;

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetector.java
@@ -76,21 +76,23 @@ public class DefaultJvmMetadataDetector implements JvmMetadataDetector {
     }
 
     private JvmInstallationMetadata asMetadata(File javaHome, EnumMap<ProbedSystemProperty, String> metadata) {
-        String implementationVersion = metadata.get(ProbedSystemProperty.VERSION);
-        if (implementationVersion == null) {
+        String javaVersion = metadata.get(ProbedSystemProperty.JAVA_VERSION);
+        if (javaVersion == null) {
             return failure(javaHome, metadata.get(ProbedSystemProperty.Z_ERROR));
         }
         try {
-            JavaVersion.toVersion(implementationVersion);
+            JavaVersion.toVersion(javaVersion);
         } catch (IllegalArgumentException e) {
-            return failure(javaHome, "Cannot parse version number: " + implementationVersion);
+            return failure(javaHome, "Cannot parse version number: " + javaVersion);
         }
+        String javaVendor = metadata.get(ProbedSystemProperty.JAVA_VENDOR);
+        String runtimeName = metadata.get(ProbedSystemProperty.RUNTIME_NAME);
         String runtimeVersion = metadata.get(ProbedSystemProperty.RUNTIME_VERSION);
+        String jvmName = metadata.get(ProbedSystemProperty.VM_NAME);
         String jvmVersion = metadata.get(ProbedSystemProperty.VM_VERSION);
-        String vendor = metadata.get(ProbedSystemProperty.VENDOR);
-        String implementationName = metadata.get(ProbedSystemProperty.VM);
-        String architecture = metadata.get(ProbedSystemProperty.ARCH);
-        return JvmInstallationMetadata.from(javaHome, implementationVersion, runtimeVersion, jvmVersion, vendor, implementationName, architecture);
+        String jvmVendor = metadata.get(ProbedSystemProperty.VM_VENDOR);
+        String architecture = metadata.get(ProbedSystemProperty.OS_ARCH);
+        return JvmInstallationMetadata.from(javaHome, javaVersion, javaVendor, runtimeName, runtimeVersion, jvmName, jvmVersion, jvmVendor, architecture);
     }
 
     private JvmInstallationMetadata getMetadataFromInstallation(File jdkPath) {

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/JvmInstallationMetadata.java
@@ -33,8 +33,18 @@ public interface JvmInstallationMetadata {
         JAVA_COMPILER, J9_VIRTUAL_MACHINE
     }
 
-    static DefaultJvmInstallationMetadata from(File javaHome, String implementationVersion, String runtimeVersion, String jvmVersion, String vendor, String implementationName, String architecture) {
-        return new DefaultJvmInstallationMetadata(javaHome, implementationVersion, runtimeVersion, jvmVersion, vendor, implementationName, architecture);
+    static DefaultJvmInstallationMetadata from(
+        File javaHome,
+        String javaVersion,
+        String javaVendor,
+        String runtimeName,
+        String runtimeVersion,
+        String jvmName,
+        String jvmVersion,
+        String jvmVendor,
+        String architecture
+    ) {
+        return new DefaultJvmInstallationMetadata(javaHome, javaVersion, javaVendor, runtimeName, runtimeVersion, jvmName, jvmVersion, jvmVendor, architecture);
     }
 
     static JvmInstallationMetadata failure(File javaHome, String errorMessage) {
@@ -45,19 +55,54 @@ public interface JvmInstallationMetadata {
         return new FailureInstallationMetadata(javaHome, cause.getMessage(), cause);
     }
 
+    Path getJavaHome();
+
+    /**
+     * Parsed equivalent of {@link #getJavaVersion()}.
+     */
     JavaVersion getLanguageVersion();
 
-    String getImplementationVersion();
-
-    String getRuntimeVersion();
-
-    String getJvmVersion();
-
+    /**
+     * A wrapper around the raw value of the toolchain vendor.
+     * <p>
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#JAVA_VENDOR
+     */
     JvmVendor getVendor();
 
-    String getArchitecture();
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#JAVA_VERSION
+     */
+    String getJavaVersion();
 
-    Path getJavaHome();
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#RUNTIME_NAME
+     */
+    String getRuntimeName();
+
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#RUNTIME_VERSION
+     */
+    String getRuntimeVersion();
+
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#VM_NAME
+     */
+    String getJvmName();
+
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#VM_VERSION
+     */
+    String getJvmVersion();
+
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#VM_VENDOR
+     */
+    String getJvmVendor();
+
+    /**
+     * @see org.gradle.internal.jvm.inspection.ProbedSystemProperty#OS_ARCH
+     */
+    String getArchitecture();
 
     String getDisplayName();
 
@@ -71,25 +116,45 @@ public interface JvmInstallationMetadata {
 
     class DefaultJvmInstallationMetadata implements JvmInstallationMetadata {
 
-        private final JavaVersion languageVersion;
-        private final String vendor;
-        private final String implementationName;
-        private final String architecture;
         private final Path javaHome;
-        private final String implementationVersion;
+        private final JavaVersion languageVersion;
+        private final String javaVersion;
+        private final String javaVendor;
+        private final String runtimeName;
         private final String runtimeVersion;
+        private final String jvmName;
         private final String jvmVersion;
+        private final String jvmVendor;
+        private final String architecture;
+
         private final Cached<Set<JavaInstallationCapability>> capabilities = Cached.of(this::gatherCapabilities);
 
-        private DefaultJvmInstallationMetadata(File javaHome, String implementationVersion, String runtimeVersion, String jvmVersion, String vendor, String implementationName, String architecture) {
+        private DefaultJvmInstallationMetadata(
+            File javaHome,
+            String javaVersion,
+            String javaVendor,
+            String runtimeName,
+            String runtimeVersion,
+            String jvmName,
+            String jvmVersion,
+            String jvmVendor,
+            String architecture
+        ) {
             this.javaHome = javaHome.toPath();
-            this.implementationVersion = implementationVersion;
-            this.languageVersion = JavaVersion.toVersion(implementationVersion);
+            this.languageVersion = JavaVersion.toVersion(javaVersion);
+            this.javaVersion = javaVersion;
+            this.javaVendor = javaVendor;
+            this.runtimeName = runtimeName;
             this.runtimeVersion = runtimeVersion;
+            this.jvmName = jvmName;
             this.jvmVersion = jvmVersion;
-            this.vendor = vendor;
-            this.implementationName = implementationName;
+            this.jvmVendor = jvmVendor;
             this.architecture = architecture;
+        }
+
+        @Override
+        public Path getJavaHome() {
+            return javaHome;
         }
 
         @Override
@@ -98,8 +163,18 @@ public interface JvmInstallationMetadata {
         }
 
         @Override
-        public String getImplementationVersion() {
-            return implementationVersion;
+        public JvmVendor getVendor() {
+            return JvmVendor.fromString(javaVendor);
+        }
+
+        @Override
+        public String getJavaVersion() {
+            return javaVersion;
+        }
+
+        @Override
+        public String getRuntimeName() {
+            return runtimeName;
         }
 
         @Override
@@ -108,23 +183,23 @@ public interface JvmInstallationMetadata {
         }
 
         @Override
+        public String getJvmName() {
+            return jvmName;
+        }
+
+        @Override
         public String getJvmVersion() {
             return jvmVersion;
         }
 
         @Override
-        public JvmVendor getVendor() {
-            return JvmVendor.fromString(vendor);
+        public String getJvmVendor() {
+            return jvmVendor;
         }
 
         @Override
         public String getArchitecture() {
             return architecture;
-        }
-
-        @Override
-        public Path getJavaHome() {
-            return javaHome;
         }
 
         @Override
@@ -137,7 +212,7 @@ public interface JvmInstallationMetadata {
         private String determineVendorName() {
             JvmVendor.KnownJvmVendor vendor = getVendor().getKnownVendor();
             if (vendor == JvmVendor.KnownJvmVendor.ORACLE) {
-                if (implementationName != null && implementationName.contains("OpenJDK")) {
+                if (jvmName != null && jvmName.contains("OpenJDK")) {
                     return "OpenJDK";
                 }
             }
@@ -165,7 +240,7 @@ public interface JvmInstallationMetadata {
             if (javaCompiler.exists()) {
                 capabilities.add(JavaInstallationCapability.JAVA_COMPILER);
             }
-            boolean isJ9vm = implementationName.contains("J9");
+            boolean isJ9vm = jvmName.contains("J9");
             if (isJ9vm) {
                 capabilities.add(JavaInstallationCapability.J9_VIRTUAL_MACHINE);
             }
@@ -202,27 +277,12 @@ public interface JvmInstallationMetadata {
         }
 
         @Override
+        public Path getJavaHome() {
+            return javaHome.toPath();
+        }
+
+        @Override
         public JavaVersion getLanguageVersion() {
-            throw unsupportedOperation();
-        }
-
-        @Override
-        public String getImplementationVersion() {
-            throw unsupportedOperation();
-        }
-
-        @Override
-        public String getRuntimeVersion() {
-            throw unsupportedOperation();
-        }
-
-        @Override
-        public String getArchitecture() {
-            throw unsupportedOperation();
-        }
-
-        @Override
-        public String getJvmVersion() {
             throw unsupportedOperation();
         }
 
@@ -232,8 +292,38 @@ public interface JvmInstallationMetadata {
         }
 
         @Override
-        public Path getJavaHome() {
-            return javaHome.toPath();
+        public String getJavaVersion() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getRuntimeName() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getRuntimeVersion() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getJvmName() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getJvmVersion() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getJvmVendor() {
+            throw unsupportedOperation();
+        }
+
+        @Override
+        public String getArchitecture() {
+            throw unsupportedOperation();
         }
 
         @Override

--- a/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/ProbedSystemProperty.java
+++ b/subprojects/jvm-services/src/main/java/org/gradle/internal/jvm/inspection/ProbedSystemProperty.java
@@ -19,13 +19,14 @@ package org.gradle.internal.jvm.inspection;
 enum ProbedSystemProperty {
 
     JAVA_HOME("java.home"),
-    VERSION("java.version"),
-    VENDOR("java.vendor"),
-    ARCH("os.arch"),
-    VM("java.vm.name"),
-    VM_VERSION("java.vm.version"),
-    RUNTIME("java.runtime.name"),
+    JAVA_VERSION("java.version"),
+    JAVA_VENDOR("java.vendor"),
+    RUNTIME_NAME("java.runtime.name"),
     RUNTIME_VERSION("java.runtime.version"),
+    VM_NAME("java.vm.name"),
+    VM_VERSION("java.vm.version"),
+    VM_VENDOR("java.vm.vendor"),
+    OS_ARCH("os.arch"),
     Z_ERROR("Internal"); // This line MUST be last!
 
     private final String key;

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmMetadataDetectorTest.groovy
@@ -70,9 +70,9 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         def metadata = detector.getMetadata(testLocation(javaHome))
 
         then:
-        assert metadata.languageVersion == javaVersion
-        assert displayName == null || displayName == metadata.displayName + " " + metadata.languageVersion.majorVersion
-        assert metadata.javaHome != null
+        metadata.languageVersion == javaVersion
+        displayName == null || displayName == (metadata.displayName + " " + metadata.languageVersion.majorVersion)
+        metadata.javaHome != null
 
         where:
         jdk              | systemProperties         | javaVersion             | displayName                  | jre
@@ -180,15 +180,19 @@ class DefaultJvmMetadataDetectorTest extends Specification {
 
         assertIsUnsupported({ metadata.languageVersion })
         assertIsUnsupported({ metadata.vendor })
-        assertIsUnsupported({ metadata.implementationVersion })
+        assertIsUnsupported({ metadata.javaVersion })
+        assertIsUnsupported({ metadata.runtimeName })
         assertIsUnsupported({ metadata.runtimeVersion })
+        assertIsUnsupported({ metadata.jvmName })
         assertIsUnsupported({ metadata.jvmVersion })
+        assertIsUnsupported({ metadata.jvmVendor })
+        assertIsUnsupported({ metadata.architecture })
 
         where:
         jdk                                   | systemProperties | exists | errorMessage
         'localGradle'                         | currentGradle()  | false  | "No such directory: "
         'binary that has invalid output'      | invalidOutput()  | true   | "Unexpected command output:"
-        'binary that returns unknown version' | invalidVersion() | true   |  "Cannot parse version number: bad luck"
+        'binary that returns unknown version' | invalidVersion() | true   | "Cannot parse version number: bad luck"
     }
 
     private DefaultJvmMetadataDetector createDefaultJvmMetadataDetector(ExecHandleFactory execHandleFactory) {
@@ -211,6 +215,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
+         'java.vm.vendor': "Oracle Corporation",
          'java.runtime.name': "Java(TM) SE Runtime Environment",
          'java.runtime.version': "bad luck"
         ]
@@ -221,7 +226,16 @@ class DefaultJvmMetadataDetectorTest extends Specification {
     }
 
     private static Map<String, String> currentGradle() {
-        ['java.home', 'java.version', 'java.vendor', 'os.arch', 'java.vm.name', 'java.vm.version', 'java.runtime.name', 'java.runtime.version'].collectEntries { [it, System.getProperty(it)] }
+        ['java.home',
+         'java.version',
+         'java.vendor',
+         'java.runtime.name',
+         'java.runtime.version',
+         'java.vm.name',
+         'java.vm.version',
+         'java.vm.vendor',
+         'os.arch',
+        ].collectEntries { [it, System.getProperty(it)] }
     }
 
     private static Map<String, String> openJdkJvm(String version) {
@@ -231,6 +245,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
+         'java.vm.vendor': "Oracle Corporation",
          'java.runtime.name': "Java(TM) SE Runtime Environment",
          'java.runtime.version': "1.${version}.0-b08"
         ]
@@ -243,6 +258,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "${version}+7",
+         'java.vm.vendor': "AdoptOpenJDK",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}+7"
         ]
@@ -255,6 +271,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "Eclipse OpenJ9 VM",
          'java.vm.version': "openj9-0.21.0",
+         'java.vm.vendor': "AdoptOpenJDK",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}+7"
         ]
@@ -267,6 +284,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64\r",
          'java.vm.name': "OpenJDK 64-Bit Server VM\r",
          'java.vm.version': "${version}+7\r",
+         'java.vm.vendor': "AdoptOpenJDK\r",
          'java.runtime.name': "OpenJDK Runtime Environment\r",
          'java.runtime.version': "${version}+7\r"
         ]
@@ -279,6 +297,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "Java HotSpot(TM) 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
+         'java.vm.vendor': "Oracle Corporation",
          'java.runtime.name': "Java(TM) SE Runtime Environment",
          'java.runtime.version': "1.${version}.0-b08"
         ]
@@ -291,6 +310,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "IBM J9 VM",
          'java.vm.version': "2.4",
+         'java.vm.vendor': "IBM Corporation",
          'java.runtime.name': "Java(TM) SE Runtime Environment",
          'java.runtime.version': "1.${version}.0-b08"
         ]
@@ -303,6 +323,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "amd64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.66-b17",
+         'java.vm.vendor': "Azul Systems, Inc.",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "1.${version}.0_66-b08"
         ]
@@ -315,6 +336,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "ia64",
          'java.vm.name': "Java HotSpot(TM) 64-Bit Server VM",
          'java.vm.version': "25.66-b17",
+         'java.vm.vendor': "Hewlett-Packard Co.",
          'java.runtime.name': "Java(TM) SE Runtime Environment",
          'java.runtime.version': "1.${version}.0_66-b08"
         ]
@@ -327,6 +349,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "13.0.2+8-sapmachine",
+         'java.vm.vendor': "SAP SE",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}.0.2-b08"
         ]
@@ -339,6 +362,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "11.0.8+10-LTS",
+         'java.vm.vendor': "Amazon.com Inc.",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}.0.8+10-LTS"
         ]
@@ -351,6 +375,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "${version}+36",
+         'java.vm.vendor': "BellSoft.",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}+36"
         ]
@@ -363,6 +388,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit GraalVM CE 19.3.5",
          'java.vm.version': "25.282-b07-jvmci-19.3-b21",
+         'java.vm.vendor': "GraalVM Community",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}-b08"
         ]
@@ -376,6 +402,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.282-b07-jvmci-19.3-b21",
+         'java.vm.vendor': "Temurin",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}-b08"
         ]
@@ -389,6 +416,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.282-b07-jvmci-19.3-b21",
+         'java.vm.vendor': "Eclipse Foundation",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}-b08"
         ]
@@ -402,6 +430,7 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.282-b07-jvmci-19.3-b21",
+         'java.vm.vendor': "Eclipse Adoptium",
          'java.runtime.name': "OpenJDK Runtime Environment",
          'java.runtime.version': "${version}-b08"
         ]
@@ -414,12 +443,18 @@ class DefaultJvmMetadataDetectorTest extends Specification {
          'os.arch': "x86_64",
          'java.vm.name': "Eclipse OpenJ9 VM",
          'java.vm.version': "openj9-0.27.0",
+         'java.vm.vendor': "International Business Machines Corporation",
          'java.runtime.name': "IBM Semeru Runtime Open Edition",
          'java.runtime.version': "${version}-b08"
         ]
     }
 
     def createExecHandleFactory(Map<String, String> actualProperties) {
+        def probedSystemProperties = ProbedSystemProperty.values().findAll { it != ProbedSystemProperty.Z_ERROR }
+        if (!actualProperties.isEmpty()) {
+            assert actualProperties.keySet() == probedSystemProperties.collect { it.systemPropertyKey }.toSet()
+        }
+
         def execHandleFactory = Mock(ExecHandleFactory)
         def exec = Mock(ExecHandleBuilder)
         execHandleFactory.newExec() >> exec
@@ -431,8 +466,13 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         def handle = Mock(ExecHandle)
         handle.start() >> handle
         handle.waitForFinish() >> {
-            actualProperties.each {
-                output.println(it.value)
+            // important to output in the order of the enum members as parsing uses enum ordinals
+            probedSystemProperties.each {
+                def actualValue = actualProperties[it.systemPropertyKey]
+                // write conditionally to simulate wrong number of outputs
+                if (actualValue != null) {
+                    output.println(actualValue)
+                }
             }
             Mock(ExecResult)
         }
@@ -447,6 +487,5 @@ class DefaultJvmMetadataDetectorTest extends Specification {
         } catch (UnsupportedOperationException ignored) {
             // expected
         }
-
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -39,7 +39,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     private final JavaCompilerFactory compilerFactory;
     private final ToolchainToolFactory toolFactory;
     private final Directory javaHome;
-    private final VersionNumber implementationVersion;
+    private final VersionNumber toolchainVersion;
     private final JavaLanguageVersion javaVersion;
     private final JvmInstallationMetadata metadata;
     private final JavaToolchainInput input;
@@ -49,7 +49,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
         this.javaVersion = JavaLanguageVersion.of(metadata.getLanguageVersion().getMajorVersion());
         this.compilerFactory = compilerFactory;
         this.toolFactory = toolFactory;
-        this.implementationVersion = VersionNumber.withPatchNumber().parse(metadata.getImplementationVersion());
+        this.toolchainVersion = VersionNumber.withPatchNumber().parse(metadata.getJavaVersion());
         this.metadata = metadata;
         this.input = input;
     }
@@ -91,8 +91,8 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     }
 
     @Internal
-    public VersionNumber getToolVersion() {
-        return implementationVersion;
+    public VersionNumber getToolchainVersion() {
+        return toolchainVersion;
     }
 
     @Internal

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainComparator.java
@@ -29,7 +29,7 @@ public class JavaToolchainComparator implements Comparator<JavaToolchain> {
             .comparing(JavaToolchain::isCurrentJvm)
             .thenComparing(JavaToolchain::isJdk)
             .thenComparing(this::extractVendor, Comparator.reverseOrder())
-            .thenComparing(JavaToolchain::getToolVersion)
+            .thenComparing(JavaToolchain::getToolchainVersion)
             // It is possible for different JDK builds to have exact same version. The input order
             // may change so the installation path breaks ties to keep sorted output consistent
             // between runs.

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainComparatorTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainComparatorTest.groovy
@@ -83,11 +83,11 @@ class JavaToolchainComparatorTest extends Specification {
 
     def "prefers jdk over jre"() {
         def jdk = Mock(JavaToolchain) {
-            getToolVersion() >> VersionNumber.parse("8.0.1")
+            getToolchainVersion() >> VersionNumber.parse("8.0.1")
             isJdk() >> true
         }
         def jre = Mock(JavaToolchain) {
-            getToolVersion() >> VersionNumber.parse("8.0.1")
+            getToolchainVersion() >> VersionNumber.parse("8.0.1")
             isJdk() >> false
         }
         given:
@@ -134,13 +134,13 @@ class JavaToolchainComparatorTest extends Specification {
     }
 
     static void assertOrder(List<JavaToolchain> list, String[] expectedOrder) {
-        assert list*.toolVersion.toString() == expectedOrder.toString()
+        assert list*.toolchainVersion.toString() == expectedOrder.toString()
     }
 
     JavaToolchain mockToolchain(String implementationVersion, boolean isJdk = false, KnownJvmVendor jvmVendor = ADOPTOPENJDK, String installPath = null, boolean isCurrentJvm = false) {
         def javaHome = new File(installPath != null ? installPath : "/" + isJdk ? "jdk" : "jre" + "s/" + implementationVersion).absoluteFile
         Mock(JavaToolchain) {
-            it.getToolVersion() >> VersionNumber.parse(implementationVersion)
+            it.getToolchainVersion() >> VersionNumber.parse(implementationVersion)
             it.isJdk() >> isJdk
             it.isCurrentJvm() >> isCurrentJvm
             it.getInstallationPath() >> TestFiles.fileFactory().dir(javaHome)

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainQueryServiceTest.groovy
@@ -335,7 +335,7 @@ class JavaToolchainQueryServiceTest extends Specification {
         Mock(JvmInstallationMetadata) {
             getLanguageVersion() >> JavaVersion.toVersion(javaHome.location.name)
             getJavaHome() >> javaHome.location.absoluteFile.toPath()
-            getImplementationVersion() >> javaHome.location.name.replace("zzz", "999")
+            getJavaVersion() >> javaHome.location.name.replace("zzz", "999")
             isValidInstallation() >> true
             getVendor() >> JvmVendor.fromString(vendor)
             hasCapability(_ as JvmInstallationMetadata.JavaInstallationCapability) >> { capability ->

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
@@ -25,8 +25,8 @@ import spock.lang.Specification
 class JavaToolchainTest extends Specification {
     def "java version is reported as specified in metadata"() {
         given:
-        def javaHome = new File("/jvm/$implementationVersion").absoluteFile
-        def metadata = JvmInstallationMetadata.from(javaHome, implementationVersion, runtimeVersion, jvmVersion, "vendor", "implName", "archName")
+        def javaHome = new File("/jvm/$javaVersion").absoluteFile
+        def metadata = JvmInstallationMetadata.from(javaHome, javaVersion, "vendor", "runtimeName", runtimeVersion, "jvmName", jvmVersion, "jvmVendor", "archName")
         def compilerFactory = Mock(JavaCompilerFactory)
         def toolFactory = Mock(ToolchainToolFactory)
 
@@ -42,9 +42,9 @@ class JavaToolchainTest extends Specification {
         javaToolchain.jvmVersion == jvmVersion
 
         where:
-        implementationVersion | runtimeVersion  | jvmVersion   | languageVersion
-        "1.8.0_292"           | "1.8.0_292-b10" | "25.292-b10" | 8
-        "11.0.11"             | "11.0.9+11"     | "11.0.9+11"  | 11
-        "16"                  | "16+36"         | "16+36"      | 16
+        javaVersion | runtimeVersion  | jvmVersion   | languageVersion
+        "1.8.0_292" | "1.8.0_292-b10" | "25.292-b10" | 8
+        "11.0.11"   | "11.0.9+11"     | "11.0.9+11"  | 11
+        "16"        | "16+36"         | "16+36"      | 16
     }
 }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ShowToolchainsTaskTest.groovy
@@ -259,10 +259,10 @@ $errorLines
 """
     }
 
-    JvmInstallationMetadata metadata(String implVersion, String build) {
-        def runtimeVersion = implVersion + build
+    JvmInstallationMetadata metadata(String javaVersion, String build) {
+        def runtimeVersion = javaVersion + build
         def jvmVersion = runtimeVersion + "-vm"
-        return JvmInstallationMetadata.from(new File("path"), implVersion, runtimeVersion, jvmVersion, "adoptopenjdk", "", "archName")
+        return JvmInstallationMetadata.from(new File("path"), javaVersion, "adoptopenjdk", "runtimeName", runtimeVersion, "", jvmVersion, "jvmVendor", "archName")
     }
 
     JvmInstallationMetadata newInvalidMetadata() {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/ToolchainReportRendererTest.groovy
@@ -36,12 +36,11 @@ class ToolchainReportRendererTest extends Specification {
         given:
         def metadata = JvmInstallationMetadata.from(
             new File("path"),
-            "1.8.0",
-            "1.8.0-b01",
-            "25.292-b01",
-            "vendorName",
-            "",
-            "myArch")
+            "1.8.0", "vendorName",
+            "runtimeName", "1.8.0-b01",
+            "jvmName", "25.292-b01", "jvmVendor",
+            "myArch"
+        )
         installation.source >> "SourceSupplier"
 
         expect:
@@ -61,12 +60,11 @@ class ToolchainReportRendererTest extends Specification {
         File javaHome = new File(temporaryFolder, "javahome").tap { mkdirs() }
         def metadata = JvmInstallationMetadata.from(
             javaHome,
-            "1.8.0",
-            "1.8.0-b01",
-            "25.292-b01",
-            "adoptopenjdk",
-            "",
-            "myArch")
+            "1.8.0", "adoptopenjdk",
+            "runtimeName", "1.8.0-b01",
+            "jvmName", "25.292-b01", "jvmVendor",
+            "myArch"
+        )
         installation.source >> "SourceSupplier"
 
         def binDir = new File(javaHome, "bin")
@@ -77,7 +75,7 @@ class ToolchainReportRendererTest extends Specification {
 
         expect:
         assertOutput(metadata, """{identifier} + AdoptOpenJDK 1.8.0-b01{normal}
-     | Location:           {description}$javaHome{normal}
+     | Location:           {description}${javaHome}{normal}
      | Language Version:   {description}8{normal}
      | Vendor:             {description}AdoptOpenJDK{normal}
      | Architecture:       {description}myArch{normal}


### PR DESCRIPTION
Adds Java runtime name (`java.runtime.name`) and Java VM vendor (`java.vm.vendor`) members to the `JvmInstallationMetadata`.

Since there are multiple properties with very similar purpose and values, the naming members of the `ProbedSystemProperty` enum has been modified to make it easier to follow. The same naming is then applied to the installation metadata itself.