### PR TITLE
No longer add version into generated verification metadata files

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouper.java
@@ -34,7 +34,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * This class is responsible for "normalizing" trusted PGP keys.
+ * This class is responsible for "normalizing" trusted PGP keys and
+ * adding them to a DependencyVerifierBuilder.
  * It tries to identify common super modules/groups/etc... which can
  * then be moved globally.
  *

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouper.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 
 import java.util.Collection;
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 
 /**
  * This class is responsible for "normalizing" trusted PGP keys and
- * adding them to a DependencyVerifierBuilder.
+ * adding them to a DependencyVerifierBuilder2.
  * It tries to identify common super modules/groups/etc... which can
  * then be moved globally.
  *
@@ -48,10 +48,10 @@ class PgpKeyGrouper {
     private static final String GROUP_SUFFIX = "($|([.].*))";
     private static final Joiner GROUP_JOINER = Joiner.on("[.]");
 
-    private final DependencyVerifierBuilder verificationsBuilder;
+    private final DependencyVerifierBuilder2 verificationsBuilder;
     private final Set<VerificationEntry> entriesToBeWritten;
 
-    PgpKeyGrouper(DependencyVerifierBuilder dependencyVerifierBuilder, Set<VerificationEntry> entriesToBeWritten) {
+    PgpKeyGrouper(DependencyVerifierBuilder2 dependencyVerifierBuilder, Set<VerificationEntry> entriesToBeWritten) {
         this.verificationsBuilder = dependencyVerifierBuilder;
         this.entriesToBeWritten = entriesToBeWritten;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -43,9 +43,11 @@ import org.gradle.api.internal.artifacts.verification.signatures.BuildTreeDefine
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationResultBuilder;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationService;
 import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerificationServiceFactory;
+import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerificationConfiguration;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.verifier.VersionRemovingDependencyVerifierBuilder;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
@@ -105,7 +107,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     private static final String PGP_VERIFICATION_FAILED = "PGP verification failed";
     private static final String KEY_NOT_DOWNLOADED = "Key couldn't be downloaded from any key server";
 
-    private final DependencyVerifierBuilder verificationsBuilder = new DependencyVerifierBuilder();
+    private final DependencyVerifierBuilder verificationsBuilder = new DefaultDependencyVerifierBuilder();
     private final BuildOperationExecutor buildOperationExecutor;
     private final List<String> checksums;
     private final Set<VerificationEntry> entriesToBeWritten = Sets.newLinkedHashSetWithExpectedSize(512);
@@ -394,6 +396,8 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
         for (String ignoredKey : collectedIgnoredKeys) {
             verificationsBuilder.addIgnoredKey(new IgnoredKey(ignoredKey, KEY_NOT_DOWNLOADED));
         }
+       
+        DependencyVerifierBuilder verificationsBuilder = new VersionRemovingDependencyVerifierBuilder(this.verificationsBuilder);
         PgpKeyGrouper grouper = new PgpKeyGrouper(verificationsBuilder, entriesToBeWritten);
         grouper.performPgpKeyGrouping();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/WriteDependencyVerificationFile.java
@@ -46,7 +46,7 @@ import org.gradle.api.internal.artifacts.verification.signatures.SignatureVerifi
 import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerificationConfiguration;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier;
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2;
 import org.gradle.api.internal.artifacts.verification.verifier.VersionRemovingDependencyVerifierBuilder;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.invocation.Gradle;
@@ -107,7 +107,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
     private static final String PGP_VERIFICATION_FAILED = "PGP verification failed";
     private static final String KEY_NOT_DOWNLOADED = "Key couldn't be downloaded from any key server";
 
-    private final DependencyVerifierBuilder verificationsBuilder = new DefaultDependencyVerifierBuilder();
+    private final DependencyVerifierBuilder2 verificationsBuilder = new DefaultDependencyVerifierBuilder();
     private final BuildOperationExecutor buildOperationExecutor;
     private final List<String> checksums;
     private final Set<VerificationEntry> entriesToBeWritten = Sets.newLinkedHashSetWithExpectedSize(512);
@@ -397,7 +397,7 @@ public class WriteDependencyVerificationFile implements DependencyVerificationOv
             verificationsBuilder.addIgnoredKey(new IgnoredKey(ignoredKey, KEY_NOT_DOWNLOADED));
         }
        
-        DependencyVerifierBuilder verificationsBuilder = new VersionRemovingDependencyVerifierBuilder(this.verificationsBuilder);
+        DependencyVerifierBuilder2 verificationsBuilder = new VersionRemovingDependencyVerifierBuilder(this.verificationsBuilder);
         PgpKeyGrouper grouper = new PgpKeyGrouper(verificationsBuilder, entriesToBeWritten);
         grouper.performPgpKeyGrouping();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.verification.DependencyVerificationException;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
+import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder;
 import org.gradle.internal.UncheckedException;
@@ -94,7 +95,7 @@ public class DependencyVerificationsXmlReader {
     }
 
     public static DependencyVerifier readFromXml(InputStream in) {
-        DependencyVerifierBuilder builder = new DependencyVerifierBuilder();
+        DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder();
         readFromXml(in, builder);
         return builder.build();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlReader.java
@@ -25,7 +25,7 @@ import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
 import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder;
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier;
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder;
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
@@ -75,7 +75,7 @@ import static org.gradle.api.internal.artifacts.verification.serializer.Dependen
 import static org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationXmlTags.VERSION;
 
 public class DependencyVerificationsXmlReader {
-    public static void readFromXml(InputStream in, DependencyVerifierBuilder builder) {
+    public static void readFromXml(InputStream in, DependencyVerifierBuilder2 builder) {
         try {
             SAXParser saxParser = createSecureParser();
             XMLReader xmlReader = saxParser.getXMLReader();
@@ -95,7 +95,7 @@ public class DependencyVerificationsXmlReader {
     }
 
     public static DependencyVerifier readFromXml(InputStream in) {
-        DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder();
+        DependencyVerifierBuilder2 builder = new DefaultDependencyVerifierBuilder();
         readFromXml(in, builder);
         return builder.build();
     }
@@ -110,7 +110,7 @@ public class DependencyVerificationsXmlReader {
 
     private static class VerifiersHandler extends DefaultHandler2 {
         private final Interner<String> stringInterner = Interners.newStrongInterner();
-        private final DependencyVerifierBuilder builder;
+        private final DependencyVerifierBuilder2 builder;
         private boolean inMetadata;
         private boolean inComponents;
         private boolean inConfiguration;
@@ -126,7 +126,7 @@ public class DependencyVerificationsXmlReader {
         private ModuleComponentArtifactIdentifier currentArtifact;
         private ChecksumKind currentChecksum;
 
-        public VerifiersHandler(DependencyVerifierBuilder builder) {
+        public VerifiersHandler(DependencyVerifierBuilder2 builder) {
             this.builder = builder;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DefaultDependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DefaultDependencyVerifierBuilder.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class DefaultDependencyVerifierBuilder implements DependencyVerifierBuilder {
+public class DefaultDependencyVerifierBuilder implements DependencyVerifierBuilder2 {
     private static final Comparator<ModuleComponentIdentifier> MODULE_COMPONENT_IDENTIFIER_COMPARATOR = Comparator.comparing(ModuleComponentIdentifier::getGroup)
         .thenComparing(ModuleComponentIdentifier::getModule)
         .thenComparing(ModuleComponentIdentifier::getVersion);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DefaultDependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DefaultDependencyVerifierBuilder.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.verifier;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.verification.DependencyVerificationException;
+import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.Checksum;
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
+import org.gradle.api.internal.artifacts.verification.model.ImmutableArtifactVerificationMetadata;
+import org.gradle.api.internal.artifacts.verification.model.ImmutableComponentVerificationMetadata;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DefaultDependencyVerifierBuilder implements DependencyVerifierBuilder {
+    private static final Comparator<ModuleComponentIdentifier> MODULE_COMPONENT_IDENTIFIER_COMPARATOR = Comparator.comparing(ModuleComponentIdentifier::getGroup)
+        .thenComparing(ModuleComponentIdentifier::getModule)
+        .thenComparing(ModuleComponentIdentifier::getVersion);
+    private final Map<ModuleComponentIdentifier, ComponentVerificationsBuilder> byComponent = Maps.newHashMap();
+    private final List<DependencyVerificationConfiguration.TrustedArtifact> trustedArtifacts = Lists.newArrayList();
+    private final Set<DependencyVerificationConfiguration.TrustedKey> trustedKeys = Sets.newLinkedHashSet();
+    private final List<URI> keyServers = Lists.newArrayList();
+    private final Set<IgnoredKey> ignoredKeys = Sets.newLinkedHashSet();
+    private boolean isVerifyMetadata = true;
+    private boolean isVerifySignatures = false;
+    private boolean useKeyServers = true;
+    private final List<String> topLevelComments = Lists.newArrayList();
+
+    public void addTopLevelComment(String comment) {
+        topLevelComments.add(comment);
+    }
+
+    public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
+        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
+        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
+            .addChecksum(artifact, kind, value, origin);
+    }
+
+    public void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key) {
+        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
+        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
+            .addTrustedKey(artifact, key);
+    }
+
+    public void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key) {
+        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
+        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
+            .addIgnoredKey(artifact, key);
+    }
+
+    public void setVerifyMetadata(boolean verifyMetadata) {
+        isVerifyMetadata = verifyMetadata;
+    }
+
+    public boolean isVerifyMetadata() {
+        return isVerifyMetadata;
+    }
+
+    public boolean isVerifySignatures() {
+        return isVerifySignatures;
+    }
+
+    public void setVerifySignatures(boolean verifySignatures) {
+        isVerifySignatures = verifySignatures;
+    }
+
+    public boolean isUseKeyServers() {
+        return useKeyServers;
+    }
+
+    public void setUseKeyServers(boolean useKeyServers) {
+        this.useKeyServers = useKeyServers;
+    }
+
+    public List<URI> getKeyServers() {
+        return keyServers;
+    }
+
+    public Set<DependencyVerificationConfiguration.TrustedKey> getTrustedKeys() {
+        return trustedKeys;
+    }
+
+    public void addTrustedArtifact(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
+        validateUserInput(group, name, version, fileName);
+        trustedArtifacts.add(new DependencyVerificationConfiguration.TrustedArtifact(group, name, version, fileName, regex));
+    }
+
+    public void addIgnoredKey(IgnoredKey keyId) {
+        ignoredKeys.add(keyId);
+    }
+
+    public void addTrustedKey(String keyId, @Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
+        validateUserInput(group, name, version, fileName);
+        trustedKeys.add(new DependencyVerificationConfiguration.TrustedKey(keyId, group, name, version, fileName, regex));
+    }
+
+    private void validateUserInput(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName) {
+        // because this can be called from parsing XML, we need to perform additional verification
+        if (group == null && name == null && version == null && fileName == null) {
+            throw new DependencyVerificationException("A trusted artifact must have at least one of group, name, version or file name not null");
+        }
+    }
+
+    public DependencyVerifier build() {
+        ImmutableMap.Builder<ModuleComponentIdentifier, ComponentVerificationMetadata> builder = ImmutableMap.builderWithExpectedSize(byComponent.size());
+        byComponent.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey(MODULE_COMPONENT_IDENTIFIER_COMPARATOR))
+            .forEachOrdered(entry -> builder.put(entry.getKey(), entry.getValue().build()));
+        return new DependencyVerifier(builder.build(), new DependencyVerificationConfiguration(isVerifyMetadata, isVerifySignatures, trustedArtifacts, useKeyServers, ImmutableList.copyOf(keyServers), ImmutableSet.copyOf(ignoredKeys), ImmutableList.copyOf(trustedKeys)), topLevelComments);
+    }
+
+    public List<DependencyVerificationConfiguration.TrustedArtifact> getTrustedArtifacts() {
+        return trustedArtifacts;
+    }
+
+    public void addKeyServer(URI uri) {
+        keyServers.add(uri);
+    }
+
+    private static class ComponentVerificationsBuilder {
+        private final ModuleComponentIdentifier component;
+        private final Map<String, ArtifactVerificationBuilder> byArtifact = Maps.newHashMap();
+
+        private ComponentVerificationsBuilder(ModuleComponentIdentifier component) {
+            this.component = component;
+        }
+
+        void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
+            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addChecksum(kind, value, origin);
+        }
+
+        void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key) {
+            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addTrustedKey(key);
+        }
+
+        void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key) {
+            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addIgnoredKey(key);
+        }
+
+        private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<String, ArtifactVerificationBuilder> entry) {
+            String key = entry.getKey();
+            ArtifactVerificationBuilder value = entry.getValue();
+            return new ImmutableArtifactVerificationMetadata(
+                key,
+                value.buildChecksums(),
+                value.buildTrustedPgpKeys(),
+                value.buildIgnoredPgpKeys());
+        }
+
+        ComponentVerificationMetadata build() {
+            return new ImmutableComponentVerificationMetadata(component,
+                byArtifact.entrySet()
+                    .stream()
+                    .map(ComponentVerificationsBuilder::toArtifactVerification)
+                    .sorted(Comparator.comparing(ArtifactVerificationMetadata::getArtifactName))
+                    .collect(Collectors.toList())
+            );
+        }
+    }
+
+    private static class ArtifactVerificationBuilder {
+        private final Map<ChecksumKind, ChecksumBuilder> builder = Maps.newEnumMap(ChecksumKind.class);
+        private final Set<String> pgpKeys = Sets.newLinkedHashSet();
+        private final Set<IgnoredKey> ignoredPgpKeys = Sets.newLinkedHashSet();
+
+        void addChecksum(ChecksumKind kind, String value, @Nullable String origin) {
+            ChecksumBuilder builder = this.builder.computeIfAbsent(kind, ChecksumBuilder::new);
+            builder.addChecksum(value);
+            if (origin != null) {
+                builder.withOrigin(origin);
+            }
+        }
+
+        List<Checksum> buildChecksums() {
+            return builder.values()
+                .stream()
+                .map(ChecksumBuilder::build)
+                .sorted(Comparator.comparing(Checksum::getKind))
+                .collect(Collectors.toList());
+        }
+
+        public void addTrustedKey(String key) {
+            pgpKeys.add(key);
+        }
+
+        public void addIgnoredKey(IgnoredKey key) {
+            ignoredPgpKeys.add(key);
+        }
+
+        public Set<String> buildTrustedPgpKeys() {
+            return pgpKeys;
+        }
+
+        public Set<IgnoredKey> buildIgnoredPgpKeys() {
+            return ignoredPgpKeys;
+        }
+    }
+
+    private static class ChecksumBuilder {
+        private final ChecksumKind kind;
+        private String value;
+        private String origin;
+        private Set<String> alternatives;
+
+        private ChecksumBuilder(ChecksumKind kind) {
+            this.kind = kind;
+        }
+
+        /**
+         * Sets the origin, if not set already. This is
+         * mostly used for automatic generation of checksums
+         */
+        void withOrigin(String origin) {
+            if (this.origin == null) {
+                this.origin = origin;
+            }
+        }
+
+        void addChecksum(String checksum) {
+            if (value == null) {
+                value = checksum;
+            } else if (!value.equals(checksum)) {
+                if (alternatives == null) {
+                    alternatives = Sets.newLinkedHashSet();
+                }
+                alternatives.add(checksum);
+            }
+        }
+
+        Checksum build() {
+            return new Checksum(
+                kind,
+                value,
+                alternatives,
+                origin
+            );
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder.java
@@ -15,253 +15,49 @@
  */
 package org.gradle.api.internal.artifacts.verification.verifier;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.internal.artifacts.verification.DependencyVerificationException;
-import org.gradle.api.internal.artifacts.verification.model.ArtifactVerificationMetadata;
-import org.gradle.api.internal.artifacts.verification.model.Checksum;
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
-import org.gradle.api.internal.artifacts.verification.model.ComponentVerificationMetadata;
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
-import org.gradle.api.internal.artifacts.verification.model.ImmutableArtifactVerificationMetadata;
-import org.gradle.api.internal.artifacts.verification.model.ImmutableComponentVerificationMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-public class DependencyVerifierBuilder {
-    private static final Comparator<ModuleComponentIdentifier> MODULE_COMPONENT_IDENTIFIER_COMPARATOR = Comparator.comparing(ModuleComponentIdentifier::getGroup)
-        .thenComparing(ModuleComponentIdentifier::getModule)
-        .thenComparing(ModuleComponentIdentifier::getVersion);
-    private final Map<ModuleComponentIdentifier, ComponentVerificationsBuilder> byComponent = Maps.newHashMap();
-    private final List<DependencyVerificationConfiguration.TrustedArtifact> trustedArtifacts = Lists.newArrayList();
-    private final Set<DependencyVerificationConfiguration.TrustedKey> trustedKeys = Sets.newLinkedHashSet();
-    private final List<URI> keyServers = Lists.newArrayList();
-    private final Set<IgnoredKey> ignoredKeys = Sets.newLinkedHashSet();
-    private boolean isVerifyMetadata = true;
-    private boolean isVerifySignatures = false;
-    private boolean useKeyServers = true;
-    private final List<String> topLevelComments = Lists.newArrayList();
+public interface DependencyVerifierBuilder {
+    void addTopLevelComment(String comment);
 
-    public void addTopLevelComment(String comment) {
-        topLevelComments.add(comment);
-    }
+    void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin);
 
-    public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
-        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
-        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
-            .addChecksum(artifact, kind, value, origin);
-    }
+    void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key);
 
