### PR TITLE
Fix configuration cache errors in writing-tasks/task-with-arguments

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -917,9 +917,6 @@ tasks.named("docsTest") { task ->
                 "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
 
                 "snippet-tutorial-task-only-if_groovy_taskOnlyIf.sample",
-
-                "task-with-arguments_groovy_projectInfoTask.sample",
-                "task-with-arguments_kotlin_projectInfoTask.sample",
             ]
 
             def brokenTests = testsForUnsupportedFeatures + testsWithThirdPartyFailures + testsForNotYetSupportedFeatures + testsToBeFixedForConfigurationCache

--- a/subprojects/docs/src/samples/writing-tasks/task-with-arguments/common/project-info/src/main/java/com/example/ProjectInfoTask.java
+++ b/subprojects/docs/src/samples/writing-tasks/task-with-arguments/common/project-info/src/main/java/com/example/ProjectInfoTask.java
@@ -15,6 +15,9 @@ class ProjectInfoTask extends DefaultTask {
 
     private Format format = Format.PLAIN;
 
+    private final String projectName = getProject().getName();
+    private final String projectVersion = getProject().getVersion().toString();
+
     public ProjectInfoTask() {
     }
 
@@ -32,12 +35,12 @@ class ProjectInfoTask extends DefaultTask {
     void projectInfo() {
         switch (format) {
             case PLAIN:
-                System.out.println(getProject().getName() + ":" + getProject().getVersion());
+                System.out.println(projectName + ":" + projectVersion);
                 break;
             case JSON:
                 System.out.println("{\n" +
-                    "    \"projectName\": \"" + getProject().getName() + "\"\n" +
-                    "    \"version\": \"" + getProject().getVersion() + "\"\n}");
+                    "    \"projectName\": \"" + projectName + "\"\n" +
+                    "    \"version\": \"" + projectVersion + "\"\n}");
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported format: " + format);


### PR DESCRIPTION
Avoid using `Task.getProject` at execution time, cache project info at the configuration time instead. Changing project information cannot be done without invalidating the cached configuration, so the accuracy is preserved. The task has no outputs, so it is never up-to-date; no need to care about the cached values being proper inputs.

Fixed outside the hackathon, because this is the only sample (not snippet) in the list of broken tests. Samples have a different workflow, so we're simplifying our docs by having no samples to fix.

<!--- The issue this PR addresses -->
Part of #21027
