### PR TITLE
Make help --task config cache compatible

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/HelpTaskIntegrationTest.groovy
@@ -461,11 +461,29 @@ BUILD SUCCESSFUL"""
     def "error message contains possible candidates"() {
         buildFile.text = """
         task aTask
-"""
+        """
         when:
         fails "help", "--task", "bTask"
         then:
         failure.assertHasCause("Task 'bTask' not found in root project '${testDirectory.getName()}'. Some candidates are: 'aTask', 'tasks'")
+
+        when:
+        run "help", "--task", "aTask"
+        then:
+        output.contains "Detailed task information for aTask"
+
+        when:
+        fails "help", "--task", "bTask"
+        then:
+        failure.assertHasCause("Task 'bTask' not found in root project '${testDirectory.getName()}'. Some candidates are: 'aTask', 'tasks'")
+
+        when:
+        buildFile << """
+        task bTask
+        """
+        run "help", "--task", "bTask"
+        then:
+        output.contains "Detailed task information for bTask"
     }
 
     def "tasks can be defined by camelCase matching"() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/Help.java
@@ -18,9 +18,10 @@ package org.gradle.configuration;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.tasks.options.OptionReader;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
-import org.gradle.execution.TaskSelection;
 import org.gradle.execution.TaskSelector;
 import org.gradle.initialization.BuildClientMetaData;
 import org.gradle.initialization.layout.ResolvedBuildLayout;