-    public void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key) {
-        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
-        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
-            .addTrustedKey(artifact, key);
-    }
+    void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key);
 
-    public void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key) {
-        ModuleComponentIdentifier componentIdentifier = artifact.getComponentIdentifier();
-        byComponent.computeIfAbsent(componentIdentifier, ComponentVerificationsBuilder::new)
-            .addIgnoredKey(artifact, key);
-    }
+    void setVerifyMetadata(boolean verifyMetadata);
 
-    public void setVerifyMetadata(boolean verifyMetadata) {
-        isVerifyMetadata = verifyMetadata;
-    }
+    boolean isVerifyMetadata();
 
-    public boolean isVerifyMetadata() {
-        return isVerifyMetadata;
-    }
+    boolean isVerifySignatures();
 
-    public boolean isVerifySignatures() {
-        return isVerifySignatures;
-    }
+    void setVerifySignatures(boolean verifySignatures);
 
-    public void setVerifySignatures(boolean verifySignatures) {
-        isVerifySignatures = verifySignatures;
-    }
+    boolean isUseKeyServers();
 
-    public boolean isUseKeyServers() {
-        return useKeyServers;
-    }
+    void setUseKeyServers(boolean useKeyServers);
 
-    public void setUseKeyServers(boolean useKeyServers) {
-        this.useKeyServers = useKeyServers;
-    }
+    List<URI> getKeyServers();
 
