### PR TITLE
Turn deprecation into error: classpath files containing path separator

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -84,6 +84,7 @@ Warnings which became errors:
 
 - An input file collection which can't be resolved.
 - Using an input with an unknown implementation. See <<validation_problems.adoc#implementation_unknown,Cannot use an input with an unknown implementation>>.
+- Converting files to a classpath where paths contain file separator.
 
 ==== Gradle does not ignore empty directories for file-trees with `@SkipWhenEmpty`
 

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -490,9 +490,10 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
         when:
         runAndFail "getAsPath"
         then:
-        failure.assertHasCause("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' is not supported." +
+        failure.assertHasDocumentedCause("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' is not supported." +
             " The path separator is not a valid element of a file path." +
             " Problematic paths in 'file collection' are: '$path'." +
-            " Add the individual files to the file collection instead.")
+            " Add the individual files to the file collection instead." +
+            " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#file_collection_to_classpath")
     }
 }

--- a/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
+++ b/subprojects/file-collections/src/integTest/groovy/org/gradle/api/file/FileCollectionIntegrationTest.groovy
@@ -476,7 +476,7 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
     }
 
     @Issue("https://github.com/gradle/gradle/issues/19817")
-    def "nag user when concatenation of files is used for path instead of single files"() {
+    def "fail when concatenation of files is used for path instead of single files"() {
         def path = file("files/file0.txt${File.pathSeparator}files/dir1").path
         buildFile """
             def files = files('${escapeString(path)}')
@@ -487,11 +487,12 @@ class FileCollectionIntegrationTest extends AbstractIntegrationSpec implements T
             }
         """
 
-        expect:
-        executer.expectDocumentedDeprecationWarning("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' has been deprecated." +
-            " The path separator is not a valid element of a file path. Problematic paths in 'file collection' are: '$path'." +
-            " This will fail with an error in Gradle 8.0. Add the individual files to the file collection instead." +
-            " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#file_collection_to_classpath")
-        succeeds "getAsPath"
+        when:
+        runAndFail "getAsPath"
+        then:
+        failure.assertHasCause("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' is not supported." +
+            " The path separator is not a valid element of a file path." +
+            " Problematic paths in 'file collection' are: '$path'." +
+            " Add the individual files to the file collection instead.")
     }
 }

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.api.tasks.util.internal.PatternSets;
 import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
-import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.util.internal.GUtil;
 
@@ -183,17 +183,17 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
             .collect(Collectors.toList());
         if (!filesAsPaths.isEmpty()) {
             String displayedFilePaths = filesAsPaths.stream().map(path -> "'" + path + "'").collect(Collectors.joining(","));
-            DeprecationLogger.deprecateBehaviour(String.format(
-                    "Converting files to a classpath string when their paths contain the path separator '%s' has been deprecated." +
-                        " The path separator is not a valid element of a file path. Problematic paths in '%s' are: %s.",
-                    File.pathSeparator,
+            throw DocumentedFailure.builder()
+                .withSummary(String.format(
+                    "Converting files to a classpath string when their paths contain the path separator '%s' is not supported. " +
+                        "The path separator is not a valid element of a file path.", File.pathSeparator))
+                .withContext(String.format("Problematic paths in '%s' are: %s.",
                     getDisplayName(),
                     displayedFilePaths
                 ))
                 .withAdvice("Add the individual files to the file collection instead.")
-                .willBecomeAnErrorInGradle8()
-                .withUpgradeGuideSection(7, "file_collection_to_classpath")
-                .nagUser();
+                .undocumented()
+                .build();
         }
     }
 

--- a/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -192,7 +192,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
                     displayedFilePaths
                 ))
                 .withAdvice("Add the individual files to the file collection instead.")
-                .undocumented()
+                .withUpgradeGuideSection(7, "file_collection_to_classpath")
                 .build();
         }
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -491,12 +491,13 @@ Joe!""")
         """
         writeSourceFile()
 
-        expect:
-        executer.expectDocumentedDeprecationWarning("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' has been deprecated." +
+        when:
+        runAndFail "javadoc"
+        then:
+        failure.assertHasDocumentedCause("Converting files to a classpath string when their paths contain the path separator '${File.pathSeparator}' is not supported." +
             " The path separator is not a valid element of a file path. Problematic paths in 'file collection' are: '${Paths.get(bootClasspath)}'." +
-            " This will fail with an error in Gradle 8.0. Add the individual files to the file collection instead." +
+            " Add the individual files to the file collection instead." +
             " Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#file_collection_to_classpath")
-        succeeds "javadoc"
     }
 
     def "can use custom stylesheet file"() {


### PR DESCRIPTION
Turn this deprecation warning into an error: https://github.com/gradle/gradle/blob/a6588a12a71a0ef3598a702cec0c90a3b16bab5c/subprojects/file-collections/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java#L179-L198

See https://github.com/gradle/gradle/issues/21648