### PR TITLE
Report Provider.forUseAtConfigurationTime() deprecation

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -22,6 +22,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
+import org.gradle.internal.deprecation.DeprecationLogger;
 import org.gradle.internal.logging.text.TreeFormatter;
 import org.gradle.internal.state.Managed;
 
@@ -120,14 +121,11 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
     @Deprecated
     @Override
     public final Provider<T> forUseAtConfigurationTime() {
-        /*
- TODO:configuration-cache start nagging in Gradle 8.x
         DeprecationLogger.deprecateMethod(Provider.class, "forUseAtConfigurationTime")
             .withAdvice("Simply remove the call.")
             .willBeRemovedInGradle9()
-            .withUpgradeGuideSection(7, "for_use_at_configuration_time_deprecation")
+            .undocumented()
             .nagUser();
-*/
         return this;
     }
 


### PR DESCRIPTION
It is already soft deprecated (@Deprecated annotation).
This issue is about adding deprecation reporting/logging for invocations.

See
* https://github.com/gradle/gradle/issues/21796