-    public List<URI> getKeyServers() {
-        return keyServers;
-    }
+    Set<DependencyVerificationConfiguration.TrustedKey> getTrustedKeys();
 
-    public Set<DependencyVerificationConfiguration.TrustedKey> getTrustedKeys() {
-        return trustedKeys;
-    }
+    void addTrustedArtifact(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex);
 
-    public void addTrustedArtifact(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
-        validateUserInput(group, name, version, fileName);
-        trustedArtifacts.add(new DependencyVerificationConfiguration.TrustedArtifact(group, name, version, fileName, regex));
-    }
+    void addIgnoredKey(IgnoredKey keyId);
 
-    public void addIgnoredKey(IgnoredKey keyId) {
-        ignoredKeys.add(keyId);
-    }
+    void addTrustedKey(String keyId, @Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex);
 
-    public void addTrustedKey(String keyId, @Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
-        validateUserInput(group, name, version, fileName);
-        trustedKeys.add(new DependencyVerificationConfiguration.TrustedKey(keyId, group, name, version, fileName, regex));
-    }
+    DependencyVerifier build();
 
-    private void validateUserInput(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName) {
-        // because this can be called from parsing XML, we need to perform additional verification
-        if (group == null && name == null && version == null && fileName == null) {
-            throw new DependencyVerificationException("A trusted artifact must have at least one of group, name, version or file name not null");
-        }
-    }
+    List<DependencyVerificationConfiguration.TrustedArtifact> getTrustedArtifacts();
 
