### PR TITLE
Drop unused ScalaRuntime field

### DIFF
--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaCompile.java
@@ -22,12 +22,9 @@ import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.tasks.scala.ScalaCompilerFactory;
 import org.gradle.api.internal.tasks.scala.ScalaJavaJointCompileSpec;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.api.tasks.scala.internal.ScalaCompileOptionsConfigurer;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.classloader.ClasspathHasher;
@@ -48,13 +45,10 @@ public class ScalaCompile extends AbstractScalaCompile {
     private FileCollection scalaClasspath;
     private FileCollection zincClasspath;
     private FileCollection scalaCompilerPlugins;
-    private final Property<ScalaRuntime> scalaRuntime;
     private org.gradle.language.base.internal.compile.Compiler<ScalaJavaJointCompileSpec> compiler;
 
     @Inject
     public ScalaCompile() {
-        ObjectFactory objectFactory = getObjectFactory();
-        this.scalaRuntime = objectFactory.property(ScalaRuntime.class);
     }
 
     @Inject


### PR DESCRIPTION
It seems it was overlooked during previous removal here:
https://github.com/gradle/gradle/commit/47e8a957d06311bae3ec0d3c1e747701ea7d90cd

There are no usages of this field, and I suppose using an object factory to create a property does not have any special side-effects on which we could be relying.