### PR TITLE
Make docs:docsTest configuration-cache compatible

### DIFF
--- a/build-logic-settings/build-logic-settings-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
+++ b/build-logic-settings/build-logic-settings-plugin/src/main/kotlin/gradlebuild.internal.cc-experiment.settings.gradle.kts
@@ -49,10 +49,8 @@ val unsupportedTasksPredicate: (Task) -> Boolean = { task: Task ->
             "quickCheck",
         ) -> true
         task.name.endsWith("Wrapper") -> true
-        task.name in listOf("docs", "stageDocs", "docsTest", "serveDocs") -> true
+        task.name in listOf("docs", "stageDocs", "serveDocs") -> true
         task.name.startsWith("userguide") -> true
-        task.name.contains("Sample") -> true
-        task.name.contains("Snippet") -> true
         task.name == "samplesMultiPage" -> true
         task.typeSimpleName in listOf(
             "KtsProjectGeneratorTask",

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -840,30 +840,33 @@ tasks.named("check") {
 
 // TODO there is some duplication with DistributionTest.kt here - https://github.com/gradle/gradle-private/issues/3126
 class GradleInstallationForTestEnvironmentProvider implements CommandLineArgumentProvider {
-    private Project project
-    private Test testTask
-
-    GradleInstallationForTestEnvironmentProvider(Project project, Test testTask) {
-        this.project = project
-        this.testTask = testTask
-    }
-
     @Internal
-    final ConfigurableFileCollection gradleHomeDir = project.objects.fileCollection()
+    final ConfigurableFileCollection gradleHomeDir
 
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputDirectory
-    final DirectoryProperty samplesdir = project.objects.directoryProperty()
+    final DirectoryProperty samplesdir
 
     @Nested
-    GradleDistribution gradleDistribution = new GradleDistribution(gradleHomeDir)
+    final GradleDistribution gradleDistribution
+
+    private final FileCollection testTaskClasspath
+    private final Directory repoRoot
+
+    GradleInstallationForTestEnvironmentProvider(Project project, Test testTask) {
+        this.gradleHomeDir = project.objects.fileCollection()
+        this.samplesdir = project.objects.directoryProperty()
+        this.gradleDistribution = new GradleDistribution(gradleHomeDir)
+        this.testTaskClasspath = testTask.classpath
+        this.repoRoot = repoRoot(project)
+    }
 
     @Override
     Iterable<String> asArguments() {
-        def distributionName = testTask.classpath.filter { it.name.startsWith("gradle-runtime-api-info") }.singleFile.parentFile.parentFile.parentFile.name
+        def distributionName = testTaskClasspath.filter { it.name.startsWith("gradle-runtime-api-info") }.singleFile.parentFile.parentFile.parentFile.name
         ["-DintegTest.gradleHomeDir=${gradleHomeDir.singleFile}",
          "-DintegTest.samplesdir=${samplesdir.get().asFile}",
-         "-DintegTest.gradleUserHomeDir=${repoRoot(project).dir("intTestHomeDir/$distributionName").asFile}"]
+         "-DintegTest.gradleUserHomeDir=${repoRoot.dir("intTestHomeDir/$distributionName")}"]
     }
 }
 


### PR DESCRIPTION
The only source of the incompatibility was the `GradleInstallationForTestEnvironmentProvider` class that was capturing
Task and Project objects. This was replaced with capturing only necessary state.

The docsTest and its dependencies were also removed from the list of
CC-incompatible tasks. I've checked most of the '*Sample*' and '*Snippet*' tasks to make sure all of these are actually compatible with the configuration cache.

It wouldn't help much, though, because of #19273 which invalidates build cache each time `docsTest` runs.