### PR TITLE
Clean up MultipleCandidateMatcher

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -318,7 +318,7 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
         }
 
         @Override
-        public PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested) {
+        public PrecedenceResult orderByPrecedence(Collection<Attribute<?>> requested) {
             if (precedence.isEmpty() && producerSchema.getAttributeDisambiguationPrecedence().isEmpty()) {
                 // if no attribute precedence has been set anywhere, we can just iterate in order
                 return new PrecedenceResult(IntStream.range(0, requested.size()).boxed().collect(Collectors.toList()));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public interface AttributeSelectionSchema {
@@ -34,13 +35,16 @@ public interface AttributeSelectionSchema {
     @Nullable
     Attribute<?> getAttribute(String name);
 
+    /**
+     * Collects attributes that were present on the candidates, but which the consumer did not ask for.
+     */
     Attribute<?>[] collectExtraAttributes(ImmutableAttributes[] candidates, ImmutableAttributes requested);
 
     class PrecedenceResult {
-        private final Collection<Integer> sortedIndices;
+        private final List<Integer> sortedIndices;
         private final Collection<Integer> unsortedIndices;
 
-        public PrecedenceResult(Collection<Integer> sortedIndices, Collection<Integer> unsortedIndices) {
+        public PrecedenceResult(List<Integer> sortedIndices, Collection<Integer> unsortedIndices) {
             this.sortedIndices = sortedIndices;
             this.unsortedIndices = unsortedIndices;
         }
@@ -49,7 +53,7 @@ public interface AttributeSelectionSchema {
             this(Collections.emptyList(), unsortedIndices);
         }
 
-        public Collection<Integer> getSortedOrder() {
+        public List<Integer> getSortedOrder() {
             return sortedIndices;
         }
 
@@ -62,9 +66,9 @@ public interface AttributeSelectionSchema {
      * Given a set of attributes, order those attributes based on the precedence defined by
      * this schema.
      *
-     * @param requested The attributes to order. Must have a consistent iteration ordering.
+     * @param requested The attributes to order. <strong>Must have a consistent iteration ordering and cannot contain duplicates</strong>.
      *
      * @return The ordered attributes.
      */
-    PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested);
+    PrecedenceResult orderByPrecedence(Collection<Attribute<?>> requested);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionUtils.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionUtils.java
@@ -32,6 +32,9 @@ public class AttributeSelectionUtils {
         Attribute<?>[] extraAttributesArray = extraAttributes.toArray(new Attribute<?>[0]);
         for (int i = 0; i < extraAttributesArray.length; i++) {
             Attribute<?> extraAttribute = extraAttributesArray[i];
+            // Some of these attributes might be weakly typed, e.g. coming as Strings from an
+            // artifact repository. We always check whether the schema has a more strongly typed
+            // version of an attribute and use that one instead to apply its disambiguation rules.
             Attribute<?> schemaAttribute = schema.getAttribute(extraAttribute.getName());
             if (schemaAttribute != null) {
                 extraAttributesArray[i] = schemaAttribute;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.IntFunction;
 
 /**
  * This is the heart of the attribute matching algorithm and is used whenever there are multiple candidates to choose from.
@@ -63,9 +64,8 @@ import java.util.Set;
  * <p>
  * Implementation notes:
  *
- * <p>For matching and disambiguating the requested values, we keep a table of values to avoid recomputing them. The table has one row for each candidate and one column for each attribute.
- * The cells contain the values of the candidate for the given attribute. The first row contains the requested values. This table is packed into a single flat array in order to reduce
- * memory usage and increase data locality.
+ * <p>For matching and disambiguating the requested values, we keep a table of candidate values to avoid recomputing them. The table has one row for each candidate and one column for each attribute.
+ * The cells contain the values of the candidate for the given attribute. This table is packed into a single flat array in order to reduce memory usage and increase data locality.
  *
  * <p>The information which candidates are compatible and which candidates are still valid during disambiguation is kept in two {@link BitSet}s. The nth bit is set if the nth candidate
  * is compatible. The longest match is kept using two integers, one containing the length of the match, the other containing the index of the candidate that was the longest.
@@ -81,31 +81,42 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
 
     private final List<Attribute<?>> requestedAttributes;
     private final BitSet compatible;
+
+    /**
+     * Cache of requested attribute values.
+     */
     private final Object[] requestedAttributeValues;
+
+    /**
+     * Cache of candidate attribute values for each requested attribute. Initialized by {@link #findCompatibleCandidates()}.
+     *
+     * @see #setCandidateValue(int, int, Object)
+     * @see #getCandidateValue(int, int)
+     */
+    private final Object[] candidateValues;
 
     private int candidateWithLongestMatch;
     private int lengthOfLongestMatch;
 
     private BitSet remaining;
-    private Attribute<?>[] extraAttributes;
 
-    MultipleCandidateMatcher(AttributeSelectionSchema schema, Collection<? extends T> candidates, ImmutableAttributes requested, AttributeMatchingExplanationBuilder explanationBuilder) {
+    <E extends T> MultipleCandidateMatcher(AttributeSelectionSchema schema, Collection<E> candidates, ImmutableAttributes requested, AttributeMatchingExplanationBuilder explanationBuilder) {
         this.schema = schema;
+        this.candidates = (candidates instanceof List) ? (List<E>) candidates : ImmutableList.copyOf(candidates);
         this.requested = requested;
-        this.candidates = (candidates instanceof List) ? (List<? extends T>) candidates : ImmutableList.copyOf(candidates);
-        candidateAttributeSets = new ImmutableAttributes[candidates.size()];
         this.explanationBuilder = explanationBuilder;
-        for (int i = 0; i < candidates.size(); i++) {
-            candidateAttributeSets[i] = ((AttributeContainerInternal) this.candidates.get(i).getAttributes()).asImmutable();
-        }
+
         this.requestedAttributes = requested.keySet().asList();
-        this.requestedAttributeValues = new Object[(1 + candidates.size()) * this.requestedAttributes.size()];
+        this.requestedAttributeValues = getRequestedValues(requestedAttributes, requested);
+
+        this.candidateAttributeSets = getCandidateAttributeSets(this.candidates);
+        this.candidateValues = new Object[candidates.size() * requestedAttributes.size()];
+
         this.compatible = new BitSet(candidates.size());
         compatible.set(0, candidates.size());
     }
 
     public List<T> getMatches() {
-        fillRequestedValues();
         findCompatibleCandidates();
         if (compatible.cardinality() <= 1) {
             return getCandidates(compatible);
@@ -118,12 +129,22 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return disambiguateCompatibleCandidates();
     }
 
-    private void fillRequestedValues() {
+    private static Object[] getRequestedValues(List<Attribute<?>> requestedAttributes, ImmutableAttributes requested) {
+        Object[] requestedAttributeValues = new Object[requestedAttributes.size()];
         for (int a = 0; a < requestedAttributes.size(); a++) {
             Attribute<?> attribute = requestedAttributes.get(a);
             AttributeValue<?> attributeValue = requested.findEntry(attribute);
-            setRequestedValue(a, attributeValue.isPresent() ? attributeValue.get() : null);
+            requestedAttributeValues[a] = attributeValue.isPresent() ? attributeValue.get() : null;
         }
+        return requestedAttributeValues;
+    }
+
+    private static ImmutableAttributes[] getCandidateAttributeSets(List<? extends HasAttributes> candidates) {
+        ImmutableAttributes[] candidateAttributeSets = new ImmutableAttributes[candidates.size()];
+        for (int i = 0; i < candidates.size(); i++) {
+            candidateAttributeSets[i] = ((AttributeContainerInternal) candidates.get(i).getAttributes()).asImmutable();
+        }
+        return candidateAttributeSets;
     }
 
     private void findCompatibleCandidates() {
@@ -157,7 +178,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
     }
 
     private MatchResult recordAndMatchCandidateValue(int c, int a) {
-        Object requestedValue = getRequestedValue(a);
+        Object requestedValue = requestedAttributeValues[a];
         Attribute<?> attribute = requestedAttributes.get(a);
         AttributeValue<?> candidateValue = candidateAttributeSets[c].findEntry(attribute.getName());
 
@@ -199,23 +220,28 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return true;
     }
 
-
     private List<T> disambiguateCompatibleCandidates() {
         remaining = new BitSet(candidates.size());
         remaining.or(compatible);
 
         disambiguateWithRequestedAttributeValues();
+        if (remaining.cardinality() == 0) {
+            return getCandidates(compatible);
+        } else if (remaining.cardinality() == 1) {
+            return getCandidates(remaining);
+        }
+
+        Attribute<?>[] extraAttributes = collectExtraAttributes();
         if (remaining.cardinality() > 1) {
-            collectExtraAttributes();
-            disambiguateWithExtraAttributes();
+            disambiguateWithExtraAttributes(extraAttributes);
         }
         if (remaining.cardinality() > 1) {
-            disambiguateWithRequestedAttributeKeys();
+            disambiguateWithRequestedAttributeKeys(extraAttributes);
         }
         return remaining.cardinality() == 0 ? getCandidates(compatible) : getCandidates(remaining);
     }
 
-    private void disambiguateWithRequestedAttributeKeys() {
+    private void disambiguateWithRequestedAttributeKeys(Attribute<?>[] extraAttributes) {
         if (requestedAttributes.isEmpty()) {
             return;
         }
@@ -256,7 +282,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         final AttributeSelectionSchema.PrecedenceResult precedenceResult = schema.orderByPrecedence(requested.keySet());
 
         for (int a : precedenceResult.getSortedOrder()) {
-            disambiguateWithAttribute(a);
+            disambiguateRequestedAttribute(a);
             if (remaining.cardinality() == 0) {
                 return;
             } else if (remaining.cardinality() == 1) {
@@ -268,26 +294,56 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         // If the attribute does not have a known precedence, then we cannot stop
         // until we've disambiguated all of the attributes.
         for (int a : precedenceResult.getUnsortedOrder()) {
-            disambiguateWithAttribute(a);
+            disambiguateRequestedAttribute(a);
             if (remaining.cardinality() == 0) {
                 return;
             }
         }
     }
 
-    private void disambiguateWithAttribute(int a) {
-        Set<Object> candidateValues = getCandidateValues(a);
+    private void disambiguateRequestedAttribute(int a) {
+        Set<Object> candidateValues = getCandidateValues(compatible, c -> getCandidateValue(c, a));
         if (candidateValues.size() <= 1) {
             return;
         }
 
-        Set<Object> matches = schema.disambiguate(getAttribute(a), getRequestedValue(a), candidateValues);
+        Set<Object> matches = schema.disambiguate(requestedAttributes.get(a), requestedAttributeValues[a], candidateValues);
         if (matches.size() < candidateValues.size()) {
-            removeCandidatesWithValueNotIn(a, matches);
+            // Remove any candidates which do not satisfy the disambiguation rule.
+            for (int c = remaining.nextSetBit(0); c >= 0; c = remaining.nextSetBit(c + 1)) {
+                if (!matches.contains(getCandidateValue(c, a))) {
+                    remaining.clear(c);
+                }
+            }
         }
     }
 
-    private Set<Object> getCandidateValues(int a) {
+    private void disambiguateExtraAttribute(Attribute<?> attribute) {
+        Set<Object> candidateValues = getCandidateValues(compatible, c -> getCandidateValue(c, attribute));
+        if (candidateValues.size() <= 1) {
+            return;
+        }
+
+        Set<Object> matches = schema.disambiguate(attribute, null, candidateValues);
+        if (matches.size() < candidateValues.size()) {
+            // Remove any candidates which do not satisfy the disambiguation rule.
+            for (int c = remaining.nextSetBit(0); c >= 0; c = remaining.nextSetBit(c + 1)) {
+                if (!matches.contains(getCandidateValue(c, attribute))) {
+                    remaining.clear(c);
+                }
+            }
+        }
+    }
+
+    /**
+     * Given each compatible candidate, determine all values corresponding to some attribute, as defined by {@code candidateValueFetcher}.
+     *
+     * @param candidateValueFetcher A function which returns the candidate value for some
+     *      attribute for the candidate at the provided index.
+     *
+     * @return A new set containing all compatible values for some attribute.
+     */
+    private static Set<Object> getCandidateValues(BitSet compatible, IntFunction<Object> candidateValueFetcher) {
         // It's often the case that all the candidate values are the same. In this case, we avoid
         // the creation of a set, and just iterate until we find a different value. Then, only in
         // this case, we lazily initialize a set and collect all the candidate values.
@@ -295,7 +351,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         Object compatibleValue = null;
         boolean first = true;
         for (int c = compatible.nextSetBit(0); c >= 0; c = compatible.nextSetBit(c + 1)) {
-            Object candidateValue = getCandidateValue(c, a);
+            Object candidateValue = candidateValueFetcher.apply(c);
             if (candidateValue == null) {
                 continue;
             }
@@ -322,21 +378,12 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return candidateValues;
     }
 
-    private void removeCandidatesWithValueNotIn(int a, Set<Object> matchedValues) {
-        for (int c = remaining.nextSetBit(0); c >= 0; c = remaining.nextSetBit(c + 1)) {
-            if (!matchedValues.contains(getCandidateValue(c, a))) {
-                remaining.clear(c);
-            }
-        }
-    }
-
-    private void disambiguateWithExtraAttributes() {
+    private void disambiguateWithExtraAttributes(Attribute<?>[] extraAttributes) {
         Set<Attribute<?>> extra = new LinkedHashSet<>(Arrays.asList(extraAttributes));
         final AttributeSelectionSchema.PrecedenceResult precedenceResult = schema.orderByPrecedence(extra);
 
-        int attributeOffset = requestedAttributes.size();
         for (int a : precedenceResult.getSortedOrder()) {
-            disambiguateWithAttribute(a + attributeOffset);
+            disambiguateExtraAttribute(extraAttributes[a]);
             if (remaining.cardinality() == 0) {
                 return;
             } else if (remaining.cardinality() == 1) {
@@ -349,7 +396,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         // If the attribute does not have a known precedence, then we cannot stop
         // until we've disambiguated all of the attributes.
         for (int a : precedenceResult.getUnsortedOrder()) {
-            disambiguateWithAttribute(a + attributeOffset);
+            disambiguateExtraAttribute(extraAttributes[a]);
             if (remaining.cardinality() == 0) {
                 return;
             }
@@ -362,11 +409,9 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
      * from an artifact repository. We always check whether the schema has a more strongly
      * typed version of an attribute and use that one instead to apply its disambiguation
      * rules.
-     *
-     * Must be called before attempting to call {@code getAttribute} with {@code a} &gt; {@code requestedAttributes.size()}.
      */
-    private void collectExtraAttributes() {
-        extraAttributes = schema.collectExtraAttributes(candidateAttributeSets, requested);
+    private Attribute<?>[] collectExtraAttributes() {
+        return schema.collectExtraAttributes(candidateAttributeSets, requested);
     }
 
     private List<T> getCandidates(BitSet liveSet) {
@@ -383,45 +428,23 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         return builder.build();
     }
 
-    private Attribute<?> getAttribute(int a) {
-        if (a < requestedAttributes.size()) {
-            return requestedAttributes.get(a);
-        } else {
-            return extraAttributes[a - requestedAttributes.size()];
-        }
-    }
-
     @Nullable
-    private Object getRequestedValue(int a) {
-        if (a < requestedAttributes.size()) {
-            return requestedAttributeValues[a];
-        } else {
-            return null;
-        }
+    private Object getCandidateValue(int c, Attribute<?> attribute) {
+        AttributeValue<?> attributeValue = candidateAttributeSets[c].findEntry(attribute.getName());
+        return attributeValue.isPresent() ? attributeValue.coerce(attribute) : null;
     }
 
     @Nullable
     private Object getCandidateValue(int c, int a) {
-        if (a < requestedAttributes.size()) {
-            return requestedAttributeValues[getValueIndex(c, a)];
-        } else {
-            Attribute<?> extraAttribute = getAttribute(a);
-            AttributeValue<?> attributeValue = candidateAttributeSets[c].findEntry(extraAttribute.getName());
-            return attributeValue.isPresent() ? attributeValue.coerce(extraAttribute) : null;
-        }
+        return candidateValues[getValueIndex(c, a)];
     }
 
-    private void setRequestedValue(int a, @Nullable Object value) {
-        requestedAttributeValues[a] = value;
+    private void setCandidateValue(int c, int a, @Nullable Object value) {
+        candidateValues[getValueIndex(c, a)] = value;
     }
-
-    private void setCandidateValue(int c, int a, Object value) {
-        requestedAttributeValues[getValueIndex(c, a)] = value;
-    }
-
 
     private int getValueIndex(int c, int a) {
-        return (1 + c) * requestedAttributes.size() + a;
+        return c * requestedAttributes.size() + a;
     }
 
     private enum MatchResult {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -661,7 +661,7 @@ class ComponentAttributeMatcherTest extends Specification {
         }
 
         @Override
-        PrecedenceResult orderByPrecedence(Set<Attribute<?>> requested) {
+        PrecedenceResult orderByPrecedence(Collection<Attribute<?>> requested) {
             return new PrecedenceResult(IntStream.range(0, requested.size()).boxed().collect(Collectors.toList()))
         }
     }


### PR DESCRIPTION
Initial round of cleanup to make this class easier to reason about by reducing side-effects and detangling some spaghetti

* Split `requestedAttributeValues` into two arrays, one containing candidate values (`candidateValues`) and the original, containing only requested attribute values
  * This simplifies querying for requested vs candidate values without making the memory layout much more complex
* Update some precomputed cache arrays to be computed in their own static method to avoid side-effectful methods
* Add some documentation
* Update methods using `extraAttributes` to accept the attrs as a parameter to ensure they are not called before the array is initialized
