### PR TITLE
Check for task cacheability annotation always

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -126,6 +126,10 @@ Warnings that became errors:
 - Using an input with an unknown implementation. See <<validation_problems.adoc#implementation_unknown,Cannot use an input with an unknown implementation>>.
 - Converting files to a classpath where paths contain file separator.
 
+Warnings that were previously only enabled in strict mode, but are now checked always:
+
+- Task types without explicit cacheability annotations. See <<build_cache.adoc#sec:task_output_caching_details,Cacheable tasks>>.
+
 ==== Gradle does not ignore empty directories for file-trees with `@SkipWhenEmpty`
 
 Previously Gradle used to detect if an input file collection annotated with `@SkipWhenEmpty` consisted only of file trees and then ignored directories automatically.

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidatePluginsIntegrationTest.groovy
@@ -487,9 +487,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
             public abstract class MyTransformAction implements TransformAction<TransformParameters.None> {
             }
         """
-        buildFile << """
-            validatePlugins.enableStricterValidation = true
-        """
 
         expect:
         assertValidationFailsWith([
@@ -507,9 +504,6 @@ class ValidatePluginsIntegrationTest extends AbstractPluginValidationIntegration
             @UntrackedTask(because = "untracked for validation test")
             public abstract class MyTask extends DefaultTask {
             }
-        """
-        buildFile << """
-            validatePlugins.enableStricterValidation = true
         """
 
         expect:

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java
@@ -122,9 +122,7 @@ public abstract class ValidateAction implements WorkAction<ValidateAction.Params
     private static DefaultTypeValidationContext createValidationContextAndValidateCacheableAnnotations(Class<?> topLevelBean, Class<? extends Annotation> cacheableAnnotationClass, boolean enableStricterValidation) {
         boolean cacheable = topLevelBean.isAnnotationPresent(cacheableAnnotationClass);
         DefaultTypeValidationContext validationContext = createValidationContext(topLevelBean, cacheable || enableStricterValidation);
-        if (enableStricterValidation) {
-            validateCacheabilityAnnotationPresent(topLevelBean, cacheable, cacheableAnnotationClass, validationContext);
-        }
+        validateCacheabilityAnnotationPresent(topLevelBean, cacheable, cacheableAnnotationClass, validationContext);
         return validationContext;
     }
 


### PR DESCRIPTION
Enable this validation always (used to require strict mode): https://github.com/gradle/gradle/blob/f68a83ff2b3576fa3e1f847332f6134f01826620/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/internal/ValidateAction.java#L149-L162

See https://github.com/gradle/gradle/issues/21648