### PR TITLE
Fix PMD file locking issue

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginToolchainsIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.quality.pmd
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
 import org.gradle.util.internal.VersionNumber
+import org.junit.Assume
 
 import static org.junit.Assume.assumeNotNull
 
@@ -33,6 +34,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
     }
 
     def "uses jdk from toolchains set through java plugin"() {
+        Assume.assumeTrue(fileLockingIssuesSolved())
         given:
         goodCode()
         def jdk = setupExecutorForToolchains()
@@ -46,6 +48,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
     }
 
     def "uses jdk from toolchains set through pmd task"() {
+        Assume.assumeTrue(fileLockingIssuesSolved())
         given:
         goodCode()
         def jdk = setupExecutorForToolchains()
@@ -59,6 +62,7 @@ class PmdPluginToolchainsIntegrationTest extends AbstractPmdPluginVersionIntegra
     }
 
     def "uses current jdk if not specified otherwise"() {
+        Assume.assumeTrue(fileLockingIssuesSolved())
         given:
         goodCode()
         writeBuildFile()


### PR DESCRIPTION
Ignore select tests on older versions of PMD since PMD fails to close files it was analyzing

(Mostly) Passing build (Except for the OOM-related errors): 
https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsIntegMultiVersion_34_bucket9/55103783?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

Previously failing build:
https://builds.gradle.org/viewType.html?buildTypeId=Gradle_Master_Check_AllVersionsIntegMultiVersion_34_bucket9&tab=buildTypeHistoryList&branch_Gradle_Master_Check_AllVersionsIntegMultiVersion_34=%3Cdefault%3E