### PR TITLE
Completely disallow injecting transform input artifact as java.io.File

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
@@ -20,7 +20,6 @@ import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
 
-import java.io.File;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -55,6 +54,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Documented
-@InjectionPointQualifier(supportedTypes = { File.class }, supportedProviderTypes = { FileSystemLocation.class })
+@InjectionPointQualifier(supportedProviderTypes = { FileSystemLocation.class })
 public @interface InputArtifact {
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -47,7 +47,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.Describables;
-import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter.FileValueSupplier;
@@ -425,13 +424,6 @@ public class DefaultTransformer implements Transformer {
         public TransformServiceLookup(Provider<FileSystemLocation> inputFileProvider, @Nullable ArtifactTransformDependencies artifactTransformDependencies, @Nullable InputChanges inputChanges, ServiceLookup delegate) {
             this.delegate = delegate;
             ImmutableList.Builder<InjectionPoint> builder = ImmutableList.builder();
-            builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, File.class, () -> {
-                throw DocumentedFailure.builder()
-                    .withSummary("Injecting the input artifact of a transform as a File is not supported.")
-                    .withAdvice("Declare the input artifact as Provider<FileSystemLocation> instead.")
-                    .withUserManual("artifact_transforms", "sec:implementing-artifact-transforms")
-                    .build();
-            }));
             builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, FILE_SYSTEM_LOCATION_PROVIDER, () -> inputFileProvider));
             if (artifactTransformDependencies != null) {
                 builder.add(InjectionPoint.injectedByAnnotation(InputArtifactDependencies.class, () -> artifactTransformDependencies.getFiles().orElseThrow(() -> new IllegalStateException("Transform does not use artifact dependencies."))));


### PR DESCRIPTION
This corrects the error message produced when injecting `@InputArtifact` as anything other than a `Provider<FSL>` to not include `java.io.File` as an option. It also removes the now unnecessary documented failure and the special test case targeted at `File`.

Fixes #15546.