### PR TITLE
Make aborting the promotion build due to release not ready cleaner in TC

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -56,7 +56,7 @@ abstract class BasePublishGradleDistribution(
                 this@BasePublishGradleDistribution.gitUserEmail,
                 this@BasePublishGradleDistribution.triggerName,
                 this@BasePublishGradleDistribution.prepTask,
-                "checkReadyToPromote"
+                "checkNeedToPromote"
             )
         }
     }

--- a/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePublishGradleDistribution.kt
@@ -16,12 +16,15 @@
 
 package promotion
 
+import common.gradleWrapper
+import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionMaster
 
 abstract class BasePublishGradleDistribution(
     // The branch to be promoted
     val promotedBranch: String,
+    val prepTask: String,
     val triggerName: String,
     val gitUserName: String = "bot-teamcity",
     val gitUserEmail: String = "bot-teamcity@gradle.com",
@@ -45,5 +48,24 @@ abstract class BasePublishGradleDistribution(
                 synchronizeRevisions = false
             }
         }
+
+        steps {
+            buildStep(
+                this@BasePublishGradleDistribution.extraParameters,
+                this@BasePublishGradleDistribution.gitUserName,
+                this@BasePublishGradleDistribution.gitUserEmail,
+                this@BasePublishGradleDistribution.triggerName,
+                this@BasePublishGradleDistribution.prepTask,
+                "checkReadyToPromote"
+            )
+        }
+    }
+}
+
+fun BuildSteps.buildStep(extraParameters: String, gitUserName: String, gitUserEmail: String, triggerName: String, prepTask: String, stepTask: String) {
+    gradleWrapper {
+        name = "Promote"
+        tasks = "$prepTask $stepTask"
+        gradleParams = """-PcommitId=%dep.${RelativeId("Check_Stage_${triggerName}_Trigger")}.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" %additional.gradle.parameters% """
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
+++ b/.teamcity/src/main/kotlin/promotion/PromotionProject.kt
@@ -13,8 +13,9 @@ class PromotionProject(branch: VersionedSettingsBranch) : Project({
     buildType(SanityCheck)
     buildType(PublishNightlySnapshot(branch))
     buildType(PublishNightlySnapshotFromQuickFeedback(branch))
-    buildType(PublishNightlySnapshotFromQuickFeedbackStep1(branch))
-    buildType(PublishNightlySnapshotFromQuickFeedbackStep2(branch))
+    buildType(PublishNightlySnapshotFromQuickFeedbackStepCheckReady(branch))
+    buildType(PublishNightlySnapshotFromQuickFeedbackStepUpload(branch))
+    buildType(PublishNightlySnapshotFromQuickFeedbackStepPromote(branch))
     buildType(PublishBranchSnapshotFromQuickFeedback)
     buildType(PublishMilestone(branch))
 

--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -20,11 +20,11 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionBranches
 
-object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionBothSteps(
+object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBuild(
     promotedBranch = "%branch.to.promote%",
     triggerName = "QuickFeedback",
     prepTask = "prepSnapshot",
-    step2TargetTask = "promoteSnapshot",
+    promoteTask = "promoteSnapshot",
     extraParameters = "-PpromotedBranch=%branch.qualifier% ",
     vcsRootId = gradlePromotionBranches
 ) {

--- a/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishGradleDistributionFullBuild.kt
@@ -16,34 +16,23 @@
 
 package promotion
 
-import common.gradleWrapper
-import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
-import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import vcsroots.gradlePromotionMaster
 
-abstract class PublishGradleDistributionBothSteps(
+abstract class PublishGradleDistributionFullBuild(
     // The branch to be promoted
     promotedBranch: String,
     prepTask: String,
-    step2TargetTask: String,
+    promoteTask: String,
     triggerName: String,
     gitUserName: String = "bot-teamcity",
     gitUserEmail: String = "bot-teamcity@gradle.com",
     extraParameters: String = "",
     vcsRootId: String = gradlePromotionMaster
-) : BasePublishGradleDistribution(promotedBranch, triggerName, gitUserName, gitUserEmail, extraParameters, vcsRootId) {
+) : BasePublishGradleDistribution(promotedBranch, prepTask, triggerName, gitUserName, gitUserEmail, extraParameters, vcsRootId) {
     init {
         steps {
             buildStep(extraParameters, gitUserName, gitUserEmail, triggerName, prepTask, "uploadAll")
-            buildStep(extraParameters, gitUserName, gitUserEmail, triggerName, prepTask, step2TargetTask)
+            buildStep(extraParameters, gitUserName, gitUserEmail, triggerName, prepTask, promoteTask)
         }
-    }
-}
-
-fun BuildSteps.buildStep(extraParameters: String, gitUserName: String, gitUserEmail: String, triggerName: String, prepTask: String, targetTask: String) {
-    gradleWrapper {
-        name = "Promote"
-        tasks = "$prepTask $targetTask"
-        gradleParams = """-PcommitId=%dep.${RelativeId("Check_Stage_${triggerName}_Trigger")}.build.vcs.number% $extraParameters "-PgitUserName=$gitUserName" "-PgitUserEmail=$gitUserEmail" %additional.gradle.parameters% """
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -21,10 +21,10 @@ import configurations.branchFilter
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistributionBothSteps(
+class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistributionFullBuild(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
-    step2TargetTask = branch.promoteNightlyTaskName(),
+    promoteTask = branch.promoteNightlyTaskName(),
     triggerName = "ReadyforNightly",
     vcsRootId = gradlePromotionBranches
 ) {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,16 @@ package promotion
 import common.VersionedSettingsBranch
 import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshotFromQuickFeedback(branch: VersionedSettingsBranch) : PublishGradleDistributionFullBuild(
+class PublishNightlySnapshotFromQuickFeedbackStepCheckReady(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
-    promoteTask = branch.promoteNightlyTaskName(),
     triggerName = "QuickFeedback",
-    vcsRootId = gradlePromotionBranches
+    vcsRootId = gradlePromotionBranches,
+    cleanCheckout = false
 ) {
     init {
-        id("Promotion_SnapshotFromQuickFeedback")
-        name = "Nightly Snapshot (from QuickFeedback)"
-        description = "Promotes the latest successful changes on '${branch.branchName}' from Quick Feedback as a new nightly snapshot"
+        id("Promotion_SnapshotFromQuickFeedbackStepCheckReady")
+        name = "Nightly Snapshot (from QuickFeedback) - Check Ready"
+        description = "Checks that a nightly snapshot can be published from QuickFeedback"
     }
 }

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
@@ -19,23 +19,24 @@ package promotion
 import common.VersionedSettingsBranch
 import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshotFromQuickFeedbackStep2(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
+class PublishNightlySnapshotFromQuickFeedbackStepPromote(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
+    prepTask = branch.prepNightlyTaskName(),
     triggerName = "QuickFeedback",
     vcsRootId = gradlePromotionBranches,
     cleanCheckout = false
 ) {
     init {
-        id("Promotion_SnapshotFromQuickFeedbackStep2")
-        name = "Nightly Snapshot (from QuickFeedback) - Step 2"
+        id("Promotion_SnapshotFromQuickFeedbackStepPromote")
+        name = "Nightly Snapshot (from QuickFeedback) - Promote"
         description = "Promotes a previously built distribution on this agent on '${branch.branchName}' from Quick Feedback as a new nightly snapshot"
 
         steps {
             buildStep(
-                this@PublishNightlySnapshotFromQuickFeedbackStep2.extraParameters,
-                this@PublishNightlySnapshotFromQuickFeedbackStep2.gitUserName,
-                this@PublishNightlySnapshotFromQuickFeedbackStep2.gitUserEmail,
-                this@PublishNightlySnapshotFromQuickFeedbackStep2.triggerName,
+                this@PublishNightlySnapshotFromQuickFeedbackStepPromote.extraParameters,
+                this@PublishNightlySnapshotFromQuickFeedbackStepPromote.gitUserName,
+                this@PublishNightlySnapshotFromQuickFeedbackStepPromote.gitUserEmail,
+                this@PublishNightlySnapshotFromQuickFeedbackStepPromote.triggerName,
                 branch.prepNightlyTaskName(),
                 branch.promoteNightlyTaskName()
             )

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
@@ -19,22 +19,23 @@ package promotion
 import common.VersionedSettingsBranch
 import vcsroots.gradlePromotionBranches
 
-class PublishNightlySnapshotFromQuickFeedbackStep1(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
+class PublishNightlySnapshotFromQuickFeedbackStepUpload(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
+    prepTask = branch.prepNightlyTaskName(),
     triggerName = "QuickFeedback",
     vcsRootId = gradlePromotionBranches
 ) {
     init {
-        id("Promotion_SnapshotFromQuickFeedbackStep1")
-        name = "Nightly Snapshot (from QuickFeedback) - Step 1"
+        id("Promotion_SnapshotFromQuickFeedbackStepUpload")
+        name = "Nightly Snapshot (from QuickFeedback) - Upload"
         description = "Builds and uploads the latest successful changes on '${branch.branchName}' from Quick Feedback as a new distribution"
 
         steps {
             buildStep(
-                this@PublishNightlySnapshotFromQuickFeedbackStep1.extraParameters,
-                this@PublishNightlySnapshotFromQuickFeedbackStep1.gitUserName,
-                this@PublishNightlySnapshotFromQuickFeedbackStep1.gitUserEmail,
-                this@PublishNightlySnapshotFromQuickFeedbackStep1.triggerName,
+                this@PublishNightlySnapshotFromQuickFeedbackStepUpload.extraParameters,
+                this@PublishNightlySnapshotFromQuickFeedbackStepUpload.gitUserName,
+                this@PublishNightlySnapshotFromQuickFeedbackStepUpload.gitUserEmail,
+                this@PublishNightlySnapshotFromQuickFeedbackStepUpload.triggerName,
                 branch.prepNightlyTaskName(),
                 "uploadAll"
             )

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -21,14 +21,14 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 
 abstract class PublishRelease(
     prepTask: String,
-    step2TargetTask: String,
+    promoteTask: String,
     requiredConfirmationCode: String,
     promotedBranch: String,
     init: PublishRelease.() -> Unit = {}
-) : PublishGradleDistributionBothSteps(
+) : PublishGradleDistributionFullBuild(
     promotedBranch = promotedBranch,
     prepTask = prepTask,
-    step2TargetTask = step2TargetTask,
+    promoteTask = promoteTask,
     triggerName = "ReadyforRelease",
     gitUserEmail = "%gitUserEmail%",
     gitUserName = "%gitUserName%",
@@ -73,7 +73,7 @@ abstract class PublishRelease(
 class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepFinalRelease",
-    step2TargetTask = "promoteFinalRelease",
+    promoteTask = "promoteFinalRelease",
     requiredConfirmationCode = "final",
     init = {
         id("Promotion_FinalRelease")
@@ -85,7 +85,7 @@ class PublishFinalRelease(branch: VersionedSettingsBranch) : PublishRelease(
 class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepRc",
-    step2TargetTask = "promoteRc",
+    promoteTask = "promoteRc",
     requiredConfirmationCode = "rc",
     init = {
         id("Promotion_ReleaseCandidate")
@@ -97,7 +97,7 @@ class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
 class PublishMilestone(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepMilestone",
-    step2TargetTask = "promoteMilestone",
+    promoteTask = "promoteMilestone",
     requiredConfirmationCode = "milestone",
     init = {
         id("Promotion_Milestone")

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -30,9 +30,9 @@ class PromotionProjectTests {
         val model = setupModelFor("master")
 
         assertEquals("Promotion", model.name)
-        assertEquals(9, model.buildTypes.size)
+        assertEquals(10, model.buildTypes.size)
         assertEquals(
-            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Step 1", "Nightly Snapshot (from QuickFeedback) - Step 2", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Start Release Cycle", "Start Release Cycle Test"),
+            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Check Ready", "Nightly Snapshot (from QuickFeedback) - Upload", "Nightly Snapshot (from QuickFeedback) - Promote", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Start Release Cycle", "Start Release Cycle Test"),
             model.buildTypes.map { it.name }
         )
     }
@@ -42,9 +42,9 @@ class PromotionProjectTests {
         val model = setupModelFor("release")
 
         assertEquals("Promotion", model.name)
-        assertEquals(9, model.buildTypes.size)
+        assertEquals(10, model.buildTypes.size)
         assertEquals(
-            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Step 1", "Nightly Snapshot (from QuickFeedback) - Step 2", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Release - Release Candidate", "Release - Final"),
+            listOf("SanityCheck", "Nightly Snapshot", "Nightly Snapshot (from QuickFeedback)", "Nightly Snapshot (from QuickFeedback) - Check Ready", "Nightly Snapshot (from QuickFeedback) - Upload", "Nightly Snapshot (from QuickFeedback) - Promote", "Publish Branch Snapshot (from Quick Feedback)", "Release - Milestone", "Release - Release Candidate", "Release - Final"),
             model.buildTypes.map { it.name }
         )
     }
@@ -60,18 +60,22 @@ class PromotionProjectTests {
     }
 
     @Test
-    fun `nightly promotion build type runs two gradle invocations`() {
+    fun `nightly promotion build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot")
+        val nightlySnapshot = model.findBuildTypeByName("Nightly Snapshot")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
@@ -103,112 +107,140 @@ class PromotionProjectTests {
     }
 
     @Test
-    fun `nightly promotion from quick feedback build type runs two gradle invocations`() {
+    fun `nightly promotion from quick feedback build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback)")
+        val nightlySnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback)")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
-    fun `publish branch snapshot build type runs two gradle invocations`() {
+    fun `publish branch snapshot build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Publish Branch Snapshot (from Quick Feedback)")
+        val nightlySnapshot = model.findBuildTypeByName("Publish Branch Snapshot (from Quick Feedback)")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepSnapshot checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepSnapshot uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepSnapshot promoteSnapshot")
         assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
-    fun `nightly promotion from quick feedback step 1 build type runs one gradle invocation`() {
+    fun `nightly promotion from quick feedback step 1 build type runs two gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Step 1")
+        val nightlySnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Upload")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(1, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(2, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     @Test
-    fun `nightly promotion from quick feedback step 2 build type runs one gradle invocation`() {
+    fun `nightly promotion from quick feedback step 2 build type runs two gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Step 2")
+        val nightlySnapshot = model.findBuildTypeByName("Nightly Snapshot (from QuickFeedback) - Promote")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(1, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(2, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly promoteReleaseNightly")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     @Test
-    fun `publish final release build type runs two gradle invocations`() {
+    fun `publish final release build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Release - Final")
+        val nightlySnapshot = model.findBuildTypeByName("Release - Final")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepFinalRelease checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepFinalRelease uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepFinalRelease promoteFinalRelease")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
-    fun `publish rc build type runs two gradle invocations`() {
+    fun `publish rc build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Release - Release Candidate")
+        val nightlySnapshot = model.findBuildTypeByName("Release - Release Candidate")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepRc checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepRc uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepRc promoteRc")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     @Test
-    fun `publish milestone build type runs two gradle invocations`() {
+    fun `publish milestone build type runs three gradle invocations`() {
         val model = setupModelFor("release")
-        val nightlytSnapshot = model.findBuildTypeByName("Release - Milestone")
+        val nightlySnapshot = model.findBuildTypeByName("Release - Milestone")
 
-        val steps = nightlytSnapshot.steps.items
-        assertEquals(2, steps.size)
+        val steps = nightlySnapshot.steps.items
+        assertEquals(3, steps.size)
 
-        val upload = gradleStep(steps, 0)
+        val checkReady = gradleStep(steps, 0)
+        checkReady.assertTasks("prepMilestone checkReadyToPromote")
+        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+
+        val upload = gradleStep(steps, 1)
         upload.assertTasks("prepMilestone uploadAll")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
-        val promote = gradleStep(steps, 1)
+        val promote = gradleStep(steps, 2)
         promote.assertTasks("prepMilestone promoteMilestone")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
     }

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -68,7 +68,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -115,7 +115,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -136,7 +136,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepSnapshot checkReadyToPromote")
+        checkReady.assertTasks("prepSnapshot checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -157,7 +157,7 @@ class PromotionProjectTests {
         assertEquals(2, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -174,7 +174,7 @@ class PromotionProjectTests {
         assertEquals(2, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepReleaseNightly checkReadyToPromote")
+        checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -191,7 +191,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepFinalRelease checkReadyToPromote")
+        checkReady.assertTasks("prepFinalRelease checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -212,7 +212,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepRc checkReadyToPromote")
+        checkReady.assertTasks("prepRc checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
@@ -233,7 +233,7 @@ class PromotionProjectTests {
         assertEquals(3, steps.size)
 
         val checkReady = gradleStep(steps, 0)
-        checkReady.assertTasks("prepMilestone checkReadyToPromote")
+        checkReady.assertTasks("prepMilestone checkNeedToPromote")
         assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)


### PR DESCRIPTION
Add a new first task to promotions which checks if we're ready to promote by calling the checkReadyToPromote task in a separate gradle build.

This PR should merge with [this PR in the promotion project](https://github.com/gradle/gradle-promote/pull/94).

[Example build in the experimental pipeline](https://builds.gradle.org/buildConfiguration/Gradle_Experimental_Promotion_SnapshotFromQuickFeedback/54241426?buildTab=log&focusLine=281&logView=linear&linesState=241.337.361.419).