### PR TITLE
Remove gradlePromotionBranches VCS root

### DIFF
--- a/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishBranchSnapshotFromQuickFeedback.kt
@@ -16,9 +16,9 @@
 
 package promotion
 
+import common.VersionedSettingsBranch
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
-import vcsroots.gradlePromotionBranches
 
 object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBuild(
     promotedBranch = "%branch.to.promote%",
@@ -26,7 +26,7 @@ object PublishBranchSnapshotFromQuickFeedback : PublishGradleDistributionFullBui
     prepTask = "prepSnapshot",
     promoteTask = "promoteSnapshot",
     extraParameters = "-PpromotedBranch=%branch.qualifier% ",
-    vcsRootId = gradlePromotionBranches
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId()
 ) {
     init {
         id("Promotion_PublishBranchSnapshotFromQuickFeedback")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshot.kt
@@ -19,14 +19,13 @@ package promotion
 import common.VersionedSettingsBranch
 import configurations.branchFilter
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshot(branch: VersionedSettingsBranch) : PublishGradleDistributionFullBuild(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
     promoteTask = branch.promoteNightlyTaskName(),
     triggerName = "ReadyforNightly",
-    vcsRootId = gradlePromotionBranches
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId()
 ) {
     init {
         id("Promotion_Nightly")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedback.kt
@@ -17,14 +17,13 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedback(branch: VersionedSettingsBranch) : PublishGradleDistributionFullBuild(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
     promoteTask = branch.promoteNightlyTaskName(),
     triggerName = "QuickFeedback",
-    vcsRootId = gradlePromotionBranches
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId()
 ) {
     init {
         id("Promotion_SnapshotFromQuickFeedback")

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepCheckReady.kt
@@ -17,13 +17,12 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepCheckReady(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
     triggerName = "QuickFeedback",
-    vcsRootId = gradlePromotionBranches,
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId(),
     cleanCheckout = false
 ) {
     init {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepPromote.kt
@@ -17,13 +17,12 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepPromote(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
     triggerName = "QuickFeedback",
-    vcsRootId = gradlePromotionBranches,
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId(),
     cleanCheckout = false
 ) {
     init {

--- a/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishNightlySnapshotFromQuickFeedbackStepUpload.kt
@@ -17,13 +17,12 @@
 package promotion
 
 import common.VersionedSettingsBranch
-import vcsroots.gradlePromotionBranches
 
 class PublishNightlySnapshotFromQuickFeedbackStepUpload(branch: VersionedSettingsBranch) : BasePublishGradleDistribution(
     promotedBranch = branch.branchName,
     prepTask = branch.prepNightlyTaskName(),
     triggerName = "QuickFeedback",
-    vcsRootId = gradlePromotionBranches
+    vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId()
 ) {
     init {
         id("Promotion_SnapshotFromQuickFeedbackStepUpload")

--- a/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
+++ b/.teamcity/src/main/kotlin/promotion/StartReleaseCycleTest.kt
@@ -20,9 +20,8 @@ import common.VersionedSettingsBranch
 import common.gradleWrapper
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
-import vcsroots.gradlePromotionBranches
 
-object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = gradlePromotionBranches, cleanCheckout = false) {
+object StartReleaseCycleTest : BasePromotionBuildType(vcsRootId = VersionedSettingsBranch.fromDslContext().vcsRootId(), cleanCheckout = false) {
     init {
         id("Promotion_AllBranchesStartReleaseCycleTest")
         name = "Start Release Cycle Test"

--- a/.teamcity/src/main/kotlin/vcsroots/VcsRoots.kt
+++ b/.teamcity/src/main/kotlin/vcsroots/VcsRoots.kt
@@ -5,7 +5,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.VcsSettings
 
 val gradlePromotionMaster = "Gradle_GradlePromoteMaster"
-val gradlePromotionBranches = "Gradle_GradlePromoteBranches"
 
 fun VcsSettings.useAbsoluteVcs(absoluteId: String) {
     root(AbsoluteId(absoluteId))


### PR DESCRIPTION
Which contains all branches (default to master),
and seems to be out-of-date.

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/12689835/186142774-32bcdf37-f69a-49a9-96b4-622640d4e5ab.png">
