### PR TITLE
Disambiguate in precedence order when considering extra attributes

### DIFF
--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
@@ -103,16 +103,20 @@ class GradleMetadataJavaLibraryCrossVersionIntegrationTest extends CrossVersionI
     }
 
     def "can consume library published with previous version of Gradle"() {
-        expect:
-        version previous withTasks ':producer:publish' run()
-        version current withTasks ':consumer:resolve' run()
+        when:
+        version(previous).withTasks(':producer:publish').run()
+        def result = version(current).withTasks(":consumer:resolve").run()
+
+        then:
+        result.output.contains("producer-1.0.jar")
     }
 
     def "previous Gradle can consume library published with current version of Gradle"() {
         expect:
-        version current withTasks ':producer:publish' run()
-        if (previous.version.compareTo(STABLE_METADATA_VERSION) >= 0) {
-            version previous withTasks ':consumer:resolve' run()
+        version(current).withTasks(':producer:publish').run()
+        if (previous.version >= STABLE_METADATA_VERSION) {
+            def result = version(previous).withTasks (':consumer:resolve').run()
+            assert result.output.contains("producer-1.0.jar")
         }
     }
 

--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
@@ -95,28 +95,25 @@ class GradleMetadataJavaLibraryCrossVersionIntegrationTest extends CrossVersionI
             }
 
             task resolve {
+                dependsOn configurations.runtimeClasspath
                 doLast {
-                    println configurations.runtimeClasspath.files
+                    assert configurations.runtimeClasspath.files*.name.contains("producer-1.0.jar")
                 }
             }
         """
     }
 
     def "can consume library published with previous version of Gradle"() {
-        when:
+        expect:
         version(previous).withTasks(':producer:publish').run()
-        def result = version(current).withTasks(":consumer:resolve").run()
-
-        then:
-        result.output.contains("producer-1.0.jar")
+        version(current).withTasks(":consumer:resolve").run()
     }
 
     def "previous Gradle can consume library published with current version of Gradle"() {
         expect:
         version(current).withTasks(':producer:publish').run()
         if (previous.version >= STABLE_METADATA_VERSION) {
-            def result = version(previous).withTasks (':consumer:resolve').run()
-            assert result.output.contains("producer-1.0.jar")
+            version(previous).withTasks(':consumer:resolve').run()
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -318,15 +318,15 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
         }
 
         @Override
-        public PrecedenceResult orderByPrecedence(ImmutableAttributes requested) {
+        public PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested) {
             if (precedence.isEmpty() && producerSchema.getAttributeDisambiguationPrecedence().isEmpty()) {
                 // if no attribute precedence has been set anywhere, we can just iterate in order
-                return new PrecedenceResult(IntStream.range(0, requested.keySet().size()).boxed().collect(Collectors.toList()));
+                return new PrecedenceResult(IntStream.range(0, requested.size()).boxed().collect(Collectors.toList()));
             } else {
                 // Populate requested attribute -> position in requested attribute list
                 final Map<String, Integer> remaining = new LinkedHashMap<>();
                 int position = 0;
-                for (Attribute<?> requestedAttribute : requested.keySet()) {
+                for (Attribute<?> requestedAttribute : requested) {
                     remaining.put(requestedAttribute.getName(), position++);
                 }
                 List<Integer> sorted = new ArrayList<>(remaining.size());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
@@ -57,5 +57,14 @@ public interface AttributeSelectionSchema {
             return unsortedIndices;
         }
     }
-    PrecedenceResult orderByPrecedence(ImmutableAttributes requested);
+
+    /**
+     * Given a set of attributes, order those attributes based on the precedence defined by
+     * this schema.
+     *
+     * @param requested The attributes to order. Must have a consistent iteration ordering.
+     *
+     * @return The ordered attributes.
+     */
+    PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -361,7 +361,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def e = thrown(IllegalArgumentException)
         e.message == "Attribute 'a' precedence has already been set."
     }
-    
+
     def "precedence order is honored with merged schema"() {
         def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         when:
@@ -385,7 +385,7 @@ class DefaultAttributesSchemaTest extends Specification {
         )
 
         then:
-        def result = schema.mergeWith(producer).orderByPrecedence(requested)
+        def result = schema.mergeWith(producer).orderByPrecedence(requested.keySet())
         result.sortedOrder == [2, 1, 0]
         result.unsortedOrder as List == [3]
     }
@@ -414,7 +414,7 @@ class DefaultAttributesSchemaTest extends Specification {
         )
 
         then:
-        def result = schema.mergeWith(producer).orderByPrecedence(requested)
+        def result = schema.mergeWith(producer).orderByPrecedence(requested.keySet())
         result.sortedOrder == [1, 0, 2]
         result.unsortedOrder as List == [3]
     }
@@ -437,7 +437,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested)
+        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
         result.sortedOrder == [2, 1]
         result.unsortedOrder as List == [0, 3]
     }
@@ -454,7 +454,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested)
+        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
         result.sortedOrder == []
         result.unsortedOrder as List == [0, 1, 2, 3]
     }
@@ -473,7 +473,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested)
+        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
         result.sortedOrder == []
         result.unsortedOrder as List == [0, 1, 2, 3]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
@@ -48,7 +48,7 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
             if (details.consumerValue == null) {
                 details.compatible()
             } else {
-                if (details.consumerValue in ["requested", "best", "compatible"] && details.producerValue in ["best", "compatible"]) {
+                if (details.producerValue in ["best", "compatible"]) {
                     details.compatible()
                 }
             }
@@ -110,24 +110,22 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
     }
 
     def "disambiguates extra attributes in precedence order"() {
-        def candidate1 = candidate("best", null, "a")
-        def candidate2 = candidate("another", "best", "b")
-        def candidate3 = candidate("another", "another", "c")
+        def candidate1 = candidate("best", "compatible", "compatible")
+        def candidate2 = candidate("compatible", "best", "compatible")
+        def candidate3 = candidate("compatible", "compatible", "best")
+        def candidate4 = candidate("compatible", "compatible", "compatible")
+        def requested = AttributeTestUtil.attributes("unknown": "unknown")
 
         expect:
-        matcher.match(selectionSchema, [candidate1, candidate2, candidate3], requested("best", null, null), null, explanationBuilder) == [candidate1]
-        matcher.match(selectionSchema, [candidate1, candidate2, candidate3], requested("another", null, null), null, explanationBuilder) == [candidate2]
-        matcher.match(selectionSchema, [candidate1, candidate2, candidate3], requested("another", "another", null), null, explanationBuilder) == [candidate3]
+        matcher.match(selectionSchema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
+        matcher.match(selectionSchema, [candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate2]
+        matcher.match(selectionSchema, [candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
     }
 
     private static AttributeContainerInternal requested(String highestValue, String middleValue, String lowestValue) {
         return candidate(highestValue, middleValue, lowestValue)
     }
     private static AttributeContainerInternal candidate(String highestValue, String middleValue, String lowestValue) {
-        return AttributeTestUtil.attributes(
-            (highestValue != null ? [highest: highestValue] : [:]) +
-            (middleValue  != null ? [middle:  middleValue]  : [:]) +
-            (lowestValue  != null ? [lowest:  lowestValue]  : [:])
-        )
+        return AttributeTestUtil.attributes([highest: highestValue, middle: middleValue, lowest: lowestValue])
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -661,8 +661,8 @@ class ComponentAttributeMatcherTest extends Specification {
         }
 
         @Override
-        PrecedenceResult orderByPrecedence(ImmutableAttributes requested) {
-            return new PrecedenceResult(IntStream.range(0, requested.keySet().size()).boxed().collect(Collectors.toList()))
+        PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested) {
+            return new PrecedenceResult(IntStream.range(0, requested.size()).boxed().collect(Collectors.toList()))
         }
     }
 }

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_attributes.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_attributes.adoc
@@ -1,7 +1,7 @@
 [[variant_attributes]]
 = Working with Variant Attributes
 
-As explained in the section on <<variant_model.adoc#sec:variant-aware-matching,variant aware matching>>, attributes give semantics to variants and are used by Gradle's dependency management engine to select the best matching variant. 
+As explained in the section on <<variant_model.adoc#sec:variant-aware-matching,variant aware matching>>, attributes give semantics to variants and are used by Gradle's dependency management engine to select the best matching variant.
 
 As a user of Gradle, attributes are often hidden as implementation details.
 But it might be useful to understand the _standard attributes_ defined by Gradle and its core plugins.
@@ -224,7 +224,7 @@ Attribute compatibility rules have to be registered via the link:{javadocPath}/o
 
 Since multiple values for an attribute can be _compatible_, Gradle needs to choose the "best" candidate between all compatible candidates. This is called "disambiguation".
 
-This is done by implementing an link:{javadocPath}/org/gradle/api/attributes/AttributeDisambiguationRule.html[attribute disambiguation rule]. 
+This is done by implementing an link:{javadocPath}/org/gradle/api/attributes/AttributeDisambiguationRule.html[attribute disambiguation rule].
 
 Attribute disambiguation rules have to be registered via the link:{javadocPath}/org/gradle/api/attributes/AttributeMatchingStrategy.html[attribute matching strategy] that you can obtain from the link:{javadocPath}/org/gradle/api/attributes/AttributesSchema.html[attributes schema].
 [[sec:abm_algorithm]]
@@ -239,11 +239,13 @@ Finding the best variant can get complicated when there are many different varia
     a. For each requested attribute, if a candidate does not have a value matching the disambiguation rule, it's eliminated from consideration.
     b. If the attribute has a known precedence, Gradle will stop as soon as there is a single candidate remaining.
     c. If the attribute does not have a known precedence, Gradle must consider all attributes.
-5. If several candidates still remain, Gradle will start to consider "extra" attributes to disambiguate between multiple candidates. Extra attributes are attributes that were not requested by the consumer. A candidate can be chosen if it is compatible with all of the disambiguation rules.
+5. If several candidates still remain, Gradle will start to consider "extra" attributes to disambiguate between multiple candidates. Extra attributes are attributes that were not requested by the consumer but are present on at least one candidate. These extra attributes are considered in precedence order.
+    a. If the attribute has a known precedence, Gradle will stop as soon as there is a single candidate remaining.
+    b. After all extra attributes with precedence are considered, the remaining candidates can be chosen if they are compatible with all of the non-ordered disambiguation rules.
 6. If several candidates still remain, Gradle will consider extra attributes again. A candidate can be chosen if it has the fewest number of extra attributes.
 
-If at any step no candidates remain compatible, resolution will fail and list all compatible candidates from step 1. 
+If at any step no candidates remain compatible, resolution will fail and list all compatible candidates from step 1.
 
-Plugins and ecosystems can influence the selection algorithm by implementing compatibility rules, disambiguation rules and telling Gradle the precedence of attributes. Attributes with a higher precedence are used to eliminate compatible matches in order. 
+Plugins and ecosystems can influence the selection algorithm by implementing compatibility rules, disambiguation rules and telling Gradle the precedence of attributes. Attributes with a higher precedence are used to eliminate compatible matches in order.
 
-For example, in the Java ecosystem, the `org.gradle.usage` attribute has a higher precedence than `org.gradle.libraryelements`. This means that if two candidates were available with compatible values for both `org.gradle.usage` and `org.gradle.libraryelements`, Gradle will choose the candidate that passes the disambiguation rule for `org.gradle.usage`. 
+For example, in the Java ecosystem, the `org.gradle.usage` attribute has a higher precedence than `org.gradle.libraryelements`. This means that if two candidates were available with compatible values for both `org.gradle.usage` and `org.gradle.libraryelements`, Gradle will choose the candidate that passes the disambiguation rule for `org.gradle.usage`.

--- a/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_attributes.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/04-modeling-features/variant_attributes.adoc
@@ -244,7 +244,8 @@ Finding the best variant can get complicated when there are many different varia
     b. After all extra attributes with precedence are considered, the remaining candidates can be chosen if they are compatible with all of the non-ordered disambiguation rules.
 6. If several candidates still remain, Gradle will consider extra attributes again. A candidate can be chosen if it has the fewest number of extra attributes.
 
-If at any step no candidates remain compatible, resolution will fail and list all compatible candidates from step 1.
+If at any step no candidates remain compatible, resolution fails.
+Additionally, Gradle outputs a list of all compatible candidates from step 1 to help with debugging variant matching failures.
 
 Plugins and ecosystems can influence the selection algorithm by implementing compatibility rules, disambiguation rules and telling Gradle the precedence of attributes. Attributes with a higher precedence are used to eliminate compatible matches in order.
 


### PR DESCRIPTION
This allows us to have multiple default attributes. Previously, if multiple of these default attributes were not requested, and no match was found pre-extra-attribute-disambiguation, disambiguation would fail. Now, as long as we find a single match after considering extra attributes in order, we can successfully use multiple default values in attribute matching.