@@ -35,7 +36,23 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style.UserInput;
 
 @DisableCachingByDefault(because = "Produces only non-cacheable console output")
 public class Help extends DefaultTask {
-    private String taskPath;
+    private final Property<String> taskPath = getObjectFactory().property(String.class);
+
+    private final Property<TaskDetailsModel> taskModel = getObjectFactory().property(TaskDetailsModel.class).convention(taskPath.map(this::mapFromTaskPath));
+
+    public Help() {
+        // optimization: so value does not need to be recomputed during execution
+        taskModel.finalizeValueOnRead();
+    }
+
+    private Property<String> getTaskPath() {
+        return taskPath;
+    }
+
+    @Inject
+    protected ObjectFactory getObjectFactory() {
+        throw new UnsupportedOperationException();
+    }
 
     @Inject
     protected StyledTextOutputFactory getTextOutputFactory() {
@@ -71,7 +88,7 @@ public class Help extends DefaultTask {
     void displayHelp() {
         StyledTextOutput output = getTextOutputFactory().create(Help.class);
         BuildClientMetaData metaData = getClientMetaData();
-        if (taskPath != null) {
+        if (getTaskPath().isPresent()) {
             printTaskHelp(output);
         } else {
             printDefaultHelp(output, metaData);
@@ -79,10 +96,8 @@ public class Help extends DefaultTask {
     }
 
     private void printTaskHelp(StyledTextOutput output) {
-        TaskSelector selector = getTaskSelector();
-        TaskSelection selection = selector.getSelection(taskPath);
-        OptionReader optionReader = getOptionReader();
-        TaskDetailPrinter taskDetailPrinter = new TaskDetailPrinter(taskPath, selection, optionReader);
+        TaskDetailsModel taskDetailModel = taskModel.get();
+        TaskDetailPrinter taskDetailPrinter = new TaskDetailPrinter(taskDetailModel.getTaskPath(), taskDetailModel.getTasks());
         taskDetailPrinter.print(output);
     }
 
@@ -136,6 +151,10 @@ public class Help extends DefaultTask {
 
     @Option(option = "task", description = "The task to show help for.")
     public void setTaskPath(String taskPath) {
-        this.taskPath = taskPath;
+        this.getTaskPath().set(taskPath);
+    }
+
+    private TaskDetailsModel mapFromTaskPath(String taskPath) {
+        return TaskDetailsModel.from(taskPath, getTaskSelector(), getOptionReader());
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetails.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetails.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration;
+
+import org.apache.commons.lang.StringUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.internal.tasks.options.OptionDescriptor;
+import org.gradle.api.internal.tasks.options.OptionReader;
+
+import javax.annotation.Nullable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A configuration-cache friendly view of @{link Task} that only projects information
+ * that is relevant for the @{link Help#} task.
+ */
+@NonNullApi
+class TaskDetails {
+    final static Comparator<TaskDetails> DEFAULT_COMPARATOR = (o1, o2) -> {
+        // tasks in higher-up projects first
+        int depthCompare = o1.getProjectDepth() - o2.getProjectDepth();
+        if (depthCompare != 0) {
+            return depthCompare;
+        }
+        return o1.getPath().compareTo(o2.getPath());
+    };
+
+    /**
+     * A read-only projection for OptionDescriptor details relevant for the help task.
+     */
+    public static class OptionDetails {
+        private final String name;
+
+        private final String description;
+
+        private final Set<String> availableValues;
+        public OptionDetails(String name, String description, Set<String> availableValues) {
+            this.name = name;
+            this.description = description;
+            this.availableValues = availableValues;
+        }
+
+        private static OptionDetails from(OptionDescriptor option) {
+            return new OptionDetails(option.getName(), option.getDescription(), option.getAvailableValues());
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public Set<String> getAvailableValues() {
+            return availableValues;
+        }
+    }
+
+    private final String path;
+
+    private final String taskType;
+
+    private final String shortTypeName;
+
+    private final String description;
+
+    private final String group;
+
+    private final int projectDepth;
+
+    private final List<OptionDetails> options;
+
+    private TaskDetails(String path, String taskType, String shortTypeName, @Nullable String description, @Nullable String group, int projectDepth, List<OptionDetails> options) {
+        this.path = path;
+        this.taskType = taskType;
+        this.shortTypeName = shortTypeName;
+        this.description = description;
+        this.group = group;
+        this.projectDepth = projectDepth;
+        this.options = options;
+    }
+
+    /**
+     * The task type implementation Java class.
+     */
+    public String getTaskType() {
+        return taskType;
+    }
+
+    public String getShortTypeName() {
+        return shortTypeName;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    @Nullable
+    public String getGroup() {
+        return group;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public int getProjectDepth() {
+        return projectDepth;
+    }
+
+    public List<OptionDetails> getOptions() {
+        return options;
+    }
+
+    public static TaskDetails from(Task task, OptionReader optionReader) {
+        String path = task.getPath();
+        int projectDepth = StringUtils.countMatches(path, Project.PATH_SEPARATOR);
+        List<OptionDetails> options = optionReader.getOptions(task).stream().map(OptionDetails::from).collect(Collectors.toList());
+        Class<?> declaredTaskType = getDeclaredTaskType(task);
+        String taskType = declaredTaskType.getName();
+        String shortTypeName = declaredTaskType.getSimpleName();
+        return new TaskDetails(path, taskType, shortTypeName, task.getDescription(), task.getGroup(), projectDepth, options);
+    }
+
+    private static Class<?> getDeclaredTaskType(Task original) {
+        Class<?> clazz = new DslObject(original).getDeclaredType();
+        if (clazz.equals(DefaultTask.class)) {
+            return org.gradle.api.Task.class;
+        } else {
+            return clazz;
+        }
+    }
+}

--- a/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetailsModel.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/configuration/TaskDetailsModel.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration;
+
+import org.gradle.api.Task;
+import org.gradle.api.internal.tasks.options.OptionReader;
+import org.gradle.execution.TaskSelectionException;
+import org.gradle.execution.TaskSelector;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A configuration-friendly view of a task selection.
+ */
+class TaskDetailsModel {
+    private final String taskPath;
+    private final List<TaskDetails> tasks;
+    private final TaskSelectionException failure;
+
+    private TaskDetailsModel(String taskPath, List<TaskDetails> tasks) {
+        this.taskPath = taskPath;
+        this.failure = null;
+        this.tasks = tasks;
+    }
+
+    private TaskDetailsModel(String taskPath, TaskSelectionException failure) {
+        this.taskPath = taskPath;
+        this.tasks = Collections.emptyList();
+        this.failure = failure;
+    }
+    public List<TaskDetails> getTasks() {
+        if (failure != null) {
+            // rethrow the original failure
+            throw failure;
+        }
+        return tasks;
+    }
+
+    public String getTaskPath() {
+        return taskPath;
+    }
+
+    public static TaskDetailsModel from(String taskPath, TaskSelector taskSelector, OptionReader optionReader) {
+        try {
+            Stream<Task> selectedTasks = taskSelector.getSelection(taskPath).getTasks().stream();
+            List<TaskDetails> tasks = selectedTasks.map(t -> TaskDetails.from(t, optionReader))
+                .sorted(TaskDetails.DEFAULT_COMPARATOR).collect(Collectors.toList());
+            return new TaskDetailsModel(taskPath, tasks);
+        } catch (TaskSelectionException exception) {
+            // collect exception so we can rethrow it during task execution
+            return new TaskDetailsModel(taskPath, exception);
+        }
+    }
+}


### PR DESCRIPTION
Make help task config cache compatible

Collects TaskDetails vanilla POJOs from tasks during configuration,
avoiding relying on Project/Task objects during execution.

Fixes #21056


### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
