### PR TITLE
Update javadoc of TaskExecutionGraph.getAllTasks

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/execution/TaskExecutionGraph.java
@@ -149,10 +149,12 @@ public interface TaskExecutionGraph {
     boolean hasTask(Task task);
 
     /**
-     * <p>Returns the tasks which are included in the execution plan. The tasks are returned in the order that they will
-     * be executed.</p>
+     * <p>Returns the tasks which are included in the execution plan.
+     * The order of the tasks in the result is compatible with the constraints (dependsOn/mustRunAfter/etc) set in the build configuration.
+     * However, Gradle may execute tasks in a slightly different order to speed up the overall execution while still respecting the constraints.
+     * </p>
      *
-     * @return The tasks. Returns an empty set if no tasks are to be executed.
+     * @return The tasks. Returns an empty list if no tasks are to be executed.
      * @throws IllegalStateException When this graph has not been populated.
      */
     List<Task> getAllTasks();


### PR DESCRIPTION
The promise of the task execution order is outdated. The actual order
can be affected by:
1. Parallel task execution and/or configuration cache - both allow
   multiple tasks to run simultaneously.
2. Worker API - tasks that use workers allow other tasks to start while
   still running themselves and blocking their dependents.
3. Producer/destroyer relationships - synthetic nodes that ensure
   ordering between producers and destroyers are located quite late in
   the queue, so unrelated tasks may start earlier than expected.
