### PR TITLE
Fix typos in "Executing Multi-Project Builds"

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -17,6 +17,7 @@ We would like to thank the following community members for their contributions t
 [aSemy](https://github.com/aSemy),
 [Ashwin Pankaj](https://github.com/ashwinpankaj),
 [BJ Hargrave](https://github.com/bjhargrave),
+[Bradley Turek](https://github.com/TurekBot)
 [Daniel Lin](https://github.com/ephemient),
 [David Morris](https://github.com/codefish1),
 [Edmund Mok](https://github.com/edmundmok),

--- a/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
@@ -73,7 +73,7 @@ You can use a task's fully qualified name to execute a specific task in a specif
 For example: `gradle :services:webservice:build` will run the `build` task of the _webservice_ subproject.
 The fully qualified name of a task is simply its project path plus the task name.
 
-A project path has the following pattern: It starts with an optional colon, which denotes the root project.
+A project path has the following pattern: it starts with an optional colon, which denotes the root project.
 The root project is the only project in a path that is not specified by its name.
 The rest of a project path is a colon-separated sequence of project names, where the next project is a subproject of the previous project.
 You can see the project paths when running `gradle projects` as shown in <<sec:identifying_project_structure,identifying project structure>> section.

--- a/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/running-builds/intro_multi_project_builds.adoc
@@ -69,7 +69,7 @@ The next section shows how this can be achieved directly from the project's root
 [[sec:executing_tasks_by_fully_qualified_name]]
 == Executing tasks by fully qualified name
 
-You can use task's fully qualified name to execute a specific task in a specific subproject.
+You can use a task's fully qualified name to execute a specific task in a specific subproject.
 For example: `gradle :services:webservice:build` will run the `build` task of the _webservice_ subproject.
 The fully qualified name of a task is simply its project path plus the task name.
 


### PR DESCRIPTION
Fixes a few typos in [the "Executing Multi-Project Builds" article.](https://docs.gradle.org/current/userguide/intro_multi_project_builds.html)

### Context
<!--- Why do you believe many users will benefit from this change? -->
I figure having fewer typos will increase users' trust in the documentation.


### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
