### PR TITLE
Change release notes fixed issues list style to use bullets instead of greater-than-sign as per discussion with DevRel team

### DIFF
--- a/subprojects/docs/src/docs/css/release-notes.css
+++ b/subprojects/docs/src/docs/css/release-notes.css
@@ -12,7 +12,7 @@
 .table-of-contents ul li:before,
 .topic ul li:before {
   color: #02303A;
-  content: '\00276F';
+  content: '\002022';
   font: 0.9em bold sans-serif;
   margin-left: -1em;
   margin-right: 0.4em;


### PR DESCRIPTION
Screenshot of the bullets as rendered now:
<img width="363" alt="Screen Shot 2022-08-02 at 4 42 32 PM" src="https://user-images.githubusercontent.com/120980/182469583-25ebbaef-2e76-4f14-83e0-3b2b8098cbda.png">

Hmmm maybe the bullets can be a little bigger, we can adjust the size in the future if needed.