### PR TITLE
Add documentation for the new strongly-typed dependencies block (Test Suites)

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -258,11 +258,11 @@ Related issues:
 
 Gradle 7.6 supports compiling, testing and running on Java 19.
 
-#### Introduced strongly typed JVM test suites `dependencies` block
+#### Introduced strongly-typed `dependencies` block for JVM test suites
 
-The test suite `dependencies` block is now [strongly typed](https://en.wikipedia.org/wiki/Strong_and_weak_typing).
+The [JVM test suite](userguide/jvm_test_suite_plugin.html) `dependencies` block now uses a [strongly-typed API](dsl/org.gradle.api.plugins.jvm.JvmComponentDependencies.html).
 
-Previously, dependencies were only accepted as a generic `Object`, and in Kotlin DSL this made it harder to configure:
+Previously, dependencies were only accepted as an untyped `Object`, and this made it harder to configure a dependency in Java and the Kotlin DSL:
 
 ```kotlin
 testing {
@@ -271,8 +271,9 @@ testing {
             useJUnitJupiter()
             dependencies {
                 implementation(project(":foo")) {
-                    // Type of the receiver (`this`) here is Dependency, but `project(...)` gives a ProjectDependency.
-                    // In order to access ProjectDependency-specific methods, it must be smart-cast:
+                    // Type of the receiver (`this`) is Dependency
+                    // To access ProjectDependency methods,
+                    // `this` must be smart-cast:
                     this as ProjectDependency
                     // Now it can be used as a ProjectDependency
                     println(dependencyProject)
@@ -283,7 +284,7 @@ testing {
 }
 ```
 
-Now, the configurations are designed in such a way that a particular notation now provides its `Dependency` subtype:
+Now, the API is designed in such a way that a particular notation provides its `Dependency` subtype:
 
 ```kotlin
 testing {
@@ -303,7 +304,7 @@ testing {
 
 For example, using a `String` provides an `ExternalModuleDependency`.
 Using a `FileCollection` provides a `FileCollectionDependency`.
-This allows Java and Kotlin to properly configure all types of dependencies and improves Groovy IDE support.
+This allows Java and Kotlin to properly configure all types of dependencies and improves IDE support for Groovy DSL.
 
 In addition, Kotlin DSL now supports using named arguments for external modules:
 
@@ -313,15 +314,16 @@ testing {
         val test by getting(JvmTestSuite::class) {
             useJUnitJupiter()
             dependencies {
-                implementation(group = "org.junit.jupiter", name = "junit-jupiter", version = "5.8.2")
-                runtimeOnly(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.8.2")
+                implementation(group = "com.google.guava", 
+                               name = "guava", 
+                               version = "31.1-jre")
             }
         }
     }
 }
 ```
 
-Groovy DSL still supports using `Map` notation for this same purpose, however using `Map` from other languages is not possible.
+See the [user manual](userguide/jvm_test_suite_plugin.html#differences_between_the_test_suite_dependencies_and_the_top_level_dependencies_blocks) for other differences between the test suite `dependencies` and top-level `dependencies` blocks.
 
 #### Introduced support for Java 9+ network debugging  
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -258,9 +258,12 @@ Related issues:
 
 Gradle 7.6 supports compiling, testing and running on Java 19.
 
-#### TODO: Introduced support for map notation in JVM `dependencies` block
+#### Introduced strongly-typed JVM test suites `dependencies` block
 
-[Issue](https://github.com/gradle/gradle/issues/19192)
+The test suites' `dependencies` block is now strongly-typed. This means that the type of added dependencies is now
+strongly-typed. For example, using a `String` will provide an `ExternalModuleDependency`, whereas using a `FileCollection` will
+provide a `FileCollectionDependency`. This allows Java and Kotlin to properly configure all types of dependencies, and improves
+IDE support for Groovy.
 
 #### Introduced support for Java 9+ network debugging  
 

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -151,29 +151,31 @@ To use these and similar methods, you need to access the top-level dependencies 
 Though it is discouraged, as suggested by the comment in the snippet above, you can also access the configurations of a test suite in a top-level `dependencies` block after creating the test suite.  The configurations used by test suites are normal Gradle configurations, but their exact names should be considered an implementation detail subject to change.  For this reason, configuration via the suite's own `dependencies` block is recommended.
 ====
 
-=== New Strongly-typed Dependencies Block
-The `dependencies` block is using a new API to declare dependencies. This API is very similar to the old API, but it provides full
-typing which makes it easier to understand the relationship between a dependency notation and its `Dependency` sub-type, and
-easier to configure from Kotlin and Java.
+=== Strongly Typed Dependencies Block
+Gradle 7.6 changed the API of the test suite's `dependencies` block to be more strongly typed.
 
-This API uses a new type, `DependencyAdder`, to provide more strongly-typed dependency addition. It is returned from getters for
-each configuration type. There is also a new `DependencyFactory` to create new dependencies separately from a `DependencyHandler`.
-It can be injected when needed. It is also the recommended way to create dependencies lazily if needed, as shown below.
+Each configuration returns a `DependencyAdder`, to provide more strongly-typed dependency addition. This features multiple `add`
+and `bundle` methods to add dependencies to a particular configuration.
 
-Notable differences from the old API are:
+There is also a `DependencyFactory` to create new dependencies separately from a `DependencyHandler`. It can be injected when
+needed. It is also the recommended way to create dependencies lazily, as shown below for Providers.
 
-- In Java, the getter and `add` must be explicitly called.
-    - Kotlin and Groovy use extensions and operator overloading to call `add` when invoked.
+This API differs from the previous API in the following ways:
+
+- You must explicitly call accessors and `add` from Java.
+    - Kotlin and Groovy: extensions and operator overloading avoid explicit calls.
     - Java: `implementation(x)` becomes `getImplementation().add(x)`
-- `Map` may not be used from Kotlin and Java to declare dependencies. Instead, there are multi-argument methods.
+- You cannot declare dependencies from Kotlin and Java with `Map`.
+  Use multi-argument methods instead.
     - Kotlin: `compileOnly(mapOf("group" to "foo", "name" to "bar"))` becomes `compileOnly(group = "foo", name = "bar")`
-    - Java: `compileOnly(Map.of("group", "foo", "name", "bar"))` becomes `getCompileOnly().add("foo", "bar")`
-    - Groovy still supports using `Map` because it is the way to do named arguments in Groovy.
-- Version catalog bundles cannot be added directly. Instead, use the `bundle` method on each configuration.
-    - This `bundle` method also supports using arbitrary `Collection` objects containing `Dependency` objects.
-    - DSLs: `implementation(libs.bundles.testing)` becomes `implementation.bundle(libs.bundles.testing)`
-- Providers for non-`Dependency` types cannot be used directly. Instead, map them to a `Dependency` using the new `DependencyFactory`.
-    - DSLs: `implementation(myStringProvider)` becomes `implementation(myStringProvider.map { project.dependencyFactory.create(it) })`
+    - Groovy: use `Map` as before -- it is a built-in language feature.
+    - Java: `compileOnly(Map.of("group", "foo", "name", "bar"))` becomes `getCompileOnly().add("foo", "bar", null)`
+- You cannot add version catalog bundles directly.
+  Instead, use the `bundle` method on each configuration.
+    - Kotlin and Groovy: `implementation(libs.bundles.testing)` becomes `implementation.bundle(libs.bundles.testing)`
+- You cannot use providers for non-`Dependency` types directly.
+  Instead, map them to a `Dependency` using the `DependencyFactory`.
+    - Kotlin and Groovy: `implementation(myStringProvider)` becomes `implementation(myStringProvider.map { project.dependencyFactory.create(it) })`
     - Java: `implementation(myStringProvider)` becomes `getImplementation().add(myStringProvider.map(project.getDependencyFactory()::create)`
 
 == Configure source directories of a test suite

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -141,43 +141,6 @@ include::sample[dir="snippets/testing/test-suite-configure-suite-dependencies/ko
 <3> Add the Auto Value annotation processor to the suite's annotation processor classpath so that it will be run when compiling the tests.
 
 
-The `dependencies` block within a test suite does not provide access to the same methods as the top-level `dependencies` block.
-For instance, the link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html#org.gradle.api.artifacts.dsl.DependencyHandler:platform(java.lang.Object)[platform()] and link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html#org.gradle.api.artifacts.dsl.DependencyHandler:platform(java.lang.Object)[enforcedPlatform()] methods are not available.
-
-To use these and similar methods, you need to access the top-level dependencies handler directly with `project.dependencies.platform(...)` or `project.dependencies.enforcedPlatform(...)`.
-
-[NOTE]
-====
-Though it is discouraged, as suggested by the comment in the snippet above, you can also access the configurations of a test suite in a top-level `dependencies` block after creating the test suite.  The configurations used by test suites are normal Gradle configurations, but their exact names should be considered an implementation detail subject to change.  For this reason, configuration via the suite's own `dependencies` block is recommended.
-====
-
-=== Strongly Typed Dependencies Block
-Gradle 7.6 changed the API of the test suite's `dependencies` block to be more strongly typed.
-
-Each configuration returns a `DependencyAdder`, to provide more strongly-typed dependency addition. This features multiple `add`
-and `bundle` methods to add dependencies to a particular configuration.
-
-There is also a `DependencyFactory` to create new dependencies separately from a `DependencyHandler`. It can be injected when
-needed. It is also the recommended way to create dependencies lazily, as shown below for Providers.
-
-This API differs from the previous API in the following ways:
-
-- You must explicitly call accessors and `add` from Java.
-    - Kotlin and Groovy: extensions and operator overloading avoid explicit calls.
-    - Java: `implementation(x)` becomes `getImplementation().add(x)`
-- You cannot declare dependencies from Kotlin and Java with `Map`.
-  Use multi-argument methods instead.
-    - Kotlin: `compileOnly(mapOf("group" to "foo", "name" to "bar"))` becomes `compileOnly(group = "foo", name = "bar")`
-    - Groovy: use `Map` as before -- it is a built-in language feature.
-    - Java: `compileOnly(Map.of("group", "foo", "name", "bar"))` becomes `getCompileOnly().add("foo", "bar", null)`
-- You cannot add version catalog bundles directly.
-  Instead, use the `bundle` method on each configuration.
-    - Kotlin and Groovy: `implementation(libs.bundles.testing)` becomes `implementation.bundle(libs.bundles.testing)`
-- You cannot use providers for non-`Dependency` types directly.
-  Instead, map them to a `Dependency` using the `DependencyFactory`.
-    - Kotlin and Groovy: `implementation(myStringProvider)` becomes `implementation(myStringProvider.map { project.dependencyFactory.create(it) })`
-    - Java: `implementation(myStringProvider)` becomes `getImplementation().add(myStringProvider.map(project.getDependencyFactory()::create)`
-
 == Configure source directories of a test suite
 ====
 include::sample[dir="snippets/testing/test-suite-configure-source-dir/groovy",files="build.gradle[tags=configure-source-dir]"]
@@ -257,6 +220,41 @@ include::sample[dir="snippets/testing/test-suite-multi-configure-each-extracted/
 <1> Define a closure which takes a single `JvmTestSuite` parameter and configures it
 <2> Apply the closure to a test suite, using the default (`test`) test suite
 <3> Alternate means of applying a configuration closure to a test suite outside of its declaration, using the `integrationTest` test suite
+
+== Differences between the test suite `dependencies` and the top-level `dependencies` blocks
+
+Gradle 7.6 changed the API of the test suite's `dependencies` block to be more strongly-typed.
+
+Each dependency bucket returns a link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyAdder.html[`DependencyAdder`] that provides strongly-typed methods to add and configure dependencies.
+
+There is also a link:{javadocPath}/org/gradle/api/artifacts/dsl/DependencyFactory.html[`DependencyFactory`] with factory methods to create new dependencies from different notations.
+Dependencies can be created lazily using these factory methods, as shown below.
+
+This API differs from the top-level `dependencies` block in the following ways:
+
+* You must explicitly call a getter and `add` outside Gradle build scripts.
+    ** `dependencies.add("implementation", x)` becomes `getImplementation().add(x)`
+* You cannot declare dependencies with the `Map` notation from Kotlin and Java.
+  Use multi-argument methods instead in Kotlin and Java.
+    ** Kotlin: `compileOnly(mapOf("group" to "foo", "name" to "bar"))` becomes `compileOnly(group = "foo", name = "bar")`
+    ** Java: `compileOnly(Map.of("group", "foo", "name", "bar"))` becomes `getCompileOnly().add("foo", "bar", null)`
+* You cannot add version catalog bundles directly.
+  Instead, use the `bundle` method on each configuration.
+    ** Kotlin and Groovy: `implementation(libs.bundles.testing)` becomes `implementation.bundle(libs.bundles.testing)`
+* You cannot use providers for non-`Dependency` types directly.
+  Instead, map them to a `Dependency` using the `DependencyFactory`.
+    ** Kotlin and Groovy: `implementation(myStringProvider)` becomes `implementation(myStringProvider.map { project.dependencyFactory.create(it) })`
+    ** Java: `implementation(myStringProvider)` becomes `getImplementation().add(myStringProvider.map(project.getDependencyFactory()::create)`
+
+The `dependencies` block within a test suite does not provide access to the same methods as the top-level `dependencies` block.
+For instance, the link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html#org.gradle.api.artifacts.dsl.DependencyHandler:platform(java.lang.Object)[platform()] and link:{groovyDslPath}/org.gradle.api.artifacts.dsl.DependencyHandler.html#org.gradle.api.artifacts.dsl.DependencyHandler:platform(java.lang.Object)[enforcedPlatform()] methods are not available.
+
+To use these and similar methods, you need to access the top-level dependencies handler directly with `project.dependencies.platform(...)` or `project.dependencies.enforcedPlatform(...)`.
+
+[NOTE]
+====
+Adding dependencies via the test suite's own `dependencies` block is the preferred and recommended way. You can also access the configurations of a test suite in a top-level `dependencies` block after creating the test suite, but the exact names of the configurations used by test suites should be considered an implementation detail subject to change.
+====
 
 == Differences between similar methods on link:{groovyDslPath}/org.gradle.api.plugins.jvm.JvmTestSuite.html[JvmTestSuite] and link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html[Test] task types
 

--- a/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/jvm_test_suite_plugin.adoc
@@ -125,7 +125,6 @@ include::sample[dir="snippets/testing/test-suite-configure-default-suite/groovy"
 include::sample[dir="snippets/testing/test-suite-configure-default-suite/kotlin",files="build.gradle.kts[tags=configure-default-suite]"]
 ====
 
-// TODO test with `./gradlew :docs:docsTest --tests "*test-suite-configure-default-suite*"`
 <1> Declare the `test` test suite uses the TestNG test framework.
 <2> Lazily configure the test task of all targets of the suite; note the return type of `testTask` is `TaskProvider<Test>`.
 <3> Configure more detailed test framework options.  The `options` will be a subclass of `org.gradle.api.tasks.testing.TestFrameworkOptions`, in this case it is `org.gradle.api.tasks.testing.testng.TestNGOptions`.
@@ -137,7 +136,6 @@ include::sample[dir="snippets/testing/test-suite-configure-suite-dependencies/gr
 include::sample[dir="snippets/testing/test-suite-configure-suite-dependencies/kotlin",files="build.gradle.kts[tags=configure-suite-dependencies]"]
 ====
 
-// TODO test with `./gradlew :docs:docsTest --tests "*test-suite-configure-suite-dependencies*"`
 <1> Configure the built-in `test` test suite.
 <2> Add the assertj library to the test's compile and runtime classpaths.  The `dependencies` block within a test suite is already scoped for that test suite.  Instead of having to know the global name of the configuration, test suites have a consistent name that you use in this block for declaring `implementation`, `compileOnly`, `runtimeOnly` and `annotationProcessor` dependencies.
 <3> Add the Auto Value annotation processor to the suite's annotation processor classpath so that it will be run when compiling the tests.
@@ -153,13 +151,37 @@ To use these and similar methods, you need to access the top-level dependencies 
 Though it is discouraged, as suggested by the comment in the snippet above, you can also access the configurations of a test suite in a top-level `dependencies` block after creating the test suite.  The configurations used by test suites are normal Gradle configurations, but their exact names should be considered an implementation detail subject to change.  For this reason, configuration via the suite's own `dependencies` block is recommended.
 ====
 
+=== New Strongly-typed Dependencies Block
+The `dependencies` block is using a new API to declare dependencies. This API is very similar to the old API, but it provides full
+typing which makes it easier to understand the relationship between a dependency notation and its `Dependency` sub-type, and
+easier to configure from Kotlin and Java.
+
+This API uses a new type, `DependencyAdder`, to provide more strongly-typed dependency addition. It is returned from getters for
+each configuration type. There is also a new `DependencyFactory` to create new dependencies separately from a `DependencyHandler`.
+It can be injected when needed. It is also the recommended way to create dependencies lazily if needed, as shown below.
+
+Notable differences from the old API are:
+
+- In Java, the getter and `add` must be explicitly called.
+    - Kotlin and Groovy use extensions and operator overloading to call `add` when invoked.
+    - Java: `implementation(x)` becomes `getImplementation().add(x)`
+- `Map` may not be used from Kotlin and Java to declare dependencies. Instead, there are multi-argument methods.
+    - Kotlin: `compileOnly(mapOf("group" to "foo", "name" to "bar"))` becomes `compileOnly(group = "foo", name = "bar")`
+    - Java: `compileOnly(Map.of("group", "foo", "name", "bar"))` becomes `getCompileOnly().add("foo", "bar")`
+    - Groovy still supports using `Map` because it is the way to do named arguments in Groovy.
+- Version catalog bundles cannot be added directly. Instead, use the `bundle` method on each configuration.
+    - This `bundle` method also supports using arbitrary `Collection` objects containing `Dependency` objects.
+    - DSLs: `implementation(libs.bundles.testing)` becomes `implementation.bundle(libs.bundles.testing)`
+- Providers for non-`Dependency` types cannot be used directly. Instead, map them to a `Dependency` using the new `DependencyFactory`.
+    - DSLs: `implementation(myStringProvider)` becomes `implementation(myStringProvider.map { project.dependencyFactory.create(it) })`
+    - Java: `implementation(myStringProvider)` becomes `getImplementation().add(myStringProvider.map(project.getDependencyFactory()::create)`
+
 == Configure source directories of a test suite
 ====
 include::sample[dir="snippets/testing/test-suite-configure-source-dir/groovy",files="build.gradle[tags=configure-source-dir]"]
 include::sample[dir="snippets/testing/test-suite-configure-source-dir/kotlin",files="build.gradle.kts[tags=configure-source-dir]"]
 ====
 
-// TODO test with `./gradlew :docs:docsTest --tests "*test-suite-configure-source-dir*"`
 <1> Declare and configure a suite named `integrationTest`.  The `SourceSet` and synthesized `Test` tasks will be based on this name.
 <2> Configure the `sources` of the test suite.
 <3> Configure the `java` SourceDirectorySet of the test suite.


### PR DESCRIPTION
In JVM test suites section for now. Might be worth moving `DependencyFactory` somewhere more general though, as it is injectable everywhere already.