### PR TITLE
Fix #21503: Refactor references to deprecated AntBuilder package

### DIFF
--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -1,6 +1,14 @@
 {
     "acceptedApiChanges": [
         {
+            "type": "org.gradle.api.AntBuilder",
+            "member": "Class org.gradle.api.AntBuilder",
+            "acceptation": "org.gradle.api.AntBuilder now extends groovy.ant.AntBuilder",
+            "changes": [
+                "Abstract method has been added in implemented interface"
+            ]
+        },
+        {
             "type": "org.gradle.api.file.SourceDirectorySet",
             "member": "Method org.gradle.api.file.SourceDirectorySet.getOutputDir()",
             "acceptation": "Deprecated method removed",

--- a/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/AntBuilder.java
@@ -20,8 +20,7 @@ import java.util.Map;
 /**
  * <p>An {@code AntBuilder} allows you to use Ant from your build script.</p>
  */
-@SuppressWarnings("deprecation")
-public abstract class AntBuilder extends groovy.util.AntBuilder {
+public abstract class AntBuilder extends groovy.ant.AntBuilder {
     /**
      * Returns the properties of the Ant project. This is a live map, you that you can make changes to the map and these
      * changes are reflected in the Ant project.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ant/BasicAntBuilder.java
@@ -36,9 +36,9 @@ public class BasicAntBuilder extends org.gradle.api.AntBuilder implements Closea
         // These are used to discard references to tasks so they can be garbage collected
         Field collectorField;
         try {
-            nodeField = groovy.util.AntBuilder.class.getDeclaredField("lastCompletedNode");
+            nodeField = groovy.ant.AntBuilder.class.getDeclaredField("lastCompletedNode");
             nodeField.setAccessible(true);
-            collectorField = groovy.util.AntBuilder.class.getDeclaredField("collectorTarget");
+            collectorField = groovy.ant.AntBuilder.class.getDeclaredField("collectorTarget");
             collectorField.setAccessible(true);
             Target target = (Target) collectorField.get(this);
             Field childrenField = Target.class.getDeclaredField("children");

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultAntBuilderTest.groovy
@@ -163,7 +163,7 @@ class DefaultAntBuilderTest extends AbstractProjectBuilderSpec {
         ant.antProject.targets.size() == 0
 
         when:
-        Field field = groovy.util.AntBuilder.class.getDeclaredField('collectorTarget')
+        Field field = groovy.ant.AntBuilder.class.getDeclaredField('collectorTarget')
         field.accessible = true
         Target target = field.get(ant)
         field = target.class.getDeclaredField('children')

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -46,7 +46,9 @@ TBD
 
 === Potential breaking changes
 
-TBD
+==== Change to `AntBuilder` parent class
+
+Previously, `org.gradle.api.AntBuilder` extended the deprecated `groovy.util.AntBuilder` class.  It now extends `groovy.ant.AntBuilder`.
 
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier


### PR DESCRIPTION
I expect this to be a breaking API change; therefore targeting 8.0.