### PR TITLE
Do not crash on IncompatibleClassChangeError in validate plugins

### DIFF
--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -92,7 +92,7 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
                     Class<?> clazz;
                     try {
                         clazz = classLoader.loadClass(className);
-                    } catch (IllegalAccessError | NoClassDefFoundError | VerifyError | ClassNotFoundException e) {
+                    } catch (IncompatibleClassChangeError | NoClassDefFoundError | VerifyError | ClassNotFoundException e) {
                         LOGGER.debug("Could not load class: " + className, e);
                         continue;
                     }


### PR DESCRIPTION
When changing a build service from being a class into an interface `:base-services:validatePlugins` can crash during the validate actions with the following error:

```
Caused by: java.lang.IncompatibleClassChangeError: class org.gradle.internal.operations.DefaultBuildOperationProgressEventEmitter can not implement org.gradle.internal.operations.BuildOperationProgressEventEmitter, because it is not an interface (org.gradle.internal.operations.BuildOperationProgressEventE
	at org.gradle.plugin.devel.tasks.internal.ValidateAction$1.visitFile(ValidateAction.java:94)
	at org.gradle.api.internal.file.collections.DefaultDirectoryWalker$PathVisitor.visitFile(DefaultDirectoryWalker.java:115)
```

Previously `ValidateAction` that does class loading soft-handled various class loading related issues such as `IllegalAccessError`. This PR extends the soft-handling to the `IncompatibleClassChangeError` exception.