### PR TITLE
Add build parameters to run docsTest with configuration cache enabled

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -33,6 +33,7 @@ import gradlebuild.basics.BuildParams.BUILD_VCS_NUMBER
 import gradlebuild.basics.BuildParams.BUILD_VERSION_QUALIFIER
 import gradlebuild.basics.BuildParams.CI_ENVIRONMENT_VARIABLE
 import gradlebuild.basics.BuildParams.DEFAULT_PERFORMANCE_BASELINES
+import gradlebuild.basics.BuildParams.ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS
 import gradlebuild.basics.BuildParams.FLAKY_TEST
 import gradlebuild.basics.BuildParams.GRADLE_INSTALL_PATH
 import gradlebuild.basics.BuildParams.INCLUDE_PERFORMANCE_TEST_SCENARIOS
@@ -48,6 +49,7 @@ import gradlebuild.basics.BuildParams.PERFORMANCE_TEST_VERBOSE
 import gradlebuild.basics.BuildParams.PREDICTIVE_TEST_SELECTION_ENABLED
 import gradlebuild.basics.BuildParams.RERUN_ALL_TESTS
 import gradlebuild.basics.BuildParams.RUN_ANDROID_STUDIO_IN_HEADLESS_MODE
+import gradlebuild.basics.BuildParams.RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS
 import gradlebuild.basics.BuildParams.STUDIO_HOME
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_ENABLED
 import gradlebuild.basics.BuildParams.TEST_DISTRIBUTION_PARTITION_SIZE
