### PR TITLE
Update dependency locking docs

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -21,6 +21,7 @@ We would like to thank the following community members for their contributions t
 [Edmund Mok](https://github.com/edmundmok),
 [Frosty-J](https://github.com/Frosty-J),
 [Gabriel Feo](https://github.com/gabrielfeo),
+[Ivan Gavrilovic](https://github.com/gavra0),
 [Jendrik Johannes](https://github.com/jjohannes),
 [John](https://github.com/goughy000),
 [Joseph Woolf](https://github.com/jsmwoolf),

--- a/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/02-declaring-dependency-versions/dependency_locking.adoc
@@ -102,7 +102,7 @@ For this, you have two options:
 * Run `gradle dependencies --write-locks`.
 This will effectively lock all resolvable configurations that have locking enabled.
 Note that in a multi project setup, `dependencies` only is executed on _one_ project, the root one in this case.
-* Declare a custom task that will resolve all configurations
+* Declare a custom task that resolves all configurations. This does not work for Android projects.
 
 .Resolving all configurations
 ====


### PR DESCRIPTION
Note that using a custom task to resolve all configurations manually does not work for Android projects.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
