### PR TITLE
Remove afterEvaluate from docs sample

### DIFF
--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingExtension.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingExtension.java
@@ -1,13 +1,12 @@
 package org.sample;
 
-public class GreetingExtension {
-    private String who;
+import org.gradle.api.provider.Property;
 
-    public String getWho() {
-        return who;
+public abstract class GreetingExtension {
+
+    public GreetingExtension() {
+        getWho().convention("mate");
     }
 
-    public void setWho(String who) {
-        this.who = who;
-    }
+    public abstract Property<String> getWho();
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
@@ -10,11 +10,8 @@ public class GreetingPlugin implements Plugin<Project> {
 
     public void apply(Project project) {
         GreetingExtension extension = project.getExtensions().create("greeting", GreetingExtension.class);
-        TaskProvider<GreetingTask> task = project.getTasks().register("greeting", GreetingTask.class);
-        project.afterEvaluate(p -> {
-            task.configure(t -> {
-                t.setWho(extension.getWho());
-            });
+        TaskProvider<GreetingTask> task = project.getTasks().register("greeting", GreetingTask.class, t -> {
+            t.getWho().set(extension.getWho());
         });
     }
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingTask.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/groovy/greeting-plugin/src/main/java/org/sample/GreetingTask.java
@@ -1,23 +1,17 @@
 package org.sample;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
-public class GreetingTask extends DefaultTask {
-    private String who = "mate";
+public abstract class GreetingTask extends DefaultTask {
 
     @Input
-    public String getWho() {
-        return who;
-    }
-
-    public void setWho(String who) {
-        this.who = who;
-    }
+    public abstract Property<String> getWho();
 
     @TaskAction
     public void greet() {
-        System.out.println("Hi " + who + "!!!");
+        System.out.println("Hi " + getWho().get() + "!!!");
     }
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingExtension.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingExtension.java
@@ -1,13 +1,12 @@
 package org.sample;
 
-public class GreetingExtension {
-    private String who;
+import org.gradle.api.provider.Property;
 
-    public String getWho() {
-        return who;
+public abstract class GreetingExtension {
+
+    public GreetingExtension() {
+        getWho().convention("mate");
     }
 
-    public void setWho(String who) {
-        this.who = who;
-    }
+    public abstract Property<String> getWho();
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingPlugin.java
@@ -10,11 +10,8 @@ public class GreetingPlugin implements Plugin<Project> {
 
     public void apply(Project project) {
         GreetingExtension extension = project.getExtensions().create("greeting", GreetingExtension.class);
-        TaskProvider<GreetingTask> task = project.getTasks().register("greeting", GreetingTask.class);
-        project.afterEvaluate(p -> {
-            task.configure(t -> {
-                t.setWho(extension.getWho());
-            });
+        TaskProvider<GreetingTask> task = project.getTasks().register("greeting", GreetingTask.class, t -> {
+            t.getWho().set(extension.getWho());
         });
     }
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingTask.java
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/greeting-plugin/src/main/java/org/sample/GreetingTask.java
@@ -1,23 +1,17 @@
 package org.sample;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 
-public class GreetingTask extends DefaultTask {
-    private String who = "mate";
+public abstract class GreetingTask extends DefaultTask {
 
     @Input
-    public String getWho() {
-        return who;
-    }
-
-    public void setWho(String who) {
-        this.who = who;
-    }
+    public abstract Property<String> getWho();
 
     @TaskAction
     public void greet() {
-        System.out.println("Hi " + who + "!!!");
+        System.out.println("Hi " + getWho().get() + "!!!");
     }
 }

--- a/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/my-greeting-app/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/composite-builds/plugin-dev/kotlin/my-greeting-app/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 greeting {
-    who = "Bob"
+    who.set("Bob")
 }


### PR DESCRIPTION
Our samples should be using the Provider API in order to avoid using `afterEvaluate`