### PR TITLE
Make snippets java/basic, tutorial/taskOnlyIf work with configuration ...caching

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -771,12 +771,6 @@ tasks.named("docsTest") { task ->
                 "snippet-ivy-publish-quickstart_kotlin_publishingIvyPublishSingle.sample",
                 "snippet-tooling-api-custom-model_groovy_sanityCheck.sample",
 
-                // TODO(https://github.com/gradle/gradle/issues/16080, https://github.com/gradle/gradle/issues/20126)
-                "snippet-java-basic_groovy_basicJavaWithIntegrationTests.sample",
-                "snippet-java-basic_kotlin_basicJavaWithIntegrationTests.sample",
-                "snippet-tutorial-task-only-if_groovy_taskOnlyIf.sample",
-                "snippet-tutorial-task-only-if_kotlin_taskOnlyIf.sample",
-
                 // TODO(https://github.com/gradle/gradle/issues/21717)
                 "snippet-java-toolchain-filters_groovy_toolchainFilters.sample",
                 "snippet-java-toolchain-filters_kotlin_toolchainFilters.sample",

--- a/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/basic/groovy/build.gradle
@@ -83,7 +83,10 @@ javadoc {
 
 
 // tag::skip-tests-condition[]
-test.onlyIf("mySkipTests property is not set") { !project.hasProperty('mySkipTests') }
+def skipTestsProvider = providers.gradleProperty('mySkipTests')
+test.onlyIf("mySkipTests property is not set") {
+    !skipTestsProvider.present
+}
 // end::skip-tests-condition[]
 
 // tag::java-compiler-options[]

--- a/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/basic/kotlin/build.gradle.kts
@@ -82,7 +82,12 @@ tasks.javadoc {
 
 
 // tag::skip-tests-condition[]
-tasks.test { onlyIf("mySkipTests property is not set") { !project.hasProperty("mySkipTests") } }
+tasks.test {
+    val skipTestsProvider = providers.gradleProperty("mySkipTests")
+    onlyIf("mySkipTests property is not set") {
+        !skipTestsProvider.isPresent()
+    }
+}
 // end::skip-tests-condition[]
 
 // tag::java-compiler-options[]

--- a/subprojects/docs/src/snippets/tutorial/taskOnlyIf/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/tutorial/taskOnlyIf/groovy/build.gradle
@@ -5,5 +5,8 @@ def hello = tasks.register('hello') {
 }
 
 hello.configure {
-    onlyIf("there is no property skipHello") { !project.hasProperty('skipHello') }
+    def skipProvider = providers.gradleProperty("skipHello")
+    onlyIf("there is no property skipHello") {
+        !skipProvider.present
+    }
 }

--- a/subprojects/docs/src/snippets/tutorial/taskOnlyIf/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/tutorial/taskOnlyIf/kotlin/build.gradle.kts
@@ -5,5 +5,8 @@ val hello by tasks.registering {
 }
 
 hello {
-    onlyIf("there is no property skipHello") { !project.hasProperty("skipHello") }
+    val skipProvider = providers.gradleProperty("skipHello")
+    onlyIf("there is no property skipHello") {
+        !skipProvider.isPresent()
+    }
 }

--- a/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
+++ b/subprojects/samples/src/integTest/groovy/org/gradle/integtests/samples/java/SamplesJavaTestingIntegrationTest.groovy
@@ -337,13 +337,20 @@ class SamplesJavaTestingIntegrationTest extends AbstractSampleIntegrationTest {
         given:
         configureExecuterForToolchains('11')
         TestFile dslDir = sample.dir.file(dsl)
-        executer.inDirectory(dslDir).withArgument("-PmySkipTests")
 
-        when:
+        when: "run first time to populate configuration cache if it is enabled"
+        executer.inDirectory(dslDir).withArgument("-PmySkipTests")
         def result = succeeds("build")
 
         then:
         result.assertTaskSkipped(":test")
+
+        when: "run second time to restore from configuration cache if it is enabled"
+        executer.inDirectory(dslDir).withArgument("-PmySkipTests")
+        def secondResult = succeeds("build")
+
+        then:
+        secondResult.assertTaskSkipped(":test")
 
         where:
         dsl << ['groovy', 'kotlin']


### PR DESCRIPTION
The `onlyIf` clauses are evaluated before the execution time even when running from the cache, so they must not capture script instance or reference project methods. Moreover, the code should not access `Task.getProject`, as the returned project instance is incomplete when running from the cache.

The change makes onlyIf predicates to only capture property providers which is well supported by the configuration cache. Additionally, an integration test is updated to ensure that no access to the incomplete result of `Task.getProject` happens.

Part of #21027