### PR TITLE
Set Checkstyle Java Launcher to current JDK when CheckstylePlugin is not applied

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -82,8 +82,14 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
         this.reports = getObjectFactory().newInstance(CheckstyleReportsImpl.class, this);
         this.minHeapSize = getObjectFactory().property(String.class);
         this.maxHeapSize = getObjectFactory().property(String.class);
+        // Set default JavaLauncher to current JVM in case
+        // CheckstylePlugin that sets Java launcher convention is not applied
+        this.javaLauncher = getCurrentJvmLauncher();
+    }
+
+    private Property<JavaLauncher> getCurrentJvmLauncher() {
         Provider<JavaLauncher> currentJvmLauncherProvider = getToolchainService().launcherFor(new CurrentJvmToolchainSpec(getObjectFactory()));
-        this.javaLauncher = getObjectFactory().property(JavaLauncher.class).convention(currentJvmLauncherProvider);
+        return getObjectFactory().property(JavaLauncher.class).convention(currentJvmLauncherProvider);
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -28,6 +28,7 @@ import org.gradle.api.plugins.quality.internal.CheckstyleAction;
 import org.gradle.api.plugins.quality.internal.CheckstyleActionParameters;
 import org.gradle.api.plugins.quality.internal.CheckstyleReportsImpl;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.Reporting;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.CacheableTask;
@@ -44,6 +45,8 @@ import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.jvm.toolchain.JavaLauncher;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec;
 import org.gradle.util.internal.ClosureBackedAction;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
@@ -77,9 +80,10 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
     public Checkstyle() {
         this.configDirectory = getObjectFactory().directoryProperty();
         this.reports = getObjectFactory().newInstance(CheckstyleReportsImpl.class, this);
-        this.javaLauncher = getObjectFactory().property(JavaLauncher.class);
         this.minHeapSize = getObjectFactory().property(String.class);
         this.maxHeapSize = getObjectFactory().property(String.class);
+        Provider<JavaLauncher> currentJvmLauncherProvider = getToolchainService().launcherFor(new CurrentJvmToolchainSpec(getObjectFactory()));
+        this.javaLauncher = getObjectFactory().property(JavaLauncher.class).convention(currentJvmLauncherProvider);
     }
 
     /**
@@ -99,6 +103,11 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
 
     @Inject
     protected ObjectFactory getObjectFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected JavaToolchainService getToolchainService() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -29,7 +29,6 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
-import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -123,11 +122,12 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
     }
 
     private void configureToolchains(Checkstyle task) {
-        Provider<JavaLauncher> javaLauncherProvider = getToolchainService().launcherFor(new CurrentJvmToolchainSpec(project.getObjects()));
-        task.getJavaLauncher().convention(javaLauncherProvider);
         project.getPluginManager().withPlugin("java-base", p -> {
             JavaToolchainSpec toolchain = getJavaPluginExtension().getToolchain();
-            task.getJavaLauncher().convention(getToolchainService().launcherFor(toolchain).orElse(javaLauncherProvider));
+            Provider<JavaLauncher> javaLauncherProvider = getToolchainService().launcherFor(toolchain);
+            if (javaLauncherProvider.isPresent()) {
+                task.getJavaLauncher().convention(javaLauncherProvider);
+            }
         });
     }
 

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
+import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -122,12 +123,11 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
     }
 
     private void configureToolchains(Checkstyle task) {
+        Provider<JavaLauncher> javaLauncherProvider = getToolchainService().launcherFor(new CurrentJvmToolchainSpec(project.getObjects()));
+        task.getJavaLauncher().convention(javaLauncherProvider);
         project.getPluginManager().withPlugin("java-base", p -> {
             JavaToolchainSpec toolchain = getJavaPluginExtension().getToolchain();
-            Provider<JavaLauncher> javaLauncherProvider = getToolchainService().launcherFor(toolchain);
-            if (javaLauncherProvider.isPresent()) {
-                task.getJavaLauncher().convention(javaLauncherProvider);
-            }
+            task.getJavaLauncher().convention(getToolchainService().launcherFor(toolchain).orElse(javaLauncherProvider));
         });
     }
 


### PR DESCRIPTION
You can create a Checkstyle task without applying CheckstylePlugin. Due to that and changes in 7.5 we broke some builds, since Java Launcher is not set in this case. It might be a case we shouldn't encourage, but for the backward compatibility I think it's still nice we fix it.

With this fix we now set the Checkstyle Java Launcher convention always to current JDK, in case CheckstylePlugin is not applied.


Fixes #21353.