### PR TITLE
Opt-in for non-nullability for javadoc internal package

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocSpec.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocSpec.java
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.javadoc.internal;
 import org.gradle.external.javadoc.MinimalJavadocOptions;
 import org.gradle.language.base.internal.compile.CompileSpec;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class JavadocSpec implements CompileSpec {
@@ -60,10 +61,11 @@ public class JavadocSpec implements CompileSpec {
         return optionsFile;
     }
 
-    public void setExecutable(String executable) {
+    public void setExecutable(@Nullable String executable) {
         this.executable = executable;
     }
 
+    @Nullable
     public String getExecutable() {
         return executable;
     }

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/package-info.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.gradle.api.tasks.javadoc.internal;
+
+import org.gradle.api.NonNullApi;


### PR DESCRIPTION
The class `JavadocToolAdapter` implements `JavadocTool` which comes from a `@NonNullApi` package, and therefore getters on the implementation are not properly marked as non-nullable.