### PR TITLE
Fix possible NPE in worker parameters isolation

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 package org.gradle.api.plugins.quality.checkstyle
+
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
-import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
+
+import static org.gradle.api.plugins.quality.checkstyle.CheckstylePluginMultiProjectTest.javaClassWithNewLineAtEnd
+import static org.gradle.api.plugins.quality.checkstyle.CheckstylePluginMultiProjectTest.simpleCheckStyleConfig
 
 class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
     @Override
@@ -31,7 +34,6 @@ class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21301")
-    @ToBeImplemented
     def "can pass a URL in configProperties"() {
         given:
         buildFile """
@@ -44,14 +46,13 @@ class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
                 configProperties["some"] = new URL("https://gradle.org/")
             }
         """
-        file('src/main/java/Some.java') << """
-            public class Some {}
-        """
+        file('src/main/java/Dummy.java') << javaClassWithNewLineAtEnd()
+        file('config/checkstyle/checkstyle.xml') << simpleCheckStyleConfig()
 
         when:
-        fails 'check'
+        succeeds 'check'
 
         then:
-        failureHasCause("Could not serialize unit of work.")
+        executedAndNotSkipped ':checkstyleMain'
     }
 }

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
@@ -40,7 +40,7 @@ class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
             apply plugin: 'checkstyle'
 
             dependencies { implementation localGroovy() }
-            repositories { mavenCentral() }
+            ${mavenCentralRepository()}
 
             checkstyle {
                 configProperties["some"] = new URL("https://gradle.org/")

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginIntegrationTest.groovy
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.plugins.quality.checkstyle
 import org.gradle.integtests.fixtures.WellBehavedPluginTest
+import org.gradle.util.internal.ToBeImplemented
+import spock.lang.Issue
 
 class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
     @Override
@@ -26,5 +28,30 @@ class CheckstylePluginIntegrationTest extends WellBehavedPluginTest {
         buildFile << """
             apply plugin: 'groovy'
         """
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/21301")
+    @ToBeImplemented
+    def "can pass a URL in configProperties"() {
+        given:
+        buildFile """
+            apply plugin: 'checkstyle'
+
+            dependencies { implementation localGroovy() }
+            repositories { mavenCentral() }
+
+            checkstyle {
+                configProperties["some"] = new URL("https://gradle.org/")
+            }
+        """
+        file('src/main/java/Some.java') << """
+            public class Some {}
+        """
+
+        when:
+        fails 'check'
+
+        then:
+        failureHasCause("Could not serialize unit of work.")
     }
 }


### PR DESCRIPTION
For instances that don't have an implementation hash - coming from the JDK.

This fixes the 7.5 regression https://github.com/gradle/gradle/issues/21301
