### PR TITLE
Properly handle Kotlin methods with multi-line signature

### DIFF
--- a/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
+++ b/build-logic/buildquality/src/main/kotlin/gradlebuild/incubation/action/IncubatingApiReportWorkAction.kt
@@ -257,6 +257,10 @@ class JavaVersionsToIncubatingCollector(srcDir: File) : VersionsToIncubatingColl
 
 
 private
+val NEWLINE_REGEX = "\\n\\s*".toRegex()
+
+
+private
 class KotlinVersionsToIncubatingCollector : VersionsToIncubatingCollector {
 
     override fun collectFrom(sourceFile: File): VersionsToIncubating {
@@ -286,7 +290,7 @@ class KotlinVersionsToIncubatingCollector : VersionsToIncubatingCollector {
                 incubating += ", top-level in ${sourceFile.name}"
             }
         }
-        return incubating
+        return incubating.replace(NEWLINE_REGEX, " ")
     }
 
     private


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/21306

Previously, a kotlin method with multi-line signature will
be copied into generated incubating report, breaking the following
`allIncubationReports` task, which expects a method in a single line:

```
Not found;unreleased;org.gradle.kotlin.dsl.exclude(group: String? = null,
      module: String? = null) with Configuration receiver, top-level in ConfigurationExtensions.kt
```

This PR fixes the issue by replacing the newlines.
