### PR TITLE
Refactor test in preparation for Groovy 4

### DIFF
--- a/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorData.groovy
+++ b/subprojects/testing-jvm/src/testFixtures/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorData.groovy
@@ -323,7 +323,7 @@ public class AnEmptyTestSuite {
 
 public class CustomSuiteRunner extends Suite {
     public CustomSuiteRunner(Class<?> klass, RunnerBuilder builder) {
-        super(builder, klass, [ATestClass.class, BTestClass.class])
+        super(builder, klass, [ATestClass.class, BTestClass.class] as Class<?>[])
     }
 }
 


### PR DESCRIPTION
Workaround an upcoming Groovy behavior change; Groovy 4.0.5 will apparently not coerce a list to typed array anymore. This may also be related to changes in calls to superclass constructors needing to be wrapped in `@CompileStatic`-built methods. Nevertheless, just fixing the problem with a cast is the cleanest solution.