-    public DependencyVerifier build() {
-        ImmutableMap.Builder<ModuleComponentIdentifier, ComponentVerificationMetadata> builder = ImmutableMap.builderWithExpectedSize(byComponent.size());
-        byComponent.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey(MODULE_COMPONENT_IDENTIFIER_COMPARATOR))
-            .forEachOrdered(entry -> builder.put(entry.getKey(), entry.getValue().build()));
-        return new DependencyVerifier(builder.build(), new DependencyVerificationConfiguration(isVerifyMetadata, isVerifySignatures, trustedArtifacts, useKeyServers, ImmutableList.copyOf(keyServers), ImmutableSet.copyOf(ignoredKeys), ImmutableList.copyOf(trustedKeys)), topLevelComments);
-    }
-
-    public List<DependencyVerificationConfiguration.TrustedArtifact> getTrustedArtifacts() {
-        return trustedArtifacts;
-    }
-
-    public void addKeyServer(URI uri) {
-        keyServers.add(uri);
-    }
-
-    private static class ComponentVerificationsBuilder {
-        private final ModuleComponentIdentifier component;
-        private final Map<String, ArtifactVerificationBuilder> byArtifact = Maps.newHashMap();
-
-        private ComponentVerificationsBuilder(ModuleComponentIdentifier component) {
-            this.component = component;
-        }
-
-        void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
-            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addChecksum(kind, value, origin);
-        }
-
-        void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key) {
-            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addTrustedKey(key);
-        }
-
-        void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key) {
-            byArtifact.computeIfAbsent(artifact.getFileName(), id -> new ArtifactVerificationBuilder()).addIgnoredKey(key);
-        }
-
-        private static ArtifactVerificationMetadata toArtifactVerification(Map.Entry<String, ArtifactVerificationBuilder> entry) {
-            String key = entry.getKey();
-            ArtifactVerificationBuilder value = entry.getValue();
-            return new ImmutableArtifactVerificationMetadata(
-                key,
-                value.buildChecksums(),
-                value.buildTrustedPgpKeys(),
-                value.buildIgnoredPgpKeys());
-        }
-
-        ComponentVerificationMetadata build() {
-            return new ImmutableComponentVerificationMetadata(component,
-                byArtifact.entrySet()
-                    .stream()
-                    .map(ComponentVerificationsBuilder::toArtifactVerification)
-                    .sorted(Comparator.comparing(ArtifactVerificationMetadata::getArtifactName))
-                    .collect(Collectors.toList())
-            );
-        }
-    }
-
-    private static class ArtifactVerificationBuilder {
-        private final Map<ChecksumKind, ChecksumBuilder> builder = Maps.newEnumMap(ChecksumKind.class);
-        private final Set<String> pgpKeys = Sets.newLinkedHashSet();
-        private final Set<IgnoredKey> ignoredPgpKeys = Sets.newLinkedHashSet();
-
-        void addChecksum(ChecksumKind kind, String value, @Nullable String origin) {
-            ChecksumBuilder builder = this.builder.computeIfAbsent(kind, ChecksumBuilder::new);
-            builder.addChecksum(value);
-            if (origin != null) {
-                builder.withOrigin(origin);
-            }
-        }
-
-        List<Checksum> buildChecksums() {
-            return builder.values()
-                .stream()
-                .map(ChecksumBuilder::build)
-                .sorted(Comparator.comparing(Checksum::getKind))
-                .collect(Collectors.toList());
-        }
-
-        public void addTrustedKey(String key) {
-            pgpKeys.add(key);
-        }
-
-        public void addIgnoredKey(IgnoredKey key) {
-            ignoredPgpKeys.add(key);
-        }
-
-        public Set<String> buildTrustedPgpKeys() {
-            return pgpKeys;
-        }
-
-        public Set<IgnoredKey> buildIgnoredPgpKeys() {
-            return ignoredPgpKeys;
-        }
-    }
-
-    private static class ChecksumBuilder {
-        private final ChecksumKind kind;
-        private String value;
-        private String origin;
-        private Set<String> alternatives;
-
-        private ChecksumBuilder(ChecksumKind kind) {
-            this.kind = kind;
-        }
-
-        /**
-         * Sets the origin, if not set already. This is
-         * mostly used for automatic generation of checksums
-         */
-        void withOrigin(String origin) {
-            if (this.origin == null) {
-                this.origin = origin;
-            }
-        }
-
-        void addChecksum(String checksum) {
-            if (value == null) {
-                value = checksum;
-            } else if (!value.equals(checksum)) {
-                if (alternatives == null) {
-                    alternatives = Sets.newLinkedHashSet();
-                }
-                alternatives.add(checksum);
-            }
-        }
-
-        Checksum build() {
-            return new Checksum(
-                kind,
-                value,
-                alternatives,
-                origin
-            );
-        }
-    }
+    void addKeyServer(URI uri);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder2.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifierBuilder2.java
@@ -24,7 +24,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
-public interface DependencyVerifierBuilder {
+public interface DependencyVerifierBuilder2 {
     void addTopLevelComment(String comment);
 
     void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/VersionRemovingDependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/VersionRemovingDependencyVerifierBuilder.java
@@ -25,13 +25,13 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * This class is a DependencyVerifierBuilder that skips adding the
+ * This class is a DependencyVerifierBuilder2 that skips adding the
  * version field.
  */
-public class VersionRemovingDependencyVerifierBuilder implements DependencyVerifierBuilder {
-    private final DependencyVerifierBuilder delegate;
+public class VersionRemovingDependencyVerifierBuilder implements DependencyVerifierBuilder2 {
+    private final DependencyVerifierBuilder2 delegate;
 
-    public VersionRemovingDependencyVerifierBuilder(DependencyVerifierBuilder wrapped) {
+    public VersionRemovingDependencyVerifierBuilder(DependencyVerifierBuilder2 wrapped) {
         delegate = wrapped;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/VersionRemovingDependencyVerifierBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/VersionRemovingDependencyVerifierBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.verification.verifier;
+
+import org.gradle.api.internal.artifacts.verification.model.ChecksumKind;
+import org.gradle.api.internal.artifacts.verification.model.IgnoredKey;
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class is a DependencyVerifierBuilder that skips adding the
+ * version field.
+ */
+public class VersionRemovingDependencyVerifierBuilder implements DependencyVerifierBuilder {
+    private final DependencyVerifierBuilder delegate;
+
+    public VersionRemovingDependencyVerifierBuilder(DependencyVerifierBuilder wrapped) {
+        delegate = wrapped;
+    }
+
+    public void addTrustedArtifact(@Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
+        delegate.addTrustedArtifact(group, name, null, fileName, regex);
+    }
+
+    public void addTrustedKey(String keyId, @Nullable String group, @Nullable String name, @Nullable String version, @Nullable String fileName, boolean regex) {
+        delegate.addTrustedKey(keyId, group, name, null, fileName, regex);
+    }
+
+    public void addTopLevelComment(String comment) {
+        delegate.addTopLevelComment(comment);
+    }
+
+    public void addChecksum(ModuleComponentArtifactIdentifier artifact, ChecksumKind kind, String value, @Nullable String origin) {
+        delegate.addChecksum(artifact, kind, value, origin);
+    }
+
+    public void addTrustedKey(ModuleComponentArtifactIdentifier artifact, String key) {
+        delegate.addTrustedKey(artifact, key);
+    }
+
+    public void addIgnoredKey(ModuleComponentArtifactIdentifier artifact, IgnoredKey key) {
+        delegate.addIgnoredKey(artifact, key);
+    }
+
+    public void setVerifyMetadata(boolean verifyMetadata) {
+        delegate.setVerifyMetadata(verifyMetadata);
+    }
+
+    public boolean isVerifyMetadata() {
+        return delegate.isVerifyMetadata();
+    }
+
+    public boolean isVerifySignatures() {
+        return delegate.isVerifySignatures();
+    }
+
+    public void setVerifySignatures(boolean verifySignatures) {
+        delegate.setVerifySignatures(verifySignatures);
+    }
+
+    public boolean isUseKeyServers() {
+        return delegate.isUseKeyServers();
+    }
+
+    public void setUseKeyServers(boolean useKeyServers) {
+        delegate.setUseKeyServers(useKeyServers);
+    }
+
+    public List<URI> getKeyServers() {
+        return delegate.getKeyServers();
+    }
+
+    public Set<DependencyVerificationConfiguration.TrustedKey> getTrustedKeys() {
+        return delegate.getTrustedKeys();
+    }
+
+    public void addIgnoredKey(IgnoredKey keyId) {
+        delegate.addIgnoredKey(keyId);
+    }
+
+    public DependencyVerifier build() {
+        return delegate.build();
+    }
+
+    public List<DependencyVerificationConfiguration.TrustedArtifact> getTrustedArtifacts() {
+        return delegate.getTrustedArtifacts();
+    }
+
+    public void addKeyServer(URI uri) {
+        delegate.addKeyServer(uri);
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
@@ -21,13 +21,13 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.Arti
 import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerificationConfiguration
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier
 import spock.lang.Specification
 
 class PgpKeyGrouperTest extends Specification {
-    private DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
+    private DependencyVerifierBuilder2 builder = new DefaultDependencyVerifierBuilder()
     private DependencyVerifier verifier
     private PgpKeyGrouper pgpKeyGrouper
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/verification/writer/PgpKeyGrouperTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.wri
 
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.verification.ArtifactVerificationOperation
+import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerificationConfiguration
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
@@ -26,7 +27,7 @@ import org.gradle.internal.component.external.model.ModuleComponentFileArtifactI
 import spock.lang.Specification
 
 class PgpKeyGrouperTest extends Specification {
-    private DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
+    private DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
     private DependencyVerifier verifier
     private PgpKeyGrouper pgpKeyGrouper
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey
 import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier
@@ -28,7 +28,7 @@ import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
 class DependencyVerificationsXmlWriterTest extends Specification {
-    private final DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
+    private final DependencyVerifierBuilder2 builder = new DefaultDependencyVerifierBuilder()
     private String rawContents
     private String contents
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/verification/serializer/DependencyVerificationsXmlWriterTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.verification.serializer
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.verification.model.ChecksumKind
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey
+import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -27,7 +28,7 @@ import org.gradle.util.internal.TextUtil
 import spock.lang.Specification
 
 class DependencyVerificationsXmlWriterTest extends Specification {
-    private final DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
+    private final DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
     private String rawContents
     private String contents
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
@@ -27,7 +27,7 @@ import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerif
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlWriter
 import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier
-import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
+import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder2
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier
@@ -223,7 +223,7 @@ class DependencyVerificationFixture {
     }
 
     static class Builder {
-        private final DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
+        private final DependencyVerifierBuilder2 builder = new DefaultDependencyVerifierBuilder()
 
         void disableKeyServers() {
             builder.useKeyServers = false

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/verification/DependencyVerificationFixture.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.verification.model.ComponentVerificatio
 import org.gradle.api.internal.artifacts.verification.model.IgnoredKey
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlReader
 import org.gradle.api.internal.artifacts.verification.serializer.DependencyVerificationsXmlWriter
+import org.gradle.api.internal.artifacts.verification.verifier.DefaultDependencyVerifierBuilder
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifier
 import org.gradle.api.internal.artifacts.verification.verifier.DependencyVerifierBuilder
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier
@@ -222,7 +223,7 @@ class DependencyVerificationFixture {
     }
 
     static class Builder {
-        private final DependencyVerifierBuilder builder = new DependencyVerifierBuilder()
+        private final DependencyVerifierBuilder builder = new DefaultDependencyVerifierBuilder()
 
         void disableKeyServers() {
             builder.useKeyServers = false


### PR DESCRIPTION
This means that the autogenerated verification metadata files will say that a certain key is valid for a group and artifact rather than only for a specific version of that group and artifact.

Fixes: #20192

Signed-off-by: Jeff Gaston <gastoj3@gmail.com>

- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes