### PR TITLE
Add conditions for setting -source-path option

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/InternalJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/InternalJavadocDocletOptions.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks.javadoc;
+
+import org.gradle.external.javadoc.StandardJavadocDocletOptions;
+import org.gradle.external.javadoc.internal.JavadocOptionFile;
+
+class InternalJavadocDocletOptions extends StandardJavadocDocletOptions {
+    public InternalJavadocDocletOptions(StandardJavadocDocletOptions options) {
+        super(options);
+    }
+
+    public JavadocOptionFile getJavadocOptionFile() {
+        return super.getJavadocOptionFile();
+    }
+}

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -136,7 +136,7 @@ public class Javadoc extends SourceTask {
             throw new UncheckedIOException(ex);
         }
 
-        StandardJavadocDocletOptions options = new StandardJavadocDocletOptions((StandardJavadocDocletOptions) getOptions());
+        InternalJavadocDocletOptions options = new InternalJavadocDocletOptions((StandardJavadocDocletOptions) getOptions());
 
         if (options.getDestinationDirectory() == null) {
             options.destinationDirectory(destinationDir);
@@ -153,7 +153,7 @@ public class Javadoc extends SourceTask {
 
         // If modularized JavaDoc is needed, we need to add the source paths - the file listing is not enough alone
         // See #19726 for more
-        if (isModule) {
+        if (isModule && !options.getJavadocOptionFile().getOptions().containsKey("-module-source-path") && options.getSourcePath().isEmpty()) {
             List<File> sourceDirectories = getSource()
                 .getFiles()
                 .stream()

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -18,6 +18,7 @@ package org.gradle.external.javadoc;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.external.javadoc.internal.JavadocOptionFile;
 import org.gradle.external.javadoc.internal.JavadocOptionFileOptionInternal;
 import org.gradle.external.javadoc.internal.JavadocOptionFileOptionInternalAdapter;
@@ -783,5 +784,17 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
         return optionFile.stringifyExtraOptionsToMap(knownOptionNames()).entrySet().stream()
                 .map(e -> e.getKey() + ":" + e.getValue())
                 .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Internal access for the option file - do not use as this will be removed in a later version
+     *
+     * @return The {@code JavadocOptionFile}
+     * @since 7.5.1
+     */
+    @Incubating
+    @Internal
+    protected JavadocOptionFile getJavadocOptionFile() {
+        return optionFile;
     }
 }


### PR DESCRIPTION
-source-path and -module-source-path are exclusive, so only set a value
for the first if the second is not present.
We also no longer overwrite what the user may have configured in
-source-path.

Fixes #21399

From playing around to create the reproduce test, looks like `-module-source-path` has strong enforcement of module name in source folder hierarchy, which `-source-path` does not have. So we should aim at supporting both options first class in an upcoming version.
The fix here unblocks usage of `-module-source-path` in user build scripts without changing the feature released in Gradle 7.5