### PR TITLE
Suppress ignorable shellcheck warnings

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -33,7 +33,8 @@ We would like to thank the following community members for their contributions t
 [teawithbrownsugar](https://github.com/teawithbrownsugar),
 [Thomas Broadley](https://github.com/tbroadley),
 [urdak](https://github.com/urdak),
-[Xin Wang](https://github.com/scaventz)
+[Xin Wang](https://github.com/scaventz),
+[Craig Andrews](https://github.com/candrews)
 
 
 ## Upgrade instructions

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -176,14 +176,16 @@ fi
 if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
     case \$MAX_FD in #(
       max*)
-        # shellcheck disable=SC3045 # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045 
         MAX_FD=\$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case \$MAX_FD in  #(
       '' | soft) :;; #(
       *)
-        # shellcheck disable=SC3045 # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC3045 
         ulimit -n "\$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to \$MAX_FD"
     esac

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -113,11 +113,8 @@ do
     esac
 done
 
-APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
-
-# shellcheck disable=SC2034 # May not be used but available in case it's useful
-APP_NAME="${applicationName}"
 APP_BASE_NAME=\${0##*/}
+APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
 
 # Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
 DEFAULT_JVM_OPTS=${defaultJvmOpts}

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -113,6 +113,8 @@ do
     esac
 done
 
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=\${0##*/}
 APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
 

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -115,6 +115,7 @@ done
 
 APP_HOME=\$( cd "\${APP_HOME:-./}${appHomeRelativePath}" && pwd -P ) || exit
 
+# shellcheck disable=SC2034 # May not be used but available in case it's useful
 APP_NAME="${applicationName}"
 APP_BASE_NAME=\${0##*/}
 
@@ -178,12 +179,14 @@ fi
 if ! "\$cygwin" && ! "\$darwin" && ! "\$nonstop" ; then
     case \$MAX_FD in #(
       max*)
+        # shellcheck disable=SC3045 # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
         MAX_FD=\$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case \$MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # shellcheck disable=SC3045 # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
         ulimit -n "\$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to \$MAX_FD"
     esac

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -27,6 +27,7 @@ if "%OS%"=="Windows_NT" setlocal
 set DIRNAME=%~dp0
 if "%DIRNAME%"=="" set DIRNAME=.\
 
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%${appHomeRelativePath}
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -46,7 +46,17 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 92
+        def scriptText = destination.toString()
+        def carriageLineEndings = scriptText.split('\r').length - 1 // over counts the final line
+        def newlineEndings = scriptText.split('\n').length
+        def windowsLineEndings = scriptText.split(TextUtil.windowsLineSeparator).length
+
+        // Windows line endings are made up of two characters,
+        // we should see an equal number of lines unless
+        // the generator is using the wrong line ending entirely
+        // or has generated some lines with one or the other character
+        carriageLineEndings == newlineEndings
+        windowsLineEndings == newlineEndings
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 91
+        destination.toString().split(TextUtil.windowsLineSeparator).length == 92
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {


### PR DESCRIPTION
* APP_BASE_NAME may not be used but available in case it's useful
* ulimit -H might not work since it's not POSIX, which is why there's a test for it
* ulimit -n might not work since it's not POSIX, which is why there's a test for it

Contributed by Craig Andrews 