### PR TITLE
Add ConfigCacheDocsTest to TeamCity

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/ConfigCacheDocsTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/ConfigCacheDocsTest.kt
@@ -1,0 +1,31 @@
+package configurations
+
+import common.JvmCategory
+import common.toCapitalized
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.parallelTests
+import model.CIBuildModel
+import model.Stage
+
+class ConfigCacheDocsTest(model: CIBuildModel, stage: Stage, testJava: JvmCategory) : BaseGradleBuildType(stage = stage, init = {
+    id("${model.projectId}_ConfigCacheDocsTest_${testJava.version.name.toCapitalized()}")
+    name = "Docs Test With Config Cache Enabled - ${testJava.version.name.toCapitalized()} Linux"
+    description = "Docs test with config cache enabled"
+
+    features {
+        publishBuildStatusToGithub(model)
+        parallelTests {
+            numberOfBatches = 4
+        }
+    }
+
+    applyTestDefaults(
+        model,
+        this,
+        "docs:docsTest",
+        timeout = 60,
+        extraParameters = buildScanTag("ConfigCacheDocsTest") +
+            " -PenableConfigurationCacheForDocsTests=true" +
+            " -PtestJavaVersion=${testJava.version.major}" +
+            " -PtestJavaVendor=${testJava.vendor.name}"
+    )
+})

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -33,7 +33,6 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
         timeout = 120,
         extraParameters = buildScanTag("SmokeTests") +
             " -PtestJavaVersion=${testJava.version.major}" +
-            " -PtestJavaVendor=${testJava.vendor.name}" +
-            " -Porg.gradle.java.installations.auto-download=false"
+            " -PtestJavaVendor=${testJava.vendor.name}"
     )
 })

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -14,6 +14,7 @@ import configurations.BaseGradleBuildType
 import configurations.BuildDistributions
 import configurations.CheckLinks
 import configurations.CompileAllProduction
+import configurations.ConfigCacheDocsTest
 import configurations.FlakyTestQuarantine
 import configurations.FunctionalTest
 import configurations.Gradleception
@@ -79,7 +80,8 @@ data class CIBuildModel(
                 SpecificBuild.ConfigCacheSantaTrackerSmokeTests,
                 SpecificBuild.GradleBuildSmokeTests,
                 SpecificBuild.ConfigCacheSmokeTestsMaxJavaVersion,
-                SpecificBuild.ConfigCacheSmokeTestsMinJavaVersion
+                SpecificBuild.ConfigCacheSmokeTestsMinJavaVersion,
+                SpecificBuild.ConfigCacheDocsTestMaxJavaVersion
             ),
             functionalTests = listOf(
                 TestCoverage(3, TestType.platform, Os.LINUX, JvmCategory.MIN_VERSION, DEFAULT_LINUX_FUNCTIONAL_TEST_BUCKET_SIZE),
@@ -393,6 +395,11 @@ enum class SpecificBuild {
     ConfigCacheSmokeTestsMaxJavaVersion {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
             return SmokeTests(model, stage, JvmCategory.MAX_LTS_VERSION, "configCacheSmokeTest", splitNumber = 4)
+        }
+    },
+    ConfigCacheDocsTestMaxJavaVersion {
+        override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
+            return ConfigCacheDocsTest(model, stage, JvmCategory.MAX_VERSION)
         }
     },
     FlakyTestQuarantineLinux {


### PR DESCRIPTION
Add a `docsTest` with `-PenableConfigurationCacheForDocsTests=true`, as requested by @mlopatkin .