### PR TITLE
Add configuration cache info to performance docs page

### DIFF
--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -26,12 +26,11 @@ In other words, the configuration cache saves the output of the configuration ph
 
 [IMPORTANT]
 ====
-This feature is currently *_incubating_* and not enabled by default.
+This feature is currently *_incubating_* and not enabled by default. This feature has the following limitations:
 
-Not all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> are supported.
-Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.
-Some Gradle features are <<configuration_cache#config_cache:not_yet_implemented, not yet implemented>>.
-Importing and syncing Gradle builds in IDEs is not improved by configuration caching yet.
+- The configuration cache does not support all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> and and <<configuration_cache#config_cache:not_yet_implemented, features>>. Full support is a work in progress.
+- Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.
+- IDE imports and syncs do not use the configuration cache.
 ====
 
 [[config_cache:intro:how_does_it_work]]
@@ -62,11 +61,11 @@ Build configuration inputs include:
 - Init scripts
 - Settings scripts
 - Build scripts
-- System properties
-- Gradle properties
+- System properties used during the configuration phase
+- Gradle properties used during the configuration phase
 - Environment variables used during the configuration phase
 - Configuration files accessed using value suppliers such as providers
-- `buildSrc` inputs and source files.
+- `buildSrc` inputs, including build configuration inputs  and source files.
 
 Gradle uses its own optimized serialization mechanism and format to store the configuration cache entries.
 It automatically serializes the state of arbitrary object graphs.

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -59,10 +59,14 @@ If a build configuration input has changed, Gradle will not use the entry and wi
 
 Build configuration inputs include:
 
-- Init scripts, settings scripts, build scripts.
-- System properties, Gradle properties, environment variables used during the configuration phase
+- Init scripts
+- Settings scripts
+- Build scripts
+- System properties
+- Gradle properties
+- Environment variables used during the configuration phase
 - Configuration files accessed using value suppliers such as providers
-- `buildSrc` build configuration inputs and source files.
+- `buildSrc` inputs and source files.
 
 Gradle uses its own optimized serialization mechanism and format to store the configuration cache entries.
 It automatically serializes the state of arbitrary object graphs.

--- a/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/configuration_cache.adoc
@@ -102,10 +102,10 @@ BUILD SUCCESSFUL in 4s
 Configuration cache entry stored.
 ----
 
-Running this for the first time, the configuration phase is executed, calculating the task graph.
+Running this for the first time, the configuration phase executes, calculating the task graph.
 
 Then, run the same command again.
-This will reuse the cached configuration:
+This reuses the cached configuration:
 
 ----
 ❯ gradle --configuration-cache help
@@ -129,21 +129,21 @@ Keep reading to learn how to tweak the configuration cache, manually invalidate 
 [[config_cache:usage:enable]]
 === Enabling the configuration cache
 
-By default, the configuration cache is not enabled.
-It can be enabled from the command line:
+By default, Gradle does not use the configuration cache.
+To enable the cache at build time, use the `configuration-cache` flag:
 
 ----
 ❯ gradle --configuration-cache
 ----
 
-It can also be enabled persistently in a `gradle.properties` file:
+You can also enable the cache persistently in a `gradle.properties` file using the `org.gradle.unsafe.configuration-cache` property:
 
 [source,properties]
 ----
 org.gradle.unsafe.configuration-cache=true
 ----
 
-If it is enabled in a `gradle.properties` file, it can be disabled on the command line for one build invocation:
+If enabled in a `gradle.properties` file, you can override that setting and disable the cache at build time with the `no-configuration-cache` flag:
 
 ----
 ❯ gradle --no-configuration-cache

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -195,21 +195,34 @@ You’ll also get auto-completion, which is always handy.
 
 [IMPORTANT]
 ====
-This feature is currently *_incubating_* and not enabled by default. The configuration cache does not support all core Gradle plugins and features. IDE imports and syncs do not use the configuration cache.
+This feature is currently *_incubating_* and not enabled by default. This feature has the following limitations:
+
+- The configuration cache does not support all <<configuration_cache#config_cache:plugins:core, core Gradle plugins>> and <<configuration_cache#config_cache:not_yet_implemented, features>>. Full support is a work in progress.
+- Your build and the plugins you depend on might require changes to fulfil the <<configuration_cache#config_cache:requirements, requirements>>.
+- IDE imports and syncs do not use the configuration cache.
 ====
 
