### PR TITLE
Add toString for snapshot values

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractArraySnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractArraySnapshot.java
@@ -58,4 +58,9 @@ class AbstractArraySnapshot<T extends Hashable> implements Hashable {
     public int hashCode() {
         return elements.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return elements.toString();
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractListSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractListSnapshot.java
@@ -58,4 +58,9 @@ class AbstractListSnapshot<T extends Hashable> implements Hashable {
     public int hashCode() {
         return elements.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return elements.toString();
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractMapSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractMapSnapshot.java
@@ -57,4 +57,9 @@ class AbstractMapSnapshot<T extends Hashable> implements Hashable {
     public int hashCode() {
         return entries.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return entries.toString();
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractScalarValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractScalarValueSnapshot.java
@@ -63,4 +63,9 @@ abstract class AbstractScalarValueSnapshot<T> implements ValueSnapshot {
     public int hashCode() {
         return value.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "" + value;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractSetSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/AbstractSetSnapshot.java
@@ -56,4 +56,9 @@ class AbstractSetSnapshot<T extends Hashable> implements Hashable {
     public int hashCode() {
         return elements.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return elements.toString();
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/EnumValueSnapshot.java
@@ -84,4 +84,9 @@ public class EnumValueSnapshot implements ValueSnapshot {
     public int hashCode() {
         return className.hashCode() ^ name.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return className + "." + name;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImmutableManagedValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImmutableManagedValueSnapshot.java
@@ -70,4 +70,9 @@ public class ImmutableManagedValueSnapshot implements ValueSnapshot {
         hasher.putString(className);
         hasher.putString(value);
     }
+
+    @Override
+    public String toString() {
+        return "(" + className + ") " + value;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ImplementationValue.java
@@ -32,4 +32,9 @@ public class ImplementationValue {
     public Object getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return "(" + classIdentifier + ") " + value;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ManagedValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/ManagedValueSnapshot.java
@@ -53,4 +53,9 @@ public class ManagedValueSnapshot extends AbstractManagedValueSnapshot<ValueSnap
         }
         return snapshot;
     }
+
+    @Override
+    public String toString() {
+        return "(" + className + ") " + state;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/NullValueSnapshot.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/snapshot/impl/NullValueSnapshot.java
@@ -57,4 +57,9 @@ public class NullValueSnapshot implements ValueSnapshot, Isolatable<Object> {
     public <S> S coerce(Class<S> type) {
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "NULL";
+    }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/MapEntrySnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/MapEntrySnapshot.java
@@ -56,4 +56,9 @@ public class MapEntrySnapshot<T> {
         result = 31 * result + value.hashCode();
         return result;
     }
+
+    @Override
+    public String toString() {
+        return key + "=" + value;
+    }
 }


### PR DESCRIPTION
All snapshot values are currently obscured in the debugger due to lacking an implementation for `toString`.

This PR fixes it.