### PR TITLE
Make workers run as session scoped

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ProcessFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/ProcessFixture.groovy
@@ -50,7 +50,8 @@ class ProcessFixture {
         if (!(OperatingSystem.current().unix)) {
             throw new RuntimeException("This implementation does not know how to get child processes on os: " + OperatingSystem.current())
         }
-        return bash("ps -o pid,ppid -ax | awk '{ if ( \$2 == ${pid} ) { print \$1 }}'").split("\\n")
+        String result = bash("ps -o pid,ppid -ax | awk '{ if ( \$2 == ${pid} ) { print \$1 }}'").trim()
+        return result == "" ? [] : result.split("\\n")
     }
 
     // Only supported on *nix platforms

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerExecutor.java
@@ -280,7 +280,7 @@ public class DefaultWorkerExecutor implements WorkerExecutor {
     WorkerRequirement getWorkerRequirement(Class<?> executionClass, WorkerSpec configuration, WorkParameters parameters) {
         if (configuration instanceof ProcessWorkerSpec) {
             DaemonForkOptionsBuilder builder = new DaemonForkOptionsBuilder(forkOptionsFactory)
-                .keepAliveMode(KeepAliveMode.DAEMON);
+                .keepAliveMode(KeepAliveMode.SESSION);
             ProcessWorkerSpec processConfiguration = (ProcessWorkerSpec) configuration;
             JavaForkOptions forkOptions = forkOptionsFactory.newJavaForkOptions();
             processConfiguration.getForkOptions().copyTo(forkOptions);


### PR DESCRIPTION
There is an issue where workers are living too long and potentially not being reused. This is causing a problem in our tests where we get OOM errors and therefore JVM crashes. For now, we will make the workers session-scoped so they are killed after the build completes. 

Passing multi-version code quality tests:
https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_AllVersionsIntegMultiVersion_34_bucket9/55260695?buildTab=dependencies&mode=timeline&type=snapshot&range=1661271220000-1661273272000