### PR TITLE
Improve the implementation of scalaCompileOptions.keepAliveMode property 

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -604,6 +604,11 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         result.assertHasPostBuildOutput(string.trim())
     }
 
+    void postBuildOutputDoesNotContain(String string) {
+        assertHasResult()
+        result.assertNotPostBuildOutput(string.trim())
+    }
+
     void outputDoesNotContain(String string) {
         assertHasResult()
         result.assertNotOutput(string.trim())

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/DaemonScalaCompiler.java
@@ -99,7 +99,7 @@ public class DaemonScalaCompiler<T extends ScalaJavaJointCompileSpec> extends Ab
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)
             .withClassLoaderStructure(classLoaderStructure)
-            .keepAliveMode(KeepAliveMode.valueOf(compileOptions.getKeepAliveMode()))
+            .keepAliveMode(KeepAliveMode.valueOf(compileOptions.getKeepAliveMode().name()))
             .build();
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/MinimalScalaCompileOptions.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.scala;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.language.scala.tasks.BaseScalaCompileOptions;
+import org.gradle.language.scala.tasks.KeepAliveMode;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -38,7 +39,7 @@ public class MinimalScalaCompileOptions implements Serializable {
     private List<String> loggingPhases;
     private MinimalScalaCompilerDaemonForkOptions forkOptions;
     private transient IncrementalCompileOptions incrementalOptions;
-    private final String keepAliveMode;
+    private final KeepAliveMode keepAliveMode;
 
     public MinimalScalaCompileOptions(BaseScalaCompileOptions compileOptions) {
         this.failOnError = compileOptions.isFailOnError();
@@ -54,7 +55,7 @@ public class MinimalScalaCompileOptions implements Serializable {
         this.loggingPhases = compileOptions.getLoggingPhases() == null ? null : ImmutableList.copyOf(compileOptions.getLoggingPhases());
         this.forkOptions = new MinimalScalaCompilerDaemonForkOptions(compileOptions.getForkOptions());
         this.incrementalOptions = compileOptions.getIncrementalOptions();
-        this.keepAliveMode = compileOptions.getKeepAliveOption().get();
+        this.keepAliveMode = compileOptions.getKeepAliveMode().get();
     }
 
     public boolean isFailOnError() {
@@ -164,7 +165,7 @@ public class MinimalScalaCompileOptions implements Serializable {
         this.incrementalOptions = incrementalOptions;
     }
 
-    public String getKeepAliveMode() {
+    public KeepAliveMode getKeepAliveMode() {
         return keepAliveMode;
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -60,6 +60,7 @@ import org.gradle.internal.logging.util.Log4jBannedVersion;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.language.scala.tasks.KeepAliveMode;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -276,6 +277,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
             compile.getConventionMapping().map("scalaClasspath", (Callable<FileCollection>) () -> scalaRuntime.inferScalaClasspath(compile.getClasspath()));
             compile.getConventionMapping().map("zincClasspath", (Callable<Configuration>) () -> project.getConfigurations().getAt(ZINC_CONFIGURATION_NAME));
             compile.getConventionMapping().map("scalaCompilerPlugins", (Callable<FileCollection>) () -> project.getConfigurations().getAt(SCALA_COMPILER_PLUGINS_CONFIGURATION_NAME));
+            compile.getScalaCompileOptions().getKeepAliveMode().convention(KeepAliveMode.SESSION);
         });
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -100,16 +100,15 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
     @Incubating
     protected AbstractScalaCompile() {
         ObjectFactory objectFactory = getObjectFactory();
-        this.scalaCompileOptions = getProject().getObjects().newInstance(ScalaCompileOptions.class);
+        this.scalaCompileOptions = objectFactory.newInstance(ScalaCompileOptions.class);
         this.scalaCompileOptions.setIncrementalOptions(objectFactory.newInstance(IncrementalCompileOptions.class));
     }
 
     @Deprecated // Kept to preserve binary compatibility; will be removed in Gradle 8.
     @SuppressWarnings("unused")
     protected AbstractScalaCompile(BaseScalaCompileOptions scalaCompileOptions) {
-        ObjectFactory objectFactory = getObjectFactory();
         this.scalaCompileOptions = scalaCompileOptions;
-        this.scalaCompileOptions.setIncrementalOptions(objectFactory.newInstance(IncrementalCompileOptions.class));
+        this.scalaCompileOptions.setIncrementalOptions(getObjectFactory().newInstance(IncrementalCompileOptions.class));
     }
 
     /**

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/BaseScalaCompileOptions.java
@@ -26,7 +26,6 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.compile.AbstractOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaForkOptions;
-import org.gradle.workers.internal.KeepAliveMode;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -65,7 +64,7 @@ public class BaseScalaCompileOptions extends AbstractOptions {
 
     private IncrementalCompileOptions incrementalOptions;
 
-    private final Property<String> keepAliveOption = getObjectFactory().property(String.class).convention(KeepAliveMode.SESSION.name());
+    private final Property<KeepAliveMode> keepAliveMode = getObjectFactory().property(KeepAliveMode.class);
 
     @Inject
     protected ObjectFactory getObjectFactory() {
@@ -240,15 +239,12 @@ public class BaseScalaCompileOptions extends AbstractOptions {
 
     /**
      * Keeps Scala compiler daemon alive across builds for faster build times
-     * Legal values:
-     * - SESSION (compiler is kept alive for a session - default)
-     * - DAEMON (compiler is kept alive across builds )
      *
      * @since 7.6
      */
     @Incubating
     @Input
-    public Property<String> getKeepAliveOption() {
-        return this.keepAliveOption;
+    public Property<KeepAliveMode> getKeepAliveMode() {
+        return this.keepAliveMode;
     }
 }

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/KeepAliveMode.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/KeepAliveMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.scala.tasks;
+
+import org.gradle.api.Incubating;
+
+/**
+ * Describes whether a Scala compiler daemon should be reused.
+ *
+ * @since 7.6
+ */
+@Incubating
+public enum KeepAliveMode {
+    /**
+     * The compiler is kept alive for a session.
+     */
+    SESSION,
+
+    /**
+     * The compiler is kept alive across builds.
+     */
+    DAEMON
+}


### PR DESCRIPTION
https://github.com/gradle/gradle/pull/20580 introduced `keepAliveOption`. The changes work fine, although a few things are missing, fixed by this PR:
- Add test coverage
- Rename keepAliveOption to keepAliveMode
- Get ObjectFactory reference once per AbstractScalaCompile constructor
- Set convention value in ScalaBasePlugin class
- Use enum property to enforce configuration time validation errors
