### PR TITLE
Do not use `DeprecationLogger` in unit test

### DIFF
--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactoryTest.groovy
@@ -37,7 +37,6 @@ import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.initialization.DefaultBuildCancellationToken
 import org.gradle.internal.Try
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
-import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.internal.enterprise.core.GradleEnterprisePluginManager
 import org.gradle.internal.execution.BuildOutputCleanupRegistry
 import org.gradle.internal.execution.OutputChangeListener
@@ -51,6 +50,7 @@ import org.gradle.internal.execution.history.OutputFilesRepository
 import org.gradle.internal.execution.history.changes.DefaultExecutionStateChangeDetector
 import org.gradle.internal.execution.history.impl.DefaultOverlappingOutputDetector
 import org.gradle.internal.execution.impl.DefaultOutputSnapshotter
+import org.gradle.internal.execution.steps.ValidateStep
 import org.gradle.internal.execution.timeout.TimeoutHandler
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer
 import org.gradle.internal.fingerprint.DirectorySensitivity
@@ -130,6 +130,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
     def buildOutputCleanupRegistry = Mock(BuildOutputCleanupRegistry)
     def outputSnapshotter = new DefaultOutputSnapshotter(fileCollectionSnapshotter)
     def deleter = TestFiles.deleter()
+    def validationWarningRecorder = Mock(ValidateStep.ValidationWarningRecorder)
     def executionEngine = new ExecutionGradleServices().createExecutionEngine(
         buildCacheController,
         cancellationToken,
@@ -147,12 +148,7 @@ class DefaultTransformerInvocationFactoryTest extends AbstractProjectBuilderSpec
         outputSnapshotter,
         new DefaultOverlappingOutputDetector(),
         Mock(TimeoutHandler),
-        { String behavior ->
-            DeprecationLogger.deprecateBehaviour(behavior)
-                .willBeRemovedInGradle8()
-                .undocumented()
-                .nagUser()
-        },
+        validationWarningRecorder,
         virtualFileSystem,
         documentationRegistry
     )


### PR DESCRIPTION
There is no need to.