### PR TITLE
Implement Zinc bug workaround

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -38,7 +38,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
 
     def setup() {
         runner.args = [AndroidGradlePluginVersions.OVERRIDE_VERSION_CHECK]
-        runner.targetVersions = ["7.5-20220504230242+0000"]
+        runner.targetVersions = ["7.5"]
         AndroidTestProject.useStableAgpVersion(runner)
         // AGP 4.1 requires 6.5+
         // forUseAtConfigurationTime API used in this scenario

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -33,7 +33,7 @@ import static org.gradle.performance.results.OperatingSystem.LINUX
 class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
     def setup() {
-        runner.targetVersions = ["7.5-20220504230242+0000"]
+        runner.targetVersions = ["7.5"]
     }
 
     def "first use"() {

--- a/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompiler.java
@@ -201,6 +201,9 @@ public class ZincScalaCompiler implements Compiler<ScalaJavaJointCompileSpec> {
 
         @Override
         public DefinesClass definesClass(VirtualFile classpathEntry) {
+            if (classpathEntry.name().equals("rt.jar")) {
+                return className -> false;
+            }
             return analysis(classpathEntry)
                 .map(a -> a instanceof Analysis ? (Analysis) a : null)
                 .<DefinesClass>map(AnalysisBakedDefineClass::new)


### PR DESCRIPTION
Workaround as implemented in Sbt and maven-scala-plugin

Fixes #21400

Unfortunately, I am not able to reproduce the issue with Gradle so far. Even when using [the reproducer for `maven-scala-plugin`](https://github.com/LuciferYang/scala-maven-plugin-test), the build does not fail with Gradle 7.5.
However the fix is based on the ones made for sbt and the Maven plugin and has been OKed by the Zinc folks, so we should indeed add this protection.