### PR TITLE
Fix flaky docsTest

### DIFF
--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -16,20 +16,21 @@
 
 package org.gradle.docs.samples;
 
+import org.gradle.exemplar.test.normalizer.FileSeparatorOutputNormalizer;
+import org.gradle.exemplar.test.normalizer.GradleOutputNormalizer;
+import org.gradle.exemplar.test.normalizer.JavaObjectSerializationOutputNormalizer;
+import org.gradle.exemplar.test.runner.SampleModifiers;
+import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
 import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier;
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.ConfigurationCacheSanitizingOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.EmbeddedKotlinOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.GradleWelcomeOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.NativeComponentReportOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.SampleOutputNormalizer;
 import org.gradle.integtests.fixtures.mirror.SetMirrorsSampleModifier;
-import org.gradle.exemplar.test.normalizer.FileSeparatorOutputNormalizer;
-import org.gradle.exemplar.test.normalizer.GradleOutputNormalizer;
-import org.gradle.exemplar.test.normalizer.JavaObjectSerializationOutputNormalizer;
-import org.gradle.exemplar.test.runner.SampleModifiers;
-import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
 
 @SamplesOutputNormalizers({
     SampleOutputNormalizer.class,
@@ -40,6 +41,7 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
     ArtifactResolutionOmittingOutputNormalizer.class,
     NativeComponentReportOutputNormalizer.class,
     DependencyInsightOutputNormalizer.class,
+    ConfigurationCacheSanitizingOutputNormalizer.class,
     ConfigurationCacheOutputNormalizer.class,
     EmbeddedKotlinOutputNormalizer.class
 })

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheSanitizingOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheSanitizingOutputNormalizer.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import groovy.transform.CompileStatic
+import org.gradle.exemplar.executor.ExecutionMetadata
+import org.gradle.exemplar.test.normalizer.OutputNormalizer
+
+/**
+ * Removes extra harmless "Configuration cache entry stored" message from the samples output.
+ */
+@CompileStatic
+class ConfigurationCacheSanitizingOutputNormalizer implements OutputNormalizer {
+
+    @Override
+    String normalize(String output, ExecutionMetadata executionMetadata) {
+        return output.replace("Configuration cache entry stored.\n", "")
+    }
+}


### PR DESCRIPTION
By removing extra "Configuration cache entry stored" text in output.

