### PR TITLE
Don't fail report generation if baseline not found

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/internal/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/internal/CollectionUtils.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.gradle.internal.Cast.cast;
@@ -108,6 +109,10 @@ public abstract class CollectionUtils {
 
     public static <T> T first(Iterable<? extends T> source) {
         return source.iterator().next();
+    }
+
+    public static <T> Optional<T> firstOrEmpty(Iterable<? extends T> source) {
+        return source == null || !source.iterator().hasNext() ? Optional.<T>empty() : Optional.of(first(source));
     }
 
     public static <T> boolean any(Iterable<? extends T> source, Spec<? super T> filter) {


### PR DESCRIPTION
Previously, if a baseline is not found in performance test history,
there will be an exception thrown, breaking the whole report generation.
Now we make the generator safer in this situation.

Example: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_PerformanceTestTestLinux_Trigger/54303473?buildTab=log&focusLine=5365&logView=flowAware&linesState=782