### PR TITLE
Restore reporting of ignore empty directories to scans

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
@@ -16,19 +16,29 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.tasks.PropertyFileCollection;
+import org.gradle.api.tasks.ClasspathNormalizer;
+import org.gradle.api.tasks.CompileClasspathNormalizer;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.DirectorySensitivity;
+import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
 import org.gradle.internal.fingerprint.LineEndingSensitivity;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
 public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
+    private static final ImmutableSet<Class<? extends FileNormalizer>> NORMALIZERS_IGNORING_DIRECTORIES = ImmutableSet.of(
+        ClasspathNormalizer.class,
+        CompileClasspathNormalizer.class,
+        IgnoredPathInputNormalizer.class
+    );
+
     private final List<InputFilePropertySpec> specs = Lists.newArrayList();
     private final FileCollectionFactory fileCollectionFactory;
     private final String ownerDisplayName;
@@ -62,12 +72,18 @@ public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
             value,
             skipWhenEmpty,
             incremental,
-            directorySensitivity,
+            normalizeDirectorySensitivity(normalizer, directorySensitivity),
             lineEndingSensitivity
         ));
         if (skipWhenEmpty) {
             hasSourceFiles = true;
         }
+    }
+
+    private DirectorySensitivity normalizeDirectorySensitivity(Class<? extends FileNormalizer> fileNormalizer, DirectorySensitivity directorySensitivity) {
+        return NORMALIZERS_IGNORING_DIRECTORIES.contains(fileNormalizer)
+            ? DirectorySensitivity.DEFAULT
+            : directorySensitivity;
     }
 
     public ImmutableSortedSet<InputFilePropertySpec> getFileProperties() {


### PR DESCRIPTION
We report that we ignore empty directories for normalization strategies which
ignore them always to build scans. This was accidentally removed in #21625, this
 PR brings back the old behaviour.