### PR TITLE
Make Java launcher a nested input for Scala compilation

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AvailableJavaHomes.java
@@ -155,7 +155,15 @@ public abstract class AvailableJavaHomes {
      */
     @Nullable
     public static Jvm getDifferentJdk() {
-        return getAvailableJdk(element -> !element.getJavaHome().toFile().equals(Jvm.current().getJavaHome()) && isSupportedVersion(element));
+        return getAvailableJdk(element -> !isCurrentJavaHome(element) && isSupportedVersion(element));
+    }
+
+    /**
+     * Returns a JDK that has a different Java home than the current one, and which is supported by the Gradle version under test.
+     */
+    @Nullable
+    public static Jvm getDifferentJdk(final Spec<? super JvmInstallationMetadata> filter) {
+        return getAvailableJdk(element -> !isCurrentJavaHome(element) && isSupportedVersion(element) && filter.isSatisfiedBy(element));
     }
 
     /**
@@ -170,9 +178,13 @@ public abstract class AvailableJavaHomes {
      * Returns a JDK that has a different Java home to the current one, is supported by the Gradle version under tests and has a valid JRE.
      */
     public static Jvm getDifferentJdkWithValidJre() {
-        return AvailableJavaHomes.getAvailableJdk(jvm -> !jvm.getJavaHome().equals(Jvm.current().getJavaHome().toPath())
+        return AvailableJavaHomes.getAvailableJdk(jvm -> !isCurrentJavaHome(jvm)
             && isSupportedVersion(jvm)
             && Jvm.discovered(jvm.getJavaHome().toFile(), null, jvm.getLanguageVersion()).getJre() != null);
+    }
+
+    private static boolean isCurrentJavaHome(JvmInstallationMetadata metadata) {
+        return metadata.getJavaHome().toFile().equals(Jvm.current().getJavaHome());
     }
 
     /**

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationsFixture.groovy
@@ -32,7 +32,6 @@ class BuildOperationsFixture extends BuildOperationTreeQueries {
     private BuildOperationTreeFixture tree
 
     BuildOperationsFixture(GradleExecuter executer, TestDirectoryProvider projectDir) {
-
         String path = projectDir.testDirectory.file("operations").absolutePath
         executer.beforeExecute {
             executer.withArgument("-D$BuildOperationTrace.SYSPROP=$path")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
@@ -21,9 +21,6 @@ import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
 import org.gradle.api.internal.tasks.execution.ResolveTaskMutationsBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.executer.ExecutionFailure
-import org.gradle.integtests.fixtures.executer.ExecutionResult
-import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.operations.BuildOperationType
 import org.gradle.internal.operations.trace.BuildOperationRecord

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsFixture.groovy
@@ -25,23 +25,27 @@ import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.operations.BuildOperationType
 import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.jvm.toolchain.internal.operations.JavaToolchainUsageProgressDetails
-import org.junit.Before
 
+/**
+ * Captures build operations and allows to make assertions about events related to Java Toolchains.
+ * <p>
+ * When using this fixture make sure to first call {@link JavaToolchainBuildOperationsFixture#captureBuildOperations captureBuildOperations}
+ * in the {@code setup} method of the test class or in the beginning of a test itself.
+ */
 @SelfType(AbstractIntegrationSpec)
 trait JavaToolchainBuildOperationsFixture {
 
     private BuildOperationsFixture operations
 
-    @Before
-    void setupBuildOperations() {
-        operations = new BuildOperationsFixture(executer, temporaryFolder)
+    void captureBuildOperations() {
+        if (operations == null) {
+            operations = new BuildOperationsFixture(executer, temporaryFolder)
+        }
     }
 
-    // Spock 2 executes @Before after the setup() methods
-    // this is a workaround for tests that use this fixture from their setup() methods
-    private void initIfNeeded() {
+    private void ensureInitialized() {
         if (operations == null) {
-            setupBuildOperations()
+            throw new IllegalStateException("Make sure to call `captureBuildOperations` before using methods that work on captured operations.")
         }
     }
 
@@ -73,7 +77,7 @@ trait JavaToolchainBuildOperationsFixture {
     }
 
     List<BuildOperationRecord.Progress> toolchainEvents(String taskPath) {
-        initIfNeeded()
+        ensureInitialized()
         return progressEventsFor(
             operations, JavaToolchainUsageProgressDetails, taskPath,
             ResolveTaskMutationsBuildOperationType, ExecuteTaskBuildOperationType

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsHelper.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/jvm/JavaToolchainBuildOperationsHelper.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.jvm
+
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
+import org.gradle.api.internal.tasks.execution.ResolveTaskMutationsBuildOperationType
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
+import org.gradle.internal.operations.BuildOperationType
+import org.gradle.internal.operations.trace.BuildOperationRecord
+import org.gradle.jvm.toolchain.internal.operations.JavaToolchainUsageProgressDetails
+
+class JavaToolchainBuildOperationsHelper {
+
+    static void assertToolchainUsages(List<BuildOperationRecord.Progress> events, JvmInstallationMetadata jdkMetadata, String tool) {
+        assert events.size() > 0
+        events.each { usageEvent ->
+            assertToolchainUsage(tool, jdkMetadata, usageEvent)
+        }
+    }
+
+    static void assertToolchainUsage(String toolName, JvmInstallationMetadata jdkMetadata, BuildOperationRecord.Progress usageEvent) {
+        assert usageEvent.details.toolName == toolName
+
+        def usedToolchain = usageEvent.details.toolchain
+        assert usedToolchain == [
+            javaVersion: jdkMetadata.javaVersion,
+            javaVendor: jdkMetadata.vendor.displayName,
+            runtimeName: jdkMetadata.runtimeName,
+            runtimeVersion: jdkMetadata.runtimeVersion,
+            jvmName: jdkMetadata.jvmName,
+            jvmVersion: jdkMetadata.jvmVersion,
+            jvmVendor: jdkMetadata.jvmVendor,
+            architecture: jdkMetadata.architecture,
+        ]
+    }
+
+    static List<BuildOperationRecord.Progress> toolchainEvents(BuildOperationsFixture operations, String taskPath) {
+        return progressEventsFor(
+            operations, JavaToolchainUsageProgressDetails, taskPath,
+            ResolveTaskMutationsBuildOperationType, ExecuteTaskBuildOperationType
+        )
+    }
+
+    private static <T extends BuildOperationType<?, ?>> List<BuildOperationRecord.Progress> progressEventsFor(
+        BuildOperationsFixture operations,
+        Class<?> detailsType,
+        String taskPath,
+        Class<T>... buildOperationTypes
+    ) {
+        List<BuildOperationRecord.Progress> events = []
+        for (def buildOperationType in buildOperationTypes) {
+            events += progressEventsFor(operations, detailsType, taskPath, buildOperationType)
+        }
+        return events
+    }
+
+    private static <T extends BuildOperationType<?, ?>> List<BuildOperationRecord.Progress> progressEventsFor(
+        BuildOperationsFixture operations,
+        Class<?> detailsType,
+        String taskPath,
+        Class<T> buildOperationType
+    ) {
+        def buildOperationRecord = operations.first(buildOperationType) { it.details.taskPath == taskPath }
+        List<BuildOperationRecord.Progress> events = []
+        operations.walk(buildOperationRecord) {
+            events.addAll(it.progress.findAll {
+                detailsType.isAssignableFrom(it.detailsType)
+            })
+        }
+        return events
+    }
+}

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -33,6 +33,8 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
 
     def setup() {
+        captureBuildOperations()
+
         buildFile << """
             apply plugin: "java"
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -16,28 +16,21 @@
 
 package org.gradle.api.tasks
 
-
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
-import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsHelper
+import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsFixture
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
-import org.gradle.internal.operations.trace.BuildOperationRecord
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
 
-import static org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsHelper.assertToolchainUsages
-
-class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
+class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec implements JavaToolchainBuildOperationsFixture {
 
     static kgpLatestVersions = new KotlinGradlePluginVersions().latests.toList()
-
-    def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
     def setup() {
         buildFile << """
@@ -581,7 +574,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
     }
 
-
     def runWithInstallation(JvmInstallationMetadata jdkMetadata, String... tasks) {
         runWithInstallationPaths(jdkMetadata.javaHome.toAbsolutePath().toString(), tasks)
     }
@@ -600,14 +592,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         executer
             .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
             .withTasks(tasks)
-    }
-
-    List<BuildOperationRecord.Progress> toolchainEvents(String taskPath) {
-        return JavaToolchainBuildOperationsHelper.toolchainEvents(operations, taskPath)
-    }
-
-    List<BuildOperationRecord.Progress> filterByJavaVersion(List<BuildOperationRecord.Progress> events, JvmInstallationMetadata jdkMetadata) {
-        events.findAll { it.details.toolchain.javaVersion == jdkMetadata.javaVersion }
     }
 
     private String latestKotlinPluginVersion(String major) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -16,22 +16,22 @@
 
 package org.gradle.api.tasks
 
-import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
-import org.gradle.api.internal.tasks.execution.ResolveTaskMutationsBuildOperationType
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
+import org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsHelper
 import org.gradle.integtests.fixtures.versions.KotlinGradlePluginVersions
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
-import org.gradle.internal.operations.BuildOperationType
 import org.gradle.internal.operations.trace.BuildOperationRecord
-import org.gradle.jvm.toolchain.internal.operations.JavaToolchainUsageProgressDetails
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.internal.TextUtil
 import org.gradle.util.internal.ToBeImplemented
 import spock.lang.Issue
+
+import static org.gradle.integtests.fixtures.jvm.JavaToolchainBuildOperationsHelper.assertToolchainUsages
 
 class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
@@ -581,28 +581,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
     }
 
-    private void assertToolchainUsages(List<BuildOperationRecord.Progress> events, JvmInstallationMetadata jdkMetadata, String tool) {
-        assert events.size() > 0
-        events.each { usageEvent ->
-            assertToolchainUsage(tool, jdkMetadata, usageEvent)
-        }
-    }
-
-    private void assertToolchainUsage(String toolName, JvmInstallationMetadata jdkMetadata, BuildOperationRecord.Progress usageEvent) {
-        assert usageEvent.details.toolName == toolName
-
-        def usedToolchain = usageEvent.details.toolchain
-        assert usedToolchain == [
-            javaVersion: jdkMetadata.javaVersion,
-            javaVendor: jdkMetadata.vendor.displayName,
-            runtimeName: jdkMetadata.runtimeName,
-            runtimeVersion: jdkMetadata.runtimeVersion,
-            jvmName: jdkMetadata.jvmName,
-            jvmVersion: jdkMetadata.jvmVersion,
-            jvmVendor: jdkMetadata.jvmVendor,
-            architecture: jdkMetadata.architecture,
-        ]
-    }
 
     def runWithInstallation(JvmInstallationMetadata jdkMetadata, String... tasks) {
         runWithInstallationPaths(jdkMetadata.javaHome.toAbsolutePath().toString(), tasks)
@@ -625,20 +603,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     }
 
     List<BuildOperationRecord.Progress> toolchainEvents(String taskPath) {
-        return toolchainEventsFor(ResolveTaskMutationsBuildOperationType, taskPath) + toolchainEventsFor(ExecuteTaskBuildOperationType, taskPath)
-    }
-
-    private <T extends BuildOperationType<?, ?>> List<BuildOperationRecord.Progress> toolchainEventsFor(Class<T> buildOperationType, String taskPath) {
-        def buildOperationRecord = operations.first(buildOperationType) {
-            it.details.taskPath == taskPath
-        }
-        List<BuildOperationRecord.Progress> events = []
-        operations.walk(buildOperationRecord) {
-            events.addAll(it.progress.findAll {
-                JavaToolchainUsageProgressDetails.isAssignableFrom(it.detailsType)
-            })
-        }
-        return events
+        return JavaToolchainBuildOperationsHelper.toolchainEvents(operations, taskPath)
     }
 
     List<BuildOperationRecord.Progress> filterByJavaVersion(List<BuildOperationRecord.Progress> events, JvmInstallationMetadata jdkMetadata) {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -112,7 +112,7 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec {
 
     def "compilation emits toolchain usage events"() {
         def operations = new BuildOperationsFixture(executer, temporaryFolder)
-        def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
+        def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentJdk { it.languageVersion.isJava8Compatible() })
 
         buildScript """
             apply plugin: 'scala'
@@ -120,15 +120,21 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec {
             ${mavenCentralRepository()}
 
             dependencies {
-                implementation "org.scala-lang:scala-library:2.12.6"
+                implementation "org.scala-lang:scala-library:2.13.8" // must be above 2.13.1
             }
 
             scala {
-                zincVersion = "${ScalaBasePlugin.DEFAULT_ZINC_VERSION}"
+                zincVersion = "1.7.1"
             }
             java {
                 toolchain {
                     languageVersion = JavaLanguageVersion.of(${jdkMetadata.languageVersion.majorVersion})
+                }
+            }
+
+            tasks.withType(ScalaCompile) {
+                scalaCompileOptions.with {
+                    additionalParameters = (additionalParameters ?: []) + "-target:8"
                 }
             }
         """

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.scala.compile
 
-
 import org.gradle.api.plugins.scala.ScalaBasePlugin
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/UpToDateScalaCompileIntegrationTest.groovy
@@ -166,6 +166,8 @@ class UpToDateScalaCompileIntegrationTest extends AbstractIntegrationSpec implem
     }
 
     def "compilation emits toolchain usage events"() {
+        captureBuildOperations()
+
         def jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.getDifferentJdk { it.languageVersion.isJava8Compatible() })
 
         buildScript """

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -43,6 +43,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.LocalState;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -147,7 +148,8 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
      * @since 7.2
      */
     @Incubating
-    @Internal
+    @Nested
+    @Optional
     public Property<JavaLauncher> getJavaLauncher() {
         return javaLauncher;
     }


### PR DESCRIPTION
Similarly to `JavaCompile` and `GroovyCompile`, the toolchain tool used in the task should be a non-internal input to that task. In case of the `ScalaCompile` it is a `JavaLauncher`, i.e. a JVM in which Scala runs the compilation.

