### PR TITLE
Check superclass changes for ABI breaks

### DIFF
--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/BinaryCompatibilityHelper.groovy
@@ -21,6 +21,7 @@ import gradlebuild.binarycompatibility.filters.KotlinInternalFilter
 import gradlebuild.binarycompatibility.rules.AcceptedRegressionsRulePostProcess
 import gradlebuild.binarycompatibility.rules.AcceptedRegressionsRuleSetup
 import gradlebuild.binarycompatibility.rules.BinaryBreakingChangesRule
+import gradlebuild.binarycompatibility.rules.BinaryBreakingSuperclassChangeRule
 import gradlebuild.binarycompatibility.rules.IncubatingInternalInterfaceAddedRule
 import gradlebuild.binarycompatibility.rules.IncubatingMissingRule
 import gradlebuild.binarycompatibility.rules.KotlinModifiersBreakingChangeRule
@@ -54,6 +55,10 @@ class BinaryCompatibilityHelper {
                     publicApiPatterns: richReport.includedClasses
                 ])
                 addRule(MethodsRemovedInInternalSuperClassRule, [
+                    acceptedApiChanges: acceptedChangesMap,
+                    publicApiPatterns: richReport.includedClasses
+                ])
+                addRule(BinaryBreakingSuperclassChangeRule, [
                     acceptedApiChanges: acceptedChangesMap,
                     publicApiPatterns: richReport.includedClasses
                 ])

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility.rules
+
+import japicmp.model.JApiClass
+import japicmp.model.JApiCompatibility
+import javassist.CtClass
+import me.champeau.gradle.japicmp.report.Violation
+
+/**
+ * Workaround for <a href="https://github.com/melix/japicmp-gradle-plugin/issues/56">japicmp issue w.r.t. superclass breakage</a>.
+ *
+ * <p>
+ * Reports simple superclass changes as a breaking change, as it affects what methods can be called with the given type, even if
+ * the methods don't change.
+ * </p>
+ */
+class BinaryBreakingSuperclassChangeRule extends AbstractSuperClassChangesRule {
+    BinaryBreakingSuperclassChangeRule(Map params) {
+        super(params)
+    }
+
+    @Override
+    protected boolean changed(JApiCompatibility member) {
+        return member instanceof JApiClass && !member.superclass.binaryCompatible && !member.superclass.compatibilityChanges.isEmpty()
+    }
+
+    @Override
+    protected Violation checkSuperClassChanges(JApiClass apiClass, CtClass oldClass, CtClass newClass) {
+        return acceptOrReject(apiClass.superclass, Violation.notBinaryCompatible(apiClass.superclass))
+    }
+}

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
@@ -36,7 +36,7 @@ class BinaryBreakingSuperclassChangeRule extends AbstractSuperClassChangesRule {
 
     @Override
     protected boolean changed(JApiCompatibility member) {
-        return member instanceof JApiClass && !member.superclass.binaryCompatible && !member.superclass.compatibilityChanges.isEmpty()
+        return member instanceof JApiClass && !member.superclass.binaryCompatible && !member.superclass.compatibilityChanges.empty
     }
 
     @Override

--- a/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
+++ b/build-logic/binary-compatibility/src/main/groovy/gradlebuild/binarycompatibility/rules/BinaryBreakingSuperclassChangeRule.groovy
@@ -25,8 +25,8 @@ import me.champeau.gradle.japicmp.report.Violation
  * Workaround for <a href="https://github.com/melix/japicmp-gradle-plugin/issues/56">japicmp issue w.r.t. superclass breakage</a>.
  *
  * <p>
- * Reports simple superclass changes as a breaking change, as it affects what methods can be called with the given type, even if
- * the methods don't change.
+ * Reports simple superclass changes (e.g. the removal of a superclass) as a breaking change, as it affects what methods can be
+ * called with the given type, even if the methods and fields inherited don't change.
  * </p>
  */
 class BinaryBreakingSuperclassChangeRule extends AbstractSuperClassChangesRule {

--- a/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
+++ b/subprojects/architecture-test/src/changes/accepted-public-api-changes.json
@@ -17,6 +17,14 @@
             ]
         },
         {
+            "type": "org.gradle.api.AntBuilder",
+            "member": "Superclass [removed]",
+            "acceptation": "org.gradle.api.AntBuilder now extends groovy.ant.AntBuilder",
+            "changes": [
+                "Superclass has been removed"
+            ]
+        },
+        {
             "type": "org.gradle.api.file.SourceDirectorySet",
             "member": "Method org.gradle.api.file.SourceDirectorySet.getOutputDir()",
             "acceptation": "Deprecated method removed",


### PR DESCRIPTION
This is a workaround for https://github.com/melix/japicmp-gradle-plugin/issues/56

I didn't add a test for this one because it's so simple I'd just be writing mocks that match the logic inside. Not really that helpful.