### PR TITLE
Do not fallback to using equals on Java serialized values

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskCustomTypesInputPropertyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/changedetection/state/TaskCustomTypesInputPropertyIntegrationTest.groovy
@@ -305,7 +305,7 @@ task someTask(type: SomeTask) {
         skipped(":someTask")
     }
 
-    def "using a custom type with non-deterministic serialized form is deprecated"() {
+    def "using a custom type with non-deterministic serialized form causes to be out of date"() {
         file("buildSrc/src/main/java/CustomType.java") << customSerializableTypeWithNonDeterministicSerializedForm()
         buildFile << """
 task someTask {
@@ -328,15 +328,10 @@ task someTask {
         // Change to "equal" value
         when:
         buildFile.replace('new CustomType("value1")', 'new CustomType("value1 ignore me")')
-        executer.expectDocumentedDeprecationWarning("Using objects as inputs that have a different serialized form but are equal has been deprecated. " +
-            "This is scheduled to be removed in Gradle 8.0. " +
-            "Type 'CustomType' has a custom implementation for equals(). " +
-            "Declare the property as @Nested instead to expose its properties as inputs. " +
-            "See https://docs.gradle.org/current/userguide/upgrading_version_7.html#equals_up_to_date_deprecation for more details.")
         run "someTask"
 
         then:
-        skipped(":someTask")
+        executedAndNotSkipped(":someTask")
 
         // Change to different value
         when:

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -67,6 +67,11 @@ Previously, `org.gradle.api.AntBuilder` extended the deprecated `groovy.util.Ant
 `org.gradle.plugin.devel.PluginDeclaration` is not serializable anymore.
 If you need to serialize it, you can convert it into your own, serializable class.
 
+==== Gradle does not use equals for serialized values in up-to-date checks
+
+Gradle now does not try to use equals when comparing serialized values in up-to-date checks.
+For more information see <<equals_up_to_date_deprecation>>.
+
 [[changes_7.6]]
 == Upgrading from 7.5 and earlier
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/JavaSerializedValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/JavaSerializedValueSnapshot.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.base.Objects;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.io.ClassLoaderObjectInputStream;
@@ -53,38 +52,10 @@ public class JavaSerializedValueSnapshot implements ValueSnapshot {
     @Override
     public ValueSnapshot snapshot(Object value, ValueSnapshotter snapshotter) {
         ValueSnapshot snapshot = snapshotter.snapshot(value);
-        if (hasSameSerializedValue(value, snapshot)) {
+        if (equals(snapshot)) {
             return this;
         }
         return snapshot;
-    }
-
-    private boolean hasSameSerializedValue(Object value, ValueSnapshot snapshot) {
-        if (snapshot instanceof JavaSerializedValueSnapshot) {
-            JavaSerializedValueSnapshot newSnapshot = (JavaSerializedValueSnapshot) snapshot;
-            if (!Objects.equal(implementationHash, newSnapshot.implementationHash)) {
-                // Different implementation - assume value has changed
-                return false;
-            }
-            if (Arrays.equals(serializedValue, newSnapshot.serializedValue)) {
-                // Same serialized content - value has not changed
-                return true;
-            }
-
-            // Deserialize the old value and use the equals() implementation. This will be removed at some point
-            Object oldValue = populateClass(value.getClass());
-            if (oldValue.equals(value)) {
-                DeprecationLogger.deprecateIndirectUsage("Using objects as inputs that have a different serialized form but are equal")
-                    .withContext("Type '" + value.getClass().getName() + "' has a custom implementation for equals().")
-                    .withAdvice("Declare the property as @Nested instead to expose its properties as inputs.")
-                    .willBeRemovedInGradle8()
-                    .withUserManual("upgrading_version_7", "equals_up_to_date_deprecation")
-                    .nagUser();
-                // Same value
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override


### PR DESCRIPTION
for up-to-date checks. Gradle will now compare the serialized values only to check whether a task is up-to-date.

Fixes #17324