### PR TITLE
Fix threaddump artifact rule

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -84,7 +84,7 @@ const val hiddenArtifactDestination = ".teamcity/gradle-logs"
 
 fun BuildType.applyDefaultSettings(os: Os = Os.LINUX, arch: Arch = Arch.AMD64, buildJvm: Jvm = BuildToolBuildJvm, timeout: Int = 30) {
     artifactRules = """
-        *.threaddump => $hiddenArtifactDestination
+        build/*.threaddump => $hiddenArtifactDestination
         build/report-* => $hiddenArtifactDestination
         build/tmp/test files/** => $hiddenArtifactDestination/test-files
         build/errorLogs/** => $hiddenArtifactDestination/errorLogs

--- a/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
+++ b/build-logic/lifecycle/src/main/kotlin/PrintStackTracesOnTimeoutBuildService.kt
@@ -19,6 +19,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.process.ExecOperations
+import java.io.File
 import java.util.Timer
 import javax.inject.Inject
 import kotlin.concurrent.timerTask
@@ -38,7 +39,7 @@ abstract class PrintStackTracesOnTimeoutBuildService @Inject constructor(private
                     commandLine(
                         "${System.getProperty("java.home")}/bin/java",
                         parameters.projectDirectory.file("subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/JavaProcessStackTracesMonitor.java").get().asFile.absolutePath,
-                        parameters.projectDirectory.asFile.get().absolutePath
+                        File(parameters.projectDirectory.asFile.get(), "build").absolutePath
                     )
                 }
             },

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/timeout/IntegrationTestTimeoutInterceptor.groovy
@@ -61,7 +61,7 @@ class IntegrationTestTimeoutInterceptor extends TimeoutInterceptor {
 
     static String getThreadDump() {
         try {
-            return JavaProcessStackTracesMonitor.printAllStackTracesByJstack(new File("."))
+            return new JavaProcessStackTracesMonitor(new File(".")).printAllStackTracesByJstack()
         } catch (Throwable e) {
             def stream = new ByteArrayOutputStream()
             e.printStackTrace(new PrintStream(stream))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
@@ -165,7 +165,7 @@ class ChainingHttpHandler implements HttpHandler, ResettableExpectations {
     // We observed jstack hanging on windows, so for now we only enable it for Linux
     private void dumpThreadsUponTimeout(String stacktrace) {
         if (stacktrace.contains("due to a timeout waiting for other requests") && OperatingSystem.current().isLinux()) {
-            JavaProcessStackTracesMonitor.printAllStackTracesByJstack(new File("."));
+            new JavaProcessStackTracesMonitor(new File(".")).printAllStackTracesByJstack();
         }
     }
 


### PR DESCRIPTION
Cherry-pick the `JavaProcessStackTracesMonitor` change to `release`.

Also, previously, the thread dumps are put in the root directory and will
not be cleaned up by `clean` task. Now we put them into `build`.