### PR TITLE
Polish the lists of doc snippets broken for the configuration cache

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -737,9 +737,7 @@ tasks.named("docsTest") { task ->
 
                 // TODO(https://github.com/gradle/gradle/issues/21027) The test expects the build to fail, but the failure looks slightly different when the configuration cache is enabled.
                 //  We need to improve the test harness to work with such tests.
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_groovy_sanityCheck.sample",
                 "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_sanityCheck.sample",
 
                 // TODO(https://github.com/gradle/gradle/issues/14880)
                 "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
@@ -760,7 +758,6 @@ tasks.named("docsTest") { task ->
                 "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
                 "snippet-init-scripts-plugins_groovy_usePluginsInInitScripts.groovy.sample",
                 "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
-
 
                 // TODO(https://github.com/gradle/gradle/issues/13469) Ivy Publish plugin support
                 "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
@@ -801,7 +798,6 @@ tasks.named("docsTest") { task ->
                 "snippet-signing-maven-publish_kotlin_signingPluginSignPublication.sample",
                 "snippet-signing-tasks_groovy_signingTaskOutput.sample",
                 "snippet-signing-tasks_kotlin_signingTaskOutput.sample",
-
 
                 // TODO(https://github.com/gradle/gradle/issues/16080) Kotlin lambdas capture the script object when accessing top-level vals
                 "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",

--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -682,6 +682,14 @@ tasks.named("docsTest") { task ->
                 "snippet-buildlifecycle-task-execution-events_kotlin_taskExecutionEvents.kotlin.sample",
                 "snippet-custom-model-internal-views_groovy_softwareModelExtend-iv-model.sample",
                 "snippet-custom-model-language-type_groovy_softwareModelExtend-components.sample",
+
+                // These snippets are not used in the documentation, but only in the integration tests.
+                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_groovy_accessingMetadataArtifact.sample",
+                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_kotlin_accessingMetadataArtifact.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-artifacts_kotlin_iterating-artifacts.sample",
+                "snippet-dependency-management-working-with-dependencies-walk-graph_groovy_walking-dependency-graph.sample",
+                "snippet-dependency-management-working-with-dependencies-walk-graph_kotlin_walking-dependency-graph.sample",
+
                 "snippet-ide-eclipse_groovy_wtpWithXml.sample",
                 "snippet-ide-eclipse_kotlin_wtpWithXml.sample",
                 "snippet-ide-idea-additional-test-sources_groovy_ideaAdditionalTestSources.sample",
@@ -723,12 +731,38 @@ tasks.named("docsTest") { task ->
             // These tests cover features that the configuration cache doesn't support yet, but we plan to do that before hitting stable.
             // The tests should be removed from this list when the feature becomes supported.
             def testsForNotYetSupportedFeatures = [
+                // TODO(https://github.com/gradle/gradle/issues/21642)
                 "publishing-credentials_groovy_publishCommandLineCredentials.sample",
                 "publishing-credentials_kotlin_publishCommandLineCredentials.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21027) The test expects the build to fail, but the failure looks slightly different when the configuration cache is enabled.
+                //  We need to improve the test harness to work with such tests.
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_groovy_sanityCheck.sample",
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
+                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_sanityCheck.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/14880)
+                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
+                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/19725) EAR plugin support
                 "snippet-ear-ear-customized_groovy_earCustomized.groovy.sample",
                 "snippet-ear-ear-customized_kotlin_earCustomized.kotlin.sample",
                 "snippet-ear-ear-with-war_groovy_earWithWar.sample",
                 "snippet-ear-ear-with-war_kotlin_earWithWar.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21714)
+                "snippet-groovy-compilation-avoidance_groovy_groovyCompilationAvoidance.sample",
+                "snippet-groovy-compilation-avoidance_kotlin_groovyCompilationAvoidance.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21718)
+                "snippet-init-scripts-configuration-injection_groovy_initScriptConfiguration.groovy.sample",
+                "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
+                "snippet-init-scripts-plugins_groovy_usePluginsInInitScripts.groovy.sample",
+                "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
+
+
+                // TODO(https://github.com/gradle/gradle/issues/13469) Ivy Publish plugin support
                 "snippet-ivy-publish-conditional-publishing_groovy_publishingIvyConditionally.sample",
                 "snippet-ivy-publish-descriptor-customization_groovy_publishingIvyGenerateDescriptor.sample",
                 "snippet-ivy-publish-descriptor-customization_kotlin_publishingIvyGenerateDescriptor.sample",
@@ -738,8 +772,27 @@ tasks.named("docsTest") { task ->
                 "snippet-ivy-publish-quickstart_groovy_publishingIvyPublishSingle.sample",
                 "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishLifecycle.sample",
                 "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishSingle.sample",
+                "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/16080, https://github.com/gradle/gradle/issues/20126)
+                "snippet-java-basic_groovy_basicJavaWithIntegrationTests.sample",
+                "snippet-java-basic_kotlin_basicJavaWithIntegrationTests.sample",
+                "snippet-tutorial-task-only-if_groovy_taskOnlyIf.sample",
+                "snippet-tutorial-task-only-if_kotlin_taskOnlyIf.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21717)
+                "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
+                "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21640)
                 "snippet-maven-publish-conditional-publishing_groovy_publishingMavenConditionally.sample",
                 "snippet-maven-publish-conditional-publishing_kotlin_publishingMavenConditionally.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/19252)
+                "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
+                "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/13470) Signing plugin support
                 "snippet-signing-configurations_groovy_signingArchivesOutput.sample",
                 "snippet-signing-configurations_kotlin_signingArchivesOutput.sample",
                 "snippet-signing-maven-publish_groovy_publishingMavenSignAndPublish.sample",
@@ -748,7 +801,22 @@ tasks.named("docsTest") { task ->
                 "snippet-signing-maven-publish_kotlin_signingPluginSignPublication.sample",
                 "snippet-signing-tasks_groovy_signingTaskOutput.sample",
                 "snippet-signing-tasks_kotlin_signingTaskOutput.sample",
-                "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
+
+
+                // TODO(https://github.com/gradle/gradle/issues/16080) Kotlin lambdas capture the script object when accessing top-level vals
+                "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",
+                "snippet-tasks-custom-task-with-missing-file-property_kotlin_missingFileProperties.sample",
+                "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21711)
+                "snippet-tutorial-configure-object-using-script_groovy_configureObjectUsingScript.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21710)
+                "snippet-tutorial-configure-object_groovy_configureObject.sample",
+
+                // TODO(https://github.com/gradle/gradle/issues/21656)
+                "snippet-tutorial-extra-properties_groovy_extraProperties.sample",
+                "snippet-tutorial-extra-properties_kotlin_extraProperties.sample",
             ]
 
             // Tests that can and has to be fixed to run with the configuration cache enabled.
@@ -784,10 +852,6 @@ tasks.named("docsTest") { task ->
                 "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFiles.sample",
                 "snippet-dependency-management-customizing-resolution-conditional-substitution-rule_kotlin_showJarFilesLocal.sample",
 
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_groovy_sanityCheck.sample",
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_resolve.sample",
-                "snippet-dependency-management-customizing-resolution-deactivate-global-substitution_kotlin_sanityCheck.sample",
-
                 "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_groovy_ivyComonentMetadataRule.sample",
                 "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_kotlin_ivyComonentMetadataRule.sample",
 
@@ -806,17 +870,6 @@ tasks.named("docsTest") { task ->
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_groovy_exclude-transitive-for-dependency.sample",
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_kotlin_exclude-transitive-for-dependency.sample",
 
-                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_groovy_accessingMetadataArtifact.sample",
-                "snippet-dependency-management-working-with-dependencies-access-metadata-artifact_kotlin_accessingMetadataArtifact.sample",
-
-                "snippet-dependency-management-working-with-dependencies-iterate-artifacts_kotlin_iterating-artifacts.sample",
-
-                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_groovy_iterating-dependencies.sample",
-                "snippet-dependency-management-working-with-dependencies-iterate-dependencies_kotlin_iterating-dependencies.sample",
-
-                "snippet-dependency-management-working-with-dependencies-walk-graph_groovy_walking-dependency-graph.sample",
-                "snippet-dependency-management-working-with-dependencies-walk-graph_kotlin_walking-dependency-graph.sample",
-
                 "snippet-files-archive-naming_groovy_archiveNaming.sample",
                 "snippet-files-archive-naming_kotlin_archiveNaming.sample",
 
@@ -830,17 +883,6 @@ tasks.named("docsTest") { task ->
                 "snippet-files-file-collections_kotlin_fileCollectionsUsage.sample",
                 "snippet-files-file-collections_kotlin_fileCollectionsWithClosure.sample",
 
-                "snippet-groovy-compilation-avoidance_groovy_groovyCompilationAvoidance.sample",
-                "snippet-groovy-compilation-avoidance_kotlin_groovyCompilationAvoidance.sample",
-
-                "snippet-init-scripts-configuration-injection_groovy_initScriptConfiguration.groovy.sample",
-                "snippet-init-scripts-configuration-injection_kotlin_initScriptConfiguration.kotlin.sample",
-
-                "snippet-init-scripts-plugins_groovy_usePluginsInInitScripts.groovy.sample",
-                "snippet-init-scripts-plugins_kotlin_usePluginsInInitScripts.kotlin.sample",
-
-                "snippet-java-basic_groovy_basicJavaWithIntegrationTests.sample",
-
                 "snippet-java-cross-compilation_groovy_java7CrossCompilation.sample",
                 "snippet-java-cross-compilation_kotlin_java7CrossCompilation.sample",
 
@@ -850,20 +892,10 @@ tasks.named("docsTest") { task ->
                 "snippet-java-fixtures_groovy_javaTestFixtures.sample",
                 "snippet-java-fixtures_kotlin_javaTestFixtures.sample",
 
-                "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
-                "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",
-
                 "snippet-kotlin-dsl-multi-project-build_kotlin_build.sample",
-
-                "snippet-providers-implicit-task-input-dependency_groovy_implicitTaskInputDependency.sample",
-                "snippet-providers-implicit-task-input-dependency_kotlin_implicitTaskInputDependency.sample",
 
                 "snippet-providers-property-convention_groovy_propertyConvention.sample",
                 "snippet-providers-property-convention_kotlin_propertyConvention.sample",
-
-                "snippet-tasks-custom-task-with-file-property_kotlin_lazyFileProperties.sample",
-
-                "snippet-tasks-custom-task-with-missing-file-property_kotlin_missingFileProperties.sample",
 
                 "snippet-tasks-incremental-build-custom-task-class_groovy_customTaskClassWithInputOutputAnnotations.sample",
                 "snippet-tasks-incremental-build-custom-task-class_groovy_incrementalAdHocTask.sample",
@@ -907,19 +939,8 @@ tasks.named("docsTest") { task ->
 
                 "snippet-testing-test-suite-multi-configure-each_groovy_checkTask.sample",
 
-                "snippet-tutorial-configure-object-using-script_groovy_configureObjectUsingScript.sample",
-
-                "snippet-tutorial-configure-object_groovy_configureObject.sample",
-
                 "snippet-tutorial-configure-task-using-project-property_groovy_configureTaskUsingProjectProperty.sample",
                 "snippet-tutorial-configure-task-using-project-property_kotlin_configureTaskUsingProjectProperty.sample",
-
-                "snippet-tutorial-extra-properties_groovy_extraProperties.sample",
-                "snippet-tutorial-extra-properties_kotlin_extraProperties.sample",
-
-                "snippet-tutorial-mkdir-trap_kotlin_mkdirTrap.sample",
-
-                "snippet-tutorial-task-only-if_groovy_taskOnlyIf.sample",
             ]
 
             def brokenTests = testsForUnsupportedFeatures + testsWithThirdPartyFailures + testsForNotYetSupportedFeatures + testsToBeFixedForConfigurationCache


### PR DESCRIPTION
* Unignore snippet tests for java toolchains
    These were failing locally because of missing IBM toolchain, but should pass on CI.

<!--- The issue this PR addresses -->
This is a part of #21027 
