### PR TITLE
Instate the Gradle Enterprise pluging before build cache config

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -308,10 +308,12 @@ class ConfigurationCacheState(
             withDebugFrame({ "environment state" }) {
                 writeCachedEnvironmentState(gradle)
             }
+            withDebugFrame({ "gradle enterprise" }) {
+                writeGradleEnterprisePluginManager(gradle)
+            }
             withDebugFrame({ "build cache" }) {
                 writeBuildCacheConfiguration(gradle)
             }
-            writeGradleEnterprisePluginManager(gradle)
         }
     }
 
@@ -319,8 +321,10 @@ class ConfigurationCacheState(
     suspend fun DefaultReadContext.readBuildTreeState(gradle: GradleInternal) {
         withGradleIsolate(gradle, userTypesCodec) {
             readCachedEnvironmentState(gradle)
-            readBuildCacheConfiguration(gradle)
+            // It is important that the Gradle Enterprise plugin be read before
+            // build cache configuration, as it may contribute build cache configuration.
             readGradleEnterprisePluginManager(gradle)
+            readBuildCacheConfiguration(gradle)
         }
     }
 


### PR DESCRIPTION
This allows the Gradle Enterprise plugin to contribute better build caching config in a from-cache build.