### PR TITLE
Remove version catalog naming pattern

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/catalog/VersionCatalogExtensionIntegrationTest.groovy
@@ -663,44 +663,6 @@ class VersionCatalogExtensionIntegrationTest extends AbstractVersionCatalogInteg
         }
     }
 
-    def "nags when not using a library name ending with 'Libs'"() {
-        settingsFile << """
-            dependencyResolutionManagement {
-                versionCatalogs {
-                    notLibsEnding {
-                        library("myLib", "org.gradle.test", "lib").version {
-                            require "1.0"
-                        }
-                    }
-                }
-            }
-        """
-        def lib = mavenHttpRepo.module("org.gradle.test", "lib", "1.0").publish()
-        buildFile << """
-            apply plugin: 'java-library'
-
-            dependencies {
-                implementation notLibsEnding.myLib
-            }
-        """
-
-        when:
-        lib.pom.expectGet()
-        lib.artifact.expectGet()
-
-        then:
-        run ':checkDeps'
-
-        then:
-        executer.expectDeprecationWarning("The name of version catalogs must end with 'Libs' to reduce chances of extension conflicts.")
-        resolve.expectGraph {
-            root(":", ":test:") {
-                module('org.gradle.test:lib:1.0')
-            }
-        }
-
-    }
-
     def "extension can be used in any subproject"() {
         settingsFile << """
             dependencyResolutionManagement {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/management/DefaultVersionCatalogBuilderContainer.java
@@ -32,7 +32,6 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
-import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.reflect.Instantiator;
 
 import javax.inject.Inject;
@@ -70,13 +69,6 @@ public class DefaultVersionCatalogBuilderContainer extends AbstractNamedDomainOb
     private static void validateName(String name) {
         if (!VALID_EXTENSION_PATTERN.matcher(name).matches()) {
             throw new InvalidUserDataException("Invalid model name '" + name + "': it must match the following regular expression: " + VALID_EXTENSION_NAME);
-        }
-
-        if (!name.equals("libs") && !name.endsWith("Libs")) {
-            DeprecationLogger.deprecateBehaviour("The name of version catalogs must end with 'Libs' to reduce chances of extension conflicts.")
-                .willBecomeAnErrorInGradle8()
-                .withUserManual("platforms", "sec:multiple")
-                .nagUser();
         }
     }
 

--- a/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
+++ b/subprojects/docs/src/docs/userguide/dep-man/03-controlling-transitive-dependencies/platforms.adoc
@@ -204,7 +204,7 @@ include::sample[dir="snippets/dependencyManagement/catalogs-settings/kotlin",fil
 ====
 Each catalog will generate an extension applied to all projects for accessing its content.
 As such it makes sense to reduce the chance of collisions by picking a name that reduces the potential conflicts.
-Gradle will emit a deprecation warning if a catalog does not have a name that ends with `Libs`.
+As an example, one option is to pick a name that ends with `Libs`.
 ====
 
 [[sub:conventional-dependencies-toml]]


### PR DESCRIPTION
No longer nag when name does not end with Libs.
Keep it as an example to reduce collisions in the documentation.

Fixes #20243