### PR TITLE
Include klib as KNOWN_ZIP_EXTENSIONS for java normalization

### DIFF
--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -48,7 +48,7 @@ import java.util.Set;
 
 public class ZipHasher implements RegularFileSnapshotContextHasher, ConfigurableNormalizer {
 
-    private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar");
+    private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar", "klib");
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipHasher.class);
     private static final HashCode EMPTY_HASH_MARKER = Hashing.signature(ZipHasher.class);
 


### PR DESCRIPTION
Fixes #21610

### Context
Projects using Kotlin Multiplatform generate `klib` binaries. Kotlin/Native libraries are zip files containing a predefined directory structure and should benefit from runtime classpath normalization. 

In projects using Kotlin MPP, when comparing builds for cache misses investigation we observe:
![Screen Shot 2022-08-22 at 3 49 55 PM](https://user-images.githubusercontent.com/475733/186032231-ee8b6e4c-cbfe-431c-ba5e-483446907e6c.png)

This change allows applying classpath runtime normalization on tasks using klib binaries:
![Screen Shot 2022-08-22 at 3 53 42 PM](https://user-images.githubusercontent.com/475733/186032664-f3a8ddf3-6720-4ebd-894c-a210977357f7.png)

To test the change, I used the project https://github.com/square/okio and applied [Build Validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts) (03-validate-local-build-caching-different-locations)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
