### PR TITLE
Include klib as KNOWN_ZIP_EXTENSIONS for java normalization

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -579,6 +579,95 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         FILE_FILTER_FLAG        | "ignore '**/ignored.txt'"                                                 | 'ignore rule'
     }
 
+    def "treats #extension as archive"() {
+        def archive = file("archive.${extension}")
+        def contents = file("archiveContents").createDir()
+        def ignoredFile = contents.file("ignored.txt")
+        ignoredFile << "this file is ignored"
+        def nonIgnoredFile = contents.file("not-ignored.txt")
+        nonIgnoredFile << "this file is not ignored"
+        contents.zipTo(archive)
+        buildFile << """
+            normalization {
+                runtimeClasspath {
+                    ignore 'ignored.txt'
+                }
+            }
+
+            task customTask {
+                def outputFile = file("build/output.txt")
+                inputs.file("${archive.name}")
+                    .withPropertyName("classpath")
+                    .withNormalizer(ClasspathNormalizer)
+                outputs.file(outputFile)
+                    .withPropertyName("outputFile")
+                outputs.cacheIf { true }
+
+                doLast {
+                    outputFile.text = "done"
+                }
+            }
+        """
+        when:
+        run "customTask"
+        then:
+        executedAndNotSkipped(":customTask")
+
+        when:
+        ignoredFile.text = "changed"
+        archive.delete()
+        contents.zipTo(archive)
+        run "customTask"
+        then:
+        skipped(":customTask")
+
+        where:
+        extension << ["zip", "jar", "war", "rar", "ear", "apk", "aar", "klib"]
+    }
+
+    def "does not treat any extension as archive"() {
+        def archive = file("archive.any")
+        def contents = file("archiveContents").createDir()
+        def ignoredFile = contents.file("ignored.txt")
+        ignoredFile << "this file is ignored"
+        def nonIgnoredFile = contents.file("not-ignored.txt")
+        nonIgnoredFile << "this file is not ignored"
+        contents.zipTo(archive)
+        buildFile << """
+            normalization {
+                runtimeClasspath {
+                    ignore 'ignored.txt'
+                }
+            }
+
+            task customTask {
+                def outputFile = file("build/output.txt")
+                inputs.file("${archive.name}")
+                    .withPropertyName("classpath")
+                    .withNormalizer(ClasspathNormalizer)
+                outputs.file(outputFile)
+                    .withPropertyName("outputFile")
+                outputs.cacheIf { true }
+
+                doLast {
+                    outputFile.text = "done"
+                }
+            }
+        """
+        when:
+        run "customTask"
+        then:
+        executedAndNotSkipped(":customTask")
+
+        when:
+        ignoredFile.text = "changed"
+        archive.delete()
+        contents.zipTo(archive)
+        run "customTask"
+        then:
+        executedAndNotSkipped(":customTask")
+    }
+
     static final String IGNORE_ME = 'ignore-me'
     static final String ALSO_IGNORE_ME = 'also-ignore-me'
     static final String IGNORE_ME_TOO = 'ignore-me-too'

--- a/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/normalization/ConfigureRuntimeClasspathNormalizationIntegrationTest.groovy
@@ -579,7 +579,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         FILE_FILTER_FLAG        | "ignore '**/ignored.txt'"                                                 | 'ignore rule'
     }
 
-    def "treats #extension as archive"() {
+    def "treats '#extension' as archive"() {
         def archive = file("archive.${extension}")
         def contents = file("archiveContents").createDir()
         def ignoredFile = contents.file("ignored.txt")
@@ -625,7 +625,7 @@ class ConfigureRuntimeClasspathNormalizationIntegrationTest extends AbstractInte
         extension << ["zip", "jar", "war", "rar", "ear", "apk", "aar", "klib"]
     }
 
-    def "does not treat any extension as archive"() {
+    def "does not treat 'any' extension as archive"() {
         def archive = file("archive.any")
         def contents = file("archiveContents").createDir()
         def ignoredFile = contents.file("ignored.txt")

--- a/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
+++ b/subprojects/normalization-java/src/main/java/org/gradle/api/internal/changedetection/state/ZipHasher.java
@@ -48,7 +48,7 @@ import java.util.Set;
 
 public class ZipHasher implements RegularFileSnapshotContextHasher, ConfigurableNormalizer {
 
-    private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar");
+    private static final Set<String> KNOWN_ZIP_EXTENSIONS = ImmutableSet.of("zip", "jar", "war", "rar", "ear", "apk", "aar", "klib");
     private static final Logger LOGGER = LoggerFactory.getLogger(ZipHasher.class);
     private static final HashCode EMPTY_HASH_MARKER = Hashing.signature(ZipHasher.class);
 


### PR DESCRIPTION
Projects using Kotlin Multiplatform generate `klib` binaries. Kotlin/Native libraries are zip files containing a predefined directory structure and should benefit from runtime classpath normalization. 

In projects using Kotlin MPP, when comparing builds for cache misses investigation we observe:
![Screen Shot 2022-08-22 at 3 49 55 PM](https://user-images.githubusercontent.com/475733/186032231-ee8b6e4c-cbfe-431c-ba5e-483446907e6c.png)

This change allows applying classpath runtime normalization on tasks using klib binaries:
![Screen Shot 2022-08-22 at 3 53 42 PM](https://user-images.githubusercontent.com/475733/186032664-f3a8ddf3-6720-4ebd-894c-a210977357f7.png)

To test the change, I used the project https://github.com/square/okio and applied [Build Validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts) (03-validate-local-build-caching-different-locations)

Fixes #21610 
Replaces #21611
