### PR TITLE
Automatically set SystemRoot environment variable for TestKit on Windows

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -30,7 +30,8 @@ We would like to thank the following community members for their contributions t
 [Stephen Topley](https://github.com/stopley),
 [Victor Maldonado](https://github.com/vmmaldonadoz),
 [Vinay Potluri](https://github.com/vinaypotluri),
-[Jeff Gaston](https://github.com/mathjeff).
+[Jeff Gaston](https://github.com/mathjeff),
+[David Morris](https://github.com/codefish1).
 
 ## Upgrade instructions
 


### PR DESCRIPTION
bugfix(#21315): Fix for #21315 to automatically set the SystemRoot environment

Signed-off-by: David Morris <dave@code-fish.co.uk>

<!--- The issue this PR addresses -->
Fixes #21315 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
When writing unit tests which make use of the gradle runner on a Linux/MacOS it is very hard to know the impact they might have on a Windows user for not including the SystemRoot environment variable and the impact it has on them.  The cause of the error isn't obvious since there are no logs detailing what was missing.

I considered simply checking that the environment variable was there early on and failing with a clear log message, but that then forces every developer to put the same if Windows do X logic across multiple code bases.  This seemed the neater option, working similar to the effective arguments.

I'm unsure on how/where to write an automated test for this or if you even have a Windows based test rig to run them on.  I've manually tested it by building the branch on my Windows dual boot and using that as the gradle implementation with my reproducible example available at https://github.com/codefish1/gradle-windows-bug

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