@@ -121,6 +123,15 @@ object BuildParams {
     const val AUTO_DOWNLOAD_ANDROID_STUDIO = "autoDownloadAndroidStudio"
     const val RUN_ANDROID_STUDIO_IN_HEADLESS_MODE = "runAndroidStudioInHeadlessMode"
     const val STUDIO_HOME = "studioHome"
+
+    /**
+     * Run docs tests with the configuration cache enabled.
+     */
+    const val ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS = "enableConfigurationCacheForDocsTests"
+    /**
+     * Run docs tests that are knowingly broken when running with the configuration cache enabled. Only applied when #ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS is also set.
+     */
+    const val RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS = "runBrokenConfigurationCacheDocsTests"
 
     internal
     val VENDOR_MAPPING = mapOf("oracle" to JvmVendorSpec.ORACLE, "openjdk" to JvmVendorSpec.ADOPTIUM)
@@ -358,6 +369,20 @@ val Project.runAndroidStudioInHeadlessMode: Boolean
 
 val Project.androidStudioHome: Provider<String>
     get() = propertyFromAnySource(STUDIO_HOME)
+
+
+/**
+ * If set to `true`, run docs tests with the configuration cache enabled.
+ */
+val Project.configurationCacheEnabledForDocsTests: Boolean
+    @JvmName("isConfigurationCacheEnabledForDocsTests") get() = gradleProperty(ENABLE_CONFIGURATION_CACHE_FOR_DOCS_TESTS).orNull.toBoolean()
+
+
+/**
+ * If set to `true`, run docs tests that are knowingly broken when running with the configuration cache enabled. Only applied when #configurationCacheEnabledForDocsTests is also set.
+ */
+val Project.runBrokenForConfigurationCacheDocsTests: Boolean
+    @JvmName("shouldRunBrokenForConfigurationCacheDocsTests") get() = gradleProperty(RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS).orNull.toBoolean()
 
 
 /**

--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -161,6 +161,9 @@ then you can run the following command line:
 
 which would run both Groovy and Kotlin tests.
 
+It is possible to run samples and snippets with the configuration cache enabled to ensure compatibility.
+To do that set the Gradle property `enableConfigurationCacheForDocsTests=true` in the command line or in the `gradle.properties` file.
+
 ## Groovy DSL Reference
 
 The DSL reference is authored in Docbook syntax, with sources under `src/docs/dsl`. 

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -2,10 +2,12 @@ import gradlebuild.integrationtests.model.GradleDistribution
 import org.asciidoctor.gradle.jvm.AsciidoctorTask
 import org.gradle.docs.internal.tasks.CheckLinks
 import org.gradle.docs.samples.internal.tasks.InstallSample
+import org.gradle.internal.os.OperatingSystem
 
 import static gradlebuild.basics.BuildEnvironmentKt.repoRoot
+import static gradlebuild.basics.BuildParamsKt.isConfigurationCacheEnabledForDocsTests
+import static gradlebuild.basics.BuildParamsKt.shouldRunBrokenForConfigurationCacheDocsTests
 import static gradlebuild.basics.Repositories_extensionsKt.googleApisJs
-import org.gradle.internal.os.OperatingSystem
 
 plugins {
     id 'gradlebuild.internal.java'
@@ -641,6 +643,179 @@ tasks.named("docsTest") { task ->
             excludeTestsMatching "org.gradle.docs.samples.*.snippet-native*.sample"
             excludeTestsMatching "org.gradle.docs.samples.*.snippet-swift*.sample"
             excludeTestsMatching "org.gradle.docs.samples.*.building-swift*.sample"
+        }
+    }
+
+    if (isConfigurationCacheEnabledForDocsTests(project)) {
+        systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
+        systemProperty("org.gradle.integtest.executer", "configCache")
+
+        filter {
+            // Configuration cache samples enable configuration cache explicitly. We're not going to run them with the configuration cache executer.
+            excludeTestsMatching "org.gradle.docs.samples.*.snippet-configuration-cache-*.sample"
+
+            // Tests that has to be addressed (in alphabetical order). Set the Gradle proeprty runBrokenConfigurationCacheDocsTests=true to run tests from this list.
+            // TODO(mlopatkin) split out tests for the features that are currently unsupported with the configuration cache.
+            [
+                "building-cpp-applications_groovy_build.sample",
+                "building-cpp-applications_kotlin_build.sample",
+                "building-cpp-libraries_groovy_build.sample",
+                "building-cpp-libraries_kotlin_build.sample",
+                "publishing-credentials_groovy_publishCommandLineCredentials.sample",
+                "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
+                "snippet-ant-add-behaviour-to-ant-target_groovy_addBehaviourToAntTarget.sample",
+                "snippet-ant-add-behaviour-to-ant-target_kotlin_addBehaviourToAntTarget.sample",
+                "snippet-ant-depends-on-ant-target_groovy_dependsOnAntTarget.sample",
+                "snippet-ant-depends-on-ant-target_kotlin_dependsOnAntTarget.sample",
+                "snippet-ant-depends-on-task_groovy_dependsOnTask.sample",
+                "snippet-ant-depends-on-task_kotlin_dependsOnTask.sample",
+                "snippet-ant-hello_groovy_antHello.sample",
+                "snippet-ant-hello_kotlin_antHello.sample",
+                "snippet-ant-rename-task_groovy_renameAntDelegate.sample",
+                "snippet-ant-rename-task_kotlin_renameAntDelegate.sample",
+                "snippet-ant-use-external-ant-task-with-config_kotlin_useExternalAntTaskWithConfig.sample",
+                "snippet-artifacts-generated-file-dependencies_kotlin_generatedFileDependencies.sample",
+                "snippet-build-cache-cacheable-bundle-task_groovy_cacheableBundleTask.sample",
+                "snippet-build-cache-cacheable-bundle-task_kotlin_cacheableBundleTask.sample",
+                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle-caching.sample",
+                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle.sample",
+                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle-caching.sample",
+                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle.sample",
+                "snippet-buildlifecycle-project-evaluate-events_groovy_projectEvaluateEvents.sample",
+                "snippet-buildlifecycle-project-evaluate-events_kotlin_projectEvaluateEvents.sample",
+                "snippet-buildlifecycle-task-execution-events_groovy_sanityCheck.sample",
+                "snippet-buildlifecycle-task-execution-events_groovy_taskExecutionEvents.groovy.sample",
+                "snippet-buildlifecycle-task-execution-events_kotlin_sanityCheck.sample",
+                "snippet-buildlifecycle-task-execution-events_kotlin_taskExecutionEvents.kotlin.sample",
+                "snippet-custom-model-internal-views_groovy_softwareModelExtend-iv-model.sample",
+                "snippet-custom-model-language-type_groovy_softwareModelExtend-components.sample",
+                "snippet-dependency-management-customizing-resolution-attribute-substitution-rule_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-capability-substitution-rule_kotlin_capability_substitution.sample",
+                "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_groovy_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFiles.sample",
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFilesLocal.sample",
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_kotlin_ivyComonentMetadataRule.sample",
+                "snippet-dependency-management-customizing-resolution-metadata-rule_kotlin_comonentMetadataRules.sample",
+                "snippet-dependency-management-defining-using-configurations-custom_kotlin_custom-configuration.sample",
+                "snippet-dependency-management-dependency-verification-disabling-verification_kotlin_disabling_verification.sample",
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-configuration_kotlin_exclude-transitive-for-configuration.sample",
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_kotlin_exclude-transitive-for-dependency.sample",
+                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_kotlin_accessingMetadataArtifact.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-artifacts_kotlin_iterating-artifacts.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",
+                "snippet-dependency-management-working-with-dependencies-walk-graph_groovy_walking-dependency-graph.sample",
+                "snippet-dependency-management-working-with-dependencies-walk-graph_kotlin_walking-dependency-graph.sample",
+                "snippet-files-archive-naming_kotlin_archiveNaming.sample",
+                "snippet-files-archives-changed-base-name_groovy_zipWithArchivesBaseName.sample",
+                "snippet-files-archives-changed-base-name_kotlin_zipWithArchivesBaseName.sample",
+                "snippet-files-file-collections_kotlin_fileCollectionsFiltering.sample",
+                "snippet-files-file-collections_kotlin_fileCollectionsUsage.sample",
+                "snippet-files-file-collections_kotlin_fileCollectionsWithClosure.sample",
+                "snippet-ide-eclipse_groovy_wtpWithXml.sample",
+                "snippet-ide-eclipse_kotlin_wtpWithXml.sample",
+                "snippet-ide-idea-additional-test-sources_groovy_ideaAdditionalTestSources.sample",
+                "snippet-ide-idea-additional-test-sources_kotlin_ideaAdditionalTestSources.sample",
+                "snippet-ide-idea_groovy_projectWithXml.sample",
+                "snippet-ide-idea_kotlin_projectWithXml.sample",
+                "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
+                "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
+                "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
+                "snippet-ivy-publish-descriptor-customization_groovy_publishingIvyGenerateDescriptor.sample",
+                "snippet-ivy-publish-descriptor-customization_kotlin_publishingIvyGenerateDescriptor.sample",
+                "snippet-ivy-publish-java-multi-project_groovy_publish-multi-project.sample",
+                "snippet-ivy-publish-java-multi-project_kotlin_publish-multi-project.sample",
+                "snippet-ivy-publish-quickstart_groovy_publishingIvyPublishLifecycle.sample",
+                "snippet-ivy-publish-quickstart_groovy_publishingIvyPublishSingle.sample",
+                "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishLifecycle.sample",
+                "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishSingle.sample",
+                "snippet-java-cross-compilation_kotlin_java7CrossCompilation.sample",
+                "snippet-java-custom-dirs_groovy_javaCustomReportDirs.sample",
+                "snippet-java-custom-dirs_kotlin_javaCustomReportDirs.sample",
+                "snippet-java-fixtures_kotlin_javaTestFixtures.sample",
+                "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
+                "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",
+                "snippet-kotlin-dsl-android-build_kotlin_sanityCheck.sample",
+                "snippet-kotlin-dsl-android-single-build_kotlin_sanityCheck.sample",
+                "snippet-kotlin-dsl-multi-project-build_kotlin_build.sample",
+                "snippet-maven-publish-conditional-publishing_groovy_publishingMavenConditionally.sample",
+                "snippet-maven-publish-conditional-publishing_kotlin_publishingMavenConditionally.sample",
+                "snippet-model-rules-basic-rule-source-plugin_groovy_basicRuleSourcePlugin-all.sample",
+                "snippet-model-rules-basic-rule-source-plugin_groovy_basicRuleSourcePlugin-model-task.sample",
+                "snippet-model-rules-configure-as-required_groovy_modelDslConfigureRuleRunWhenRequired.sample",
+                "snippet-model-rules-configure-elements-of-map_groovy_modelDslModelMapNestedAll.sample",
+                "snippet-model-rules-initialization-rule-runs-before-configuration-rules_groovy_modelDslInitializationRuleRunsBeforeConfigurationRule.sample",
+                "snippet-native-binaries-cpp_groovy_nativeComponentReport.sample",
+                "snippet-native-binaries-cunit_groovy_assembleDependentComponents.sample",
+                "snippet-native-binaries-cunit_groovy_assembleDependentComponentsReport.sample",
+                "snippet-native-binaries-cunit_groovy_buildDependentComponents.sample",
+                "snippet-native-binaries-cunit_groovy_buildDependentComponentsReport.sample",
+                "snippet-native-binaries-cunit_groovy_completeCUnitExample.sample",
+                "snippet-native-binaries-cunit_groovy_dependentComponentsReport.sample",
+                "snippet-native-binaries-cunit_groovy_dependentComponentsReportAll.sample",
+                "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
+                "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
+                "snippet-providers-property-convention_kotlin_propertyConvention.sample",
+                "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
+                "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",
+                "snippet-signing-maven-publish_groovy_publishingMavenSignAndPublish.sample",
+                "snippet-signing-maven-publish_groovy_signingPluginSignPublication.sample",
+                "snippet-signing-maven-publish_kotlin_publishingMavenSignAndPublish.sample",
+                "snippet-signing-maven-publish_kotlin_signingPluginSignPublication.sample",
+                "snippet-signing-tasks_groovy_signingTaskOutput.sample",
+                "snippet-signing-tasks_kotlin_signingTaskOutput.sample",
+                "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",
+                "snippet-tasks-custom-task-with-missing-file-property_kotlin_missingFileProperties.sample",
+                "snippet-tasks-incremental-build-custom-task-class_groovy_customTaskClassWithInputOutputAnnotations.sample",
+                "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep.sample",
+                "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep2.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_customTaskClassWithInputOutputAnnotations.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_incrementalAdHocTask.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_incrementalAdHocTaskNoSource.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_inferredTaskDep.sample",
+                "snippet-tasks-incremental-build-custom-task-class_kotlin_inferredTaskDep2.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildCustomMethods.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildCustomMethodsWithTaskArg.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildInputFilesConfig.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildInputFilesConfigUsingTask.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_incrementalBuildUpToDateWhen.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_groovy_inferredTaskDependencyWithBuiltBy.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildCustomMethods.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildCustomMethodsWithTaskArg.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildInputFilesConfig.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildInputFilesConfigUsingTask.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildUpToDateWhen.sample",
+                "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_inferredTaskDependencyWithBuiltBy.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskChangedProperty.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskFirstRun.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskNoChange.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskRemovedInput.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskRemovedOutput.sample",
+                "snippet-tasks-incremental-task_kotlin_incrementalTaskUpdatedInputs.sample",
+                "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
+                "snippet-tutorial-ant-loadfile-with-method_kotlin_antLoadfileWithMethod.sample",
+                "snippet-tutorial-ant-loadfile_kotlin_antLoadfile.sample",
+                "snippet-tutorial-configure-task-using-project-property_groovy_configureTaskUsingProjectProperty.sample",
+                "snippet-tutorial-configure-task-using-project-property_kotlin_configureTaskUsingProjectProperty.sample",
+                "snippet-tutorial-extra-properties_kotlin_extraProperties.sample",
+                "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
+                "structuring-software-projects_groovy_aggregate-reports.sample",
+                "structuring-software-projects_groovy_build-server-application.sample",
+                "structuring-software-projects_groovy_umbrella-build.sample",
+                "structuring-software-projects_kotlin_aggregate-reports.sample",
+                "structuring-software-projects_kotlin_build-server-application.sample",
+                "structuring-software-projects_kotlin_umbrella-build.sample",
+                "task-with-arguments_groovy_projectInfoTask.sample",
+                "task-with-arguments_kotlin_projectInfoTask.sample",
+            ].forEach { testName ->
+                def testMask = "org.gradle.docs.samples.*.$testName"
+                if (shouldRunBrokenForConfigurationCacheDocsTests(project)) {
+                    includeTestsMatching testMask
+                } else {
+                    excludeTestsMatching testMask
+                }
+            }
         }
     }
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/BaseSamplesTest.java
@@ -18,6 +18,7 @@ package org.gradle.docs.samples;
 
 import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier;
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer;
+import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputCleaner;
 import org.gradle.integtests.fixtures.logging.ConfigurationCacheOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer;
 import org.gradle.integtests.fixtures.logging.EmbeddedKotlinOutputNormalizer;
@@ -40,6 +41,7 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
     ArtifactResolutionOmittingOutputNormalizer.class,
     NativeComponentReportOutputNormalizer.class,
     DependencyInsightOutputNormalizer.class,
+    ConfigurationCacheOutputCleaner.class,
     ConfigurationCacheOutputNormalizer.class,
     EmbeddedKotlinOutputNormalizer.class
 })
@@ -61,4 +63,3 @@ import org.gradle.exemplar.test.runner.SamplesOutputNormalizers;
  */
 abstract class BaseSamplesTest {
 }
-

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheOutputCleaner.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ConfigurationCacheOutputCleaner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging;
+
+import org.gradle.exemplar.executor.ExecutionMetadata;
+import org.gradle.exemplar.test.normalizer.OutputNormalizer;
+
+import java.util.regex.Pattern;
+
+/**
+ * Conditionally removes the configuration cache logging from the Gradle output.
+ * This normalization is only enabled if {@link #CLEAN_CONFIGURATION_CACHE_OUTPUT}
+ * system property is set to {@code true}.
+ * <p>
+ * Most of our samples that aren't aiming to test the configuration cache itself, do not care about
+ * its output much. This normalizer allows to reuse the same "golden" output files when testing such
+ * samples with the configuration cache enabled.
+ */
+public class ConfigurationCacheOutputCleaner implements OutputNormalizer {
+    // The configuration of the normalizers is static (defined in the annotations), so this
+    // normalizer is going to be applied everywhere. We don't want, however, to remove configuration
+    // cache output from the tests that check this very output, thus this switch exists.
+    private static final String CLEAN_CONFIGURATION_CACHE_OUTPUT = "org.gradle.integtest.samples.cleanConfigurationCacheOutput";
+    private static final Pattern CONFIGURATION_CACHE_OUTPUT = Pattern.compile(
+        "((Configuration cache entry[^\\n]+\\.)|" +
+            "(See the complete report at [^\\n]+\\n)|" +
+            "(0 problems were found storing the configuration cache.\\n))(\\n)?"
+    );
+
+    @Override
+    public String normalize(String commandOutput, ExecutionMetadata executionMetadata) {
+        if (!Boolean.parseBoolean(System.getProperty(CLEAN_CONFIGURATION_CACHE_OUTPUT))) {
+            return commandOutput;
+        }
+        return CONFIGURATION_CACHE_OUTPUT.matcher(commandOutput).replaceAll("");
+    }
+}


### PR DESCRIPTION
As we're getting closer to declaring the configuration cache a stable
feature, we have to make sure that our documentation snippets are
compatible with the configuration caching. This commit adds basic
infrastructure of testing doc snippets and samples with the
configuration cache enabled, similar to existing configCacheIntegTest
integration test tasks.

To run the docs test with CC enabled, one should specify the property:
```
./gradlew -PenableConfigurationCacheForDocsTests=true docs:docsTest
```
The `subprojects/docs/build.gradle` contains the ignorelist of tests
that are known to be broken. One could run tests from this list only by
adding `-PrunBrokenConfigurationCacheDocsTests=true` to the command
above.

Making a separate task for the docs test with CC was considered, but
turned out to be a very non-trivial task due to the amount of
configuration applied to the `docsTest` by the supporting binary
plugins that have to be replicated.

This is a first step of #21027.
