### PR TITLE
Ignore progress events in ProjectBuilder

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationProgressEventEmitter.java
@@ -18,59 +18,19 @@ package org.gradle.internal.operations;
 
 import org.gradle.internal.service.scopes.Scope.Global;
 import org.gradle.internal.service.scopes.ServiceScope;
-import org.gradle.internal.time.Clock;
 
 import javax.annotation.Nullable;
 
 /**
- * Specialised event emitter for cross cutting type progress events not tied more deeply to operation execution.
+ * Specialised event emitter for cross-cutting type progress events not tied more deeply to operation execution.
  */
 @ServiceScope(Global.class)
-public class BuildOperationProgressEventEmitter {
+public interface BuildOperationProgressEventEmitter {
+    void emit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details);
 
-    private final Clock clock;
-    private final CurrentBuildOperationRef current;
-    private final BuildOperationListener listener;
+    void emitNowIfCurrent(Object details);
 
-    public BuildOperationProgressEventEmitter(Clock clock, CurrentBuildOperationRef current, BuildOperationListener listener) {
-        this.clock = clock;
-        this.current = current;
-        this.listener = listener;
-    }
+    void emitIfCurrent(long time, Object details);
 
-    public void emit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details) {
-        // Explicit check in case of unsafe CurrentBuildOperationRef usage
-        if (operationIdentifier == null) {
-            throw new IllegalArgumentException("operationIdentifier is null");
-        }
-        doEmit(operationIdentifier, timestamp, details);
-    }
-
-    public void emitNowIfCurrent(Object details) {
-        emitIfCurrent(clock.getCurrentTime(), details);
-    }
-
-    public void emitIfCurrent(long time, Object details) {
-        OperationIdentifier currentOperationIdentifier = current.getId();
-        if (currentOperationIdentifier != null) {
-            doEmit(currentOperationIdentifier, time, details);
-        }
-    }
-
-    public void emitNowForCurrent(Object details) {
-        emitForCurrent(clock.getCurrentTime(), details);
-    }
-
-    private void emitForCurrent(long time, Object details) {
-        OperationIdentifier currentOperationIdentifier = current.getId();
-        if (currentOperationIdentifier == null) {
-            throw new IllegalStateException("No current build operation");
-        } else {
-            doEmit(currentOperationIdentifier, time, details);
-        }
-    }
-
-    private void doEmit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details) {
-        listener.progress(operationIdentifier, new OperationProgressEvent(timestamp, details));
-    }
+    void emitNowForCurrent(Object details);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationProgressEventEmitter.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationProgressEventEmitter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.operations;
+
+import org.gradle.internal.time.Clock;
+
+import javax.annotation.Nullable;
+
+public class DefaultBuildOperationProgressEventEmitter implements BuildOperationProgressEventEmitter {
+
+    private final Clock clock;
+    private final CurrentBuildOperationRef current;
+    private final BuildOperationListener listener;
+
+    public DefaultBuildOperationProgressEventEmitter(Clock clock, CurrentBuildOperationRef current, BuildOperationListener listener) {
+        this.clock = clock;
+        this.current = current;
+        this.listener = listener;
+    }
+
+    @Override
+    public void emit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details) {
+        // Explicit check in case of unsafe CurrentBuildOperationRef usage
+        if (operationIdentifier == null) {
+            throw new IllegalArgumentException("operationIdentifier is null");
+        }
+        doEmit(operationIdentifier, timestamp, details);
+    }
+
+    @Override
+    public void emitNowIfCurrent(Object details) {
+        emitIfCurrent(clock.getCurrentTime(), details);
+    }
+
+    @Override
+    public void emitIfCurrent(long time, Object details) {
+        OperationIdentifier currentOperationIdentifier = current.getId();
+        if (currentOperationIdentifier != null) {
+            doEmit(currentOperationIdentifier, time, details);
+        }
+    }
+
+    @Override
+    public void emitNowForCurrent(Object details) {
+        emitForCurrent(clock.getCurrentTime(), details);
+    }
+
+    private void emitForCurrent(long time, Object details) {
+        OperationIdentifier currentOperationIdentifier = current.getId();
+        if (currentOperationIdentifier == null) {
+            throw new IllegalStateException("No current build operation");
+        } else {
+            doEmit(currentOperationIdentifier, time, details);
+        }
+    }
+
+    private void doEmit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details) {
+        listener.progress(operationIdentifier, new OperationProgressEvent(timestamp, details));
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -76,6 +76,7 @@ import org.gradle.internal.operations.BuildOperationListenerManager;
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.DefaultBuildOperationListenerManager;
+import org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.scripts.DefaultScriptFileResolver;
 import org.gradle.internal.service.CachingServiceLocator;
@@ -143,12 +144,12 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new DefaultBuildOperationListenerManager();
     }
 
