### PR TITLE
Make generated-file-dependencies snippet configuration cache compatible (#21799)

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -820,9 +820,6 @@ tasks.named("docsTest") { task ->
             def testsToBeFixedForConfigurationCache = [
                 "snippet-artifacts-define-repository_groovy_defineMavenCentral.sample",
 
-                "snippet-artifacts-generated-file-dependencies_groovy_generatedFileDependencies.sample",
-                "snippet-artifacts-generated-file-dependencies_kotlin_generatedFileDependencies.sample",
-
                 "snippet-build-cache-cacheable-bundle-task_groovy_cacheableBundleTask.sample",
                 "snippet-build-cache-cacheable-bundle-task_kotlin_cacheableBundleTask.sample",
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -10,7 +10,8 @@ Include only their name, impactful features should be called out separately belo
 -->
 We would like to thank the following community members for their contributions to this release of Gradle:
 
-[Herbert von Broeuschmeul](https://github.com/HvB)
+[Herbert von Broeuschmeul](https://github.com/HvB),
+[Björn Kautler](https://github.com/Vampire)
 
 ## Upgrade instructions
 

--- a/subprojects/docs/src/snippets/artifacts/generatedFileDependencies/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/artifacts/generatedFileDependencies/groovy/build.gradle
@@ -17,9 +17,10 @@ tasks.register('compile') {
 }
 
 tasks.register('list') {
-    dependsOn configurations.compileClasspath
+    FileCollection compileClasspath = configurations.compileClasspath
+    dependsOn compileClasspath
     doLast {
-        println "classpath = ${configurations.compileClasspath.collect { File file -> file.name }}"
+        println "classpath = ${compileClasspath.collect { File file -> file.name }}"
     }
 }
 // end::generated-file-dependencies[]

--- a/subprojects/docs/src/snippets/artifacts/generatedFileDependencies/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/artifacts/generatedFileDependencies/kotlin/build.gradle.kts
@@ -17,9 +17,10 @@ tasks.register("compile") {
 }
 
 tasks.register("list") {
-    dependsOn(configurations["compileClasspath"])
+    val compileClasspath: FileCollection = configurations["compileClasspath"]
+    dependsOn(compileClasspath)
     doLast {
-        println("classpath = ${configurations["compileClasspath"].map { file: File -> file.name }}")
+        println("classpath = ${compileClasspath.map { file: File -> file.name }}")
     }
 }
 // end::generated-file-dependencies[]


### PR DESCRIPTION
Fixes #21799

Documentation around snippet does not look like it nees changes.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- n/a Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
