### PR TITLE
Add ResolveTaskMutationsBuildOperationType

### DIFF
--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildTaskGraphParallelTest.groovy
@@ -196,7 +196,7 @@ class DefaultIncludedBuildTaskGraphParallelTest extends AbstractIncludedBuildTas
 
     private BuildWorkGraphController buildWorkGraphController(String displayName, Services services) {
         def builder = Mock(BuildLifecycleController.WorkGraphBuilder)
-        def nodeFactory = new TaskNodeFactory(Stub(GradleInternal), Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator))
+        def nodeFactory = new TaskNodeFactory(Stub(GradleInternal), Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationExecutor())
         def hierarchies = new ExecutionNodeAccessHierarchies(CaseSensitivity.CASE_SENSITIVE, TestFiles.fileSystem())
         def plan = new DefaultExecutionPlan(displayName, nodeFactory, new OrdinalGroupFactory(), Stub(TaskDependencyResolver), hierarchies.outputHierarchy, hierarchies.destroyableHierarchy, services.coordinationService)
         def workPlan = Stub(BuildWorkPlan) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
@@ -16,9 +16,9 @@
 
 package org.gradle.api.internal.tasks.execution
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractIntegrationSpec {
 
@@ -60,8 +60,14 @@ class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractInte
         fails "t"
 
         then:
-        assertResolveTaskMutationsBuildOperationEmitted(":t")
-        failureDescriptionStartsWith("Execution failed for task ':t'.")
+        if (GradleContextualExecuter.configCache) {
+            // Configuration caching resolves the outputs when storing to the configuration cache
+            // This fails already, so we don't even get to resolving the mutations.
+            failureDescriptionStartsWith("BOOM!")
+        } else {
+            assertResolveTaskMutationsBuildOperationEmitted(":t")
+            failureDescriptionStartsWith("Execution failed for task ':t'.")
+        }
     }
 
     void assertResolveTaskMutationsBuildOperationEmitted(String taskPath) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationTypeIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+
