### PR TITLE
Polish DefaultAttributesSchema and ComponentAttributeMatcher

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.internal.attributes.CompatibilityRule
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
 import org.gradle.api.internal.attributes.DisambiguationRule
 import org.gradle.api.internal.attributes.MultipleCandidatesResult
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
@@ -34,7 +33,7 @@ class TargetJvmVersionRulesTest extends Specification {
     private DisambiguationRule<Object> disambiguationRules
 
     def setup() {
-        AttributesSchema schema = new DefaultAttributesSchema(Stub(ComponentAttributeMatcher), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        AttributesSchema schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
         compatibilityRules = schema.compatibilityRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
         disambiguationRules = schema.disambiguationRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -113,7 +113,6 @@ import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
-import org.gradle.internal.component.model.ComponentAttributeMatcher;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.execution.ExecutionEngine;
 import org.gradle.internal.execution.InputFingerprinter;
@@ -204,7 +203,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory, PlatformSupport platformSupport) {
-            DefaultAttributesSchema attributesSchema = instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
+            DefaultAttributesSchema attributesSchema = instantiatorFactory.decorateLenient().newInstance(DefaultAttributesSchema.class, instantiatorFactory, isolatableFactory);
             platformSupport.configureSchema(attributesSchema);
             GradlePluginVariantsSupport.configureSchema(attributesSchema);
             return attributesSchema;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.attributes;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.internal.component.model.AttributeMatcher;
 
+import javax.annotation.Nullable;
+
 public interface AttributesSchemaInternal extends DescribableAttributesSchema {
     /**
      * Returns a matcher that uses the consumer rules from this schema, and the producer rules from the given schema.
@@ -33,4 +35,7 @@ public interface AttributesSchemaInternal extends DescribableAttributesSchema {
     CompatibilityRule<Object> compatibilityRules(Attribute<?> attribute);
 
     DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute);
+
+    @Nullable
+    Attribute<?> getAttributeByName(String name);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
@@ -21,6 +21,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.internal.component.model.AttributeMatcher;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -102,6 +103,12 @@ public class EmptySchema implements AttributesSchemaInternal {
     @Override
     public List<Attribute<?>> getAttributeDisambiguationPrecedence() {
         return Collections.emptyList();
+    }
+
+    @Nullable
+    @Override
+    public Attribute<?> getAttributeByName(String name) {
+        return null;
     }
 
     private static class DoNothingCompatibilityRule implements CompatibilityRule<Object> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.attributes.MultipleCandidatesResult;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Cast;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -52,6 +53,17 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
     @Override
     public Set<Attribute<?>> getAttributes() {
         return SUPPORTED_ATTRIBUTES;
+    }
+
+    @Nullable
+    @Override
+    public Attribute<?> getAttributeByName(String name) {
+        for (Attribute<?> attr : SUPPORTED_ATTRIBUTES) {
+            if (name.equals(attr.getName())) {
+                return attr;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeMatcher.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -26,13 +27,23 @@ import java.util.Collection;
 import java.util.List;
 
 public interface AttributeMatcher {
+
+    @VisibleForTesting
+    AttributeSelectionSchema getSelectionSchema();
+
+    /**
+     * Determines whether the given candidate is compatible with the requested criteria.
+     */
     boolean isMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested);
 
     <T> boolean isMatching(Attribute<T> attribute, T candidate, T requested);
 
     <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, AttributeMatchingExplanationBuilder builder);
 
-    <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, @Nullable T fallback, AttributeMatchingExplanationBuilder builder);
+    /**
+     * Selects the candidates from the given set that are compatible with the requested criteria.
+     */
+    <T extends HasAttributes, E extends T> List<T> matches(Collection<E> candidates, AttributeContainerInternal requested, @Nullable T fallback, AttributeMatchingExplanationBuilder builder);
 
     List<MatchingDescription<?>> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentAttributeMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentAttributeMatcher.java
@@ -17,8 +17,6 @@ package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -28,30 +26,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
- * An attribute matcher, which optimizes for the case of only comparing 0 or 1 candidates and delegates to {@link MultipleCandidateMatcher} for all other cases.
+ * An {@link AttributeMatcher}, which optimizes for the case of only comparing 0 or 1 candidates and delegates to {@link MultipleCandidateMatcher} for all other cases.
  */
-public class ComponentAttributeMatcher {
+public class ComponentAttributeMatcher implements AttributeMatcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ComponentAttributeMatcher.class);
+
+    private final AttributeSelectionSchema schema;
 
     /**
      * Attribute matching can be very expensive. In case there are multiple candidates, we
      * cache the result of the query, because it's often the case that we ask for the same
      * disambiguation of attributes several times in a row (but with different candidates).
      */
-    private final Map<CachedQuery, int[]> cachedQueries = Maps.newConcurrentMap();
+    private final ConcurrentMap<CachedQuery, int[]> cachedQueries = new ConcurrentHashMap<>();
 
-    /**
-     * Determines whether the given candidate is compatible with the requested criteria, according to the given schema.
-     */
-    public boolean isMatching(AttributeSelectionSchema schema, AttributeContainerInternal candidate, AttributeContainerInternal requested) {
+    public ComponentAttributeMatcher(AttributeSelectionSchema schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public AttributeSelectionSchema getSelectionSchema() {
+        return schema;
+    }
+
+    @Override
+    public boolean isMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested) {
         if (requested.isEmpty() || candidate.isEmpty()) {
             return true;
         }
@@ -73,8 +81,14 @@ public class ComponentAttributeMatcher {
         return true;
     }
 
+    @Override
+    public <T> boolean isMatching(Attribute<T> attribute, T candidate, T requested) {
+        return schema.matchValue(attribute, requested, candidate);
+    }
+
+    @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public List<AttributeMatcher.MatchingDescription<?>> describeMatching(AttributeSelectionSchema schema, AttributeContainerInternal candidate, AttributeContainerInternal requested) {
+    public List<AttributeMatcher.MatchingDescription<?>> describeMatching(AttributeContainerInternal candidate, AttributeContainerInternal requested) {
         if (requested.isEmpty() || candidate.isEmpty()) {
             return Collections.emptyList();
         }
@@ -83,7 +97,7 @@ public class ComponentAttributeMatcher {
         ImmutableAttributes candidateAttributes = candidate.asImmutable();
 
         ImmutableSet<Attribute<?>> attributes = requestedAttributes.keySet();
-        List<AttributeMatcher.MatchingDescription<?>> result = Lists.newArrayListWithCapacity(attributes.size());
+        List<AttributeMatcher.MatchingDescription<?>> result = new ArrayList<>(attributes.size());
         for (Attribute<?> attribute : attributes) {
             AttributeValue<?> requestedValue = requestedAttributes.findEntry(attribute);
             AttributeValue<?> candidateValue = candidateAttributes.findEntry(attribute.getName());
@@ -98,12 +112,15 @@ public class ComponentAttributeMatcher {
         return result;
     }
 
-    /**
-     * Selects the candidates from the given set that are compatible with the requested criteria, according to the given schema.
-     */
-    public <T extends HasAttributes, E extends T> List<T> match(AttributeSelectionSchema schema, Collection<E> candidates, AttributeContainerInternal requested, @Nullable T fallback, AttributeMatchingExplanationBuilder explanationBuilder) {
+    @Override
+    public <T extends HasAttributes> List<T> matches(Collection<? extends T> candidates, AttributeContainerInternal requested, AttributeMatchingExplanationBuilder explanationBuilder) {
+        return matches(candidates, requested, null, explanationBuilder);
+    }
+
+    @Override
+    public <T extends HasAttributes, E extends T> List<T> matches(Collection<E> candidates, AttributeContainerInternal requested, @Nullable T fallback, AttributeMatchingExplanationBuilder explanationBuilder) {
         if (candidates.size() == 0) {
-            if (fallback != null && isMatching(schema, (AttributeContainerInternal) fallback.getAttributes(), requested)) {
+            if (fallback != null && isMatching((AttributeContainerInternal) fallback.getAttributes(), requested)) {
                 explanationBuilder.selectedFallbackConfiguration(requested, fallback);
                 return ImmutableList.of(fallback);
             }
@@ -113,7 +130,7 @@ public class ComponentAttributeMatcher {
 
         if (candidates.size() == 1) {
             T candidate = candidates.iterator().next();
-            if (isMatching(schema, (AttributeContainerInternal) candidate.getAttributes(), requested)) {
+            if (isMatching((AttributeContainerInternal) candidate.getAttributes(), requested)) {
                 explanationBuilder.singleMatch(candidate, candidates, requested);
                 return Collections.singletonList(candidate);
             }
@@ -123,98 +140,83 @@ public class ComponentAttributeMatcher {
 
         ImmutableAttributes requestedAttributes = requested.asImmutable();
         List<E> candidateList = (candidates instanceof List) ? (List<E>) candidates : ImmutableList.copyOf(candidates);
-        CachedQuery query = null;
-        if (explanationBuilder.canSkipExplanation()) {
-            query = CachedQuery.of(schema, requestedAttributes, candidateList);
-            int[] index = cachedQueries.get(query);
-            if (index != null) {
-                return CachedQuery.select(index, candidateList);
-            }
-        }
-        List<T> matches = new MultipleCandidateMatcher<T>(schema, candidateList, requestedAttributes, explanationBuilder).getMatches();
-        if (query != null) {
-            LOGGER.debug("Selected matches {} from candidates {} for {}", matches, candidateList, requested);
-            cacheMatchingResult(candidateList, query, matches);
-        }
-        return matches;
-    }
 
-    // in theory we don't need the synchronized here, but let's be safer in the beginning
-    private synchronized <T extends HasAttributes> void cacheMatchingResult(Collection<? extends T> candidates, CachedQuery query, List<T> matches) {
-        int[] queryResult;
-        if (matches.isEmpty()) {
-            queryResult = new int[0];
-        } else {
-            queryResult = new int[matches.size()];
-            int i = 0;
-            int j = 0;
-            Iterator<T> resultIterator = matches.iterator();
-            T next = resultIterator.next();
-            for (T candidate : candidates) {
-                if (candidate == next) {
-                    queryResult[i++] = j;
-                    if (resultIterator.hasNext()) {
-                        next = resultIterator.next();
-                    } else {
-                        break;
-                    }
-                }
-                j++;
+        // Often times, collections of candidates will themselves differ even though their attributes are the same.
+        // Disambiguating two different candidate lists which map to the same attribute lists in reality performs
+        // the same work, so instead we cache disambiguation results based on the attributes being disambiguated.
+        // The result of this is a list of indices into the original candidate list from which the
+        // attributes-to-disambiguate are derived. When retrieving a result from the cache, we use the resulting
+        // indices to index back into the original candidates list.
+        CachedQuery query = CachedQuery.from(requestedAttributes, candidateList);
+        int[] indices = cachedQueries.compute(query, (key, value) -> {
+            if (value == null || !explanationBuilder.canSkipExplanation()) {
+                List<T> matches = new MultipleCandidateMatcher<T>(schema, candidateList, requestedAttributes, explanationBuilder).getMatches();
+                LOGGER.debug("Selected matches {} from candidates {} for {}", matches, candidateList, requested);
+                return CachedQuery.getCandidateIndicesFromMatches(candidateList, matches);
             }
-        }
-        cachedQueries.put(query, queryResult);
+            return value;
+        });
+
+        return CachedQuery.getMatchesFromCandidateIndices(indices, candidateList);
     }
 
     private static class CachedQuery {
-        private final AttributeSelectionSchema schema;
         private final ImmutableAttributes requestedAttributes;
         private final ImmutableAttributes[] candidates;
         private final int hashCode;
 
-        private CachedQuery(AttributeSelectionSchema schema, ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
-            this.schema = schema;
+        private CachedQuery(ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
             this.requestedAttributes = requestedAttributes;
             this.candidates = candidates;
-            this.hashCode = computeHashCode(schema, requestedAttributes, candidates);
+            this.hashCode = computeHashCode(requestedAttributes, candidates);
         }
 
-        private int computeHashCode(AttributeSelectionSchema schema, ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
-            int hash = schema.hashCode();
-            hash = 31 * hash + requestedAttributes.hashCode();
+        private int computeHashCode(ImmutableAttributes requestedAttributes, ImmutableAttributes[] candidates) {
+            int hash = requestedAttributes.hashCode();
             for (ImmutableAttributes candidate : candidates) {
                 hash = 31 * hash + candidate.hashCode();
             }
             return hash;
         }
 
-        public static <T extends HasAttributes> CachedQuery of(AttributeSelectionSchema schema, ImmutableAttributes requestedAttributes, Collection<T> candidates) {
+        public static <T extends HasAttributes> CachedQuery from(ImmutableAttributes requestedAttributes, List<T> candidates) {
             ImmutableAttributes[] attributes = new ImmutableAttributes[candidates.size()];
-            int i = 0;
-            for (T candidate : candidates) {
-                attributes[i++] = ((AttributeContainerInternal) candidate.getAttributes()).asImmutable();
+            for (int i = 0; i < candidates.size(); i++) {
+                attributes[i] = ((AttributeContainerInternal) candidates.get(i).getAttributes()).asImmutable();
             }
-            return new CachedQuery(schema, requestedAttributes, attributes);
+            return new CachedQuery(requestedAttributes, attributes);
         }
 
-        public static <T extends HasAttributes> List<T> select(int[] index, Collection<? extends T> unfiltered) {
-            if (index.length == 0) {
+        public static <T extends HasAttributes> int[] getCandidateIndicesFromMatches(List<? extends T> candidates, List<T> matches) {
+            if (matches.isEmpty()) {
+                return new int[0];
+            }
+
+            int[] indices = new int[matches.size()];
+
+            int c = 0;
+            for (int i = 0; i < matches.size(); i++) {
+                T match = matches.get(i);
+                while (match != candidates.get(c)) {
+                    c++; // Skip candidates until we find the next match.
+                }
+                indices[i] = c;
+            }
+
+            return indices;
+        }
+
+        public static <T extends HasAttributes> List<T> getMatchesFromCandidateIndices(int[] indices, List<? extends T> candidates) {
+            if (indices.length == 0) {
                 return Collections.emptyList();
             }
-            List<T> result = Lists.newArrayListWithCapacity(index.length);
-            int i = 0;
-            int j = 0;
-            int k = index[j];
-            for (T t : unfiltered) {
-                if (i == k) {
-                    result.add(t);
-                    if (result.size() == index.length) {
-                        break;
-                    }
-                    k = index[++j];
-                }
-                i++;
+
+            List<T> matches = new ArrayList<>(indices.length);
+            for (int c = 0; c < indices.length; c++) {
+                matches.add(candidates.get(indices[c]));
             }
-            return result;
+
+            return matches;
         }
 
         @Override
@@ -227,7 +229,6 @@ public class ComponentAttributeMatcher {
             }
             CachedQuery that = (CachedQuery) o;
             return hashCode == that.hashCode &&
-                schema.equals(that.schema) &&
                 requestedAttributes.equals(that.requestedAttributes) &&
                 Arrays.equals(candidates, that.candidates);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.component.model;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.HasAttributes;
@@ -114,7 +113,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         compatible.set(0, candidates.size());
     }
 
-    public List<T> getMatches() {
+    public int[] getMatches() {
         findCompatibleCandidates();
         if (compatible.cardinality() <= 1) {
             return getCandidates(compatible);
@@ -122,7 +121,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         if (longestMatchIsSuperSetOfAllOthers()) {
             T o = candidates.get(candidateWithLongestMatch);
             explanationBuilder.candidateIsSuperSetOfAllOthers(o);
-            return Collections.singletonList(o);
+            return new int[] {candidateWithLongestMatch};
         }
         return disambiguateCompatibleCandidates();
     }
@@ -218,7 +217,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return true;
     }
 
-    private List<T> disambiguateCompatibleCandidates() {
+    private int[] disambiguateCompatibleCandidates() {
         remaining = new BitSet(candidates.size());
         remaining.or(compatible);
 
@@ -414,18 +413,20 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         }
     }
 
-    private List<T> getCandidates(BitSet liveSet) {
+    private int[] getCandidates(BitSet liveSet) {
         if (liveSet.cardinality() == 0) {
-            return Collections.emptyList();
+            return new int[0];
         }
         if (liveSet.cardinality() == 1) {
-            return Collections.singletonList(this.candidates.get(liveSet.nextSetBit(0)));
+            return new int[] {liveSet.nextSetBit(0)};
         }
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
+
+        int i = 0;
+        int[] result = new int[liveSet.cardinality()];
         for (int c = liveSet.nextSetBit(0); c >= 0; c = liveSet.nextSetBit(c + 1)) {
-            builder.add(this.candidates.get(c));
+            result[i++] = c;
         }
-        return builder.build();
+        return result;
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupportTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/GradlePluginVariantsSupportTest.groovy
@@ -16,14 +16,10 @@
 
 package org.gradle.api.internal.artifacts.dsl.dependencies
 
-
 import org.gradle.api.attributes.plugin.GradlePluginApiVersion
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
-import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.internal.component.model.AttributeMatchingExplanationBuilder
-import org.gradle.internal.component.model.AttributeSelectionSchema
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
@@ -33,8 +29,7 @@ class GradlePluginVariantsSupportTest extends Specification {
 
     def attributes = AttributeTestUtil.attributesFactory()
     def objects = TestUtil.objectFactory()
-    def matcher = new ComponentAttributeMatcher()
-    def schema = new DefaultAttributesSchema(matcher, TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+    def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
     def ep = Stub(AttributeMatchingExplanationBuilder)
 
     def setup() {
@@ -50,8 +45,8 @@ class GradlePluginVariantsSupportTest extends Specification {
         def producer = versionAttribute('7.0')
 
         then:
-        accepts == (matcher.match(schema(), [producer], consumer, null, ep) == [producer])
-        accepts == matcher.isMatching(schema(), producer, consumer)
+        accepts == (schema.matcher().matches([producer], consumer, null, ep) == [producer])
+        accepts == schema.matcher().isMatching(producer, consumer)
 
         where:
         currentGradleVersion       | acceptsOrRejects
@@ -79,7 +74,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        matcher.match(schema(), producer, consumer, null, ep) == [versionAttribute('7.0')]
+        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.0')]
 
     }
 
@@ -97,7 +92,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        matcher.match(schema(), producer, consumer, null, ep) == [versionAttribute('7.1')]
+        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.1')]
     }
 
     def "fails to select one candidate if there is no clear preference"() {
@@ -112,12 +107,7 @@ class GradlePluginVariantsSupportTest extends Specification {
         ]
 
         then:
-        matcher.match(schema(), producer, consumer, null, ep) == [versionAttribute('7.1'), versionAttribute('7.1')]
-    }
-
-    private AttributeSelectionSchema schema() {
-        //noinspection GroovyAccessibility
-        schema.mergeWith(EmptySchema.INSTANCE)
+        schema.matcher().matches(producer, consumer, null, ep) == [versionAttribute('7.1'), versionAttribute('7.1')]
     }
 
     private AttributeContainerInternal versionAttribute(String version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultVersionedComponentChooserTest.groovy
@@ -30,7 +30,6 @@ import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata
 import org.gradle.internal.component.model.AttributeMatcher
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.caching.ComponentMetadataSupplierRuleExecutor
@@ -48,7 +47,7 @@ class DefaultVersionedComponentChooserTest extends Specification {
     def versionComparator = new DefaultVersionComparator()
     def versionSelectorScheme = new DefaultVersionSelectorScheme(versionComparator, versionParser)
     def componentSelectionRules = Mock(ComponentSelectionRulesInternal)
-    def attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+    def attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
     def consumerAttributes = ImmutableAttributes.EMPTY
     def cachePolicy = new DefaultCachePolicy()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -31,7 +31,6 @@ import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.external.model.maven.MutableMavenModuleResolveMetadata
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.util.AttributeTestUtil
@@ -52,7 +51,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
     def componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     def testAttribute = Attribute.of("someAttribute", String)
     def attributes = AttributeTestUtil.attributesFactory().of(testAttribute, "someValue")
-    def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+    def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
     def ivyMetadataFactory = DependencyManagementTestUtil.ivyMetadataFactory()
     def mavenMetadataFactory = DependencyManagementTestUtil.mavenMetadataFactory()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributeSelectionSchemaTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributeSelectionSchemaTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.attributes
+
+import com.google.common.collect.ImmutableMap
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.attributes.Usage
+import org.gradle.internal.component.model.AttributeSelectionSchema
+import org.gradle.util.AttributeTestUtil
+import org.gradle.util.SnapshotTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+import static org.gradle.util.TestUtil.objectFactory
+
+/**
+ * Tests {@link DefaultAttributesSchema.DefaultAttributeSelectionSchema}. The class-under-test should
+ * eventually be moved into its own file so that we don't need to instantiate it indirectly through a
+ * {@link DefaultAttributesSchema} instance. Most tests in {@link DefaultAttributesSchemaTest} probably
+ * belong here instead.
+ */
+class DefaultAttributeSelectionSchemaTest extends Specification {
+    private static final ImmutableAttributesFactory ATTRIBUTES_FACTORY = AttributeTestUtil.attributesFactory()
+
+    private AttributesSchemaInternal attributesSchema = Spy(new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory()))
+    private AttributeSelectionSchema schema = attributesSchema.matcher().selectionSchema
+
+    def "collects extra attributes, single candidate"() {
+        def attr1 = Attribute.of("foo", String)
+        def attr2 = Attribute.of("bar", String)
+
+        given:
+        ImmutableAttributes[] candidates = [candidate(ImmutableMap.of(attr1, "v1", attr2, "v2"))]
+        AttributeContainer requested = attribute(attr1, "v3")
+
+        when:
+        def extraAttributes = schema.collectExtraAttributes(candidates, requested).toList()
+
+        then:
+        extraAttributes.contains(attr2)
+        !extraAttributes.contains(attr1)
+    }
+
+    def "collects extra attributes, two candidates"() {
+        def attr1 = Attribute.of("foo", String)
+        def attr2 = Attribute.of("bar", String)
+        def attr3 = Attribute.of("baz", String)
+
+        given:
+        ImmutableAttributes[] candidates = [
+            candidate(ImmutableMap.of(attr1, "v1", attr2, "v2")),
+            candidate(ImmutableMap.of(attr2, "v1", attr3, "v2"))
+        ]
+        AttributeContainer requested = attribute(attr1, "v3")
+
+        when:
+        def extraAttributes = schema.collectExtraAttributes(candidates, requested).toList()
+
+        then:
+        extraAttributes.contains(attr2)
+        extraAttributes.contains(attr3)
+        !extraAttributes.contains(attr1)
+    }
+
+    def "prefers extra attributes from the selection schema"() {
+        def foo1 = Attribute.of("foo", String)
+        def foo2 = Attribute.of("foo", String)
+        def attr3 = Attribute.of("baz", String)
+
+        given:
+
+        ImmutableAttributes[] candidates = [candidate(ImmutableMap.of(attr3, "v2", foo1, "v2"))]
+        AttributeContainer requested = attribute(attr3, "v3")
+        attributesSchema.getAttributeByName("foo") >> foo2
+
+        when:
+        def extraAttributes = schema.collectExtraAttributes(candidates, requested).toList()
+
+        then:
+        extraAttributes.contains(foo2)
+        extraAttributes.every {
+            !it.is(foo1)
+        }
+        !extraAttributes.contains(attr3)
+    }
+
+    def "ignores attribute type when computing extra attributes"() {
+        def attr1 = Attribute.of("foo", String)
+        def attr2 = Attribute.of("foo", Usage)
+
+        given:
+
+        ImmutableAttributes[] candidates = [candidate(ImmutableMap.of(attr2, objectFactory().named(Usage, "foo")))]
+        AttributeContainer requested = attribute(attr1, "v3")
+
+        expect:
+        schema.collectExtraAttributes(candidates, requested).length == 0
+    }
+
+    def attribute(Attribute<String> attr, String value) {
+        def mutable = ATTRIBUTES_FACTORY.mutable()
+        mutable.attribute(attr, value)
+        mutable.asImmutable()
+    }
+
+    private <T> ImmutableAttributes candidate(Map<Attribute<T>, T> map) {
+        def mutable = ATTRIBUTES_FACTORY.mutable()
+        map.each { mutable.attribute(it.key, it.value)}
+        mutable.asImmutable()
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -22,14 +22,13 @@ import org.gradle.api.attributes.AttributeCompatibilityRule
 import org.gradle.api.attributes.AttributeDisambiguationRule
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.MultipleCandidatesDetails
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultAttributesSchemaTest extends Specification {
-    def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+    def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
     def "can create an attribute of scalar type #type"() {
         when:
@@ -78,8 +77,8 @@ class DefaultAttributesSchemaTest extends Specification {
         schema.attribute(attribute)
 
         expect:
-        !schema.mergeWith(EmptySchema.INSTANCE).matchValue(attribute, "a", "b")
-        schema.mergeWith(EmptySchema.INSTANCE).matchValue(attribute, "a", "a")
+        !schema.matcher().selectionSchema.matchValue(attribute, "a", "b")
+        schema.matcher().selectionSchema.matchValue(attribute, "a", "a")
 
         !schema.matcher().isMatching(attribute, "a", "b")
         schema.matcher().isMatching(attribute, "a", "a")
@@ -100,8 +99,8 @@ class DefaultAttributesSchemaTest extends Specification {
         schema.attribute(attribute).compatibilityRules.add(DoNothingRule)
 
         expect:
-        !schema.mergeWith(EmptySchema.INSTANCE).matchValue(attribute, "a", "b")
-        schema.mergeWith(EmptySchema.INSTANCE).matchValue(attribute, "a", "a")
+        !schema.matcher().selectionSchema.matchValue(attribute, "a", "b")
+        schema.matcher().selectionSchema.matchValue(attribute, "a", "a")
 
         !schema.matcher().isMatching(attribute, "a", "b")
         schema.matcher().isMatching(attribute, "a", "a")
@@ -120,7 +119,7 @@ class DefaultAttributesSchemaTest extends Specification {
         schema.attribute(attribute).compatibilityRules.add(BrokenRule)
 
         expect:
-        schema.mergeWith(EmptySchema.INSTANCE).matchValue(attribute, "a", "a")
+        schema.matcher().selectionSchema.matchValue(attribute, "a", "a")
 
         schema.matcher().isMatching(attribute, "a", "a")
     }
@@ -173,8 +172,8 @@ class DefaultAttributesSchemaTest extends Specification {
         def value2 = flavor('otherValue')
 
         expect:
-        schema.mergeWith(EmptySchema.INSTANCE).matchValue(attr, value1, value2)
-        !schema.mergeWith(EmptySchema.INSTANCE).matchValue(attr, value2, value1)
+        schema.matcher().selectionSchema.matchValue(attr, value1, value2)
+        !schema.matcher().selectionSchema.matchValue(attr, value2, value1)
 
         schema.matcher().isMatching(attr, value2, value1)
         !schema.matcher().isMatching(attr, value1, value2)
@@ -195,7 +194,7 @@ class DefaultAttributesSchemaTest extends Specification {
         schema.attribute(attr).compatibilityRules.add(BrokenRule)
 
         expect:
-        !schema.mergeWith(EmptySchema.INSTANCE).matchValue(attr, "a", "b")
+        !schema.matcher().selectionSchema.matchValue(attr, "a", "b")
 
         !schema.matcher().isMatching(attr, "a", "b")
     }
@@ -208,7 +207,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = ["foo", "bar"] as Set
 
         when:
-        def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "bar", candidates)
+        def best = schema.matcher().selectionSchema.disambiguate(attr, "bar", candidates)
 
         then:
         best == ["bar"] as Set
@@ -228,7 +227,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = ["foo", "bar"] as Set
 
         when:
-        def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "bar", candidates)
+        def best = schema.matcher().selectionSchema.disambiguate(attr, "bar", candidates)
 
         then:
         best == ["bar"] as Set
@@ -242,7 +241,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = ["foo", "bar"] as Set
 
         when:
-        def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "other", candidates)
+        def best = schema.matcher().selectionSchema.disambiguate(attr, "other", candidates)
 
         then:
         best == null
@@ -256,7 +255,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = ["foo", "bar"] as Set
 
         when:
-        def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "other", candidates)
+        def best = schema.matcher().selectionSchema.disambiguate(attr, "other", candidates)
 
         then:
         best == null
@@ -274,20 +273,20 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = [value1, value2] as Set
 
         when:
-        def best= schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, flavor('requested'), candidates)
+        def best = schema.matcher().selectionSchema.disambiguate(attr, flavor('requested'), candidates)
 
         then:
         best == [value1] as Set
 
         when:
-        best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, value2, candidates)
+        best = schema.matcher().selectionSchema.disambiguate(attr, value2, candidates)
 
         then:
         best == [value1] as Set
     }
 
     def "merging creates schema with additional attributes defined by producer"() {
-        def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def producer = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
         def attr1 = Attribute.of("a", String)
         def attr2 = Attribute.of("b", Integer)
@@ -299,14 +298,13 @@ class DefaultAttributesSchemaTest extends Specification {
         producer.attribute(attr3)
 
         expect:
-        def merged = schema.mergeWith(producer)
-        merged.hasAttribute(attr1)
-        merged.hasAttribute(attr2)
-        merged.hasAttribute(attr3)
+        schema.withProducer(producer).selectionSchema.hasAttribute(attr1)
+        schema.withProducer(producer).selectionSchema.hasAttribute(attr2)
+        schema.withProducer(producer).selectionSchema.hasAttribute(attr3)
     }
 
     def "uses the producers compatibility rules when the consumer does not express an opinion"() {
-        def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def producer = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
         def attr = Attribute.of("a", Flavor)
 
@@ -314,12 +312,11 @@ class DefaultAttributesSchemaTest extends Specification {
         producer.attribute(attr).compatibilityRules.add(CustomCompatibilityRule)
 
         expect:
-        def merged = schema.mergeWith(producer)
-        merged.matchValue(attr, flavor('value'), flavor('otherValue'))
+        schema.withProducer(producer).selectionSchema.matchValue(attr, flavor('value'), flavor('otherValue'))
     }
 
     def "uses the producers selection rules when the consumer does not express an opinion"() {
-        def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def producer = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
         def attr = Attribute.of("a", Flavor)
 
@@ -332,7 +329,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def candidates = [value1, value2] as Set
 
         when:
-        def best = schema.mergeWith(producer).disambiguate(attr, flavor('requested'), candidates)
+        def best = schema.withProducer(producer).selectionSchema.disambiguate(attr, flavor('requested'), candidates)
 
         then:
         best == [value1] as Set
@@ -363,7 +360,7 @@ class DefaultAttributesSchemaTest extends Specification {
     }
 
     def "precedence order is honored with merged schema"() {
-        def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def producer = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         when:
         def x = Attribute.of("x", String)
         producer.attributeDisambiguationPrecedence(x, Attribute.of("a", String))
@@ -385,13 +382,13 @@ class DefaultAttributesSchemaTest extends Specification {
         )
 
         then:
-        def result = schema.mergeWith(producer).orderByPrecedence(requested.keySet())
+        def result = schema.withProducer(producer).selectionSchema.orderByPrecedence(requested.keySet())
         result.sortedOrder == [2, 1, 0]
         result.unsortedOrder as List == [3]
     }
 
     def "precedence order is honored with merged schema when producer has attributes with the same name"() {
-        def producer = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def producer = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         when:
         def producerA = Attribute.of("a", String)
         def x = Attribute.of("x", String)
@@ -414,7 +411,7 @@ class DefaultAttributesSchemaTest extends Specification {
         )
 
         then:
-        def result = schema.mergeWith(producer).orderByPrecedence(requested.keySet())
+        def result = schema.withProducer(producer).selectionSchema.orderByPrecedence(requested.keySet())
         result.sortedOrder == [1, 0, 2]
         result.unsortedOrder as List == [3]
     }
@@ -437,7 +434,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
+        def result = schema.matcher().selectionSchema.orderByPrecedence(requested.keySet())
         result.sortedOrder == [2, 1]
         result.unsortedOrder as List == [0, 3]
     }
@@ -454,7 +451,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
+        def result = schema.matcher().selectionSchema.orderByPrecedence(requested.keySet())
         result.sortedOrder == []
         result.unsortedOrder as List == [0, 1, 2, 3]
     }
@@ -473,7 +470,7 @@ class DefaultAttributesSchemaTest extends Specification {
                 (Attribute.of("z", String)): "z"
         )
         expect:
-        def result = schema.mergeWith(EmptySchema.INSTANCE).orderByPrecedence(requested.keySet())
+        def result = schema.matcher().selectionSchema.orderByPrecedence(requested.keySet())
         result.sortedOrder == []
         result.unsortedOrder as List == [0, 1, 2, 3]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -35,7 +35,6 @@ import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.util.AttributeTestUtil
@@ -65,7 +64,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     }
 
     private DefaultAttributesSchema createSchema() {
-        def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         DependencyManagementTestUtil.platformSupport().configureSchema(schema)
         GradlePluginVariantsSupport.configureSchema(schema)
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/VariantFilesMetadataRulesTest.groovy
@@ -35,7 +35,6 @@ import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyType
-import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.ComponentGraphResolveState
 import org.gradle.internal.component.model.DefaultIvyArtifactName
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
@@ -57,7 +56,7 @@ class VariantFilesMetadataRulesTest extends Specification {
     @Shared defaultVariant
 
     private DefaultAttributesSchema createSchema() {
-        def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         DependencyManagementTestUtil.platformSupport().configureSchema(schema)
         GradlePluginVariantsSupport.configureSchema(schema)
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
@@ -41,7 +41,7 @@ import spock.lang.Specification
 import static org.gradle.util.AttributeTestUtil.attributes
 
 class AttributeConfigurationSelectorTest extends Specification {
-    private final AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+    private final AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
 
     private ComponentGraphResolveState targetState
     private ComponentGraphResolveMetadata targetComponent

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.MultipleCandidatesDetails
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
-import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.internal.isolation.TestIsolatableFactory
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
@@ -31,9 +30,7 @@ import spock.lang.Specification
 
 class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
 
-    def matcher = new ComponentAttributeMatcher()
-    def schema = new DefaultAttributesSchema(matcher, TestUtil.instantiatorFactory(), new TestIsolatableFactory())
-    def selectionSchema
+    def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), new TestIsolatableFactory())
     def explanationBuilder = Stub(AttributeMatchingExplanationBuilder)
 
     def highest = Attribute.of("highest", String)
@@ -90,7 +87,6 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
             compatibilityRules.add(CompatibilityRule)
             disambiguationRules.add(DisambiguationRule)
         }
-        selectionSchema = schema.mergeWith(EmptySchema.INSTANCE)
     }
 
     def "when precedence is known, disambiguates by ordered elimination"() {
@@ -102,13 +98,13 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
         def candidate6 = candidate("compatible", "compatible", "compatible")
         def requested = requested("requested", "requested","requested")
         expect:
-        matcher.match(selectionSchema, [candidate1], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(selectionSchema, [candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(selectionSchema, [candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate2]
-        matcher.match(selectionSchema, [candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate3]
-        matcher.match(selectionSchema, [candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate4]
-        matcher.match(selectionSchema, [candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
-        matcher.match(selectionSchema, [candidate6], requested, null, explanationBuilder) == [candidate6]
+        schema.matcher().matches([candidate1], requested, null, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate2]
+        schema.matcher().matches([candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate3]
+        schema.matcher().matches([candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate4]
+        schema.matcher().matches([candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
+        schema.matcher().matches([candidate6], requested, null, explanationBuilder) == [candidate6]
     }
 
     def "disambiguates extra attributes in precedence order"() {
@@ -119,9 +115,9 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
         def requested = AttributeTestUtil.attributes("unknown": "unknown")
 
         expect:
-        matcher.match(selectionSchema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(selectionSchema, [candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate2]
-        matcher.match(selectionSchema, [candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
+        schema.matcher().matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
+        schema.matcher().matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate2]
+        schema.matcher().matches([candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
     }
 
     private static AttributeContainerInternal requested(String highestValue, String middleValue, String lowestValue) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -41,7 +41,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "selects candidate with same set of attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -51,16 +51,16 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(schema, [candidate2], requested, null, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2], requested, null, explanationBuilder) == []
 
-        matcher.isMatching(schema, candidate1, requested)
-        !matcher.isMatching(schema, candidate2, requested)
+        matcher.isMatching(candidate1, requested)
+        !matcher.isMatching(candidate2, requested)
     }
 
     def "selects candidate with subset of attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -75,18 +75,18 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(schema, [candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate4]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate4]
 
-        matcher.isMatching(schema, candidate1, requested)
-        !matcher.isMatching(schema, candidate2, requested)
-        !matcher.isMatching(schema, candidate3, requested)
-        matcher.isMatching(schema, candidate4, requested)
+        matcher.isMatching(candidate1, requested)
+        !matcher.isMatching(candidate2, requested)
+        !matcher.isMatching(candidate3, requested)
+        matcher.isMatching(candidate4, requested)
     }
 
     def "selects candidate with additional attributes and whose values match"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -98,16 +98,16 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(schema, [candidate2], requested, null, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2], requested, null, explanationBuilder) == []
 
-        matcher.isMatching(schema, candidate1, requested)
-        !matcher.isMatching(schema, candidate2, requested)
+        matcher.isMatching(candidate1, requested)
+        !matcher.isMatching(candidate2, requested)
     }
 
     def "selects multiple candidates with compatible values"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -123,12 +123,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate5]
     }
 
     def "applies disambiguation rules and selects intersection of best matches for each attribute"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -150,15 +150,15 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "requested", other: "requested")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate5]
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4]
-        matcher.match(schema, [candidate1, candidate2, candidate4], requested, null, explanationBuilder) == [candidate1]
-        matcher.match(schema, [candidate2, candidate4], requested, null, explanationBuilder) == [candidate4]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5], requested, null, explanationBuilder) == [candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4]
+        matcher.matches([candidate1, candidate2, candidate4], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate2, candidate4], requested, null, explanationBuilder) == [candidate4]
     }
 
     def "rule can disambiguate based on requested value"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         def rule = new AttributeDisambiguationRule<String>() {
@@ -185,13 +185,13 @@ class ComponentAttributeMatcherTest extends Specification {
 
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested1, null, explanationBuilder) == [candidate3]
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested2, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested1, null, explanationBuilder) == [candidate3]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4], requested2, null, explanationBuilder) == [candidate1]
     }
 
     def "disambiguation rule is presented with all non-null candidate values"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
         def usage = Attribute.of("usage", String)
         def rule = new AttributeDisambiguationRule<String>() {
             @Override
@@ -213,12 +213,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "requested")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2, candidate3], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "prefers match with superset of matching attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of('usage', String)
         schema.attribute(usage)
@@ -234,15 +234,15 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match", other: "match")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
-        matcher.match(schema, [candidate1, candidate2, candidate3, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate6]
-        matcher.match(schema, [candidate1, candidate2, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate4, candidate6]
-        matcher.match(schema, [candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate5, candidate6], requested, null, explanationBuilder) == [candidate5]
+        matcher.matches([candidate1, candidate2, candidate3, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate3, candidate4, candidate6]
+        matcher.matches([candidate1, candidate2, candidate4, candidate6], requested, null, explanationBuilder) == [candidate1, candidate4, candidate6]
+        matcher.matches([candidate2, candidate3, candidate4], requested, null, explanationBuilder) == [candidate3]
     }
 
     def "disambiguates multiple matches using extra attributes from producer"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
         def usage = Attribute.of("usage", String)
         def other = Attribute.of("other", String)
         schema.attribute(usage)
@@ -254,13 +254,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "match")
 
         expect:
-        def matches = matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
         matches == [candidate2]
     }
 
     def "ignores extra attributes if match is found after disambiguation requested attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         schema.attribute(usage)
@@ -277,13 +277,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: "foo")
 
         expect:
-        def matches = matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
         matches == [candidate2]
     }
 
     def "empty consumer attributes match any producer attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         schema.attribute(usage)
@@ -293,30 +293,30 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes()
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1, candidate2]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1, candidate2]
 
-        matcher.match(schema, [candidate1], requested, null, explanationBuilder) == [candidate1]
-        matcher.isMatching(schema, candidate1, requested)
+        matcher.matches([candidate1], requested, null, explanationBuilder) == [candidate1]
+        matcher.isMatching(candidate1, requested)
 
-        matcher.match(schema, [candidate2], requested, null, explanationBuilder) == [candidate2]
-        matcher.isMatching(schema, candidate2, requested)
+        matcher.matches([candidate2], requested, null, explanationBuilder) == [candidate2]
+        matcher.isMatching(candidate2, requested)
     }
 
     def "non-empty consumer attributes match empty producer attributes"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def candidate = attributes()
         def requested = attributes(usage: "dont care", other: "dont care")
 
         expect:
-        matcher.match(schema, [candidate], requested, null, explanationBuilder) == [candidate]
-        matcher.isMatching(schema, candidate, requested)
+        matcher.matches([candidate], requested, null, explanationBuilder) == [candidate]
+        matcher.isMatching(candidate, requested)
     }
 
     def "selects fallback when it matches requested and there are no candidates"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         def other = Attribute.of("other", String)
@@ -335,30 +335,30 @@ class ComponentAttributeMatcherTest extends Specification {
 
         expect:
         // No candidates, fallback matches
-        matcher.match(schema, [], requested, fallback1, explanationBuilder) == [fallback1]
-        matcher.match(schema, [], requested, fallback2, explanationBuilder) == [fallback2]
-        matcher.match(schema, [], requested, fallback3, explanationBuilder) == [fallback3]
+        matcher.matches([], requested, fallback1, explanationBuilder) == [fallback1]
+        matcher.matches([], requested, fallback2, explanationBuilder) == [fallback2]
+        matcher.matches([], requested, fallback3, explanationBuilder) == [fallback3]
 
         // Fallback does not match
-        matcher.match(schema, [], requested, fallback4, explanationBuilder) == []
+        matcher.matches([], requested, fallback4, explanationBuilder) == []
 
         // Candidates, fallback matches
-        matcher.match(schema, [candidate1, candidate2], requested, fallback1, explanationBuilder) == []
-        matcher.match(schema, [candidate1, candidate2], requested, fallback2, explanationBuilder) == []
-        matcher.match(schema, [candidate1, candidate2], requested, fallback3, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, fallback1, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, fallback2, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, fallback3, explanationBuilder) == []
 
         // No fallback
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == []
-        matcher.match(schema, [], requested, null, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == []
+        matcher.matches([], requested, null, explanationBuilder) == []
 
         // Fallback also a candidate
-        matcher.match(schema, [candidate1, fallback4], requested, fallback4, explanationBuilder) == []
-        matcher.match(schema, [candidate1, candidate2, fallback1], requested, fallback1, explanationBuilder) == [fallback1]
+        matcher.matches([candidate1, fallback4], requested, fallback4, explanationBuilder) == []
+        matcher.matches([candidate1, candidate2, fallback1], requested, fallback1, explanationBuilder) == [fallback1]
     }
 
     def "can match when consumer uses more general type for attribute"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", Number)
         def producer = Attribute.of("a", Integer)
@@ -369,12 +369,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, 1)
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "can match when producer uses desugared attribute of type Named"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", NamedTestAttribute)
         def producer = Attribute.of("a", String)
@@ -385,12 +385,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, objectFactory().named(NamedTestAttribute, "name1"))
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "can match when consumer uses desugared attribute of type Named"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", NamedTestAttribute)
@@ -401,12 +401,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "name1")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "can match when producer uses desugared attribute of type Enum"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", EnumTestAttribute)
         def producer = Attribute.of("a", String)
@@ -417,12 +417,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, EnumTestAttribute.NAME1)
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "can match when consumer uses desugared attribute of type Enum"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", EnumTestAttribute)
@@ -433,12 +433,12 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "NAME1")
 
         expect:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder) == [candidate1]
     }
 
     def "cannot match when producer uses desugared attribute of unsupported type"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
         def producer = Attribute.of("a", String)
@@ -449,7 +449,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, new NotSerializableInGradleMetadataAttribute("name1"))
 
         when:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder)
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -458,7 +458,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "cannot match when consumer uses desugared attribute of unsupported type"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", NotSerializableInGradleMetadataAttribute)
@@ -469,7 +469,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "name1")
 
         when:
-        matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder)
+        matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -478,7 +478,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "matching fails when attribute has incompatible types in consumer and producer"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def consumer = Attribute.of("a", String)
         def producer = Attribute.of("a", Number)
@@ -488,7 +488,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes().attribute(consumer, "1")
 
         when:
-        matcher.match(schema, [candidate], requested, null, explanationBuilder)
+        matcher.matches([candidate], requested, null, explanationBuilder)
 
         then:
         def e = thrown(IllegalArgumentException)
@@ -497,7 +497,7 @@ class ComponentAttributeMatcherTest extends Specification {
 
     def "prefers a strict match with requested values"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         def other = Attribute.of("other", String)
@@ -509,13 +509,13 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: 'match')
 
         expect:
-        def matches = matcher.match(schema, [candidate1, candidate2], requested, null, explanationBuilder)
+        def matches = matcher.matches([candidate1, candidate2], requested, null, explanationBuilder)
         matches == [candidate1]
     }
 
     def "prefers a shorter match with compatible requested values and more than one extra attribute (type: #type)"() {
         given:
-        def matcher = new ComponentAttributeMatcher()
+        def matcher = new ComponentAttributeMatcher(schema)
 
         def usage = Attribute.of("usage", String)
         def bundling = Attribute.of("bundling", type)
@@ -537,7 +537,7 @@ class ComponentAttributeMatcherTest extends Specification {
         def requested = attributes(usage: 'java-api')
 
         when:
-        def result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        def result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
         then:
         result == [candidate1]
 
@@ -547,7 +547,7 @@ class ComponentAttributeMatcherTest extends Specification {
         candidate3 = attributes(usage: 'java-api-extra', bundling: value2, status: 'integration')
         candidate4 = attributes(usage: 'java-runtime-extra', bundling: value1, status: 'integration')
 
-        result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
 
         then:
         result == [candidate1]
@@ -558,7 +558,7 @@ class ComponentAttributeMatcherTest extends Specification {
         candidate3 = attributes(bundling: value1, status: 'integration', usage: 'java-api-extra')
         candidate4 = attributes(status: 'integration', usage: 'java-runtime-extra', bundling: value2)
 
-        result = matcher.match(schema, [candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
+        result = matcher.matches([candidate1, candidate2, candidate3, candidate4], requested, null, explanationBuilder)
 
         then:
         result == [candidate1]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/JavaEcosystemAttributeMatcherTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
-import org.gradle.api.internal.attributes.EmptySchema
 import org.gradle.internal.isolation.TestIsolatableFactory
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
@@ -39,14 +38,11 @@ import spock.lang.Specification
  */
 class JavaEcosystemAttributeMatcherTest extends Specification {
 
-    def matcher = new ComponentAttributeMatcher()
-    def schema = new DefaultAttributesSchema(matcher, TestUtil.instantiatorFactory(), new TestIsolatableFactory())
-    AttributeSelectionSchema selectionSchema
+    def schema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), new TestIsolatableFactory())
     def explanationBuilder = Stub(AttributeMatchingExplanationBuilder)
 
     def setup() {
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
-        selectionSchema = schema.mergeWith(EmptySchema.INSTANCE)
     }
 
     def "resolve compileClasspath with java plugin"() {
@@ -324,7 +320,7 @@ class JavaEcosystemAttributeMatcherTest extends Specification {
     def matchConfigurations(List<List<AttributeContainerInternal>> candidates, AttributeContainerInternal requested) {
         // The first element in each configuration array is the implicit variant.
         def implicitVariants = candidates.collect { it.first() }
-        def configurationMatches = matcher.match(selectionSchema, implicitVariants, requested, null, explanationBuilder)
+        def configurationMatches = schema.matcher().matches(implicitVariants, requested, null, explanationBuilder)
 
         // This test is checking only for successful (single) matches. If we matched multiple configurations
         // in the first round, something is wrong here. Fail before attempting the second round of variant matching.
@@ -332,7 +328,7 @@ class JavaEcosystemAttributeMatcherTest extends Specification {
 
         // Get all the variants for the configuration which was selected and apply variant matching on them.
         def configurationVariants = candidates.get(implicitVariants.indexOf(configurationMatches.get(0)))
-        def variantMatches = matcher.match(selectionSchema, configurationVariants, requested, null, explanationBuilder)
+        def variantMatches = schema.matcher().matches(configurationVariants, requested, null, explanationBuilder)
 
         // Once again, the purpose of this test is for successful results. Something is wrong if we have
         // multiple matched variants.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -58,7 +58,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def setup() {
-        attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        attributesSchema = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         factory = AttributeTestUtil.attributesFactory()
     }
 
@@ -429,7 +429,7 @@ Configuration 'bar':
         def toState = Stub(ComponentGraphResolveState) {
             getMetadata() >> toComponent
         }
-        def attributeSchemaWithCompatibility = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
+        def attributeSchemaWithCompatibility = new DefaultAttributesSchema(TestUtil.instantiatorFactory(), SnapshotTestUtil.isolatableFactory())
         attributeSchemaWithCompatibility.attribute(Attribute.of('key', String), {
             it.compatibilityRules.add(EqualsValuesCompatibleRule)
             it.compatibilityRules.add(ValueCompatibleRule)


### PR DESCRIPTION
A collection of changes I've wanted to make since getting comfortable with this code. 

- Make `DefaultAttributesSchema.MergedSchema` -- the sole implementation of `AttributeSelectionSchema` -- static. Rename to `DefaultAttributeSelectionSchema`.
  - Move associated `extraAttributesCache` into static class. previous implementation could have improper cache behavior if consumer and producer schemas differed.
  - Updated `equals` and `hashCode` implementation to take into account consumer schema. Previous implementation was incorrect and did not.
  - This class should eventually be moved into its own file so it can be unit tested separately. We're leaving it where it is for now to limit unnecessary changes.
- Remove `DefaultAttributesSchema.DefaultAttributeMatcher` in favor of having `ComponentAttributeMatcher` implement `AttributeMatcher` itself.
  - The existing default implementation was a very light wrapper over `ComponentAttributeMatcher` which captured a `AttributeSelectionSchema` instance. Now, `ComponentAttributeMatcher` saves this instance itself.
- Update caching implementation of `ComponentAttributeMatcher`
  - Remove `schema` as a key to the cache, since each `ComponentAttributeMatcher` has its own schema and thus it will always be the same in each cache key.
  - Better document caching logic by renaming methods/variables and adding comment block explaining the reasoning for caching the way we do
  - Utilize `ConcurrentHashMap.computeIfAbsent` to simplify caching logic and thus make it more understandable.
  - Make candidateList to indices logic list-aware now that we always matching on a list of candidates. This simplifies the logic greatly.
- Optimize `MultipleCandidateMatcher` and `ComponentAttributeMatcher` by removing intermediary List, for performance. 