### PR TITLE
Fix flaky FinalizerTaskIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -157,7 +157,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         2.times {
             succeeds 'entryPoint'
-            result.assertTaskOrder ':entryPoint', ':finalizerDep3', ':finalizerDep2', ':finalizerDep1', ':finalizer2', ':finalizer1'
+            result.assertTaskOrder ':entryPoint', ':finalizerDep3', ':finalizerDep2', ':finalizerDep1', any(':finalizer2', ':finalizer1')
         }
     }
 


### PR DESCRIPTION
By not asserting the strict order between finalizer1 and finalizer2.

For example, if fails here: https://ge.gradle.org/s/y7nxtzpxrej2c/tests/:core:configCacheIntegTest/org.gradle.api.FinalizerTaskIntegrationTest/task%20can%20be%20finalized%20by%20and%20dependency%20of%20multiple%20finalizers?top-execution=1