+class ResolveTaskMutationsBuildOperationTypeIntegrationTest extends AbstractIntegrationSpec {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def "emits operation for task execution"() {
+        when:
+        buildScript """
+            task t {}
+        """
+        succeeds "t"
+
+        then:
+        assertResolveTaskMutationsBuildOperationEmitted(":t")
+    }
+
+    def "emits operation for failed task execution"() {
+        when:
+        buildScript """
+            task t {
+                doLast {
+                    throw new RuntimeException("BOOM!")
+                }
+            }
+        """
+        fails "t"
+
+        then:
+        assertResolveTaskMutationsBuildOperationEmitted(":t")
+    }
+
+    def "emits operation when resolving mutations fails"() {
+        when:
+        buildScript """
+            task t {
+                outputs.files({ -> throw new RuntimeException("BOOM!") })
+            }
+        """
+        fails "t"
+
+        then:
+        assertResolveTaskMutationsBuildOperationEmitted(":t")
+        failureDescriptionStartsWith("Execution failed for task ':t'.")
+    }
+
+    void assertResolveTaskMutationsBuildOperationEmitted(String taskPath) {
+        def op = operations.first(ResolveTaskMutationsBuildOperationType) {
+            it.details.taskPath == taskPath
+        }
+        op.details.buildPath == ":"
+        op.details.taskId != null
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.execution.WorkValidationContext;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.service.ServiceRegistry;
 
@@ -50,10 +51,10 @@ public class LocalTaskNode extends TaskNode {
     private List<? extends ResourceLock> resourceLocks;
     private TaskProperties taskProperties;
 
-    public LocalTaskNode(TaskInternal task, NodeValidator nodeValidator, WorkValidationContext workValidationContext) {
+    public LocalTaskNode(TaskInternal task, NodeValidator nodeValidator, WorkValidationContext workValidationContext, BuildOperationRunner buildOperationRunner) {
         this.task = task;
         this.validationContext = workValidationContext;
-        resolveMutationsNode = new ResolveMutationsNode(this, nodeValidator);
+        this.resolveMutationsNode = new ResolveMutationsNode(this, nodeValidator, buildOperationRunner);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ResolveMutationsNode.java
@@ -17,7 +17,13 @@
 package org.gradle.execution.plan;
 
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.tasks.NodeExecutionContext;
+import org.gradle.api.internal.tasks.execution.ResolveTaskMutationsBuildOperationType;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationRunner;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resources.ResourceLock;
 
 import javax.annotation.Nullable;
@@ -25,11 +31,13 @@ import javax.annotation.Nullable;
 public class ResolveMutationsNode extends Node implements SelfExecutingNode {
     private final LocalTaskNode node;
     private final NodeValidator nodeValidator;
+    private final BuildOperationRunner buildOperationRunner;
     private Exception failure;
 
-    public ResolveMutationsNode(LocalTaskNode node, NodeValidator nodeValidator) {
+    public ResolveMutationsNode(LocalTaskNode node, NodeValidator nodeValidator, BuildOperationRunner buildOperationRunner) {
         this.node = node;
         this.nodeValidator = nodeValidator;
+        this.buildOperationRunner = buildOperationRunner;
     }
 
     public Node getNode() {
@@ -65,12 +73,55 @@ public class ResolveMutationsNode extends Node implements SelfExecutingNode {
 
     @Override
     public void execute(NodeExecutionContext context) {
-        try {
-            MutationInfo mutations = node.getMutationInfo();
-            node.resolveMutations();
-            mutations.hasValidationProblem = nodeValidator.hasValidationProblems(node);
-        } catch (Exception e) {
-            failure = e;
+        buildOperationRunner.run(new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                try {
+                    doResolveMutations();
+                    context.setResult(RESOLVE_TASK_MUTATIONS_RESULT);
+                } catch (Exception e) {
+                    failure = e;
+                    context.failed(failure);
+                }
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                TaskIdentity<?> taskIdentity = node.getTask().getTaskIdentity();
+                return BuildOperationDescriptor.displayName("Resolve mutations for task " + taskIdentity.getIdentityPath())
+                    .details(new ResolveTaskMutationsDetails(taskIdentity));
+            }
+        });
+    }
+
+    private void doResolveMutations() {
+        MutationInfo mutations = node.getMutationInfo();
+        node.resolveMutations();
+        mutations.hasValidationProblem = nodeValidator.hasValidationProblems(node);
+    }
+
+    private static final class ResolveTaskMutationsDetails implements ResolveTaskMutationsBuildOperationType.Details {
+        private final TaskIdentity<?> taskIdentity;
+
+        public ResolveTaskMutationsDetails(TaskIdentity<?> taskIdentity) {
+            this.taskIdentity = taskIdentity;
+        }
+
+        @Override
+        public String getBuildPath() {
+            return taskIdentity.getBuildPath();
+        }
+
+        @Override
+        public String getTaskPath() {
+            return taskIdentity.getTaskPath();
+        }
+
+        @Override
+        public long getTaskId() {
+            return taskIdentity.getId();
         }
     }
+
+    private static final ResolveTaskMutationsBuildOperationType.Result RESOLVE_TASK_MUTATIONS_RESULT = new ResolveTaskMutationsBuildOperationType.Result() {};
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -30,6 +30,7 @@ import org.gradle.composite.internal.BuildTreeWorkGraphController;
 import org.gradle.internal.Cast;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.impl.DefaultWorkValidationContext;
+import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 import org.gradle.plugin.use.PluginId;
@@ -50,6 +51,7 @@ public class TaskNodeFactory {
     private final Map<Task, TaskNode> nodes = new HashMap<>();
     private final BuildTreeWorkGraphController workGraphController;
     private final NodeValidator nodeValidator;
+    private final BuildOperationRunner buildOperationRunner;
     private final GradleInternal thisBuild;
     private final DocumentationRegistry documentationRegistry;
     private final DefaultTypeOriginInspectorFactory typeOriginInspectorFactory;
@@ -58,12 +60,14 @@ public class TaskNodeFactory {
         GradleInternal thisBuild,
         DocumentationRegistry documentationRegistry,
         BuildTreeWorkGraphController workGraphController,
-        NodeValidator nodeValidator
+        NodeValidator nodeValidator,
+        BuildOperationRunner buildOperationRunner
     ) {
         this.thisBuild = thisBuild;
         this.documentationRegistry = documentationRegistry;
         this.workGraphController = workGraphController;
         this.nodeValidator = nodeValidator;
+        this.buildOperationRunner = buildOperationRunner;
         this.typeOriginInspectorFactory = new DefaultTypeOriginInspectorFactory();
     }
 
@@ -80,7 +84,7 @@ public class TaskNodeFactory {
         TaskNode node = nodes.get(task);
         if (node == null) {
             if (task.getProject().getGradle() == thisBuild) {
-                node = new LocalTaskNode((TaskInternal) task, nodeValidator, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)));
+                node = new LocalTaskNode((TaskInternal) task, nodeValidator, new DefaultWorkValidationContext(documentationRegistry, typeOriginInspectorFactory.forTask(task)), buildOperationRunner);
             } else {
                 node = TaskInAnotherBuild.of((TaskInternal) task, workGraphController);
             }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/AbstractExecutionPlanSpec.groovy
@@ -66,6 +66,8 @@ abstract class AbstractExecutionPlanSpec extends Specification {
 
         def project = Mock(ProjectInternal, name: name)
         _ * project.identityPath >> (parent == null ? Path.ROOT : Path.ROOT.child(name))
+        _ * project.projectPath(_) >> { taskName -> Path.ROOT.child(taskName) }
+        _ * project.identityPath(_) >> { taskName -> (parent == null ? Path.ROOT : Path.ROOT.child(name)).child(taskName) }
         _ * project.gradle >> thisBuild
         _ * project.owner >> projectState
         _ * project.services >> backing.services

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.tasks.NodeExecutionContext
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.tasks.Destroys
@@ -33,6 +34,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import org.gradle.util.Path
@@ -52,7 +54,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     DefaultExecutionPlan executionPlan
 
-    def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator)
+    def taskNodeFactory = new TaskNodeFactory(project.gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor())
 
     def setup() {
         def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
@@ -72,6 +74,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         _ * task.shouldRunAfter >> taskDependencyResolvingTo(task, options.shouldRunAfter ?: [])
         _ * task.mustRunAfter >> taskDependencyResolvingTo(task, options.mustRunAfter ?: [])
         _ * task.sharedResources >> (options.resources ?: [])
+        _ * task.taskIdentity >> TaskIdentity.create(name, DefaultTask, project)
         TaskStateInternal state = Mock()
         _ * task.state >> state
         if (options.failure != null) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.composite.internal.BuildTreeWorkGraphController
 import org.gradle.internal.file.Stat
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.util.Path
 import org.gradle.util.internal.TextUtil
 import spock.lang.Issue
@@ -40,7 +41,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
     DefaultExecutionPlan executionPlan
     int order = 0
 
-    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator)
+    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor())
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
 
     def setup() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/TaskNodeFactoryTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.composite.internal.BuildTreeWorkGraphController
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Specification
 
 class TaskNodeFactoryTest extends Specification {
@@ -38,7 +39,7 @@ class TaskNodeFactoryTest extends Specification {
         project.gradle >> gradle
         project.pluginManager >> Stub(PluginManagerInternal)
 
-        graph = new TaskNodeFactory(gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator))
+        graph = new TaskNodeFactory(gradle, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), Stub(NodeValidator), new TestBuildOperationExecutor())
     }
 
     private TaskInternal task(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -79,7 +79,7 @@ class DefaultTaskExecutionGraphSpec extends AbstractExecutionPlanSpec {
     def parallelismConfiguration = new DefaultParallelismConfiguration(true, 1)
     def workerLeases = new DefaultWorkerLeaseService(coordinator, parallelismConfiguration)
     def executorFactory = Mock(ExecutorFactory)
-    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator)
+    def taskNodeFactory = new TaskNodeFactory(thisBuild, Stub(DocumentationRegistry), Stub(BuildTreeWorkGraphController), nodeValidator, new TestBuildOperationExecutor())
     def dependencyResolver = new TaskDependencyResolver([new TaskNodeDependencyResolver(taskNodeFactory)])
     def projectStateRegistry = Stub(ProjectStateRegistry)
     def executionPlan = newExecutionPlan()

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
@@ -22,12 +22,12 @@ import org.gradle.internal.operations.BuildOperationType;
  * Represents resolving the mutations of a task.
  * <p>
  * Before task execution ({@link org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType}),
- * the mutation of the tasks need to be resolved. The mutations of the task are the locations it may modify,
+ * the mutations of the task need to be resolved. The mutations of a task are the locations it may modify,
  * e.g. its outputs, destroyables and local state. In order to resolve the mutations, the task input and output
  * properties are detected as well. Since Gradle 7.5, resolving of the mutations happens in a separate node
  * in the execution graph.
  *
- * @since 6.7
+ * @since 7.6
  */
 public final class ResolveTaskMutationsBuildOperationType implements BuildOperationType<ResolveTaskMutationsBuildOperationType.Details, ResolveTaskMutationsBuildOperationType.Result> {
     public interface Details {

--- a/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
+++ b/subprojects/enterprise-operations/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskMutationsBuildOperationType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * Represents resolving the mutations of a task.
+ * <p>
+ * Before task execution ({@link org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType}),
+ * the mutation of the tasks need to be resolved. The mutations of the task are the locations it may modify,
+ * e.g. its outputs, destroyables and local state. In order to resolve the mutations, the task input and output
+ * properties are detected as well. Since Gradle 7.5, resolving of the mutations happens in a separate node
+ * in the execution graph.
+ *
+ * @since 6.7
+ */
+public final class ResolveTaskMutationsBuildOperationType implements BuildOperationType<ResolveTaskMutationsBuildOperationType.Details, ResolveTaskMutationsBuildOperationType.Result> {
+    public interface Details {
+        String getBuildPath();
+
+        String getTaskPath();
+
+        /**
+         * @see org.gradle.api.internal.project.taskfactory.TaskIdentity#uniqueId
+         */
+        long getTaskId();
+    }
+
+    public interface Result {
+    }
+}


### PR DESCRIPTION
to capture task parameter resolution which happens as part of resolving mutations. This allows for attributing the resolution of nested input properties to a task.

This is particular interesting for capturing the progress events for Java toolchains, see #21281.