### PR TITLE
Fix potential deadlock when a finalizer depends on task it finalizes

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/WorkNodeCodec.kt
@@ -119,6 +119,7 @@ class WorkNodeCodec(
                 }
                 is CompositeNodeGroup -> {
                     writeSmallInt(2)
+                    writeBoolean(group.isReachableFromEntryPoint)
                     writeNodeGroup(group.ordinalGroup, nodesById)
                     writeCollection(group.finalizerGroups) {
                         writeNodeGroup(it, nodesById)
@@ -146,9 +147,10 @@ class WorkNodeCodec(
                     FinalizerGroup(finalizerNode, delegate)
                 }
                 2 -> {
+                    val reachableFromCommandLine = readBoolean()
                     val ordinalGroup = readNodeGroup(nodesById)
                     val groups = readCollectionInto({ c -> HashSet() }) { readNodeGroup(nodesById) as FinalizerGroup }
-                    CompositeNodeGroup(ordinalGroup, groups)
+                    CompositeNodeGroup(reachableFromCommandLine, ordinalGroup, groups)
                 }
                 3 -> NodeGroup.DEFAULT_GROUP
                 else -> throw IllegalArgumentException()

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/CompositeNodeGroup.java
@@ -33,6 +33,12 @@ public class CompositeNodeGroup extends HasFinalizers {
         this.reachableFromEntryPoint = reachableFromEntryPoint();
     }
 
+    public CompositeNodeGroup(boolean reachableFromEntryPoint, NodeGroup newOrdinal, Set<FinalizerGroup> finalizerGroups) {
+        this.ordinalGroup = newOrdinal;
+        this.finalizerGroups = finalizerGroups;
+        this.reachableFromEntryPoint = reachableFromEntryPoint;
+    }
+
     @Override
     public String toString() {
         return "composite group, entry point: " + isReachableFromEntryPoint() + " groups: " + finalizerGroups;
@@ -46,7 +52,7 @@ public class CompositeNodeGroup extends HasFinalizers {
 
     @Override
     public NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal) {
-        return new CompositeNodeGroup(newOrdinal, finalizerGroups);
+        return new CompositeNodeGroup(reachableFromEntryPoint, newOrdinal, finalizerGroups);
     }
 
     public NodeGroup getOrdinalGroup() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -48,7 +48,7 @@ public class FinalizerGroup extends HasFinalizers {
 
     @Override
     public String toString() {
-        return "finalizer " + node + " in " + ordinal;
+        return "finalizer " + node + " ordinal " + ordinal + ", delegate " + delegate;
     }
 
     public TaskNode getNode() {

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -92,6 +92,8 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
         then:
         executionPlan.tasks as List == [dep, finalized, finalizerDep1, finalizerDep2, finalizer, task]
+        ordinalGroups == [0, 0, 0, 0, 0, 0]
+        reachableFromEntryPoint == [true, true, false, false, false, true]
         assertTaskReady(dep)
         assertTaskReady(finalized)
         assertTasksReady(finalizerDep1, finalizerDep2, task)
@@ -279,6 +281,8 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
         then:
         executionPlan.tasks as List == [a, finalizerDepDep, finalizerDep1, finalizer1, b, finalizerDep2, finalizer2]
+        ordinalGroups == [0, null, 0, 0, 1, 1, 1]
+        reachableFromEntryPoint == [true, false, false, false, true, false, false]
         assertTaskReady(a)
         assertTasksReady(finalizerDepDep, b)
         assertTasksReady(finalizerDep1, finalizerDep2)
@@ -373,6 +377,8 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
         then:
         executionPlan.tasks as List == [a, finalizerDep1, finalizer1, b, finalizerDep2, finalizer2]
+        ordinalGroups == [0, 0, 0, 1, 1, 1]
+        reachableFromEntryPoint == [true, false, false, true, false, false]
         assertTaskReady(a)
         assertTasksReady(finalizerDep1, b)
         assertTaskReady(finalizer1)
@@ -790,6 +796,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         then:
         executionPlan.tasks as List == [dep, c, finalizerDep, finalizer, a]
         ordinalGroups == [0, 1, 0, 1, 1]
+        reachableFromEntryPoint == [true, true, true, true, true]
         assertTasksReady(dep, c, finalizerDep)
         assertTaskReady(finalizer)
         assertTaskReadyAndNoMoreToStart(a)
@@ -2003,6 +2010,10 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     private List<Integer> getOrdinalGroups() {
         return executionPlan.tasks.collect { taskNodeFactory.getNode(it).group.asOrdinal()?.ordinal }
+    }
+
+    private List<Boolean> getReachableFromEntryPoint() {
+        return executionPlan.tasks.collect { taskNodeFactory.getNode(it).group.reachableFromEntryPoint }
     }
 
     private TaskInternal selectNextTask() {


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
