### PR TITLE
Attempt to fix flakiness in finalizer test

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -133,6 +133,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         buildFile '''
             task finalizer1 {
                 dependsOn 'finalizerDep1'
+                mustRunAfter 'finalizer2'
             }
             task finalizer2 {
                 dependsOn 'finalizerDep1'


### PR DESCRIPTION
There was no strong ordering guarantee between finalizer1 and finalizer2.

The test expects finalizer2 to run first, so add a mustRunAfter to
finalizer1 so that it will run after finalizer2 without a hard dependency.
