### PR TITLE
Add deprecations expectations for Gradle 9.0

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecationMessageBuilder.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
 
     private static final GradleVersion GRADLE8 = GradleVersion.version("8.0");
+    private static final GradleVersion GRADLE9 = GradleVersion.version("9.0");
 
     private String summary;
     private DeprecationTimeline deprecationTimeline;
@@ -72,6 +73,31 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         this.deprecationTimeline = DeprecationTimeline.willChangeInVersion(GRADLE8);
         return new WithDeprecationTimeline(this);
     }
+
+    /**
+     * Output: This is scheduled to be removed in Gradle 9.0.
+     */
+    public WithDeprecationTimeline willBeRemovedInGradle9() {
+        this.deprecationTimeline = DeprecationTimeline.willBeRemovedInVersion(GRADLE9);
+        return new WithDeprecationTimeline(this);
+    }
+
+    /**
+     * Output: This will fail with an error in Gradle 9.0.
+     */
+    public WithDeprecationTimeline willBecomeAnErrorInGradle9() {
+        this.deprecationTimeline = DeprecationTimeline.willBecomeAnErrorInVersion(GRADLE9);
+        return new WithDeprecationTimeline(this);
+    }
+
+    /**
+     * Output: This will change in Gradle 9.0.
+     */
+    public WithDeprecationTimeline willChangeInGradle9() {
+        this.deprecationTimeline = DeprecationTimeline.willChangeInVersion(GRADLE9);
+        return new WithDeprecationTimeline(this);
+    }
+
 
     void setIndirectUsage() {
         this.usageType = DeprecatedFeatureUsage.Type.USER_CODE_INDIRECT;
@@ -237,6 +263,12 @@ public class DeprecationMessageBuilder<T extends DeprecationMessageBuilder<T>> {
         @Override
         public WithDeprecationTimeline willBeRemovedInGradle8() {
             setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE8));
+            return new WithDeprecationTimeline(this);
+        }
+
+        @Override
+        public WithDeprecationTimeline willBeRemovedInGradle9() {
+            setDeprecationTimeline(DeprecationTimeline.willBeRemovedInVersion(GRADLE9));
             return new WithDeprecationTimeline(this);
         }
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithAndroidDeprecations.groovy
@@ -20,7 +20,7 @@ import groovy.transform.SelfType
 import org.gradle.util.internal.VersionNumber
 
 @SelfType(BaseDeprecations)
-trait WithAndroidDeprecations {
+trait WithAndroidDeprecations implements WithReportDeprecations {
     private static final VersionNumber AGP_VERSION_WITH_FIXED_SKIP_WHEN_EMPTY = VersionNumber.parse('7.1.1')
     private static final VersionNumber AGP_VERSION_WITH_FIXED_NEW_WORKERS_API = VersionNumber.parse('4.2')
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithKotlinDeprecations.groovy
@@ -21,7 +21,7 @@ import org.gradle.util.GradleVersion
 import org.gradle.util.internal.VersionNumber
 
 @SelfType(BaseDeprecations)
-trait WithKotlinDeprecations {
+trait WithKotlinDeprecations implements WithReportDeprecations{
     private static final VersionNumber KOTLIN_VERSION_USING_NEW_WORKERS_API = VersionNumber.parse('1.5.0')
     private static final VersionNumber KOTLIN_VERSION_USING_INPUT_CHANGES_API = VersionNumber.parse('1.6.0')
 

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/WithReportDeprecations.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import groovy.transform.SelfType
+import org.gradle.util.GradleVersion
+
+@SelfType(BaseDeprecations)
+trait WithReportDeprecations {
+    private static final String REPORT_DESTINATION_DEPRECATION = "The Report.destination property has been deprecated. " +
+            "This is scheduled to be removed in Gradle 9.0. " +
+            "Please use the outputLocation property instead. " +
+            "See https://docs.gradle.org/${GradleVersion.current().version}/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:destination for more details."
+
+    void expectReportDestinationPropertyDeprecation() {
+        runner.expectDeprecationWarning(REPORT_DESTINATION_DEPRECATION, "https://github.com/gradle/gradle/issues/21533")
+    }
+}


### PR DESCRIPTION
Moving this to a separate PR, so I can merge to master and avoid repeating it in multiple deprecation removal branches.