### PR TITLE
De-incubate useExpectContinue on HttpBuildCache

### DIFF
--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -17,7 +17,6 @@
 package org.gradle.caching.http;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.caching.configuration.AbstractBuildCache;
 
 import javax.annotation.Nullable;
@@ -170,7 +169,6 @@ public class HttpBuildCache extends AbstractBuildCache {
      *
      * @since 7.2
      */
-    @Incubating
     public void setUseExpectContinue(boolean useExpectContinue) {
         this.useExpectContinue = useExpectContinue;
     }
@@ -191,7 +189,6 @@ public class HttpBuildCache extends AbstractBuildCache {
      * @see #setUseExpectContinue(boolean)
      * @since 7.2
      */
-    @Incubating
     public boolean isUseExpectContinue() {
         return useExpectContinue;
     }


### PR DESCRIPTION
De-incubating `isUseExpectContinue` and `setUseExpectContinue` methods on `HttpBuildCache` introduced in `7.2`