### PR TITLE
Detect Java toolchain usage when setting executable on Test task

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -81,14 +81,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
         assertToolchainUsages(events, jdkMetadata, tool)
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         events = toolchainEvents(task)
         then:
         skipped(task)
@@ -140,14 +140,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
         assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         events = toolchainEvents(task)
         then:
         skipped(task)
@@ -188,10 +188,8 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             }
         """
 
-        def installationPaths = [jdkMetadata1, jdkMetadata2].collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-
         when:
-        runWithInstallationPaths(installationPaths, task)
+        withInstallations(jdkMetadata1, jdkMetadata2).run(task)
         def events = toolchainEvents(task)
         def events1 = filterByJavaVersion(events, jdkMetadata1)
         def events2 = filterByJavaVersion(events, jdkMetadata2)
@@ -203,7 +201,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertToolchainUsages(events2, jdkMetadata2, "JavaLauncher")
 
         when:
-        runWithInstallationPaths(installationPaths, task)
+        withInstallations(jdkMetadata1, jdkMetadata2).run(task)
         events = toolchainEvents(task)
         events1 = filterByJavaVersion(events, jdkMetadata1)
         events2 = filterByJavaVersion(events, jdkMetadata2)
@@ -248,10 +246,8 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
             }
         """
 
-        def installationPaths = [jdkMetadata1, jdkMetadata2].collect { it.javaHome.toAbsolutePath().toString() }.join(",")
-
         when:
-        runWithInstallationPaths(installationPaths, ":myToolchainTask1", ":myToolchainTask2")
+        withInstallations(jdkMetadata1, jdkMetadata2).run(":myToolchainTask1", ":myToolchainTask2")
         def events1 = toolchainEvents(":myToolchainTask1")
         def events2 = toolchainEvents(":myToolchainTask2")
         then:
@@ -260,7 +256,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertToolchainUsages(events2, jdkMetadata2, "JavaLauncher")
 
         when:
-        runWithInstallationPaths(installationPaths, ":myToolchainTask1", ":myToolchainTask2")
+        withInstallations(jdkMetadata1, jdkMetadata2).run(":myToolchainTask1", ":myToolchainTask2")
         events1 = toolchainEvents(":myToolchainTask1")
         events2 = toolchainEvents(":myToolchainTask2")
         then:
@@ -285,14 +281,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def task = ":compileJava"
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
         assertToolchainUsages(events, jdkMetadata, "JavaCompiler")
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         events = toolchainEvents(task)
         then:
         skipped(task)
@@ -316,14 +312,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def task = ":compileJava"
 
         when:
-        runWithInstallation(jdkMetadata1, task)
+        withInstallations(jdkMetadata1).run(task)
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
         assertToolchainUsages(events, jdkMetadata2, "JavaCompiler")
 
         when:
-        runWithInstallation(jdkMetadata1, task)
+        withInstallations(jdkMetadata1).run(task)
         events = toolchainEvents(task)
         then:
         skipped(task)
@@ -360,14 +356,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def task = ":test"
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
         assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
 
         when:
-        runWithInstallation(jdkMetadata, task)
+        withInstallations(jdkMetadata).run(task)
         events = toolchainEvents(task)
         then:
         skipped(task)
@@ -413,7 +409,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallation(jdkMetadata, ":compileKotlin", ":test")
+        withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         def eventsOnCompile = toolchainEvents(":compileKotlin")
         def eventsOnTest = toolchainEvents(":test")
         then:
@@ -425,7 +421,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertToolchainUsages(eventsOnTest, jdkMetadata, "JavaLauncher")
 
         when:
-        runWithInstallation(jdkMetadata, ":compileKotlin", ":test")
+        withInstallations(jdkMetadata).run(":compileKotlin", ":test")
         eventsOnCompile = toolchainEvents(":compileKotlin")
         eventsOnTest = toolchainEvents(":test")
         then:
@@ -459,7 +455,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallationExpectingFailure(jdkMetadata, task)
+        withInstallations(jdkMetadata).fails(task)
         def events = toolchainEvents(task)
         then:
         failureDescriptionStartsWith("Execution failed for task '${task}'.")
@@ -483,7 +479,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallationExpectingFailure(jdkMetadata, task)
+        withInstallations(jdkMetadata).fails(task)
         def events = toolchainEvents(task)
         then:
         failureDescriptionStartsWith("Execution failed for task '${task}'.")
@@ -506,7 +502,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallationExpectingFailure(jdkMetadata, task)
+        withInstallations(jdkMetadata).fails(task)
         def events = toolchainEvents(task)
         then:
         failureDescriptionStartsWith("Execution failed for task '${task}'.")
@@ -529,7 +525,7 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
 
         when:
-        runWithInstallation(jdkMetadata, ":myTask")
+        withInstallations(jdkMetadata).run(":myTask")
         def events = toolchainEvents(":myTask")
 
         then:
