### PR TITLE
Support side effects for collection and map properties

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -315,7 +315,9 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
                 ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(delegate.size());
                 Value<Void> valueWithSideEffects = super.collectInto(builder);
                 // run side effects if any
-                valueWithSideEffects.get();
+                if (!valueWithSideEffects.isMissing()) {
+                    valueWithSideEffects.get();
+                }
                 cache = new ArrayList<>(builder.build());
                 cache.removeAll(removedValues);
                 realized = true;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -313,11 +313,8 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
         public void realize() {
             if (cache == null) {
                 ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(delegate.size());
-                Value<Void> valueWithSideEffects = super.collectInto(builder);
-                // run side effects if any
-                if (!valueWithSideEffects.isMissing()) {
-                    valueWithSideEffects.get();
-                }
+                // Collect elements discarding potential side effects aggregated in the returned value
+                super.collectInto(builder);
                 cache = new ArrayList<>(builder.build());
                 cache.removeAll(removedValues);
                 realized = true;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -330,12 +330,11 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
         }
 
         @Override
-        public Value<Void> collectInto(ImmutableCollection.Builder<T> builder) {
+        public void collectInto(ImmutableCollection.Builder<T> builder) {
             if (!realized) {
                 realize();
             }
             builder.addAll(cache);
-            return Value.present();
         }
 
         List<T> getValues() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -313,7 +313,9 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
         public void realize() {
             if (cache == null) {
                 ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(delegate.size());
-                super.collectInto(builder);
+                Value<Void> valueWithSideEffects = super.collectInto(builder);
+                // run side effects if any
+                valueWithSideEffects.get();
                 cache = new ArrayList<>(builder.build());
                 cache.removeAll(removedValues);
                 realized = true;
@@ -329,11 +331,12 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
         }
 
         @Override
-        public void collectInto(ImmutableCollection.Builder<T> builder) {
+        public Value<Void> collectInto(ImmutableCollection.Builder<T> builder) {
             if (!realized) {
                 realize();
             }
             builder.addAll(cache);
+            return Value.present();
         }
 
         List<T> getValues() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollectionProvider;
 import org.gradle.api.internal.provider.Collectors.TypedCollector;
 import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.api.internal.provider.ValueSupplier;
 
 import java.util.Iterator;
 import java.util.List;
@@ -58,7 +59,9 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
             if (flushAction != null) {
                 pending.remove(collector);
                 ImmutableList.Builder<T> builder = ImmutableList.builder();
-                collector.collectInto(builder);
+                ValueSupplier.Value<Void> valueWithSideEffects = collector.collectInto(builder);
+                // run side effects if any
+                valueWithSideEffects.get();
                 List<T> realized = builder.build();
                 for (T element : realized) {
                     flushAction.execute(element);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -60,8 +60,10 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
                 pending.remove(collector);
                 ImmutableList.Builder<T> builder = ImmutableList.builder();
                 ValueSupplier.Value<Void> valueWithSideEffects = collector.collectInto(builder);
-                // run side effects if any
-                valueWithSideEffects.get();
+                if (!valueWithSideEffects.isMissing()) {
+                    // run side effects if any
+                    valueWithSideEffects.get();
+                }
                 List<T> realized = builder.build();
                 for (T element : realized) {
                     flushAction.execute(element);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.provider.Collectors.ElementFromProvider;
 import org.gradle.api.internal.provider.Collectors.ElementsFromCollectionProvider;
 import org.gradle.api.internal.provider.Collectors.TypedCollector;
 import org.gradle.api.internal.provider.ProviderInternal;
-import org.gradle.api.internal.provider.ValueSupplier;
 
 import java.util.Iterator;
 import java.util.List;
@@ -59,11 +58,8 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
             if (flushAction != null) {
                 pending.remove(collector);
                 ImmutableList.Builder<T> builder = ImmutableList.builder();
-                ValueSupplier.Value<Void> valueWithSideEffects = collector.collectInto(builder);
-                if (!valueWithSideEffects.isMissing()) {
-                    // run side effects if any
-                    valueWithSideEffects.get();
-                }
+                // Collect elements discarding potential side effects aggregated in the returned value
+                collector.collectInto(builder);
                 List<T> realized = builder.build();
                 for (T element : realized) {
                     flushAction.execute(element);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
@@ -38,7 +38,6 @@ abstract class AbstractNamedDomainObjectContainerSpec<T> extends AbstractNamedDo
 
     def "allow query and mutating methods from create using #methods.key"() {
         setupContainerDefaults()
-        String methodUnderTest = methods.key
         Closure method = bind(methods.value)
 
         when:
@@ -68,7 +67,6 @@ abstract class AbstractNamedDomainObjectContainerSpec<T> extends AbstractNamedDo
 
     def "allow query methods from register using #queryMethods.key"() {
         setupContainerDefaults()
-        String methodUnderTest = queryMethods.key
         Closure method = bind(queryMethods.value)
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSourceTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.collections
 
-abstract class AbstractIterationOrderRetainingElementSourceTest extends AbstractElementSourceTest {
+abstract class AbstractIterationOrderRetainingElementSourceTest extends ElementSourceSpec {
     @Override
     List<CharSequence> iterationOrder(CharSequence... values) {
         return values as List

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/DefaultPendingSourceTest.groovy
@@ -19,10 +19,12 @@ package org.gradle.api.internal.collections
 import org.gradle.api.Action
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.ValueSupplier
-import spock.lang.Specification
 
-class DefaultPendingSourceTest extends Specification {
-    def pending = new DefaultPendingSource()
+class DefaultPendingSourceTest extends PendingSourceSpec {
+
+    DefaultPendingSource<CharSequence> source = new DefaultPendingSource<>()
+
+    def pending = source
     def provider1 = Mock(ProviderInternal)
     def provider2 = Mock(ProviderInternal)
     def provider3 = Mock(ProviderInternal)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ElementSourceSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ElementSourceSpec.groovy
@@ -22,9 +22,10 @@ import org.gradle.api.internal.provider.ChangingValue
 import org.gradle.api.internal.provider.ChangingValueHandler
 import org.gradle.api.internal.provider.CollectionProviderInternal
 import org.gradle.api.internal.provider.ProviderInternal
-import spock.lang.Specification
 
-abstract class AbstractElementSourceTest extends Specification {
+abstract class ElementSourceSpec extends PendingSourceSpec {
+
+    @Override
     abstract ElementSource<CharSequence> getSource()
 
     abstract List<CharSequence> iterationOrder(CharSequence... values)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/PendingSourceSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/PendingSourceSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections
+
+import org.gradle.api.internal.provider.DefaultPropertyFactory
+import org.gradle.api.internal.provider.PropertyHost
+import org.gradle.api.internal.provider.Providers
+import org.gradle.api.internal.provider.ValueSupplier
+import spock.lang.Specification
+
+abstract class PendingSourceSpec extends Specification {
+
+    abstract PendingSource<CharSequence> getSource()
+
+    def "runs side effects of pending providers when realizing pending elements"() {
+        given:
+        def sideEffect1 = Mock(ValueSupplier.SideEffect)
+        def sideEffect2 = Mock(ValueSupplier.SideEffect)
+        def sideEffect3 = Mock(ValueSupplier.SideEffect)
+        def sideEffect4 = Mock(ValueSupplier.SideEffect)
+        def sideEffect5 = Mock(ValueSupplier.SideEffect)
+        def propertyFactory = new DefaultPropertyFactory(Stub(PropertyHost))
+        def source = getSource()
+
+        when:
+        def provider1 = Providers.of("v1").withSideEffect(sideEffect1)
+        source.addPending(provider1)
+        def provider2 = Providers.of("v2").withSideEffect(sideEffect2)
+        source.addPending(provider2)
+        def provider3 = Providers.of("v3").withSideEffect(sideEffect3)
+        source.addPending(provider3)
+        def provider4 = propertyFactory.listProperty(String).with {
+            it.add(Providers.of("v4").withSideEffect(sideEffect4))
+            it
+        }
+        source.addPendingCollection(provider4)
+        def provider5 = propertyFactory.listProperty(String).with {
+            it.add(Providers.of("v5").withSideEffect(sideEffect5))
+            it
+        }
+        source.addPendingCollection(provider5)
+
+        then:
+        0 * _ // no side effects until elements are realized
+
+        when:
+        source.removePending(provider2)
+        source.removePendingCollection(provider4)
+
+        then:
+        0 * _ // can remove pending without running side effects
+
+        when:
+        source.realizePending()
+
+        then:
+        1 * sideEffect1.execute("v1")
+
+        then: // ensure ordering
+        1 * sideEffect3.execute("v3")
+
+        then: // ensure ordering
+        1 * sideEffect5.execute("v5")
+
+        // side effects of removed providers do not execute
+        0 * sideEffect2.execute(_)
+        0 * sideEffect4.execute(_)
+
+        when:
+        source.realizePending()
+
+        then:
+        0 * _ // realizing again does not run side effects
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/PendingSourceSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/PendingSourceSpec.groovy
@@ -26,7 +26,7 @@ abstract class PendingSourceSpec extends Specification {
 
     abstract PendingSource<CharSequence> getSource()
 
-    def "runs side effects of pending providers when realizing pending elements"() {
+    def "does not run side effects of pending providers when realizing pending elements"() {
         given:
         def sideEffect1 = Mock(ValueSupplier.SideEffect)
         def sideEffect2 = Mock(ValueSupplier.SideEffect)
@@ -68,13 +68,13 @@ abstract class PendingSourceSpec extends Specification {
         source.realizePending()
 
         then:
-        1 * sideEffect1.execute("v1")
+        0 * sideEffect1.execute("v1")
 
         then: // ensure ordering
-        1 * sideEffect3.execute("v3")
+        0 * sideEffect3.execute("v3")
 
         then: // ensure ordering
-        1 * sideEffect5.execute("v5")
+        0 * sideEffect5.execute("v5")
 
         // side effects of removed providers do not execute
         0 * sideEffect2.execute(_)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/SortedSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/SortedSetElementSourceTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.collections
 import org.gradle.api.Action
 
 
-class SortedSetElementSourceTest extends AbstractElementSourceTest {
+class SortedSetElementSourceTest extends ElementSourceSpec {
     ElementSource source = new SortedSetElementSource<CharSequence>()
 
     def setup() {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -92,6 +92,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
         addCollector(new ElementsFromCollectionProvider<>(Providers.internal(provider)));
     }
 
+    @Override
+    public int size() {
+        return calculateOwnPresentValue().getWithoutSideEffect().size();
+    }
+
     private void addCollector(Collector<T> collector) {
         assertCanMutate();
         setSupplier(getExplicitValue(defaultValue).plus(collector));

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -306,7 +306,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
         @Override
         public Value<? extends C> calculateValue(ValueConsumer consumer) {
-            return SideEffect.attach(Value.of(value), sideEffect);
+            return Value.of(value).withSideEffect(sideEffect);
         }
 
         @Override
@@ -316,7 +316,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
         @Override
         public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
-            return SideEffect.attach(ExecutionTimeValue.fixedValue(value), sideEffect);
+            return ExecutionTimeValue.fixedValue(value).withSideEffect(sideEffect);
         }
 
         @Override
@@ -345,7 +345,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.of(Cast.uncheckedCast(builder.build())), result);
+            return Value.of(Cast.<C>uncheckedNonnullCast(builder.build())).withSideEffect(SideEffect.fixedFrom(result));
         }
 
         @Override
@@ -374,7 +374,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 SideEffectBuilder<C> sideEffectBuilder = SideEffect.builder();
                 for (ExecutionTimeValue<? extends Iterable<? extends T>> value : values) {
                     builder.addAll(value.getFixedValue());
-                    sideEffectBuilder.addFixedFrom(value);
+                    sideEffectBuilder.add(SideEffect.fixedFrom(value));
                 }
 
                 ExecutionTimeValue<C> mergedValue = ExecutionTimeValue.fixedValue(Cast.uncheckedNonnullCast(builder.build()));
@@ -382,7 +382,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                     mergedValue = mergedValue.withChangingContent();
                 }
 
-                return SideEffect.attach(mergedValue, sideEffectBuilder.build());
+                return mergedValue.withSideEffect(sideEffectBuilder.build());
             }
 
             // At least one of the values is a changing value
@@ -432,10 +432,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                     return Value.missing();
                 }
                 builder.addAll(value.getWithoutSideEffect());
-                sideEffectBuilder.addFixedFrom(value);
+                sideEffectBuilder.add(SideEffect.fixedFrom(value));
             }
 
-            return SideEffect.attach(Value.of(Cast.uncheckedNonnullCast(builder.build())), sideEffectBuilder.build());
+            Value<? extends C> resultValue = Value.of(Cast.uncheckedNonnullCast(builder.build()));
+            return resultValue.withSideEffect(sideEffectBuilder.build());
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -68,6 +68,15 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     protected abstract ValueSupplier.Value<? extends T> calculateOwnValue(ValueConsumer consumer);
 
+    protected Value<? extends T> calculateOwnPresentValue() {
+        Value<? extends T> value = calculateOwnValue(ValueConsumer.IgnoreUnsafeRead);
+        if (value.isMissing()) {
+            throw new MissingValueException(cannotQueryValueOf(value));
+        }
+
+        return value;
+    }
+
     @Override
     public boolean isPresent() {
         return calculatePresence(ValueConsumer.IgnoreUnsafeRead);
@@ -80,11 +89,7 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public T get() {
-        Value<? extends T> value = calculateOwnValue(ValueConsumer.IgnoreUnsafeRead);
-        if (value.isMissing()) {
-            throw new MissingValueException(cannotQueryValueOf(value));
-        }
-        return value.get();
+        return calculateOwnPresentValue().get();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/BiProvider.java
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.provider;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;
@@ -60,24 +59,11 @@ class BiProvider<R, A, B> extends AbstractMinimalProvider<R> {
             return rightValue.asType();
         }
 
-        A leftUnpackedValue = leftValue.getWithoutSideEffect();
-        B rightUnpackedValue = rightValue.getWithoutSideEffect();
-        R combinedUnpackedValue = combiner.apply(leftUnpackedValue, rightUnpackedValue);
+        R combinedUnpackedValue = combiner.apply(leftValue.getWithoutSideEffect(), rightValue.getWithoutSideEffect());
 
-        SideEffect<?> leftSideEffect = leftValue.getSideEffect();
-        SideEffect<R> fixedLeftSideEffect = leftSideEffect == null ? null : SideEffect.fixed(leftUnpackedValue, Cast.uncheckedNonnullCast(leftSideEffect));
-        SideEffect<?> rightSideEffect = rightValue.getSideEffect();
-        SideEffect<R> fixedRightSideEffect = rightSideEffect == null ? null : SideEffect.fixed(rightUnpackedValue, Cast.uncheckedNonnullCast(rightSideEffect));
-
-        Value<R> result = Value.of(combinedUnpackedValue);
-        if (leftSideEffect != null && rightSideEffect != null) {
-            result = result.withSideEffect(SideEffect.composite(fixedLeftSideEffect, fixedRightSideEffect));
-        } else if (leftSideEffect != null) {
-            result = result.withSideEffect(fixedLeftSideEffect);
-        } else if (rightSideEffect != null) {
-            result = result.withSideEffect(fixedRightSideEffect);
-        }
-        return result;
+        return Value.of(combinedUnpackedValue)
+            .withSideEffect(SideEffect.fixedFrom(leftValue))
+            .withSideEffect(SideEffect.fixedFrom(rightValue));
     }
 
     @Nullable

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/CollectionPropertyInternal.java
@@ -22,9 +22,4 @@ import java.util.Collection;
 
 public interface CollectionPropertyInternal<T, C extends Collection<T>> extends PropertyInternal<C>, HasMultipleValues<T>, CollectionProviderInternal<T, C> {
     Class<T> getElementType();
-
-    @Override
-    default int size() {
-        return get().size();
-    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -101,8 +101,9 @@ public class Collectors {
             if (value.isMissing()) {
                 return value.asType();
             }
-            collector.add(value.get(), collection);
-            return Value.present();
+
+            collector.add(value.getWithoutSideEffect(), collection);
+            return SideEffect.attachFixedFrom(Value.present(), value);
         }
 
         @Override
@@ -116,11 +117,10 @@ public class Collectors {
             if (value.isMissing()) {
                 visitor.execute(ExecutionTimeValue.missing());
             } else if (value.hasFixedValue()) {
-                visitor.execute(ExecutionTimeValue.fixedValue(ImmutableList.of(value.getFixedValue())));
+                // transform preserving side effects
+                visitor.execute(ExecutionTimeValue.value(value.toValue().transform(ImmutableList::of)));
             } else {
-                visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue()
-                    .map(transformer(e -> ImmutableList.of(e)))
-                ));
+                visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue().map(transformer(ImmutableList::of))));
             }
         }
 
@@ -221,8 +221,9 @@ public class Collectors {
             if (value.isMissing()) {
                 return value.asType();
             }
-            collector.addAll(value.get(), collection);
-            return Value.present();
+
+            collector.addAll(value.getWithoutSideEffect(), collection);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
         }
 
         @Override
@@ -324,8 +325,8 @@ public class Collectors {
             return delegate.calculatePresence(consumer);
         }
 
-        public void collectInto(ImmutableCollection.Builder<T> builder) {
-            collectEntries(ValueConsumer.IgnoreUnsafeRead, valueCollector, builder);
+        public Value<Void> collectInto(ImmutableCollection.Builder<T> builder) {
+            return collectEntries(ValueConsumer.IgnoreUnsafeRead, valueCollector, builder);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -325,8 +325,8 @@ public class Collectors {
             return delegate.calculatePresence(consumer);
         }
 
-        public Value<Void> collectInto(ImmutableCollection.Builder<T> builder) {
-            return collectEntries(ValueConsumer.IgnoreUnsafeRead, valueCollector, builder);
+        public void collectInto(ImmutableCollection.Builder<T> builder) {
+            collectEntries(ValueConsumer.IgnoreUnsafeRead, valueCollector, builder);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -103,7 +103,7 @@ public class Collectors {
             }
 
             collector.add(value.getWithoutSideEffect(), collection);
-            return SideEffect.attachFixedFrom(Value.present(), value);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -276,7 +276,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.ofNullable(result.getWithoutSideEffect().get(key)), result);
+            Value<? extends V> resultValue = Value.ofNullable(result.getWithoutSideEffect().get(key));
+            return resultValue.withSideEffect(SideEffect.fixedFrom(result));
         }
     }
 
@@ -384,7 +385,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         public Value<? extends Map<K, V>> calculateValue(ValueConsumer consumer) {
-            return SideEffect.attach(Value.of(entries), sideEffect);
+            return Value.of(entries).withSideEffect(sideEffect);
         }
 
         @Override
@@ -399,7 +400,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
-            return SideEffect.attach(ExecutionTimeValue.fixedValue(entries), sideEffect);
+            return ExecutionTimeValue.fixedValue(entries).withSideEffect(sideEffect);
         }
 
         @Override
@@ -442,7 +443,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.of(ImmutableMap.copyOf(entries)), result);
+            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(SideEffect.fixedFrom(result));
         }
 
         @Override
@@ -471,14 +472,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
                 SideEffectBuilder<? super Map<K, V>> sideEffectBuilder = SideEffect.builder();
                 for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
                     entryCollector.addAll(value.getFixedValue().entrySet(), entries);
-                    sideEffectBuilder.addFixedFrom(value);
+                    sideEffectBuilder.add(SideEffect.fixedFrom(value));
                 }
 
                 ExecutionTimeValue<Map<K, V>> value = ExecutionTimeValue.fixedValue(ImmutableMap.copyOf(entries));
                 if (changingContent) {
                     value = value.withChangingContent();
                 }
-                return SideEffect.attach(value, sideEffectBuilder.build());
+                return value.withSideEffect(sideEffectBuilder.build());
             }
             List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers = new ArrayList<>();
             for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
@@ -516,11 +517,10 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
                     return Value.missing();
                 }
                 entries.putAll(value.getWithoutSideEffect());
-                sideEffectBuilder.addFixedFrom(value);
+                sideEffectBuilder.add(SideEffect.fixedFrom(value));
             }
 
-            Value<ImmutableMap<K, V>> resultValue = Value.of(ImmutableMap.copyOf(entries));
-            return SideEffect.attach(resultValue, sideEffectBuilder.build());
+            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(sideEffectBuilder.build());
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -276,7 +276,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return Value.ofNullable(result.get().get(key));
+            return SideEffect.attachFixedFrom(Value.ofNullable(result.getWithoutSideEffect().get(key)), result);
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -442,7 +442,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return Value.of(ImmutableMap.copyOf(entries));
+            return SideEffect.attachFixedFrom(Value.of(ImmutableMap.copyOf(entries)), result);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/FlatMapProvider.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider;
 
 import org.gradle.api.Transformer;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 
@@ -58,16 +57,11 @@ public class FlatMapProvider<S, T> extends AbstractMinimalProvider<S> {
             return Providers.notDefined();
         }
 
-        ProviderInternal<? extends S> result = Providers.internal(transformedProvider);
-        SideEffect<?> sideEffect = value.getSideEffect();
-        if (sideEffect != null) {
-            // Note, that the potential side effect of the transformed provider
-            // is going to be executed before this fixed side effect.
-            // It is not possible to preserve linear execution order in the general case,
-            // as the transformed provider can have side effects hidden under other wrapping providers.
-            result = result.withSideEffect(SideEffect.fixed(unpackedValue, Cast.uncheckedNonnullCast(sideEffect)));
-        }
-        return result;
+        // Note, that the potential side effect of the transformed provider
+        // is going to be executed before this fixed side effect.
+        // It is not possible to preserve linear execution order in the general case,
+        // as the transformed provider can have side effects hidden under other wrapping providers.
+        return Providers.internal(transformedProvider).withSideEffect(SideEffect.fixedFrom(value));
     }
 
     private ProviderInternal<? extends S> backingProvider(ValueConsumer consumer) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/MapCollectors.java
@@ -100,8 +100,8 @@ public class MapCollectors {
             if (value.isMissing()) {
                 return value.asType();
             }
-            collector.add(key, value.get(), dest);
-            return Value.present();
+            collector.add(key, value.getWithoutSideEffect(), dest);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
         }
 
         @Override
@@ -120,7 +120,8 @@ public class MapCollectors {
             if (value.isMissing()) {
                 visitor.execute(ExecutionTimeValue.missing());
             } else if (value.hasFixedValue()) {
-                visitor.execute(ExecutionTimeValue.fixedValue(ImmutableMap.of(key, value.getFixedValue())));
+                // transform preserving side effects
+                visitor.execute(ExecutionTimeValue.value(value.toValue().transform(v -> ImmutableMap.of(key, v))));
             } else {
                 visitor.execute(ExecutionTimeValue.changingValue(value.getChangingValue().map(v -> ImmutableMap.of(key, v))));
             }
@@ -187,8 +188,8 @@ public class MapCollectors {
             if (value.isMissing()) {
                 return value.asType();
             }
-            collector.addAll(value.get().entrySet(), dest);
-            return Value.present();
+            collector.addAll(value.getWithoutSideEffect().entrySet(), dest);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -168,6 +168,6 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      * This new "fixed" side effect will be executed when the resulting provider produces its values.
      */
     default ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
-        return new WithSideEffectProvider<>(this, sideEffect);
+        return WithSideEffectProvider.of(this, sideEffect);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -167,7 +167,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      * The new side effect for the captured value is then attached to the transformed provider.
      * This new "fixed" side effect will be executed when the resulting provider produces its values.
      */
-    default ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
+    default ProviderInternal<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
         return WithSideEffectProvider.of(this, sideEffect);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -241,7 +241,7 @@ public interface ValueSupplier {
          */
         @Nullable
         static <T, A> SideEffect<T> fixedFrom(ExecutionTimeValue<A> value) {
-            if (value.hasFixedValue()) {
+            if (!value.hasFixedValue()) {
                 return null;
             }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -212,7 +212,7 @@ public interface ValueSupplier {
          * and instead always executes against the given {@code value}.
          */
         static <T, A> SideEffect<T> fixed(A value, SideEffect<A> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? EmptySideEffect.value() : new FixedSideEffect<>(value, sideEffect);
+            return EmptySideEffect.isEmpty(sideEffect) ? EmptySideEffect.value() : FixedSideEffect.of(value, sideEffect);
         }
 
         static <T, A> SideEffect<T> fixedFrom(Value<A> value) {
@@ -267,6 +267,15 @@ public interface ValueSupplier {
      * A side effect that ignores its argument and always runs on a fixed value instead.
      */
     class FixedSideEffect<T, A> implements SideEffect<T> {
+
+        private static <T, A> FixedSideEffect<T, A> of(A value, SideEffect<? super A> sideEffect) {
+            if (sideEffect instanceof FixedSideEffect) {
+                // Optimization to not nest fixed side effect, since they ignore the argument
+                return Cast.uncheckedNonnullCast(sideEffect);
+            }
+
+            return new FixedSideEffect<>(value, sideEffect);
+        }
 
         private final A value;
         private final SideEffect<? super A> sideEffect;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -211,22 +211,47 @@ public interface ValueSupplier {
          * Creates a new side effect that ignores its argument
          * and instead always executes against the given {@code value}.
          */
-        static <T, A> SideEffect<T> fixed(A value, SideEffect<A> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? EmptySideEffect.value() : FixedSideEffect.of(value, sideEffect);
+        @Nullable
+        static <T, A> SideEffect<T> fixed(A value, @Nullable SideEffect<A> sideEffect) {
+            return FixedSideEffect.of(value, sideEffect);
         }
 
+        /**
+         * Extracts the side effect from the {@code value} if any, and fixes it on that value.
+         * <p>
+         * If the value is {@link Value#isMissing() missing} then null is returned.
+         *
+         * @see #fixed
+         */
+        @Nullable
         static <T, A> SideEffect<T> fixedFrom(Value<A> value) {
             if (value.isMissing()) {
-                return EmptySideEffect.value();
+                return null;
             }
 
-            SideEffect<? super A> sideEffect = value.getSideEffect();
-            return EmptySideEffect.isEmpty(sideEffect) ? EmptySideEffect.value() : fixed(value.getWithoutSideEffect(), sideEffect);
+            return fixed(value.getWithoutSideEffect(), value.getSideEffect());
+        }
+
+        /**
+         * Extracts the side effect from the {@code value} if any, and fixes it on that value.
+         * <p>
+         * If the execution time value is {@link ExecutionTimeValue#hasFixedValue() not fixed} then null is returned.
+         *
+         * @see #fixed
+         */
+        @Nullable
+        static <T, A> SideEffect<T> fixedFrom(ExecutionTimeValue<A> value) {
+            if (value.hasFixedValue()) {
+                return null;
+            }
+
+            return fixed(value.getFixedValue(), value.getSideEffect());
         }
 
         /**
          * Creates a new side effect that executes given side effects sequentially.
          */
+        @Nullable
         static <T> SideEffect<T> composite(Iterable<SideEffect<T>> sideEffects) {
             return CompositeSideEffect.of(sideEffects);
         }
@@ -235,29 +260,16 @@ public interface ValueSupplier {
          * Creates a new side effect that executes given side effects sequentially.
          */
         @SafeVarargs
+        @Nullable
         static <T> SideEffect<T> composite(SideEffect<? super T>... sideEffects) {
             @SuppressWarnings("varargs")
             List<SideEffect<T>> sideEffectList = Cast.uncheckedNonnullCast(Arrays.asList(sideEffects));
             return CompositeSideEffect.of(sideEffectList);
         }
 
-        static <T> ProviderInternal<T> attach(ProviderInternal<T> provider, @Nullable SideEffect<? super T> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? provider : provider.withSideEffect(sideEffect);
-        }
-
-        static <T> Value<T> attach(Value<T> value, @Nullable SideEffect<? super T> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? value : value.withSideEffect(sideEffect);
-        }
-
-        static <T, S> Value<T> attachFixedFrom(Value<T> value, Value<S> sideEffectSource) {
-            SideEffect<? super S> sideEffect = sideEffectSource.getSideEffect();
-            return EmptySideEffect.isEmpty(sideEffect) ? value : value.withSideEffect(SideEffect.fixed(sideEffectSource.getWithoutSideEffect(), sideEffect));
-        }
-
-        static <T> ExecutionTimeValue<T> attach(ExecutionTimeValue<T> value, @Nullable SideEffect<? super T> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? value : value.withSideEffect(sideEffect);
-        }
-
+        /**
+         * Creates a new builder for collecting side effects and building a composite side effect later.
+         */
         static <T> SideEffectBuilder<T> builder() {
             return new SideEffectBuilder<>();
         }
@@ -268,7 +280,12 @@ public interface ValueSupplier {
      */
     class FixedSideEffect<T, A> implements SideEffect<T> {
 
-        private static <T, A> FixedSideEffect<T, A> of(A value, SideEffect<? super A> sideEffect) {
+        @Nullable
+        private static <T, A> FixedSideEffect<T, A> of(A value, @Nullable SideEffect<? super A> sideEffect) {
+            if (sideEffect == null) {
+                return null;
+            }
+
             if (sideEffect instanceof FixedSideEffect) {
                 // Optimization to not nest fixed side effect, since they ignore the argument
                 return Cast.uncheckedNonnullCast(sideEffect);
@@ -298,11 +315,12 @@ public interface ValueSupplier {
 
     class CompositeSideEffect<T> implements SideEffect<T> {
 
+        @Nullable
         private static <T> SideEffect<T> of(Iterable<SideEffect<T>> sideEffects) {
             List<SideEffect<? super T>> flatSideEffects = new ArrayList<>();
 
             for (SideEffect<? super T> sideEffect : sideEffects) {
-                if (EmptySideEffect.isEmpty(sideEffect)) {
+                if (sideEffect == null) {
                     continue;
                 }
 
@@ -315,7 +333,7 @@ public interface ValueSupplier {
             }
 
             if (flatSideEffects.isEmpty()) {
-                return EmptySideEffect.value();
+                return null;
             } else if (flatSideEffects.size() == 1) {
                 return Cast.uncheckedNonnullCast(flatSideEffects.get(0));
             } else {
@@ -342,65 +360,21 @@ public interface ValueSupplier {
         }
     }
 
-    class EmptySideEffect<T> implements SideEffect<T> {
-
-        public static boolean isEmpty(@Nullable SideEffect<?> sideEffect) {
-            return sideEffect == null || sideEffect == INSTANCE;
-        }
-
-        private static <T> SideEffect<T> value() {
-            return Cast.uncheckedNonnullCast(INSTANCE);
-        }
-
-        private static final EmptySideEffect<Object> INSTANCE = new EmptySideEffect<>();
-
-        private EmptySideEffect() {}
-
-        @Override
-        public void execute(T t) {}
-
-        @Override
-        public String toString() {
-            return "empty";
-        }
-    }
-
     class SideEffectBuilder<T> {
 
         List<SideEffect<T>> sideEffects = new ArrayList<>();
 
-        <V> SideEffectBuilder<T> addFixedFrom(ExecutionTimeValue<V> value) {
-            if (!value.hasFixedValue()) {
-                throw new IllegalArgumentException("expected fixed value, got: " + value);
-            }
-
-            add(fixed(value.getFixedValue(), value.getSideEffect()));
-            return this;
-        }
-
-        <V> SideEffectBuilder<T> addFixedFrom(Value<V> value) {
-            if (value.isMissing()) {
-                throw new IllegalArgumentException("expected present value, got: " + value);
-            }
-
-            add(fixed(value.getWithoutSideEffect(), value.getSideEffect()));
-            return this;
-        }
-
-        private void add(SideEffect<? super T> sideEffect) {
-            if (EmptySideEffect.isEmpty(sideEffect)) {
+        void add(@Nullable SideEffect<? super T> sideEffect) {
+            if (sideEffect == null) {
                 return;
             }
 
             sideEffects.add(Cast.uncheckedCast(sideEffect));
         }
 
+        @Nullable
         public SideEffect<T> build() {
-            return sideEffects.isEmpty() ? EmptySideEffect.value() : SideEffect.composite(sideEffects);
-        }
-
-        private static <T, S> SideEffect<T> fixed(S value, @Nullable SideEffect<? super S> sideEffect) {
-            return EmptySideEffect.isEmpty(sideEffect) ? EmptySideEffect.value() : SideEffect.fixed(value, sideEffect);
+            return sideEffects.isEmpty() ? null : SideEffect.composite(sideEffects);
         }
     }
 
@@ -440,7 +414,7 @@ public interface ValueSupplier {
             if (value == null) {
                 throw new IllegalArgumentException();
             }
-            return EmptySideEffect.isEmpty(sideEffect) ? new Present<>(value) : new Present<>(value, sideEffect);
+            return new Present<>(value, sideEffect);
         }
 
         T get() throws IllegalStateException;
@@ -463,7 +437,7 @@ public interface ValueSupplier {
          */
         <R> Value<R> transform(Transformer<? extends R, ? super T> transformer);
 
-        Value<T> withSideEffect(SideEffect<? super T> sideEffect);
+        Value<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect);
 
         // Only populated when value is missing
         List<DisplayName> getPathToOrigin();
@@ -494,7 +468,7 @@ public interface ValueSupplier {
             this.sideEffect = null;
         }
 
-        private Present(T result, SideEffect<? super T> sideEffect) {
+        private Present(T result, @Nullable SideEffect<? super T> sideEffect) {
             this.result = result;
             this.sideEffect = sideEffect;
         }
@@ -531,12 +505,12 @@ public interface ValueSupplier {
             if (transformResult == null || sideEffect == null) {
                 return Value.ofNullable(transformResult);
             }
-            return Value.withSideEffect(transformResult, SideEffect.fixed(result, sideEffect));
+            return new Present<>(transformResult, SideEffect.fixed(result, sideEffect));
         }
 
         @Override
-        public Value<T> withSideEffect(SideEffect<? super T> sideEffect) {
-            if (EmptySideEffect.isEmpty(sideEffect)) {
+        public Value<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+            if (sideEffect == null) {
                 return this;
             }
 
@@ -550,8 +524,8 @@ public interface ValueSupplier {
             return this;
         }
 
-        @Override
         @Nullable
+        @Override
         public SideEffect<? super T> getSideEffect() {
             return sideEffect;
         }
@@ -601,8 +575,8 @@ public interface ValueSupplier {
             return true;
         }
 
-        @Override
         @Nullable
+        @Override
         public SideEffect<? super T> getSideEffect() {
             return null;
         }
@@ -633,7 +607,7 @@ public interface ValueSupplier {
         }
 
         @Override
-        public Value<T> withSideEffect(SideEffect<? super T> sideEffect) {
+        public Value<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
             // Missing value never carries a side effect
             return this;
         }
@@ -733,7 +707,7 @@ public interface ValueSupplier {
 
         public abstract ExecutionTimeValue<T> withChangingContent();
 
-        public abstract ExecutionTimeValue<T> withSideEffect(SideEffect<? super T> sideEffect);
+        public abstract ExecutionTimeValue<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect);
 
         public static <T> ExecutionTimeValue<T> missing() {
             return Cast.uncheckedCast(MISSING);
@@ -756,7 +730,7 @@ public interface ValueSupplier {
             if (value.isMissing()) {
                 return missing();
             } else {
-                return SideEffect.attach(fixedValue(value.getWithoutSideEffect()), value.getSideEffect());
+                return fixedValue(value.getWithoutSideEffect()).withSideEffect(value.getSideEffect());
             }
         }
 
@@ -793,7 +767,7 @@ public interface ValueSupplier {
         }
 
         @Override
-        public ExecutionTimeValue<Object> withSideEffect(SideEffect<? super Object> sideEffect) {
+        public ExecutionTimeValue<Object> withSideEffect(@Nullable SideEffect<? super Object> sideEffect) {
             return this;
         }
     }
@@ -829,8 +803,8 @@ public interface ValueSupplier {
             return value;
         }
 
-        @Override
         @Nullable
+        @Override
         public SideEffect<? super T> getSideEffect() {
             return sideEffect;
         }
@@ -858,8 +832,8 @@ public interface ValueSupplier {
         }
 
         @Override
-        public ExecutionTimeValue<T> withSideEffect(SideEffect<? super T> sideEffect) {
-            if (EmptySideEffect.isEmpty(sideEffect)) {
+        public ExecutionTimeValue<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+            if (sideEffect == null) {
                 return this;
             }
 
@@ -909,8 +883,8 @@ public interface ValueSupplier {
         }
 
         @Override
-        public ExecutionTimeValue<T> withSideEffect(SideEffect<? super T> sideEffect) {
-            if (EmptySideEffect.isEmpty(sideEffect)) {
+        public ExecutionTimeValue<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+            if (sideEffect == null) {
                 return this;
             }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ValueSupplier.java
@@ -531,11 +531,9 @@ public interface ValueSupplier {
                 return this;
             }
 
-            if (this.sideEffect == null) {
-                return Value.withSideEffect(result, sideEffect);
-            }
-
-            return Value.withSideEffect(result, SideEffect.composite(this.sideEffect, sideEffect));
+            SideEffect<? super T> composedSideEffect = this.sideEffect == null ? sideEffect : SideEffect.composite(this.sideEffect, sideEffect);
+            // Using the direct constructor call, because `result` can be null due to `Value.SUCCESS`
+            return new Present<>(result, composedSideEffect);
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
@@ -21,8 +21,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
 
-    public static <T> ProviderInternal<T> of(ProviderInternal<T> provider, SideEffect<? super T> sideEffect) {
-        return EmptySideEffect.isEmpty(sideEffect) ? provider : new WithSideEffectProvider<>(provider, sideEffect);
+    public static <T> ProviderInternal<T> of(ProviderInternal<T> provider, @Nullable SideEffect<? super T> sideEffect) {
+        return sideEffect == null ? provider : new WithSideEffectProvider<>(provider, sideEffect);
     }
 
     private final ProviderInternal<T> provider;
@@ -60,12 +60,12 @@ public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
-    public ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
-        if (EmptySideEffect.isEmpty(sideEffect)) {
+    public ProviderInternal<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+        if (sideEffect == null) {
             return this;
         }
 
-        return new WithSideEffectProvider<>(provider, SideEffect.composite(this.sideEffect, sideEffect));
+        return of(provider, SideEffect.composite(this.sideEffect, sideEffect));
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
@@ -21,10 +21,14 @@ import org.jetbrains.annotations.Nullable;
 
 public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
 
+    public static <T> ProviderInternal<T> of(ProviderInternal<T> provider, SideEffect<? super T> sideEffect) {
+        return EmptySideEffect.isEmpty(sideEffect) ? provider : new WithSideEffectProvider<>(provider, sideEffect);
+    }
+
     private final ProviderInternal<T> provider;
     private final SideEffect<? super T> sideEffect;
 
-    public WithSideEffectProvider(ProviderInternal<T> provider, SideEffect<? super T> sideEffect) {
+    private WithSideEffectProvider(ProviderInternal<T> provider, SideEffect<? super T> sideEffect) {
         this.provider = provider;
         this.sideEffect = sideEffect;
     }
@@ -57,6 +61,10 @@ public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
 
     @Override
     public ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
+        if (EmptySideEffect.isEmpty(sideEffect)) {
+            return this;
+        }
+
         return new WithSideEffectProvider<>(provider, SideEffect.composite(this.sideEffect, sideEffect));
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -1021,4 +1021,17 @@ The value of this property is derived from: <source>""")
         "getOrNull" | _
         "getOrElse" | _
     }
+
+    def "does not run side effect when calling 'size'"() {
+        def sideEffect1 = Mock(ValueSupplier.SideEffect)
+        def sideEffect2 = Mock(ValueSupplier.SideEffect)
+
+        when:
+        property.add(Providers.of("some value").withSideEffect(sideEffect1))
+        property.addAll(Providers.of(["other value"]).withSideEffect(sideEffect2))
+        property.size()
+
+        then:
+        0 * _
+    }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -970,6 +970,7 @@ The value of this property is derived from: <source>""")
         def sideEffect1 = Mock(ValueSupplier.SideEffect)
         def sideEffect2 = Mock(ValueSupplier.SideEffect)
         property.add(Providers.of("some value").withSideEffect(sideEffect1))
+        property.add(Providers.of("simple value"))
         property.add(Providers.of("other value").withSideEffect(sideEffect2))
 
         property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
@@ -982,7 +983,7 @@ The value of this property is derived from: <source>""")
         def unpackedValue = getter(property, getter, toMutable(["yet another value"]))
 
         then:
-        unpackedValue == toImmutable(["some value", "other value"])
+        unpackedValue == toImmutable(["some value", "simple value", "other value"])
         1 * sideEffect1.execute("some value")
 
         then: // ensure ordering

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1064,25 +1064,42 @@ The value of this property is derived from: <source>""")
     }
 
     def "runs side effect when calling '#getter' on property to which providers were added via 'put'"() {
-        when:
         def sideEffect1 = Mock(ValueSupplier.SideEffect)
         def sideEffect2 = Mock(ValueSupplier.SideEffect)
+        def expectedUnpackedValue = ["some key": "some value", "other key": "other value"]
+
+        when:
         property.put("some key", Providers.of("some value").withSideEffect(sideEffect1))
         property.put("other key", Providers.of("other value").withSideEffect(sideEffect2))
 
-        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
-        property.calculateExecutionTimeValue()
-
+        def value = property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        def executionTimeValue = property.calculateExecutionTimeValue()
         then:
         0 * _ // no side effects until values are unpacked
 
         when:
-        def unpackedValue = getter(property, getter, ["yet another key": "yet another value"])
-
+        def unpackedValue = value.get()
         then:
-        unpackedValue == ["some key": "some value", "other key": "other value"]
+        unpackedValue == expectedUnpackedValue
         1 * sideEffect1.execute("some value")
+        then: // ensure ordering
+        1 * sideEffect2.execute("other value")
+        0 * _
 
+        when:
+        unpackedValue = executionTimeValue.toValue().get()
+        then:
+        unpackedValue == expectedUnpackedValue
+        1 * sideEffect1.execute("some value")
+        then: // ensure ordering
+        1 * sideEffect2.execute("other value")
+        0 * _
+
+        when:
+        unpackedValue = getter(property, getter, ["yet another key": "yet another value"])
+        then:
+        unpackedValue == expectedUnpackedValue
+        1 * sideEffect1.execute("some value")
         then: // ensure ordering
         1 * sideEffect2.execute("other value")
         0 * _
@@ -1095,19 +1112,32 @@ The value of this property is derived from: <source>""")
     }
 
     def "runs side effect when calling '#getter' on property to which providers were added via 'putAll'"() {
-        when:
         def sideEffect = Mock(ValueSupplier.SideEffect)
+
+        when:
         property.putAll(Providers.of(someValue()).withSideEffect(sideEffect))
 
-        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
-        property.calculateExecutionTimeValue()
-
+        def value = property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        def executionTimeValue = property.calculateExecutionTimeValue()
         then:
         0 * _ // no side effects until values are unpacked
 
         when:
-        def unpackedValue = getter(property, getter, ["yet another key": "yet another value"])
+        def unpackedValue = value.get()
+        then:
+        unpackedValue == someValue()
+        1 * sideEffect.execute(someValue())
+        0 * _
 
+        when:
+        unpackedValue = executionTimeValue.toValue().get()
+        then:
+        unpackedValue == someValue()
+        1 * sideEffect.execute(someValue())
+        0 * _
+
+        when:
+        unpackedValue = getter(property, getter, ["yet another key": "yet another value"])
         then:
         unpackedValue == someValue()
         1 * sideEffect.execute(someValue())
@@ -1121,27 +1151,24 @@ The value of this property is derived from: <source>""")
     }
 
     def "runs side effect when getting #description"() {
-        given:
         def valueSideEffect = Mock(ValueSupplier.SideEffect)
 
         when:
         property.put("some key", Providers.of("some value").withSideEffect(valueSideEffect))
         def valueProvider = property.getting(key)
-
         then:
         0 * _ // no side effects until values are unpacked
 
         when:
         valueProvider.getOrNull()
-
         then:
         expectSideEffect * valueSideEffect.execute("some value")
         0 * _
 
         where:
-        description        | key         | expectSideEffect
-        "existing key"     | "some key"  | 1
-        "non-existing key" | "oops key"  | 0
+        description        | key        | expectSideEffect
+        "existing key"     | "some key" | 1
+        "non-existing key" | "oops key" | 0
     }
 
     private ProviderInternal<String> brokenValueSupplier() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -1120,28 +1120,6 @@ The value of this property is derived from: <source>""")
         "getOrElse" | _
     }
 
-    def "runs only own side effect when calling '#getter' on property's 'keySet'"() {
-        given:
-        def ownSideEffect = Mock(ValueSupplier.SideEffect)
-        def valueSideEffect = Mock(ValueSupplier.SideEffect)
-        property.withSideEffect(ownSideEffect)
-
-        when:
-        property.put("some key", Providers.of("some value").withSideEffect(valueSideEffect))
-        def keySetValue = property.keySet().get()
-
-        then:
-        keySetValue == ["some key"].toSet()
-        0 * ownSideEffect.execute(["some key": "some value"])
-        0 * _
-
-        where:
-        getter      | _
-        "get"       | _
-        "getOrNull" | _
-        "getOrElse" | _
-    }
-
     def "runs side effect when getting #description"() {
         given:
         def valueSideEffect = Mock(ValueSupplier.SideEffect)

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
@@ -26,12 +26,12 @@ class WithSideEffectProviderTest extends ProviderSpec<Integer> {
 
     @Override
     Provider providerWithNoValue() {
-        return new WithSideEffectProvider(Providers.notDefined(), Stub(ValueSupplier.SideEffect))
+        return WithSideEffectProvider.of(Providers.notDefined(), Stub(ValueSupplier.SideEffect))
     }
 
     @Override
     Provider<Integer> providerWithValue(Integer value) {
-        return new WithSideEffectProvider(Providers.of(value), Stub(ValueSupplier.SideEffect))
+        return WithSideEffectProvider.of(Providers.of(value), Stub(ValueSupplier.SideEffect))
     }
 
     @Override

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
@@ -80,23 +80,23 @@ class WithSideEffectProviderTest extends ProviderSpec<Integer> {
 
         when:
         counter.set(23)
-        def unpackedValue = extract(provider)
+        def unpackedValue = getter(provider, method, 88)
         then:
         unpackedValue == 23
         1 * sideEffect.execute(23)
 
         when:
-        unpackedValue = extract(provider)
+        unpackedValue = getter(provider, method, 88)
         then:
         unpackedValue == 24
         1 * sideEffect.execute(24)
         0 * _
 
         where:
-        method      | extract
-        "get"       | { it.get() }
-        "getOrNull" | { it.getOrNull() }
-        "getOrElse" | { it.getOrElse(88) }
+        method      | _
+        "get"       | _
+        "getOrNull" | _
+        "getOrElse" | _
     }
 
     def "runs the side effect when changing provider is mapped with '#description'"() {

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -2710,6 +2710,143 @@ The value of this provider is derived from:
         copy2.get() == someValue()
     }
 
+    def "runs side effect when calling '#getter' when empty property value is set via '#setter'"() {
+        given:
+        def property = providerWithNoValue()
+
+        when:
+        def sideEffect = Mock(ValueSupplier.SideEffect)
+        def providerWithSideEffect = Providers.of(someValue()).withSideEffect(sideEffect)
+        // `PropertyInternal` does not directly provide these setters,
+        // but all user-facing interfaces and their implementations do.
+        property."$setter"(providerWithSideEffect)
+
+        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        property.calculateExecutionTimeValue()
+
+        then:
+        0 * _ // no side effects when calling setter or calculated values are not unpacked
+
+        when:
+        def unpackedValue = getter(property, getter, someOtherValue())
+
+        then:
+        unpackedValue == someValue()
+        1 * sideEffect.execute(someValue())
+        0 * _
+
+        where:
+        setter  | getter
+        "set"   | "get"
+        "set"   | "getOrNull"
+        "set"   | "getOrElse"
+        "value" | "get"
+        "value" | "getOrNull"
+        "value" | "getOrElse"
+    }
+
+    def "runs side effect when calling '#getter' when property's value is overridden via '#setter'"() {
+        given:
+        def property = providerWithValue(someOtherValue())
+
+        when:
+        def sideEffect = Mock(ValueSupplier.SideEffect)
+        def providerWithSideEffect = Providers.of(someValue()).withSideEffect(sideEffect)
+        // `PropertyInternal` does not directly provide these setters,
+        // but all user-facing interfaces and their implementations do.
+        property."$setter"(providerWithSideEffect)
+
+        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        property.calculateExecutionTimeValue()
+
+        then:
+        0 * _ // no side effects when calling setter or calculated values are not unpacked
+
+        when:
+        def unpackedValue = getter(property, getter, someOtherValue2())
+
+        then:
+        unpackedValue == someValue()
+        1 * sideEffect.execute(someValue())
+        0 * _
+
+        where:
+        setter  | getter
+        "set"   | "get"
+        "set"   | "getOrNull"
+        "set"   | "getOrElse"
+        "value" | "get"
+        "value" | "getOrNull"
+        "value" | "getOrElse"
+    }
+
+    def "runs side effect when calling '#getter' on default property with convention with side effect"() {
+        given:
+        def property = providerWithNoValue()
+        def sideEffect = Mock(ValueSupplier.SideEffect)
+        def providerWithSideEffect = Providers.of(someValue()).withSideEffect(sideEffect)
+
+        when:
+        // `PropertyInternal` does not directly provide `convention` method,
+        // but all user-facing interfaces and their implementations do.
+        property.convention(providerWithSideEffect)
+
+        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        property.calculateExecutionTimeValue()
+
+        then:
+        0 * _ // no side effects when setting convention or calculated values are not unpacked
+
+        when:
+        def unpackedValue = getter(property, getter, someOtherValue())
+
+        then:
+        unpackedValue == someValue()
+        1 * sideEffect.execute(someValue())
+        0 * _
+
+        where:
+        getter      | _
+        "get"       | _
+        "getOrNull" | _
+        "getOrElse" | _
+    }
+
+    def "does not run side effect from convention when calling '#getter' when property's value is explicitly set"() {
+        given:
+        def sideEffect = Mock(ValueSupplier.SideEffect)
+        def providerWithSideEffect = Providers.of(someValue()).withSideEffect(sideEffect)
+        def property = providerWithNoValue()
+
+        when:
+        // `PropertyInternal` does not directly provide `convention` nor setter methods,
+        // but all user-facing interfaces and their implementations do.
+        property.convention(providerWithSideEffect)
+        property."$setter"(someOtherValue())
+
+        property.calculateValue(ValueSupplier.ValueConsumer.IgnoreUnsafeRead)
+        property.calculateExecutionTimeValue()
+
+        then:
+        0 * _ // no side effects when calling convention, setter or calculated values are not unpacked
+
+        when:
+        def unpackedValue = getter(property, getter, someOtherValue2())
+
+        then:
+        unpackedValue == someOtherValue()
+        0 * _
+
+        where:
+        setter  | getter
+        "set"   | "get"
+        "set"   | "getOrNull"
+        "set"   | "getOrElse"
+        "value" | "get"
+        "value" | "getOrNull"
+        "value" | "getOrElse"
+    }
+
     ModelObject owner() {
         return Stub(ModelObject)
     }


### PR DESCRIPTION
Follow-up for https://github.com/gradle/gradle/pull/21619

Extends the support for side effect propagation in the Provider infrastructure.