### PR TITLE
Fixed docs typo from "describes" to "described"

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -116,7 +116,7 @@ In addition to the top-level performance summary of your build execution, you ca
 
 == Configuration
 
-As describes in <<build_lifecycle.adoc#build_lifecycle,the build lifecycle chapter>>, a Gradle build goes through 3 phases: initialization, configuration, and execution.
+As described in <<build_lifecycle.adoc#build_lifecycle,the build lifecycle chapter>>, a Gradle build goes through 3 phases: initialization, configuration, and execution.
 The important thing to understand here is that configuration code always executes regardless of which tasks will run.
 That means any expensive work performed during configuration will slow every invocation down, even simple ones like `gradle help` and `gradle tasks`.
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
The introductory line of the "Improving the Performance of Gradle Builds" [page](https://docs.gradle.org/current/userguide/performance.html#configuration) has a typo. It says "as describes" when it should say "as described".

### Context
I noticed this issue browsing the docs. This PR is a test of my ability to improve the docs.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
