### PR TITLE
Accept nulls in withSideEffect methods

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractCollectionProperty.java
@@ -306,7 +306,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
         @Override
         public Value<? extends C> calculateValue(ValueConsumer consumer) {
-            return SideEffect.attach(Value.of(value), sideEffect);
+            return Value.of(value).withSideEffect(sideEffect);
         }
 
         @Override
@@ -316,7 +316,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
 
         @Override
         public ExecutionTimeValue<? extends C> calculateExecutionTimeValue() {
-            return SideEffect.attach(ExecutionTimeValue.fixedValue(value), sideEffect);
+            return ExecutionTimeValue.fixedValue(value).withSideEffect(sideEffect);
         }
 
         @Override
@@ -345,7 +345,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.of(Cast.uncheckedCast(builder.build())), result);
+            return Value.of(Cast.<C>uncheckedNonnullCast(builder.build())).withSideEffect(SideEffect.fixedFrom(result));
         }
 
         @Override
@@ -374,7 +374,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                 SideEffectBuilder<C> sideEffectBuilder = SideEffect.builder();
                 for (ExecutionTimeValue<? extends Iterable<? extends T>> value : values) {
                     builder.addAll(value.getFixedValue());
-                    sideEffectBuilder.addFixedFrom(value);
+                    sideEffectBuilder.add(SideEffect.fixedFrom(value));
                 }
 
                 ExecutionTimeValue<C> mergedValue = ExecutionTimeValue.fixedValue(Cast.uncheckedNonnullCast(builder.build()));
@@ -382,7 +382,7 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                     mergedValue = mergedValue.withChangingContent();
                 }
 
-                return SideEffect.attach(mergedValue, sideEffectBuilder.build());
+                return mergedValue.withSideEffect(sideEffectBuilder.build());
             }
 
             // At least one of the values is a changing value
@@ -432,10 +432,11 @@ public abstract class AbstractCollectionProperty<T, C extends Collection<T>> ext
                     return Value.missing();
                 }
                 builder.addAll(value.getWithoutSideEffect());
-                sideEffectBuilder.addFixedFrom(value);
+                sideEffectBuilder.add(SideEffect.fixedFrom(value));
             }
 
-            return SideEffect.attach(Value.of(Cast.uncheckedNonnullCast(builder.build())), sideEffectBuilder.build());
+            Value<? extends C> resultValue = Value.of(Cast.uncheckedNonnullCast(builder.build()));
+            return resultValue.withSideEffect(sideEffectBuilder.build());
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -103,7 +103,7 @@ public class Collectors {
             }
 
             collector.add(value.getWithoutSideEffect(), collection);
-            return SideEffect.attachFixedFrom(Value.present(), value);
+            return Value.present().withSideEffect(SideEffect.fixedFrom(value));
         }
 
         @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -276,7 +276,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.ofNullable(result.getWithoutSideEffect().get(key)), result);
+            Value<? extends V> resultValue = Value.ofNullable(result.getWithoutSideEffect().get(key));
+            return resultValue.withSideEffect(SideEffect.fixedFrom(result));
         }
     }
 
@@ -384,7 +385,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         public Value<? extends Map<K, V>> calculateValue(ValueConsumer consumer) {
-            return SideEffect.attach(Value.of(entries), sideEffect);
+            return Value.of(entries).withSideEffect(sideEffect);
         }
 
         @Override
@@ -399,7 +400,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
 
         @Override
         public ExecutionTimeValue<? extends Map<K, V>> calculateOwnExecutionTimeValue() {
-            return SideEffect.attach(ExecutionTimeValue.fixedValue(entries), sideEffect);
+            return ExecutionTimeValue.fixedValue(entries).withSideEffect(sideEffect);
         }
 
         @Override
@@ -442,7 +443,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
             if (result.isMissing()) {
                 return result.asType();
             }
-            return SideEffect.attachFixedFrom(Value.of(ImmutableMap.copyOf(entries)), result);
+            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(SideEffect.fixedFrom(result));
         }
 
         @Override
@@ -471,14 +472,14 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
                 SideEffectBuilder<? super Map<K, V>> sideEffectBuilder = SideEffect.builder();
                 for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
                     entryCollector.addAll(value.getFixedValue().entrySet(), entries);
-                    sideEffectBuilder.addFixedFrom(value);
+                    sideEffectBuilder.add(SideEffect.fixedFrom(value));
                 }
 
                 ExecutionTimeValue<Map<K, V>> value = ExecutionTimeValue.fixedValue(ImmutableMap.copyOf(entries));
                 if (changingContent) {
                     value = value.withChangingContent();
                 }
-                return SideEffect.attach(value, sideEffectBuilder.build());
+                return value.withSideEffect(sideEffectBuilder.build());
             }
             List<ProviderInternal<? extends Map<? extends K, ? extends V>>> providers = new ArrayList<>();
             for (ExecutionTimeValue<? extends Map<? extends K, ? extends V>> value : values) {
@@ -516,11 +517,10 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>, MapSup
                     return Value.missing();
                 }
                 entries.putAll(value.getWithoutSideEffect());
-                sideEffectBuilder.addFixedFrom(value);
+                sideEffectBuilder.add(SideEffect.fixedFrom(value));
             }
 
-            Value<ImmutableMap<K, V>> resultValue = Value.of(ImmutableMap.copyOf(entries));
-            return SideEffect.attach(resultValue, sideEffectBuilder.build());
+            return Value.of(ImmutableMap.copyOf(entries)).withSideEffect(sideEffectBuilder.build());
         }
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/ProviderInternal.java
@@ -167,7 +167,7 @@ public interface ProviderInternal<T> extends Provider<T>, ValueSupplier, TaskDep
      * The new side effect for the captured value is then attached to the transformed provider.
      * This new "fixed" side effect will be executed when the resulting provider produces its values.
      */
-    default ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
+    default ProviderInternal<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
         return WithSideEffectProvider.of(this, sideEffect);
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/WithSideEffectProvider.java
@@ -21,8 +21,8 @@ import org.jetbrains.annotations.Nullable;
 
 public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
 
-    public static <T> ProviderInternal<T> of(ProviderInternal<T> provider, SideEffect<? super T> sideEffect) {
-        return EmptySideEffect.isEmpty(sideEffect) ? provider : new WithSideEffectProvider<>(provider, sideEffect);
+    public static <T> ProviderInternal<T> of(ProviderInternal<T> provider, @Nullable SideEffect<? super T> sideEffect) {
+        return sideEffect == null ? provider : new WithSideEffectProvider<>(provider, sideEffect);
     }
 
     private final ProviderInternal<T> provider;
@@ -60,12 +60,12 @@ public class WithSideEffectProvider<T> extends AbstractMinimalProvider<T> {
     }
 
     @Override
-    public ProviderInternal<T> withSideEffect(SideEffect<? super T> sideEffect) {
-        if (EmptySideEffect.isEmpty(sideEffect)) {
+    public ProviderInternal<T> withSideEffect(@Nullable SideEffect<? super T> sideEffect) {
+        if (sideEffect == null) {
             return this;
         }
 
-        return new WithSideEffectProvider<>(provider, SideEffect.composite(this.sideEffect, sideEffect));
+        return of(provider, SideEffect.composite(this.sideEffect, sideEffect));
     }
 
     @Override


### PR DESCRIPTION
Supporting `withSideEffect(null)` calls allows to get rid of `EmptySideEffect`, `attach*` methods on `SideEffect` and some methods on the `SideEffectBuilder`.