### PR TITLE
Clarify javadoc on ProjectConnection

### DIFF
--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/GradleConnector.java
@@ -157,6 +157,9 @@ public abstract class GradleConnector {
     /**
      * Creates a connection to the project in the specified project directory. You should call {@link org.gradle.tooling.ProjectConnection#close()} when you are finished with the connection.
      *
+     * <p>
+     * Note, that the returned instance does not automatically pick up changes if the connection configuration (e.g. the gradle.properties file) changes. It's the client's responsibility to close the connection and create a new one in that scenario.
+     *
      * @return The connection. Never return null.
      * @throws UnsupportedVersionException When the target Gradle version does not support this version of the tooling API.
      * @throws GradleConnectionException On failure to establish a connection with the target Gradle version.


### PR DESCRIPTION
After several discussions, we decided that the Tooling API client is responsible for creating new ProjectConnection instances when the underlying configuration changes.

For full context, see https://github.com/gradle/gradle/pull/21146.