### PR TITLE
Reset default performance baseline

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 # Default performance baseline
-defaultPerformanceBaselines=7.6-commit-0778ab5
+defaultPerformanceBaselines=7.6-commit-0f1793e


### PR DESCRIPTION
To accept a ~0.8% regression in JavaFirstUsePerformanceTest.
