### PR TITLE
Fix flaky FinalizerTaskIntegrationTest

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -190,7 +190,7 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
         expect:
         2.times {
             succeeds 'processResources'
-            result.assertTaskOrder ':processResources', ':compileJava', ':classes', ':generatePermissions', ':assemble'
+            result.assertTaskOrder ':processResources', ':compileJava', ':classes', any(':generatePermissions', ':assemble')
         }
     }
 


### PR DESCRIPTION
Cherry-picked from `master` (https://github.com/gradle/gradle/pull/21408).

The two finalizers can run in parallel.