### PR TITLE
Fix failing test

### DIFF
--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/ScalaPluginIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.scala
 import org.gradle.api.plugins.scala.ScalaBasePlugin
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.hamcrest.CoreMatchers.containsString
@@ -259,6 +260,7 @@ task someTask
         Integer.valueOf(matcher.group(1)) >= 16
     }
 
+    @IgnoreIf({ GradleContextualExecuter.noDaemon })
     def "Scala compiler daemon respects keepalive option"() {
         buildFile << """
             plugins {


### PR DESCRIPTION
The failing test checks the Gradle logs whether a worker process
gets killed at the end of the build based on the build
configuration. In noDaemon mode, the workers are always killed
regardless of the configuration which makes the build invalid.
