### PR TITLE
Exit on failure from clean dir checking by default, but allow android dir checking to opt out if necessary

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -158,9 +158,9 @@ fun BuildSteps.checkCleanM2AndAndroidUserHome(os: Os = Os.LINUX) {
         name = "CHECK_CLEAN_M2_ANDROID_USER_HOME"
         executionMode = BuildStep.ExecutionMode.ALWAYS
         scriptContent = if (os == Os.WINDOWS) {
-            checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.m2\\repository") + checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.m2\\.gradle-enterprise") + checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.android")
+            checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.m2\\repository") + checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.m2\\.gradle-enterprise") + checkCleanDirWindows("%teamcity.agent.jvm.user.home%\\.android", false)
         } else {
-            checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/repository") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/.gradle-enterprise") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.android")
+            checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/repository") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/.gradle-enterprise") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.android", false)
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -24,24 +24,24 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import model.CIBuildModel
 import model.StageName
 
-fun checkCleanDirUnixLike(dir: String) = """
+fun checkCleanDirUnixLike(dir: String, exitOnFailure: Boolean = true) = """
     REPO=$dir
     if [ -e ${'$'}REPO ] ; then
         tree ${'$'}REPO
         rm -rf ${'$'}REPO
         echo "${'$'}REPO was polluted during the build"
-        exit 1
+        ${if (exitOnFailure) "exit 1" else ""}
     else
         echo "${'$'}REPO does not exist"
     fi
 
 """.trimIndent()
 
-fun checkCleanDirWindows(dir: String) = """
+fun checkCleanDirWindows(dir: String, exitOnFailure: Boolean = true) = """
     IF exist $dir (
         TREE $dir
         RMDIR /S /Q $dir
-        EXIT 1
+        ${if (exitOnFailure) "EXIT 1" else ""}
     )
 
 """.trimIndent()


### PR DESCRIPTION
This PR is awaiting review.  It exists to patch [the problem reported here](https://gradle.slack.com/archives/CBSJ2GUTV/p1659463529599569) by restoring the log-only behavior for `.android`.

**I'm unsure if this is the intended behavior or if this is a latent problem this change revealed.**  See [this line](https://github.com/gradle/gradle/pull/21410/files#diff-97d297c924f24591f6c2e27f487e25a2290bd88263bb2b41915287529232f376L55), which is commented out prior to my recent change without an explanation.  

If this check if meant to only log, please merge this PR.