### PR TITLE
Don't overwrite nightly version in promotion build

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -358,3 +358,10 @@ val Project.runAndroidStudioInHeadlessMode: Boolean
 
 val Project.androidStudioHome: Provider<String>
     get() = propertyFromAnySource(STUDIO_HOME)
+
+
+/**
+ * Is a promotion build task called?
+ */
+val Project.isPromotionBuild: Boolean
+    get() = gradle.startParameter.taskNames.contains("promotionBuild")

--- a/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
+++ b/build-logic/module-identity/src/main/kotlin/gradlebuild.module-identity.gradle.kts
@@ -21,6 +21,7 @@ import gradlebuild.basics.buildRunningOnCi
 import gradlebuild.basics.buildTimestamp
 import gradlebuild.basics.buildVersionQualifier
 import gradlebuild.basics.ignoreIncomingBuildReceipt
+import gradlebuild.basics.isPromotionBuild
 import gradlebuild.basics.releasedVersionsFile
 import gradlebuild.basics.repoRoot
 import gradlebuild.identity.extension.ModuleIdentityExtension
@@ -82,7 +83,7 @@ fun Project.collectVersionDetails(moduleIdentity: ModuleIdentityExtension): Stri
     moduleIdentity.version.convention(GradleVersion.version(versionNumber))
     moduleIdentity.snapshot.convention(isSnapshot)
     moduleIdentity.buildTimestamp.convention(buildTimestamp)
-    moduleIdentity.promotionBuild.convention(isPromotionBuild())
+    moduleIdentity.promotionBuild.convention(isPromotionBuild)
 
     moduleIdentity.releasedVersions.set(
         provider {
@@ -95,11 +96,6 @@ fun Project.collectVersionDetails(moduleIdentity: ModuleIdentityExtension): Stri
 
     return versionNumber
 }
-
-/**
- * Is a promotion build task called?
- */
-fun isPromotionBuild(): Boolean = gradle.startParameter.taskNames.contains("promotionBuild")
 
 /**
  * Returns the trimmed contents of the file at the given [path] after

--- a/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
+++ b/build-logic/profiling/src/main/kotlin/gradlebuild.buildscan.gradle.kts
@@ -22,6 +22,7 @@ import gradlebuild.basics.BuildEnvironment.isTeamCity
 import gradlebuild.basics.BuildEnvironment.isTravis
 import gradlebuild.basics.buildBranch
 import gradlebuild.basics.environmentVariable
+import gradlebuild.basics.isPromotionBuild
 import gradlebuild.basics.kotlindsl.execAndGetStdout
 import gradlebuild.basics.logicalBranch
 import gradlebuild.basics.predictiveTestSelectionEnabled
@@ -134,7 +135,8 @@ fun Project.extractCiData() {
             tag("CODEQL")
         }
     }
-    if (isTeamCity && !isKillLeakingProcessesStep()) {
+    if (isTeamCity && !isKillLeakingProcessesStep() && !isPromotionBuild) {
+        // don't overwrite the nightly version in promotion build
         buildScan {
             buildScanPublished {
                 println("##teamcity[buildStatus text='{build.status.text}: ${this.buildScanUri}']")


### PR DESCRIPTION
In promotion build, a service message is emitted to display the
nightly version. In our recent change, it's overwritten by the
build scan url, which is not expected. This PR detects the promotion
build and avoids the overwriting.
