### PR TITLE
Build operation for ProjectBuilder

### DIFF
--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationContext.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/BuildOperationContext.java
@@ -31,7 +31,7 @@ public interface BuildOperationContext {
     /**
      * Finishes the build operation which should only be done once.
      */
-    void setResult(Object result);
+    void setResult(@Nullable Object result);
 
     /**
      * Record a status or outcome for given build operation.

--- a/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/internal/operations/DefaultBuildOperationRunner.java
@@ -99,7 +99,7 @@ public class DefaultBuildOperationRunner implements BuildOperationRunner {
                     }
 
                     @Override
-                    public void setResult(Object result) {
+                    public void setResult(@Nullable Object result) {
                         assertNotFinished();
                         context.setResult(result);
                         finish();

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.testfixtures;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.internal.ProjectBuilderImpl;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -70,7 +71,7 @@ public class ProjectBuilder {
      * @param dir The project directory
      * @return The builder
      */
-    public ProjectBuilder withProjectDir(File dir) {
+    public ProjectBuilder withProjectDir(@Nullable File dir) {
         projectDir = dir;
         return this;
     }
@@ -81,7 +82,7 @@ public class ProjectBuilder {
      *
      * @return The builder
      */
-    public ProjectBuilder withGradleUserHomeDir(File dir) {
+    public ProjectBuilder withGradleUserHomeDir(@Nullable File dir) {
         gradleUserHomeDir = dir;
         return this;
     }
@@ -103,7 +104,7 @@ public class ProjectBuilder {
      * @param parent parent project
      * @return The builder
      */
-    public ProjectBuilder withParent(Project parent) {
+    public ProjectBuilder withParent(@Nullable Project parent) {
         this.parent = parent;
         return this;
     }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -38,7 +38,6 @@ import org.gradle.initialization.DefaultProjectDescriptor;
 import org.gradle.initialization.LegacyTypesSupport;
 import org.gradle.initialization.NoOpBuildEventConsumer;
 import org.gradle.initialization.ProjectDescriptorRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.Pair;
 import org.gradle.internal.SystemProperties;
@@ -56,6 +55,9 @@ import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistry;
@@ -80,7 +82,7 @@ import static org.gradle.internal.concurrent.CompositeStoppable.stoppable;
 public class ProjectBuilderImpl {
     private static ServiceRegistry globalServices;
 
-    public Project createChildProject(String name, Project parent, File projectDir) {
+    public Project createChildProject(String name, Project parent, @Nullable File projectDir) {
         ProjectInternal parentProject = (ProjectInternal) parent;
         ProjectDescriptorRegistry descriptorRegistry = parentProject.getServices().get(ProjectDescriptorRegistry.class);
         DefaultProjectDescriptor parentDescriptor = descriptorRegistry.getProject(parentProject.getPath());
@@ -100,7 +102,7 @@ public class ProjectBuilderImpl {
         return project;
     }
 
-    public ProjectInternal createProject(String name, File inputProjectDir, File gradleUserHomeDir) {
+    public ProjectInternal createProject(String name, File inputProjectDir, @Nullable File gradleUserHomeDir) {
 
         final File projectDir = prepareProjectDir(inputProjectDir);
         File userHomeDir = gradleUserHomeDir == null ? new File(projectDir, "userHome") : FileUtils.canonicalize(gradleUserHomeDir);
@@ -147,9 +149,15 @@ public class ProjectBuilderImpl {
         // Lock root project; this won't ever be released as ProjectBuilder has no lifecycle
         coordinationService.withStateLock(DefaultResourceLockCoordinationService.lock(project.getOwner().getAccessLock()));
 
+        BuildOperationRunner buildOperationRunner = buildServices.get(BuildOperationRunner.class);
+        BuildOperationDescriptor.Builder rootBuildOperationDescriptor = BuildOperationDescriptor.displayName("Build in progress for ProjectBuilder");
+        BuildOperationContext rootBuildOperationContext = buildOperationRunner.start(rootBuildOperationDescriptor);
+        Stoppable stopRootBuildOperation = () -> rootBuildOperationContext.setResult(null);
+
         project.getExtensions().getExtraProperties().set(
             "ProjectBuilder.stoppable",
             stoppable(
+                stopRootBuildOperation,
                 (Stoppable) workerLeaseService::runAsIsolatedTask,
                 (Stoppable) workerLease::leaseFinish,
                 buildServices,
@@ -199,17 +207,14 @@ public class ProjectBuilderImpl {
             return FileUtils.canonicalize(projectDir);
         }
 
-        TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(new Factory<File>() {
-            @Override
-            public File create() {
-                String rootTmpDir = SystemProperties.getInstance().getWorkerTmpDir();
-                if (rootTmpDir == null) {
-                    @SuppressWarnings("deprecation")
-                    String javaIoTmpDir = SystemProperties.getInstance().getJavaIoTmpDir();
-                    rootTmpDir = javaIoTmpDir;
-                }
-                return FileUtils.canonicalize(new File(rootTmpDir));
+        TemporaryFileProvider temporaryFileProvider = new DefaultTemporaryFileProvider(() -> {
+            String rootTmpDir = SystemProperties.getInstance().getWorkerTmpDir();
+            if (rootTmpDir == null) {
+                @SuppressWarnings("deprecation")
+                String javaIoTmpDir = SystemProperties.getInstance().getJavaIoTmpDir();
+                rootTmpDir = javaIoTmpDir;
             }
+            return FileUtils.canonicalize(new File(rootTmpDir));
         });
         File tempDirectory = temporaryFileProvider.createTemporaryDirectory("gradle", "projectDir");
         // TODO deleteOnExit won't clean up non-empty directories (and it leaks memory for long-running processes).

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+package org.gradle.testfixtures.internal;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/package-info.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test fixtures for Gradle plugin testing.
+ */
+@NonNullApi
+package org.gradle.testfixtures;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -339,7 +339,7 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
                 }
 
                 @Override
-                public void setResult(Object result) {
+                public void setResult(@Nullable Object result) {
                     context.setResult(result);
                 }
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocSpec.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaDocSpec.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.tasks.scala
 
-import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
 import org.gradle.api.tasks.AbstractConventionTaskTest
 import org.gradle.util.internal.WrapUtil
@@ -35,15 +34,6 @@ class ScalaDocSpec extends AbstractConventionTaskTest {
     @Override
     ScalaDoc getTask() {
         return scalaDoc
-    }
-
-    def "scala classpath must not be empty"() {
-        when:
-        scalaDoc.setScalaClasspath(TestFiles.empty())
-        scalaDoc.generate()
-
-        then:
-        thrown(IllegalStateException)
     }
 
     def "test ScalaDoc maxMemory"() {


### PR DESCRIPTION
This PR adds a build operation to the `ProjectBuilder` which allows the build under test to emit progress events.

Previously, an attempt to issue a progress event led to an exception due to a missing ongoing build operation.

Required for #21281
