### PR TITLE
Add language name and version properties for PMD task

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -335,33 +335,68 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         failure.assertHasFailures(2)
     }
 
-    def "only defining a language name does nothing"() {
+    def "gets reasonable message when only languageName is specified from extension"() {
         given:
         goodCode()
         buildFile << """
             pmd {
-                languageName = "unsupportedLanguageName"
+                languageName = "languageNameExample"
             }
         """
 
         expect:
-        succeeds("check")
+        // Use --continue so that when executing in parallel mode a deterministic set of tests run
+        // without --continue, sometimes both pmd tasks are run and sometimes only the only one task is run
+        fails("check", "--continue")
+        failure.assertHasCause("Invalid language declaration.  Both 'languageName' and 'languageVersion' should be specified.")
+        // pmdMain and pmdTest
+        failure.assertHasFailures(2)
     }
 
-    def "only defining a language version uses 'java' as default language name"() {
+    def "gets reasonable message when only languageName is specified from task"() {
         given:
         goodCode()
         buildFile << """
-            pmd {
-                languageVersion = "unsupportedLanguageVersion"
+            pmdMain {
+                languageName = "languageNameExample"
             }
         """
 
         expect:
         fails("check")
-        failure.assertHasCause("The following language is not supported:<sourceLanguage name=\"java\" version=\"unsupportedLanguageVersion\" />.")
+        failure.assertHasCause("Invalid language declaration.  Both 'languageName' and 'languageVersion' should be specified.")
+    }
+
+    def "gets reasonable message when only languageVersion is specified from extension"() {
+        given:
+        goodCode()
+        buildFile << """
+            pmd {
+                languageVersion = "languageVersionExample"
+            }
+        """
+
+        expect:
+        // Use --continue so that when executing in parallel mode a deterministic set of tests run
+        // without --continue, sometimes both pmd tasks are run and sometimes only the only one task is run
+        fails("check", "--continue")
+        failure.assertHasCause("Invalid language declaration.  Both 'languageName' and 'languageVersion' should be specified.")
         // pmdMain and pmdTest
         failure.assertHasFailures(2)
+    }
+
+    def "gets reasonable message when only languageVersion is specified from task"() {
+        given:
+        goodCode()
+        buildFile << """
+            pmdMain {
+                languageVersion = "languageVersionExample"
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasCause("Invalid language declaration.  Both 'languageName' and 'languageVersion' should be specified.")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/2326")

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/PmdPluginVersionIntegrationTest.groovy
@@ -318,6 +318,52 @@ class PmdPluginVersionIntegrationTest extends AbstractPmdPluginVersionIntegratio
         failure.assertHasCause("Invalid number of threads '-1'.  Number should not be negative.")
     }
 
+    def "gets stacktrace when language name and version are not supported"() {
+        given:
+        goodCode()
+        buildFile << """
+            pmd {
+                languageName = "unsupportedLanguageName"
+                languageVersion = "unsupportedLanguageVersion"
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasCause("The following language is not supported:<sourceLanguage name=\"unsupportedLanguageName\" version=\"unsupportedLanguageVersion\" />.")
+        // pmdMain and pmdTest
+        failure.assertHasFailures(2)
+    }
+
+    def "only defining a language name does nothing"() {
+        given:
+        goodCode()
+        buildFile << """
+            pmd {
+                languageName = "unsupportedLanguageName"
+            }
+        """
+
+        expect:
+        succeeds("check")
+    }
+
+    def "only defining a language version uses 'java' as default language name"() {
+        given:
+        goodCode()
+        buildFile << """
+            pmd {
+                languageVersion = "unsupportedLanguageVersion"
+            }
+        """
+
+        expect:
+        fails("check")
+        failure.assertHasCause("The following language is not supported:<sourceLanguage name=\"java\" version=\"unsupportedLanguageVersion\" />.")
+        // pmdMain and pmdTest
+        failure.assertHasFailures(2)
+    }
+
     @Issue("https://github.com/gradle/gradle/issues/2326")
     def "check task should not be up-to-date after clean if it only outputs to console"() {
         given:

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -83,6 +83,8 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     private final Property<Boolean> incrementalAnalysis;
     private final Property<Integer> threads;
     private final Property<JavaLauncher> javaLauncher;
+    private final Property<String> languageName;
+    private final Property<String> languageVersion;
 
     public Pmd() {
         ObjectFactory objects = getObjectFactory();
@@ -91,6 +93,8 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
         this.incrementalAnalysis = objects.property(Boolean.class);
         this.maxFailures = objects.property(Integer.class);
         this.threads = objects.property(Integer.class);
+        this.languageName = objects.property(String.class);
+        this.languageVersion = objects.property(String.class);
         // Set default JavaLauncher to current JVM in case
         // PmdPlugin that sets Java launcher convention is not applied
         this.javaLauncher = configureFromCurrentJvmLauncher(getToolchainService(), getObjectFactory());
@@ -170,6 +174,8 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
             newReport.getOutputLocation().set(report.getOutputLocation());
             return newReport;
         }).collect(Collectors.toList()));
+        parameters.getLanguageName().set(getLanguageName());
+        parameters.getLanguageVersion().set(getLanguageVersion());
     }
 
     public boolean stdOutIsAttachedToTerminal() {
@@ -484,5 +490,30 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     @Incubating
     public Property<Integer> getThreads() {
         return threads;
+    }
+
+    /**
+     * Specifies the language name used by PMD.
+     *
+     * @see PmdExtension#getLanguageName()
+     * @since 7.7
+     */
+    @Input
+    @Incubating
+    public Property<String> getLanguageName() {
+        return languageName;
+    }
+
+    /**
+     * Specifies the language version used by PMD.
+     *
+     * @see PmdExtension#getLanguageVersion()
+     * @since 7.7
+     */
+    @Input
+    @Optional
+    @Incubating
+    public Property<String> getLanguageVersion() {
+        return languageVersion;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -53,7 +53,7 @@ public class PmdExtension extends CodeQualityExtension {
         this.incrementalAnalysis = project.getObjects().property(Boolean.class).convention(true);
         this.maxFailures = project.getObjects().property(Integer.class).convention(0);
         this.threads = project.getObjects().property(Integer.class).convention(1);
-        this.languageName = project.getObjects().property(String.class).convention("java");
+        this.languageName = project.getObjects().property(String.class);
         this.languageVersion = project.getObjects().property(String.class);
     }
 
@@ -252,7 +252,7 @@ public class PmdExtension extends CodeQualityExtension {
     /**
      * The language name used by PMD.
      *
-     * @since 7.7
+     * @since 8.0
      */
     @Incubating
     public Property<String> getLanguageName() {
@@ -262,7 +262,7 @@ public class PmdExtension extends CodeQualityExtension {
     /**
      * The language version used by PMD.
      *
-     * @since 7.7
+     * @since 8.0
      */
     @Incubating
     public Property<String> getLanguageVersion() {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -44,6 +44,8 @@ public class PmdExtension extends CodeQualityExtension {
     private final Property<Integer> maxFailures;
     private final Property<Boolean> incrementalAnalysis;
     private final Property<Integer> threads;
+    private final Property<String> languageName;
+    private final Property<String> languageVersion;
 
     public PmdExtension(Project project) {
         this.project = project;
@@ -51,6 +53,8 @@ public class PmdExtension extends CodeQualityExtension {
         this.incrementalAnalysis = project.getObjects().property(Boolean.class).convention(true);
         this.maxFailures = project.getObjects().property(Integer.class).convention(0);
         this.threads = project.getObjects().property(Integer.class).convention(1);
+        this.languageName = project.getObjects().property(String.class).convention("java");
+        this.languageVersion = project.getObjects().property(String.class);
     }
 
     /**
@@ -243,5 +247,25 @@ public class PmdExtension extends CodeQualityExtension {
     @Incubating
     public Property<Integer> getThreads() {
         return threads;
+    }
+
+    /**
+     * The language name used by PMD.
+     *
+     * @since 7.7
+     */
+    @Incubating
+    public Property<String> getLanguageName() {
+        return languageName;
+    }
+
+    /**
+     * The language version used by PMD.
+     *
+     * @since 7.7
+     */
+    @Incubating
+    public Property<String> getLanguageVersion() {
+        return languageVersion;
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -152,6 +152,8 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
         task.getMaxFailures().convention(extension.getMaxFailures());
         task.getIncrementalAnalysis().convention(extension.getIncrementalAnalysis());
         task.getThreads().convention(extension.getThreads());
+        task.getLanguageName().convention(extension.getLanguageName());
+        task.getLanguageVersion().convention(extension.getLanguageVersion());
     }
 
     private void configureReportsConventionMapping(Pmd task, final String baseName) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdActionParameters.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdActionParameters.java
@@ -59,6 +59,10 @@ public interface PmdActionParameters extends WorkParameters {
 
     ListProperty<EnabledReport> getEnabledReports();
 
+    Property<String> getLanguageName();
+
+    Property<String> getLanguageVersion();
+
     /**
      * Based off of {@link PmdReports}.
      */

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
@@ -145,6 +145,10 @@ class PmdInvoker implements Action<AntBuilderDelegate> {
                 ant.builder.saveStreams = false
                 formatter(type: consoleOutputType, toConsole: true)
             }
+
+            if (parameters.languageName.isPresent() && parameters.languageVersion.isPresent()) {
+                sourceLanguage(name: parameters.languageName.get(), version: parameters.languageVersion.get())
+            }
         }
         def failureCount = ant.builder.project.properties["pmdFailureCount"]
         if (failureCount) {

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -58,6 +58,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         extension.maxFailures.get() == 0
         extension.rulesMinimumPriority.get() == 5
         extension.threads.get() == 1
+        extension.languageName.get() == "java"
+        extension.languageVersion.getOrElse(null) == null
     }
 
     def "configures pmd task for each source set"() {
@@ -114,6 +116,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert rulesMinimumPriority.get() == 5
             assert incrementalAnalysis.get() == true
             assert threads.get() == 1
+            assert languageName.get() == "java"
+            assert languageVersion.getOrElse(null) == null
         }
     }
 
@@ -134,6 +138,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.rulesMinimumPriority.get() == 5
         task.incrementalAnalysis.get() == true
         task.threads.get() == 1
+        task.languageName.get() == "java"
+        task.languageVersion.getOrElse(null) == null
     }
 
     def "adds pmd tasks to check lifecycle task"() {
@@ -166,6 +172,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             maxFailures = 17
             rulesMinimumPriority = 3
             threads = 2
+            languageName = "java"
+            languageVersion = "11"
         }
 
         expect:
@@ -192,6 +200,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert maxFailures.get() == 17
             assert rulesMinimumPriority.get() == 3
             task.threads.get() == 2
+            task.languageName.get() == "java"
+            task.languageVersion.get() == "11"
         }
     }
 
@@ -206,6 +216,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             maxFailures = 5
             rulesMinimumPriority = 3
             threads = 2
+            languageName = "java"
+            languageVersion = "11"
         }
 
         expect:
@@ -222,6 +234,8 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.maxFailures.get() == 5
         task.rulesMinimumPriority.get() == 3
         task.threads.get() == 2
+        task.languageName.get() == "java"
+        task.languageVersion.get() == "11"
     }
 
     def "configures pmd classpath based on sourcesets"() {

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
@@ -77,9 +77,7 @@
             </tr>
             <tr>
                 <td>languageName</td>
-                <td>
-                    <literal>"java"</literal>
-                </td>
+                <td></td>
             </tr>
             <tr>
                 <td>languageVersion</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.Pmd.xml
@@ -75,6 +75,16 @@
                 <td>javaLauncher</td>
                 <td></td>
             </tr>
+            <tr>
+                <td>languageName</td>
+                <td>
+                    <literal>"java"</literal>
+                </td>
+            </tr>
+            <tr>
+                <td>languageVersion</td>
+                <td></td>
+            </tr>
         </table>
     </section>
     <section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -58,7 +58,7 @@
             </tr>
             <tr>
                 <td>languageName</td>
-                <td><literal>"java"</literal></td>
+                <td>null</td>
             </tr>
             <tr>
                 <td>languageVersion</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -56,6 +56,14 @@
                 <td>threads</td>
                 <td><literal>1</literal></td>
             </tr>
+            <tr>
+                <td>languageName</td>
+                <td><literal>"java"</literal></td>
+            </tr>
+            <tr>
+                <td>languageVersion</td>
+                <td>null</td>
+            </tr>
         </table>
     </section>
     <section>


### PR DESCRIPTION
Fixes #21519

### Context
Currently it is not possible to run the PMD task on code that uses java preview features. The PMD task will not fail, but will also not run the rules on those classes. The following error is displayed:  `Error during type resolution of field '{redacted}' in class {redacted} due to: java.lang.UnsupportedClassVersionError: Preview features are not enabled for {redacted} (class file version 61.65535). Try running with '--enable-preview'`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

### Open questions

For PMD to correctly parse java files 2 things should be configured:
* The first thing is that the version passed to PMD should contain the `-preview` suffix (e.g. `17-preview`).
  * This PR allows us to configure PMD to use a specific version.
* The second thing is that the jvm argument `--enable-preview` should be present in the worker that runs PMD.
  * Previously we could add the argument to the `org.gradle.jvmargs` property and it would work, but with the addition of the worker api from #21429 jvm arguments are no longer passed through to the PMD task.

**This PR currently only fixes the first issue. The second issue is blocking and without it this fix does not work.**