### PR TITLE
Turn deprecation warning into error: invalid toolchain spec

### DIFF
--- a/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
+++ b/subprojects/docs/src/docs/userguide/jvm/toolchains.adoc
@@ -107,9 +107,8 @@ A `JavaToolchainSpec` is considered _valid_ in two cases:
 In other words, if a vendor or an implementation are specified, they must be accompanied by the language version.
 Gradle distinguishes between toolchain specifications that configure the language version and the ones that do not.
 A specification without a language version, in most cases, would be treated as a one that selects the toolchain of the current build.
-If the language version is not set then Gradle will ignore values provided for other properties of the specification.
 
-Usage of _invalid_ instances of `JavaToolchainSpec` is deprecated and will be removed in the future versions of Gradle.
+Usage of _invalid_ instances of `JavaToolchainSpec` results in a build error since Gradle 8.0.
 
 
 == Specify custom toolchains for individual tasks

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -193,7 +193,7 @@ systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 Along with the Java language version, the <<toolchains#toolchains, Java toolchain>> DSL allows configuring other criteria such as specific vendors or VM implementations.
 Starting with Gradle 7.6, toolchain specifications that configure other properties without specifying the language version are considered _invalid_.
-Invalid specifications are deprecated and will become build errors in Gradle 8.0.
+Usage of invalid specifications results in build errors since Gradle 8.0.
 
 See more details about toolchain configuration in the <<toolchains#sec:configuring_toolchain_specifications,user manual>>.
 

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -52,6 +52,12 @@ Creating a TAR tree from a resource with no backing file is no longer supported.
 Instead, convert the resource to a file and use `project.tarTree()` on the file.
 For more information, see <<tar_tree_no_backing_file>>.
 
+==== Using invalid Java toolchain specifications
+
+Usage of invalid Java toolchain specifications is no longer supported.
+Related build errors can be avoided by making sure that language version is set on all toolchain specifications.
+See <<toolchains#sec:configuring_toolchain_specifications,user manual>> for more information.
+
 === Removed APIs
 
 ==== Legacy ArtifactTransform API
@@ -193,7 +199,7 @@ systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 Along with the Java language version, the <<toolchains#toolchains, Java toolchain>> DSL allows configuring other criteria such as specific vendors or VM implementations.
 Starting with Gradle 7.6, toolchain specifications that configure other properties without specifying the language version are considered _invalid_.
-Usage of invalid specifications results in build errors since Gradle 8.0.
+Invalid specifications are deprecated and will become build errors in Gradle 8.0.
 
 See more details about toolchain configuration in the <<toolchains#sec:configuring_toolchain_specifications,user manual>>.
 

--- a/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainSpecIntegrationTest.groovy
+++ b/subprojects/platform-jvm/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainSpecIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class JavaToolchainSpecIntegrationTest extends AbstractIntegrationSpec {
 
-    def "nag user about invalid toolchain spec when #description"() {
+    def "fails when using an invalid toolchain spec when #description"() {
         buildScript """
             apply plugin: "java"
 
@@ -31,11 +31,10 @@ class JavaToolchainSpecIntegrationTest extends AbstractIntegrationSpec {
         """
 
         when:
-        executer.expectDocumentedDeprecationWarning("Using toolchain specifications without setting a language version has been deprecated. This will fail with an error in Gradle 8.0. Consider configuring the language version. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#invalid_toolchain_specification_deprecation")
-        run ':help'
+        runAndFail ':help'
 
         then:
-        executedAndNotSkipped ':help'
+        failure.assertHasDocumentedCause("Using toolchain specifications without setting a language version is not supported. Consider configuring the language version. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#invalid_toolchain_specification_deprecation")
 
         where:
         description                                | configureInvalid

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchainQueryService.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
-import org.gradle.internal.deprecation.DeprecationLogger;
+import org.gradle.internal.deprecation.DocumentedFailure;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaToolchainSpec;
 import org.gradle.jvm.toolchain.install.internal.DefaultJavaToolchainProvisioningService;
@@ -74,11 +74,11 @@ public class JavaToolchainQueryService {
     ProviderInternal<JavaToolchain> findMatchingToolchain(JavaToolchainSpec filter) {
         JavaToolchainSpecInternal filterInternal = (JavaToolchainSpecInternal) filter;
         if (!filterInternal.isValid()) {
-            DeprecationLogger.deprecate("Using toolchain specifications without setting a language version")
+            throw DocumentedFailure.builder()
+                .withSummary("Using toolchain specifications without setting a language version is not supported.")
                 .withAdvice("Consider configuring the language version.")
-                .willBecomeAnErrorInGradle8()
                 .withUpgradeGuideSection(7, "invalid_toolchain_specification_deprecation")
-                .nagUser();
+                .build();
         }
 
         return new DefaultProvider<>(() -> {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle/issues/21794