-    BuildOperationProgressEventEmitter createBuildOperationProgressEventEmitter(
+    protected BuildOperationProgressEventEmitter createBuildOperationProgressEventEmitter(
         Clock clock,
         CurrentBuildOperationRef currentBuildOperationRef,
         BuildOperationListenerManager listenerManager
     ) {
-        return new BuildOperationProgressEventEmitter(
+        return new DefaultBuildOperationProgressEventEmitter(
             clock,
             currentBuildOperationRef,
             listenerManager.getBroadcaster()

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/NoOpBuildOperationProgressEventEmitter.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/NoOpBuildOperationProgressEventEmitter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testfixtures.internal;
+
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.OperationIdentifier;
+
+import javax.annotation.Nullable;
+
+public class NoOpBuildOperationProgressEventEmitter implements BuildOperationProgressEventEmitter {
+    @Override
+    public void emit(OperationIdentifier operationIdentifier, long timestamp, @Nullable Object details) {}
+
+    @Override
+    public void emitNowIfCurrent(Object details) {}
+
+    @Override
+    public void emitIfCurrent(long time, Object details) {}
+
+    @Override
+    public void emitNowForCurrent(Object details) {}
+}

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/ProjectBuilderImpl.java
@@ -55,9 +55,6 @@ import org.gradle.internal.composite.IncludedBuildInternal;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.logging.services.LoggingServiceRegistry;
 import org.gradle.internal.nativeintegration.services.NativeServices;
-import org.gradle.internal.operations.BuildOperationContext;
-import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationRunner;
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistry;
@@ -149,15 +146,9 @@ public class ProjectBuilderImpl {
         // Lock root project; this won't ever be released as ProjectBuilder has no lifecycle
         coordinationService.withStateLock(DefaultResourceLockCoordinationService.lock(project.getOwner().getAccessLock()));
 
-        BuildOperationRunner buildOperationRunner = buildServices.get(BuildOperationRunner.class);
-        BuildOperationDescriptor.Builder rootBuildOperationDescriptor = BuildOperationDescriptor.displayName("Build in progress for ProjectBuilder");
-        BuildOperationContext rootBuildOperationContext = buildOperationRunner.start(rootBuildOperationDescriptor);
-        Stoppable stopRootBuildOperation = () -> rootBuildOperationContext.setResult(null);
-
         project.getExtensions().getExtraProperties().set(
             "ProjectBuilder.stoppable",
             stoppable(
-                stopRootBuildOperation,
                 (Stoppable) workerLeaseService::runAsIsolatedTask,
                 (Stoppable) workerLease::leaseFinish,
                 buildServices,

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/internal/TestGlobalScopeServices.java
@@ -21,7 +21,11 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.operations.BuildOperationListenerManager;
+import org.gradle.internal.operations.BuildOperationProgressEventEmitter;
+import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.service.scopes.GlobalScopeServices;
+import org.gradle.internal.time.Clock;
 
 public class TestGlobalScopeServices extends GlobalScopeServices {
     public TestGlobalScopeServices() {
@@ -35,5 +39,14 @@ public class TestGlobalScopeServices extends GlobalScopeServices {
 
     LoggingManagerInternal createLoggingManager(Factory<LoggingManagerInternal> loggingManagerFactory) {
         return loggingManagerFactory.create();
+    }
+
+    @Override
+    protected BuildOperationProgressEventEmitter createBuildOperationProgressEventEmitter(
+        Clock clock,
+        CurrentBuildOperationRef currentBuildOperationRef,
+        BuildOperationListenerManager listenerManager
+    ) {
+        return new NoOpBuildOperationProgressEventEmitter();
     }
 }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/deprecation/LoggingDeprecatedFeatureHandlerTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.internal.logging.ConfigureLogging
 import org.gradle.internal.operations.BuildOperationListener
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
 import org.gradle.internal.operations.CurrentBuildOperationRef
+import org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter
 import org.gradle.internal.operations.DefaultBuildOperationRef
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
@@ -50,7 +51,7 @@ class LoggingDeprecatedFeatureHandlerTest extends Specification {
     final Clock clock = Mock(Clock)
     final BuildOperationListener buildOperationListener = Mock()
     final CurrentBuildOperationRef currentBuildOperationRef = new CurrentBuildOperationRef()
-    final BuildOperationProgressEventEmitter progressBroadcaster = new BuildOperationProgressEventEmitter(
+    final BuildOperationProgressEventEmitter progressBroadcaster = new DefaultBuildOperationProgressEventEmitter(
         clock, currentBuildOperationRef, buildOperationListener
     )
 


### PR DESCRIPTION
The way `ProjectBuilder` API is designed does not enforce or even encourage the usage of `ProjectBuilderImpl#stop`, which is the only proper way of deallocating resources used by the `ProjectBuilder` instance. As a consequence, when multiple instances of the `ProjectBuilder` are created in a single JVM, this could lead to unexpected outcomes.

This became especially apparent with addition of a root build operation for the `ProjectBuilder` (#21331). The root build operation was initially added to stop the unit tests from failing when Java toolchains were involved. This is because the usage of toolchains is reported via progress events, which require an active build operation when registered.

Since this is mostly a problem in tests in the Gradle project and does not affect users, it was decided that we can ignore such progress events in the `ProjectBuilder` entirely. In order to achieve this, `BuildOperationProgressEventEmitter` became an interface from previously being a concrete implementation. Then the `ProjectBuilder` infrastructure provides a no-op implementation of this interface.

Related to #21388, but instead of ensuring the instances are stopped, solves the problem that causes the tests to fail