### PR TITLE
Deprecate usage of invalid Java toolchain specs

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -235,8 +235,8 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
 
     private Provider<JavaCompiler> getCompilerTool() {
         JavaToolchainSpec explicitToolchain = determineExplicitToolchain();
-        if(explicitToolchain == null) {
-            if(javaCompiler.isPresent()) {
+        if (explicitToolchain == null) {
+            if (javaCompiler.isPresent()) {
                 return this.javaCompiler;
             } else {
                 explicitToolchain = new CurrentJvmToolchainSpec(objectFactory);
@@ -254,7 +254,7 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
             final String customExecutable = getOptions().getForkOptions().getExecutable();
             if (customExecutable != null) {
                 final File executable = new File(customExecutable);
-                if(executable.exists()) {
+                if (executable.exists()) {
                     return new SpecificInstallationToolchainSpec(objectFactory, executable.getParentFile().getParentFile());
                 }
             }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/DefaultToolchainSpec.java
@@ -26,7 +26,7 @@ import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import javax.inject.Inject;
 
-public class DefaultToolchainSpec implements ToolchainSpecInternal {
+public class DefaultToolchainSpec implements JavaToolchainSpecInternal {
 
     private final Property<JavaLanguageVersion> languageVersion;
     private final Property<JvmVendorSpec> vendor;
@@ -57,6 +57,15 @@ public class DefaultToolchainSpec implements ToolchainSpecInternal {
     @Override
     public boolean isConfigured() {
         return languageVersion.isPresent();
+    }
+
+    @Override
+    public boolean isValid() {
+        return languageVersion.isPresent() || !isSecondaryPropertySet();
+    }
+
+    private boolean isSecondaryPropertySet() {
+        return vendor.isPresent() || implementation.isPresent();
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainSpecInternal.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainSpecInternal.java
@@ -18,8 +18,21 @@ package org.gradle.jvm.toolchain.internal;
 
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 
-public interface ToolchainSpecInternal extends JavaToolchainSpec {
+public interface JavaToolchainSpecInternal extends JavaToolchainSpec {
 
+    /**
+     * A spec is considered configured when at least {@link #getLanguageVersion() language version} is set.
+     * <p>
+     * A spec that is not configured always directly matches the toolchain of the current JVM.
+     */
     boolean isConfigured();
+
+    /**
+     * A spec is valid when {@link #getLanguageVersion() language version} is set (along with any other properties)
+     * or when no properties are set.
+     * <p>
+     * A {@link #isConfigured() non-configured} spec is always valid.
+     */
+    boolean isValid();
 
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SpecificInstallationToolchainSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/SpecificInstallationToolchainSpec.java
@@ -36,6 +36,11 @@ public class SpecificInstallationToolchainSpec extends DefaultToolchainSpec {
         return true;
     }
 
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
     public File getJavaHome() {
         return javaHome;
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -54,7 +54,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
 import org.gradle.jvm.toolchain.internal.JavaToolchainQueryService;
-import org.gradle.jvm.toolchain.internal.ToolchainSpecInternal;
+import org.gradle.jvm.toolchain.internal.JavaToolchainSpecInternal;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
 
@@ -304,7 +304,7 @@ public class JavaBasePlugin implements Plugin<Project> {
     }
 
     private void checkToolchainAndCompatibilityUsage(JavaPluginExtension javaExtension, Supplier<JavaVersion> rawJavaVersionSupplier) {
-        if (((ToolchainSpecInternal) javaExtension.getToolchain()).isConfigured() && rawJavaVersionSupplier.get() != null) {
+        if (((JavaToolchainSpecInternal) javaExtension.getToolchain()).isConfigured() && rawJavaVersionSupplier.get() != null) {
             throw new InvalidUserDataException("The new Java toolchain feature cannot be used at the project level in combination with source and/or target compatibility");
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -44,7 +44,7 @@ import org.gradle.internal.component.external.model.ProjectDerivedCapability;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.DefaultToolchainSpec;
-import org.gradle.jvm.toolchain.internal.ToolchainSpecInternal;
+import org.gradle.jvm.toolchain.internal.JavaToolchainSpecInternal;
 import org.gradle.testing.base.plugins.TestingBasePlugin;
 
 import javax.inject.Inject;
@@ -62,7 +62,7 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private static final Pattern VALID_FEATURE_NAME = Pattern.compile("[a-zA-Z0-9]+");
     private final SourceSetContainer sourceSets;
 
-    private final ToolchainSpecInternal toolchainSpec;
+    private final JavaToolchainSpecInternal toolchainSpec;
     private final ObjectFactory objectFactory;
     private final SoftwareComponentContainer components;
     private final ModularitySpec modularity;


### PR DESCRIPTION
In preparation to change behavior of the toolchain resolution for an unconfigured toolchain spec, we deprecate the usage of invalid toolchain specs.

A spec is valid when the language version is set (along with any other properties) or when no properties are set. An unconfigured spec is always valid.

Previously there was a corner case that was not handled explicitly: how to react to a spec that does not have the language version configured, but has a configured vendor. This PR declared such specs invalid.