### PR TITLE
Reduce number of file changes on macOS

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
@@ -148,9 +148,14 @@ class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSy
     }
 
     private static getMaxFileChangesWithoutOverflow() {
-        OperatingSystem.current().windows
-            ? 200
-            : 1000
+        def os = OperatingSystem.current()
+        if (os.windows) {
+            return 200
+        } else if (os.macOsX) {
+            return 500
+        } else {
+            return 1000
+        }
     }
 
     private static boolean detectOverflow(DaemonFixture daemon, long fromLine) {


### PR DESCRIPTION
We now do more file changes for recompilation, since we stash away the deleted outputs and move the resulting classes around to support incremental compilation after failure. This causes overflows on macOS, since we change twice the files during the build. So I needed to half the number of changes on macOS.