### PR TITLE
Increase lower version bound for TransformProgressEventCrossVersionSpec

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TransformProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TransformProgressEventCrossVersionSpec.groovy
@@ -27,7 +27,7 @@ import org.gradle.tooling.events.OperationType
 import org.gradle.util.GradleVersion
 
 @ToolingApiVersion('>=5.1')
-@TargetGradleVersion('>=5.3')
+@TargetGradleVersion('>=5.4')
 class TransformProgressEventCrossVersionSpec extends ToolingApiSpecification {
 
     def events = ProgressEvents.create()


### PR DESCRIPTION
Injecting a Provider<FileSystemLocation> has only been introduced in Gradle 5.4,
 so the test was failing on Gradle 5.3. I don't think it is worth to keep the
 test running on Gradle 5.3.