@@ -575,24 +571,11 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         """
     }
 
-    def runWithInstallation(JvmInstallationMetadata jdkMetadata, String... tasks) {
-        runWithInstallationPaths(jdkMetadata.javaHome.toAbsolutePath().toString(), tasks)
-    }
-
-    def runWithInstallationPaths(String installationPaths, String... tasks) {
-        result = prepareRunWithInstallationPaths(installationPaths, tasks)
-            .run()
-    }
-
-    def runWithInstallationExpectingFailure(JvmInstallationMetadata jdkMetadata, String... tasks) {
-        failure = prepareRunWithInstallationPaths(jdkMetadata.javaHome.toAbsolutePath().toString(), tasks)
-            .runWithFailure()
-    }
-
-    def prepareRunWithInstallationPaths(String installationPaths, String... tasks) {
+    private withInstallations(JvmInstallationMetadata... jdkMetadata) {
+        def installationPaths = jdkMetadata.collect { it.javaHome.toAbsolutePath().toString() }.join(",")
         executer
             .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
-            .withTasks(tasks)
+        this
     }
 
     private static String latestStableKotlinPluginVersion(String major) {

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/JavaToolchainBuildOperationsIntegrationTest.groovy
@@ -330,7 +330,6 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         assertToolchainUsages(events, jdkMetadata2, "JavaCompiler")
     }
 
-    @ToBeImplemented("finding a used toolchain by the path of the launcher executable")
     @Issue("https://github.com/gradle/gradle/issues/21367")
     def "emits toolchain usages for test that configures executable path"() {
         JvmInstallationMetadata jdkMetadata = AvailableJavaHomes.getJvmInstallationMetadata(AvailableJavaHomes.differentVersion)
@@ -365,18 +364,14 @@ class JavaToolchainBuildOperationsIntegrationTest extends AbstractIntegrationSpe
         def events = toolchainEvents(task)
         then:
         executedAndNotSkipped(task)
-        // TODO: replace when fixed
-        events.size() == 0
-//        assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
+        assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
 
         when:
         runWithInstallation(jdkMetadata, task)
         events = toolchainEvents(task)
         then:
         skipped(task)
-        // TODO: replace when fixed
-        events.size() == 0
-//        assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
+        assertToolchainUsages(events, jdkMetadata, "JavaLauncher")
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21368")

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -255,7 +255,9 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
             if (customExecutable != null) {
                 final File executable = new File(customExecutable);
                 if (executable.exists()) {
-                    return new SpecificInstallationToolchainSpec(objectFactory, executable.getParentFile().getParentFile());
+                    // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
+                    File parentJavaHome = executable.getParentFile().getParentFile();
+                    return new SpecificInstallationToolchainSpec(objectFactory, parentJavaHome);
                 }
             }
         }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -1277,7 +1277,9 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         if (customExecutable != null) {
             File executable = new File(customExecutable);
             if (executable.exists()) {
-                return new SpecificInstallationToolchainSpec(getObjectFactory(), executable.getParentFile().getParentFile());
+                // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
+                File parentJavaHome = executable.getParentFile().getParentFile();
+                return new SpecificInstallationToolchainSpec(getObjectFactory(), parentJavaHome);
             }
         }
 

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -73,13 +73,14 @@ import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.jvm.DefaultModularitySpec;
 import org.gradle.internal.jvm.JavaModuleDetector;
 import org.gradle.internal.jvm.UnsupportedJavaRuntimeException;
-import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.internal.scan.UsedByScanPlugin;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec;
+import org.gradle.jvm.toolchain.internal.SpecificInstallationToolchainSpec;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaDebugOptions;
 import org.gradle.process.JavaForkOptions;
@@ -276,7 +277,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      */
     @Input
     public JavaVersion getJavaVersion() {
-        return getServices().get(JvmVersionDetector.class).getJavaVersion(getEffectiveExecutable());
+        return JavaVersion.toVersion(getLauncherTool().get().getMetadata().getLanguageVersion().asInt());
     }
 
     /**
@@ -1254,28 +1255,33 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
     }
 
     private String getEffectiveExecutable() {
-        String executable = forkOptions.getExecutable();
-        if (executable != null) {
-            return executable;
-        }
-
-        return getLauncher().get().getExecutablePath().toString();
+        return getLauncherTool().get().getExecutablePath().toString();
     }
 
-    /**
-     * We create a launcher for the current JVM as well, so the progress event for toolchains is emitted.
-     */
-    private Provider<JavaLauncher> getLauncher() {
-        if (forkOptions.getExecutable() != null) {
-            throw new IllegalStateException("Explicit executable cannot be resolved into a toolchain");
+    private Provider<JavaLauncher> getLauncherTool() {
+        JavaToolchainSpec toolchainSpec = determineExplicitToolchain();
+        if (toolchainSpec == null) {
+            if (javaLauncher.isPresent()) {
+                return javaLauncher;
+            } else {
+                toolchainSpec = new CurrentJvmToolchainSpec(getObjectFactory());
+            }
         }
 
-        if (javaLauncher.isPresent()) {
-            return this.javaLauncher;
+        return getJavaToolchainService().launcherFor(toolchainSpec);
+    }
+
+    @Nullable
+    private JavaToolchainSpec determineExplicitToolchain() {
+        String customExecutable = forkOptions.getExecutable();
+        if (customExecutable != null) {
+            File executable = new File(customExecutable);
+            if (executable.exists()) {
+                return new SpecificInstallationToolchainSpec(getObjectFactory(), executable.getParentFile().getParentFile());
+            }
         }
 
-        CurrentJvmToolchainSpec currentToolchainSpec = new CurrentJvmToolchainSpec(getObjectFactory());
-        return getJavaToolchainService().launcherFor(currentToolchainSpec);
+        return null;
     }
 
     @Inject


### PR DESCRIPTION
This PR aligns how explicit executable path override is handled by the `Test` task with how it is handled in the `JavaCompile` task.

Fixes #21367