### PR TITLE
Run doc snippets twice to check loading from the configuration cache

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -648,6 +648,7 @@ tasks.named("docsTest") { task ->
 
     if (isConfigurationCacheEnabledForDocsTests(project)) {
         systemProperty("org.gradle.integtest.samples.cleanConfigurationCacheOutput", "true")
+        systemProperty("org.gradle.integtest.samples.checkLoadingFromConfigurationCache", "true")
         systemProperty("org.gradle.integtest.executer", "configCache")
 
         filter {
@@ -670,6 +671,7 @@ tasks.named("docsTest") { task ->
                 "snippet-ant-hello_kotlin_antHello.sample",
                 "snippet-ant-rename-task_groovy_renameAntDelegate.sample",
                 "snippet-ant-rename-task_kotlin_renameAntDelegate.sample",
+                "snippet-ant-use-external-ant-task-with-config_groovy_useExternalAntTaskWithConfig.sample",
                 "snippet-ant-use-external-ant-task-with-config_kotlin_useExternalAntTaskWithConfig.sample",
                 "snippet-buildlifecycle-task-execution-events_groovy_sanityCheck.sample",
                 "snippet-buildlifecycle-task-execution-events_groovy_taskExecutionEvents.groovy.sample",
@@ -696,7 +698,9 @@ tasks.named("docsTest") { task ->
                 "snippet-native-binaries-cunit_groovy_completeCUnitExample.sample",
                 "snippet-native-binaries-cunit_groovy_dependentComponentsReport.sample",
                 "snippet-native-binaries-cunit_groovy_dependentComponentsReportAll.sample",
+                "snippet-tutorial-ant-loadfile-with-method_groovy_antLoadfileWithMethod.sample",
                 "snippet-tutorial-ant-loadfile-with-method_kotlin_antLoadfileWithMethod.sample",
+                "snippet-tutorial-ant-loadfile_groovy_antLoadfile.sample",
                 "snippet-tutorial-ant-loadfile_kotlin_antLoadfile.sample",
             ]
 
@@ -718,6 +722,10 @@ tasks.named("docsTest") { task ->
             def testsForNotYetSupportedFeatures = [
                 "publishing-credentials_groovy_publishCommandLineCredentials.sample",
                 "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
+                "snippet-ear-ear-customized_groovy_earCustomized.groovy.sample",
+                "snippet-ear-ear-customized_kotlin_earCustomized.kotlin.sample",
+                "snippet-ear-ear-with-war_groovy_earWithWar.sample",
+                "snippet-ear-ear-with-war_kotlin_earWithWar.sample",
                 "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
                 "snippet-ivy-publish-descriptor-customization_groovy_publishingIvyGenerateDescriptor.sample",
                 "snippet-ivy-publish-descriptor-customization_kotlin_publishingIvyGenerateDescriptor.sample",
@@ -743,6 +751,9 @@ tasks.named("docsTest") { task ->
             // Tests that can and has to be fixed to run with the configuration cache enabled.
             // Set the Gradle property runBrokenConfigurationCacheDocsTests=true to run tests from this list or any of the lists above.
             def testsToBeFixedForConfigurationCache = [
+                "snippet-artifacts-define-repository_groovy_defineMavenCentral.sample",
+
+                "snippet-artifacts-generated-file-dependencies_groovy_generatedFileDependencies.sample",
                 "snippet-artifacts-generated-file-dependencies_kotlin_generatedFileDependencies.sample",
 
                 "snippet-build-cache-cacheable-bundle-task_groovy_cacheableBundleTask.sample",
@@ -756,57 +767,84 @@ tasks.named("docsTest") { task ->
                 "snippet-buildlifecycle-project-evaluate-events_groovy_projectEvaluateEvents.sample",
                 "snippet-buildlifecycle-project-evaluate-events_kotlin_projectEvaluateEvents.sample",
 
+                "snippet-dependency-management-customizing-resolution-attribute-substitution-rule_groovy_resolve.sample",
                 "snippet-dependency-management-customizing-resolution-attribute-substitution-rule_kotlin_resolve.sample",
 
+                "snippet-dependency-management-customizing-resolution-capability-substitution-rule_groovy_capability_substitution.sample",
                 "snippet-dependency-management-customizing-resolution-capability-substitution-rule_kotlin_capability_substitution.sample",
 
                 "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_groovy_resolve.sample",
                 "snippet-dependency-management-customizing-resolution-classifier-substitution-rule_kotlin_resolve.sample",
 
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_groovy_showJarFiles.sample",
+                "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_groovy_showJarFilesLocal.sample",
                 "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFiles.sample",
                 "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFilesLocal.sample",
 
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_groovy_sanityCheck.sample",
                 "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_sanityCheck.sample",
 
+                "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_groovy_ivyComonentMetadataRule.sample",
                 "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_kotlin_ivyComonentMetadataRule.sample",
 
+                "snippet-dependency-management-customizing-resolution-metadata-rule_groovy_comonentMetadataRules.sample",
                 "snippet-dependency-management-customizing-resolution-metadata-rule_kotlin_comonentMetadataRules.sample",
 
+                "snippet-dependency-management-defining-using-configurations-custom_groovy_custom-configuration.sample",
                 "snippet-dependency-management-defining-using-configurations-custom_kotlin_custom-configuration.sample",
 
+                "snippet-dependency-management-dependency-verification-disabling-verification_groovy_disabling_verification.sample",
                 "snippet-dependency-management-dependency-verification-disabling-verification_kotlin_disabling_verification.sample",
 
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-configuration_groovy_exclude-transitive-for-configuration.sample",
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-configuration_kotlin_exclude-transitive-for-configuration.sample",
 
+                "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_groovy_exclude-transitive-for-dependency.sample",
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_kotlin_exclude-transitive-for-dependency.sample",
 
+                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_groovy_accessingMetadataArtifact.sample",
                 "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_kotlin_accessingMetadataArtifact.sample",
 
                 "snippet-dependency-management-working-with-dependencies-iterate-artifacts_kotlin_iterating-artifacts.sample",
 
+                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",
 
                 "snippet-dependency-management-working-with-dependencies-walk-graph_groovy_walking-dependency-graph.sample",
                 "snippet-dependency-management-working-with-dependencies-walk-graph_kotlin_walking-dependency-graph.sample",
 
+                "snippet-files-archive-naming_groovy_archiveNaming.sample",
                 "snippet-files-archive-naming_kotlin_archiveNaming.sample",
 
                 "snippet-files-archives-changed-base-name_groovy_zipWithArchivesBaseName.sample",
                 "snippet-files-archives-changed-base-name_kotlin_zipWithArchivesBaseName.sample",
 
+                "snippet-files-file-collections_groovy_fileCollectionsFiltering.sample",
+                "snippet-files-file-collections_groovy_fileCollectionsUsage.sample",
+                "snippet-files-file-collections_groovy_fileCollectionsWithClosure.sample",
                 "snippet-files-file-collections_kotlin_fileCollectionsFiltering.sample",
                 "snippet-files-file-collections_kotlin_fileCollectionsUsage.sample",
                 "snippet-files-file-collections_kotlin_fileCollectionsWithClosure.sample",
 
+                "snippet-groovy-compilation-avoidance_groovy_groovyCompilationAvoidance.sample",
+                "snippet-groovy-compilation-avoidance_kotlin_groovyCompilationAvoidance.sample",
+
+                "snippet-init-scripts-configuration-injection_groovy_initScriptConfiguration.groovy.sample",
                 "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
 
+                "snippet-init-scripts-plugins_groovy_usePluginsInInitScripts.groovy.sample",
                 "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
 
+                "snippet-java-basic_groovy_basicJavaWithIntegrationTests.sample",
+
+                "snippet-java-cross-compilation_groovy_java7CrossCompilation.sample",
                 "snippet-java-cross-compilation_kotlin_java7CrossCompilation.sample",
 
                 "snippet-java-custom-dirs_groovy_javaCustomReportDirs.sample",
                 "snippet-java-custom-dirs_kotlin_javaCustomReportDirs.sample",
 
+                "snippet-java-fixtures_groovy_javaTestFixtures.sample",
                 "snippet-java-fixtures_kotlin_javaTestFixtures.sample",
 
                 "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
@@ -817,6 +855,7 @@ tasks.named("docsTest") { task ->
                 "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
                 "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
 
+                "snippet-providers-property-convention_groovy_propertyConvention.sample",
                 "snippet-providers-property-convention_kotlin_propertyConvention.sample",
 
                 "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",
@@ -824,6 +863,7 @@ tasks.named("docsTest") { task ->
                 "snippet-tasks-custom-task-with-missing-file-property_kotlin_missingFileProperties.sample",
 
                 "snippet-tasks-incremental-build-custom-task-class_groovy_customTaskClassWithInputOutputAnnotations.sample",
+                "snippet-tasks-incremental-build-custom-task-class_groovy_incrementalAdHocTask.sample",
                 "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep.sample",
                 "snippet-tasks-incremental-build-custom-task-class_groovy_inferredTaskDep2.sample",
                 "snippet-tasks-incremental-build-custom-task-class_kotlin_customTaskClassWithInputOutputAnnotations.sample",
@@ -845,6 +885,12 @@ tasks.named("docsTest") { task ->
                 "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_incrementalBuildUpToDateWhen.sample",
                 "snippet-tasks-incremental-build-incremental-build-advanced_kotlin_inferredTaskDependencyWithBuiltBy.sample",
 
+                "snippet-tasks-incremental-task_groovy_incrementalTaskChangedProperty.sample",
+                "snippet-tasks-incremental-task_groovy_incrementalTaskFirstRun.sample",
+                "snippet-tasks-incremental-task_groovy_incrementalTaskNoChange.sample",
+                "snippet-tasks-incremental-task_groovy_incrementalTaskRemovedInput.sample",
+                "snippet-tasks-incremental-task_groovy_incrementalTaskRemovedOutput.sample",
+                "snippet-tasks-incremental-task_groovy_incrementalTaskUpdatedInputs.sample",
                 "snippet-tasks-incremental-task_kotlin_incrementalTaskChangedProperty.sample",
                 "snippet-tasks-incremental-task_kotlin_incrementalTaskFirstRun.sample",
                 "snippet-tasks-incremental-task_kotlin_incrementalTaskNoChange.sample",
@@ -852,12 +898,25 @@ tasks.named("docsTest") { task ->
                 "snippet-tasks-incremental-task_kotlin_incrementalTaskRemovedOutput.sample",
                 "snippet-tasks-incremental-task_kotlin_incrementalTaskUpdatedInputs.sample",
 
+                "snippet-testing-test-suite-multi-configure-each-extracted_groovy_checkTask.sample",
+
+                "snippet-testing-test-suite-multi-configure-each-matching_groovy_checkTask.sample",
+
+                "snippet-testing-test-suite-multi-configure-each_groovy_checkTask.sample",
+
+                "snippet-tutorial-configure-object-using-script_groovy_configureObjectUsingScript.sample",
+
+                "snippet-tutorial-configure-object_groovy_configureObject.sample",
+
                 "snippet-tutorial-configure-task-using-project-property_groovy_configureTaskUsingProjectProperty.sample",
                 "snippet-tutorial-configure-task-using-project-property_kotlin_configureTaskUsingProjectProperty.sample",
 
+                "snippet-tutorial-extra-properties_groovy_extraProperties.sample",
                 "snippet-tutorial-extra-properties_kotlin_extraProperties.sample",
 
                 "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
+
+                "snippet-tutorial-task-only-if_groovy_taskOnlyIf.sample",
 
                 "task-with-arguments_groovy_projectInfoTask.sample",
                 "task-with-arguments_kotlin_projectInfoTask.sample",

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -43,6 +43,8 @@ import static java.util.stream.Collectors.toMap;
 
 class IntegrationTestSamplesExecutor extends CommandExecutor {
 
+    private static final String CHECK_LOADING_FROM_CONFIGURATION_CACHE = "org.gradle.integtest.samples.checkLoadingFromConfigurationCache";
+
     private static final String WARNING_MODE_FLAG_PREFIX = "--warning-mode=";
 
     private static final String NO_STACKTRACE_CHECK = "-Dorg.gradle.sampletest.noStackTraceCheck=true";
@@ -62,6 +64,34 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
 
     @Override
     protected int run(String executable, List<String> args, List<String> flags, OutputStream outputStream) {
+        try {
+            GradleExecuter executer = createExecuter(args, flags);
+            if (expectFailure) {
+                // TODO(mlopatkin) sometimes it is still possible to save the configuration cache state in the event of failure.
+                //  We need to figure out how to separate expected failure from the CC store failure.
+                ExecutionFailure result = executer.runWithFailure();
+                outputStream.write((result.getOutput() + result.getError()).getBytes());
+            } else {
+                ExecutionResult result = executer.run();
+                outputStream.write(result.getOutput().getBytes());
+
+                if (shouldCheckLoadingFromConfigurationCache()) {
+                    rerunReusingStoredConfigurationCacheEntry(args, flags);
+                }
+            }
+            return expectFailure ? 1 : 0;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void rerunReusingStoredConfigurationCacheEntry(List<String> args, List<String> flags) {
+        // Rerun tasks. If the task is up-to-date, then its actions aren't executed.
+        // This might hide issues with Groovy closures, as the methods referenced inside the closure are resolved dynamically.
+        createExecuter(args, flags).withArgument("--rerun-tasks").run();
+    }
+
+    private GradleExecuter createExecuter(List<String> args, List<String> flags) {
         WarningMode warningMode = flags.stream()
             .filter(it -> it.startsWith(WARNING_MODE_FLAG_PREFIX))
             .map(it -> WarningMode.valueOf(capitalize(it.replace(WARNING_MODE_FLAG_PREFIX, "").toLowerCase())))
@@ -90,19 +120,7 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
         if (!env.isEmpty()) {
             executer.withEnvironmentVars(env);
         }
-
-        try {
-            if (expectFailure) {
-                ExecutionFailure result = executer.runWithFailure();
-                outputStream.write((result.getOutput() + result.getError()).getBytes());
-            } else {
-                ExecutionResult result = executer.run();
-                outputStream.write(result.getOutput().getBytes());
-            }
-            return expectFailure ? 1 : 0;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return executer;
     }
 
     private String getAvailableJdksFlag() {
@@ -115,5 +133,9 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
 
     private static String capitalize(String s) {
         return s.substring(0, 1).toUpperCase() + s.substring(1);
+    }
+
+    private static boolean shouldCheckLoadingFromConfigurationCache() {
+        return Boolean.parseBoolean(System.getProperty(CHECK_LOADING_FROM_CONFIGURATION_CACHE));
     }
 }

--- a/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
+++ b/subprojects/docs/src/docsTest/java/org/gradle/docs/samples/IntegrationTestSamplesExecutor.java
@@ -27,6 +27,7 @@ import org.gradle.integtests.fixtures.executer.GradleDistribution;
 import org.gradle.integtests.fixtures.executer.GradleExecuter;
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext;
 import org.gradle.integtests.fixtures.executer.UnderDevelopmentGradleDistribution;
+import org.gradle.integtests.fixtures.executer.UnexpectedBuildFailure;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider;
 
@@ -88,7 +89,13 @@ class IntegrationTestSamplesExecutor extends CommandExecutor {
     private void rerunReusingStoredConfigurationCacheEntry(List<String> args, List<String> flags) {
         // Rerun tasks. If the task is up-to-date, then its actions aren't executed.
         // This might hide issues with Groovy closures, as the methods referenced inside the closure are resolved dynamically.
-        createExecuter(args, flags).withArgument("--rerun-tasks").run();
+        try {
+            createExecuter(args, flags).withArgument("--rerun-tasks").run();
+        } catch (UnexpectedBuildFailure e) {
+            UnexpectedBuildFailure tweakedException = new UnexpectedBuildFailure("Failed to rerun the build when reusing the configuration cache entry.\n" + e.getMessage());
+            tweakedException.setStackTrace(e.getStackTrace());
+            throw tweakedException;
+        }
     }
 
     private GradleExecuter createExecuter(List<String> args, List<String> flags) {


### PR DESCRIPTION
When running the second time, the "--rerun-tasks" is specified to ensure that all doFirst/doLast actions are restored and executed.
The serialization of the Groovy closures used for these skips closure's delegates, so sometimes methods referenced in closures are not resolvable when running from cache.

This is a part of the #21027 work
