### PR TITLE
Test toolchain usage when not explicitly configured for JavaCompile and Test

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -41,6 +41,7 @@ import org.gradle.test.fixtures.ivy.IvyFileRepository
 import org.gradle.test.fixtures.maven.M2Installation
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.maven.MavenLocalRepository
+import org.gradle.util.internal.TextUtil
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.intellij.lang.annotations.Language
@@ -668,5 +669,34 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
     void resetExecuter() {
         this.ignoreCleanupAssertions = false
         recreateExecuter()
+    }
+
+    /**
+     * Creates a file-system specific path string suitable for embedding in build scripts.
+     * <p>
+     * Any additional {@code relative} paths are added to the initial path before being converted
+     * to the file-system specific string.
+     * <p>
+     * Example:
+     * <pre>
+     * buildFile << """
+     *     test {
+     *         executable = "${pathString(jdk11.javaHome.absolutePath, "bin/javac")}"
+     *     }
+     * """
+     * </pre>
+     */
+    String pathString(String path, String... relative) {
+        def combinedPath = ([path] + relative.toList()).join("/")
+        TextUtil.normaliseFileSeparators(combinedPath)
+    }
+
+    /**
+     * Convenience method that accepts the initial path as {@code File}.
+     *
+     * @see #pathString(String, String...)
+     */
+    String pathString(File path, String... relative) {
+        pathString(path.toString(), relative)
     }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileToolchainIntegrationTest.groovy
@@ -93,7 +93,7 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
                     languageVersion = JavaLanguageVersion.of(99)
                 }
             }
-"""
+        """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
@@ -145,12 +145,12 @@ class JavaCompileToolchainIntegrationTest extends AbstractIntegrationSpec {
         """
 
         file("src/main/java/Foo.java") << """
-public class Foo {
-    public void foo() {
-        java.util.function.Function<String, String> append = (var string) -> string + " ";
-    }
-}
-"""
+            public class Foo {
+                public void foo() {
+                    java.util.function.Function<String, String> append = (var string) -> string + " ";
+                }
+            }
+        """
 
         when:
         runWithToolchainConfigured(jdk11)
@@ -240,7 +240,7 @@ public class Foo {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
                 }
             }
-"""
+        """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
@@ -280,7 +280,7 @@ public class Foo {
                     logger.lifecycle("task.targetCompatibility = \$targetCompatibility")
                 }
             }
-"""
+        """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
@@ -320,7 +320,7 @@ public class Foo {
                     logger.lifecycle("task.targetCompatibility = \$targetCompatibility")
                 }
             }
-"""
+        """
 
         file("src/main/java/Foo.java") << "public class Foo {}"
 
@@ -338,10 +338,9 @@ public class Foo {
         '9'    | '10'   | '1.9'     | '1.10'
         '9'    | 'none' | '1.9'     | '11'
         'none' | 'none' | '11'      | '11'
-
     }
 