-You can cache the result of the configuration phase by enabling the <<configuration_cache.adoc#config_cache,Configuration Cache>>. When build configuration inputs remain the same across builds, the configuration cache allows Gradle to skip the configuration phase entirely.
+You can cache the result of the configuration phase by enabling the <<configuration_cache.adoc#config_cache, Configuration Cache>>. When build configuration inputs remain the same across builds, the configuration cache allows Gradle to skip the configuration phase entirely.
 
 Build configuration inputs include:
 
 - Init scripts
 - Settings scripts
 - Build scripts
-- System properties
-- Gradle properties
+- System properties used during the configuration phase
+- Gradle properties used during the configuration phase
 - Environment variables used during the configuration phase
 - Configuration files accessed using value suppliers such as providers
-- `buildSrc` inputs and source files.
+- `buildSrc` inputs, including build configuration inputs and source files.
+
+==== Additional configuration cache optimizations
+
+The configuration cache enables additional optimizations as well. When enabled, Gradle:
+
+- executes all tasks in parallel, even those in the same project.
+- caches dependency resolution results.
+
+==== Flags and properties
 
 By default, Gradle does not use the configuration cache.
 To enable the cache at build time, use the `configuration-cache` flag:

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -198,7 +198,7 @@ You’ll also get auto-completion, which is always handy.
 This feature is currently *_incubating_* and not enabled by default. The configuration cache does not support all core Gradle plugins and features. IDE imports and syncs do not use the configuration cache.
 ====
 
-You can cache the result of the configuration phase by enabling the <<configuration_cache.adoc#config_cache,Configuration Cache>>. When build configuration input remains the same across builds, the configuration cache allows Gradle to skip the configuration phase entirely.
+You can cache the result of the configuration phase by enabling the <<configuration_cache.adoc#config_cache,Configuration Cache>>. When build configuration inputs remain the same across builds, the configuration cache allows Gradle to skip the configuration phase entirely.
 
 Build configuration inputs include:
 

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -211,14 +211,14 @@ Build configuration inputs include:
 - Configuration files accessed using value suppliers such as providers
 - `buildSrc` inputs and source files.
 
-By default, the configuration cache is not enabled.
-It can be enabled from the command line:
+By default, Gradle does not use the configuration cache.
+To enable the cache at build time, use the `configuration-cache` flag:
 
 ----
 ❯ gradle --configuration-cache
 ----
 
-It can also be enabled persistently in a `gradle.properties` file:
+You can also enable the cache persistently in a `gradle.properties` file using the `org.gradle.unsafe.configuration-cache` property:
 
 [source,properties]
 ----

--- a/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/performance.adoc
@@ -191,6 +191,40 @@ Some collections have dedicated types, `TaskContainer` being one of them, that h
 If you do decide to use static compilation, using an IDE can quickly show errors due to unrecognised types, properties, and methods.
 You’ll also get auto-completion, which is always handy.
 
+=== Enable the configuration cache
+
+[IMPORTANT]
+====
+This feature is currently *_incubating_* and not enabled by default. The configuration cache does not support all core Gradle plugins and features. IDE imports and syncs do not use the configuration cache.
+====
+
+You can cache the result of the configuration phase by enabling the <<configuration_cache.adoc#config_cache,Configuration Cache>>. When build configuration input remains the same across builds, the configuration cache allows Gradle to skip the configuration phase entirely.
+
+Build configuration inputs include:
+
+- Init scripts
+- Settings scripts
+- Build scripts
+- System properties
+- Gradle properties
+- Environment variables used during the configuration phase
+- Configuration files accessed using value suppliers such as providers
+- `buildSrc` inputs and source files.
+
+By default, the configuration cache is not enabled.
+It can be enabled from the command line:
+
+----
+❯ gradle --configuration-cache
+----
+
+It can also be enabled persistently in a `gradle.properties` file:
+
+[source,properties]
+----
+org.gradle.unsafe.configuration-cache=true
+----
+
 [[dependency_resolution]]
 == Dependency resolution
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
The "Improving the Performance of Gradle Builds" page doesn't currently mention the configuration cache at all. Adding a small section on it. Additionally, I tweaked the wording of a bulleted list of inputs that impact the configuration cache that now appears on both the performance and the configuration cache docs pages (readability improvement).

### Context
We'd like to surface the configuration cache in trainings and developer advocacy programs soon, so I'm adding it to this page to make it more discoverable.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [N/A] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [N/A] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
