### PR TITLE
HelpTaskPlugin: Incompatible with Configuration Cache when `taskpath` is specified

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
@@ -136,6 +136,7 @@ public class Help extends DefaultTask {
 
     @Option(option = "task", description = "The task to show help for.")
     public void setTaskPath(String taskPath) {
+        notCompatibleWithConfigurationCache("Task requires access to Gradle model");
         this.taskPath = taskPath;
     }
 }


### PR DESCRIPTION
It is incompatible because:
Only scheduled tasks are stored into configuration cache, the specified task follows `--task` would not be scheduled and won't be part of our stored work graph in most cases.

To get an instance of that task, the plugin tries to reconfigure the project, but task `Help` is already registered into task container once configuration cache is loaded, it cannot be registered again, which causes failure of the reconfiguration.

Fixes #21056

Signed-off-by: Xin Wang <scaventz@outlook.com>

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