-    def "can compile Java using different JDKs"() {
+    def "can compile Java using JDK #javaVersion"() {
         def jdk = AvailableJavaHomes.getJdk(javaVersion)
         assumeNotNull(jdk)
 
@@ -380,11 +379,11 @@ public class Foo {
         ]
     }
 
-    /*
-    This test covers the case where in Java8 the class name becomes fully qualified in the deprecation message which is
-    somehow caused by invoking javacTask.getElements() in the IncrementalCompileTask of the incremental compiler plugin.
+    /**
+     * This test covers the case where in Java8 the class name becomes fully qualified in the deprecation message which is
+     * somehow caused by invoking javacTask.getElements() in the IncrementalCompileTask of the incremental compiler plugin.
      */
-    def "Java deprecation messages with different JDKs"() {
+    def "Java deprecation messages with JDK #javaVersion"() {
         def jdk = AvailableJavaHomes.getJdk(javaVersion)
         assumeNotNull(jdk)
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskToolchainIntegrationTest.groovy
@@ -16,15 +16,16 @@
 
 package org.gradle.testing
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
+import org.gradle.util.Requires
 import spock.lang.IgnoreIf
 
 class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
 
-    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
-    def "can manually set java launcher via  #type toolchain on java test task #jdk"() {
+    def setup() {
         buildFile << """
             apply plugin: "java"
 
@@ -33,7 +34,14 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
             dependencies {
                 testImplementation 'junit:junit:4.13'
             }
+        """
 
+        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
+    }
+
+    @IgnoreIf({ AvailableJavaHomes.differentJdk == null })
+    def "can manually set java launcher via  #type toolchain on java test task #jdk"() {
+        buildFile << """
             tasks.withType(JavaCompile).configureEach {
                 javaCompiler = javaToolchains.compilerFor {
                     languageVersion = JavaLanguageVersion.of(${jdk.javaVersion.majorVersion})
@@ -46,14 +54,8 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
-
         when:
-        result = executer
-            .withArgument("-Porg.gradle.java.installations.paths=" + jdk.javaHome.absolutePath)
-            .withArgument("--info")
-            .withTasks("test")
-            .run()
+        runWithToolchainConfigured(jdk)
 
         then:
         outputContains("Tests running with ${jdk.javaHome.absolutePath}")
@@ -69,14 +71,6 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
     def "Test task is configured using default toolchain"() {
         def someJdk = AvailableJavaHomes.getDifferentVersion()
         buildFile << """
-            apply plugin: "java"
-
-            ${mavenCentralRepository()}
-
-            dependencies {
-                testImplementation 'junit:junit:4.13'
-            }
-
             java {
                 toolchain {
                     languageVersion = JavaLanguageVersion.of(${someJdk.javaVersion.majorVersion})
@@ -84,17 +78,71 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
             }
         """
 
-        file('src/test/java/ToolchainTest.java') << testClass("ToolchainTest")
-
         when:
-        result = executer
-            .withArguments("-Porg.gradle.java.installations.paths=" + someJdk.javaHome.absolutePath, "--info")
-            .withTasks("test")
-            .run()
+        runWithToolchainConfigured(someJdk)
 
         then:
         outputContains("Tests running with ${someJdk.javaHome.absolutePath}")
         noExceptionThrown()
+    }
+
+    def "uses toolchain launcher when nothing is explicitly configured"() {
+        def jdk = Jvm.current()
+
+        when:
+        runWithToolchainConfigured(jdk)
+
+        then:
+        outputContains("Tests running with ${jdk.javaHome.absolutePath}")
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8) != null && AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) != null })
+    def "uses toolchain launcher when setting executable path on fork options"() {
+        def jdk8 = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+        def jdk11 = AvailableJavaHomes.getJdk(JavaVersion.VERSION_11)
+
+        buildFile << """
+            tasks.withType(JavaCompile).configureEach {
+                javaCompiler = javaToolchains.compilerFor {
+                    languageVersion = JavaLanguageVersion.of(${jdk8.javaVersion.majorVersion})
+                }
+            }
+
+            test {
+                executable = "${pathString(jdk11.javaHome, "bin/javac")}"
+            }
+        """
+
+        when:
+        runWithToolchainConfigured(jdk8, jdk11)
+
+        then:
+        outputContains("Tests running with ${jdk11.javaHome.absolutePath}")
+    }
+
+    @Requires(adhoc = { AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8) != null && AvailableJavaHomes.getJdk(JavaVersion.VERSION_11) != null })
+    def "cannot configure both toolchain and executable path on fork options"() {
+        def jdk8 = AvailableJavaHomes.getJdk(JavaVersion.VERSION_1_8)
+        def jdk11 = AvailableJavaHomes.getJdk(JavaVersion.VERSION_11)
+
+        buildFile << """
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${jdk8.javaVersion.majorVersion})
+                }
+            }
+
+            test {
+                executable = "${pathString(jdk11.javaHome, "bin/javac")}"
+            }
+        """
+
+        when:
+        executer.withArgument("-Porg.gradle.java.installations.paths=" + jdk8.javaHome.absolutePath + "," + jdk11.javaHome.absolutePath)
+        fails("test")
+
+        then:
+        failureHasCause("Must not use `executable` property on `Test` together with `javaLauncher` property")
     }
 
     private static String testClass(String className) {
@@ -111,4 +159,12 @@ class TestTaskToolchainIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent()
     }
 
+    def runWithToolchainConfigured(Jvm... jvms) {
+        def installationPaths = jvms.collect { it.javaHome.absolutePath }.join(",")
+        result = executer
+            .withArgument("-Porg.gradle.java.installations.paths=" + installationPaths)
+            .withArgument("--info")
+            .withTasks("test")
+            .run()
+    }
 }


### PR DESCRIPTION
These tests check that toolchains are being used even when no explicitly configured or when other means are used to specify executables for the tasks