### PR TITLE
Create projectComplete() dependency method in JvmComponentDepenencies

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -339,6 +339,25 @@ one of the addresses of the current machine's network interfaces.
 Similarly, the new Gradle property `org.gradle.debug.host` now enables [running the Gradle process with the debugger server](userguide/troubleshooting.html#sec:troubleshooting_build_logic)
 accepting connections via network on Java 9+.
 
+#### Introduced `projectComplete()` dependency for creating unit-like test suites
+
+The [JVM test suite](userguide/jvm_test_suite_plugin.html) `dependencies` block now has support for depending on the complete view of the current project during compile-time. Previously it was only possible to depend on the current project's API. This allows declaration of unit-like test suites which have access to dependencies of project internals which are not declared on the `api` or `compileOnlyApi` configurations. 
+
+For example, the following snippet uses the new `projectComplete()` API to define a new unit-like test suite:
+
+```kotlin
+testing {
+    suites {
+        val unitLikeTestSuite by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
+            dependencies {
+                implementation(projectComplete())
+            }
+        }
+    }
+}
+```
+
 <a name="ide"></a>
 ### IDE
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectCompleteDependencyIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ProjectCompleteDependencyIntegrationTest.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+/**
+ * Tests that {@code JvmComponentDependencies#projectComplete()} behaves as expected.
+ */
+class ProjectCompleteDependencyIntegrationTest extends AbstractIntegrationSpec {
+
+    def "can test against complete view of java application"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'application'
+            }
+
+            dependencies {
+                runtimeOnly "com.h2database:h2:2.1.214"
+                implementation "com.fasterxml.jackson.core:jackson-databind:2.13.3"
+                compileOnly "org.apache.commons:commons-lang3:3.12.0"
+            }
+        """
+        writeBaseBuildFile()
+        writeSuccessfulNonApiAccessibilityTest()
+
+        when:
+        succeeds "customTest"
+
+        then:
+        result.assertTaskExecuted(":jar")
+        result.assertTaskExecuted(":customTest")
+    }
+
+    def "can test against complete view of java library"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                runtimeOnly "com.h2database:h2:2.1.214"
+                implementation "com.fasterxml.jackson.core:jackson-databind:2.13.3"
+                compileOnly "org.apache.commons:commons-lang3:3.12.0"
+
+                api "org.springframework:spring-core:5.3.22"
+                compileOnlyApi "com.google.guava:guava:31.1-jre"
+            }
+        """
+        writeBaseBuildFile()
+        writeSuccessfulNonApiAccessibilityTest()
+        writeSuccessfulApiAccessibilityTest()
+
+        when:
+        succeeds "customTest"
+
+        then:
+        result.assertTaskExecuted(":jar")
+        result.assertTaskExecuted(":customTest")
+    }
+
+    def writeBaseBuildFile() {
+        buildFile("""
+            ${mavenCentralRepository()}
+
+            testing {
+                suites {
+                    customTest(JvmTestSuite) {
+                        dependencies {
+                            implementation projectComplete()
+                        }
+                        useJUnit()
+                    }
+                }
+            }
+        """)
+
+        file ("src/main/java/com/example/MyClass.java") << """
+            package com.example;
+            public class MyClass {
+                public int getSpecialValue() {
+                    return 13;
+                }
+            }
+        """
+    }
+
+    def writeSuccessfulNonApiAccessibilityTest() {
+        file("src/customTest/java/com/example/SuccessfulNonApiAccessibilityTest.java") << """
+            package com.example;
+            public class SuccessfulNonApiAccessibilityTest {
+                @org.junit.Test
+                public void verifyNonApiConfigurationsAreAccessible() throws Exception {
+                    // project outputs are available
+                    assert new MyClass().getSpecialValue() == 13;
+
+                    // `implementation` dependencies are accessible
+                    assert new com.fasterxml.jackson.databind.ObjectMapper().readTree("{\\\"hello\\\": \\\"test\\\"}").get("hello").asText().equals("test");
+
+                    // `compileOnly` dependencies are accessible at compile-time
+                    try {
+                        assert org.apache.commons.lang3.StringUtils.length("Hello, Gradle!") == 14;
+                    } catch (NoClassDefFoundError e) {
+                        // Expected
+                    }
+
+                    // `runtimeOnly` dependencies are accessible at runtime
+                    assert getClass().getClassLoader().loadClass("org.h2.Driver") != null;
+                }
+            }
+        """
+    }
+
+    def writeSuccessfulApiAccessibilityTest() {
+        file("src/customTest/java/com/example/SuccessfulApiAccessibilityTest.java") << """
+            package com.example;
+            public class SuccessfulApiAccessibilityTest {
+                @org.junit.Test
+                public void verifyApiConfigurationsAreAccessible() throws Exception {
+                    // `api` dependencies are accessible
+                    assert new org.springframework.core.io.ByteArrayResource("Hello, Test!".getBytes()).contentLength() == 12;
+
+                    // `compileOnlyApi` dependencies are accessible at compile-time
+                    try {
+                        assert com.google.common.collect.ImmutableList.of("123").equals("123");
+                    } catch (NoClassDefFoundError e) {
+                        // Expected
+                    }
+                }
+            }
+        """
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmComponentDependencies.java
@@ -125,4 +125,15 @@ public interface JvmComponentDependencies {
      * @since 7.6
      */
     Dependency testFixtures(ModuleDependency moduleDependency);
+
+    /**
+     * Create a dependency on the current project's complete view. During compile-time, this dependency will
+     * resolve the current project's implementation in addition to its API. During runtime, this dependency
+     * behaves as a usual project dependency.
+     *
+     * @return A new dependency
+     *
+     * @since 7.6
+     */
+    ModuleDependency projectComplete();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmComponentDependencies.java
@@ -21,7 +21,9 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyAdder;
+import org.gradle.api.attributes.CompileView;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.jvm.JvmComponentDependencies;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.external.model.ProjectTestFixtures;
@@ -30,7 +32,7 @@ import javax.inject.Inject;
 
 import static org.gradle.internal.component.external.model.TestFixturesSupport.TEST_FIXTURES_CAPABILITY_APPENDIX;
 
-public class DefaultJvmComponentDependencies implements JvmComponentDependencies {
+public abstract class DefaultJvmComponentDependencies implements JvmComponentDependencies {
     private final DependencyAdder implementation;
     private final DependencyAdder compileOnly;
     private final DependencyAdder runtimeOnly;
@@ -81,6 +83,19 @@ public class DefaultJvmComponentDependencies implements JvmComponentDependencies
             capabilities.requireCapability(new ImmutableCapability(moduleDependency.getGroup(), moduleDependency.getName() + TEST_FIXTURES_CAPABILITY_APPENDIX, null));
         });
         return moduleDependency;
+    }
+
+    @Inject
+    protected abstract Project getCurrentProject();
+
+    @Inject
+    protected abstract ObjectFactory getObjectFactory();
+
+    @Override
+    public ModuleDependency projectComplete() {
+        return getDependencyFactory().create(getCurrentProject()).attributes(attrs -> {
+            attrs.attribute(CompileView.VIEW_ATTRIBUTE, getObjectFactory().named(CompileView.class, CompileView.JAVA_COMPLETE));
+        });
     }
 
     @Override


### PR DESCRIPTION
Adds a method which creates a dependency on the current project, except with an additional CompileView#JAVA_COMPLETE attribute.
