### PR TITLE
Fix maven-publish integration tests under configuration cache

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -682,4 +682,17 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         Assume.assumeTrue('Requires Groovy 4', isAtLeastGroovy4)
     }
 
+    /**
+     * Generates a `repositories` block pointing to the standard maven repo fixture.
+     *
+     * This is often required for running with configuration cache enabled, as
+     * configuration cache eagerly resolves dependencies when storing the classpath.
+     */
+    protected String mavenTestRepository(GradleDsl dsl = GROOVY) {
+        """
+        repositories {
+            ${RepoScriptBlockUtil.repositoryDefinition(dsl, "maven", mavenRepo.rootDir.name, mavenRepo.uri.toString())}
+        }
+        """
+    }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishJavaIntegTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.publish.maven
 import org.gradle.api.attributes.Category
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenDependencyExclusion
 import org.gradle.test.fixtures.maven.MavenFileModule
@@ -82,16 +81,9 @@ abstract class AbstractMavenPublishJavaIntegTest extends AbstractMavenPublishInt
                     }
                 }
             }
-        """)
 
-        if (GradleContextualExecuter.configCache) {
-            // Configuration cache resolves dependencies before publishing
-            buildFile << """
-                repositories {
-                    maven { url "${mavenRepo.uri}" }
-                }
-            """
-        }
+            ${mavenTestRepository()}
+        """)
 
         when:
         run "publish"
@@ -667,10 +659,18 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish java-library with capability requests"() {
         given:
         createBuildScripts("""
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
+            ${withDocs() ? """tasks.javadoc {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
+            """ : ""}
             dependencies {
                 implementation("org.test:foo:1.0") {
                     capabilities {
@@ -808,9 +808,10 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5034, https://github.com/gradle/gradle/issues/5035")
-    @ToBeFixedForConfigurationCache
     void "configuration exclusions are published in generated POM and Gradle metadata"() {
         given:
+        javaLibrary(mavenRepo.module("org.test", "a", "1.0")).withModuleMetadata().publish()
+        javaLibrary(mavenRepo.module("org.test", "b", "2.0")).withModuleMetadata().publish()
         createBuildScripts("""
             configurations {
                 api.exclude(group: "api-group", module: "api-module")
@@ -833,7 +834,9 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                     }
                 }
             }
+            ${mavenTestRepository()}
         """)
+
         settingsFile << """
             include "subproject"
         """
@@ -1014,6 +1017,7 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                     }
                 }
             }
+            ${mavenTestRepository()}
 """)
 
         when:
@@ -1106,13 +1110,18 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
 
     }
 
-    @ToBeFixedForConfigurationCache
     def 'can publish a java library using a virtual platform by ignoring it explicitly'() {
         given:
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
         javaLibrary(mavenRepo.module("org.test", "bar", "1.1")).withModuleMetadata().publish()
 
         createBuildScripts("""
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
+
             dependencies {
                 api "org.test:bar:1.0"
                 api platform("org.test:platform:1.0")
@@ -1141,7 +1150,10 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
                     }
                 }
             }
+
+            ${mavenTestRepository()}
         """)
+
 
         when:
         run "publish"
@@ -1156,7 +1168,6 @@ Maven publication 'maven' pom metadata warnings (silence with 'suppressPomMetada
         // Sadly this does not take care of the Gradle metadata
     }
 
-    @ToBeFixedForConfigurationCache
     def 'can publish java library with a #config dependency on a java-platform subproject"'() {
         given:
         javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
@@ -1189,6 +1200,7 @@ include(':platform')
                     }
                 }
             }
+            ${mavenTestRepository()}
 """)
 
         when:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBasicIntegTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.api.publish.maven
 
-
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.test.fixtures.maven.MavenLocalRepository
 import org.gradle.util.SetSystemProperties
@@ -420,7 +418,6 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
         succeeds 'publish'
     }
 
-    @ToBeFixedForConfigurationCache(because = "configuration cache doesn't support task failures")
     @Issue("https://github.com/gradle/gradle/issues/15009")
     def "fails publishing if a variant contains a dependency on an enforced platform"() {
         settingsFile << """
@@ -430,6 +427,11 @@ class MavenPublishBasicIntegTest extends AbstractMavenPublishIntegTest {
             plugins {
                 id 'java'
                 id 'maven-publish'
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -458,8 +460,8 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
     }
 
     @Issue("https://github.com/gradle/gradle/issues/15009")
-    @ToBeFixedForConfigurationCache(because = "configuration cache doesn't support task failures")
     def "can disable validation of publication of dependencies on enforced platforms"() {
+        mavenRepo.module("org", "platform", "1.0").asGradlePlatform().publish()
         settingsFile << """
             rootProject.name = 'publish'
         """
@@ -471,6 +473,11 @@ In general publishing dependencies to enforced platforms is a mistake: enforced 
 
             group = 'com.acme'
             version = '0.999'
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
 
             dependencies {
                 implementation enforcedPlatform('org:platform:1.0')

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBuildOperationIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishBuildOperationIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import org.gradle.internal.resource.ExternalResourceReadBuildOperationType
 import org.gradle.internal.resource.ExternalResourceWriteBuildOperationType
@@ -29,7 +28,6 @@ class MavenPublishBuildOperationIntegrationTest extends AbstractMavenPublishInte
     def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
     def repo = new MavenHttpRepository(server, mavenRepo)
 
-    @ToBeFixedForConfigurationCache
     def "generates build operation events while publishing"() {
         server.start()
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishDependenciesIntegTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import spock.lang.Issue
 
@@ -24,7 +23,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
     def repoModule = javaLibrary(mavenRepo.module('group', 'root', '1.0'))
 
     @Issue('GRADLE-1574')
-    @ToBeFixedForConfigurationCache
     def "publishes wildcard exclusions for a non-transitive dependency"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -34,6 +32,11 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
 
             group = 'group'
             version = '1.0'
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
 
             dependencies {
                 api('org.test:non-transitive:1.0') { transitive = false }
@@ -68,7 +71,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
     }
 
     @Issue("GRADLE-3233")
-    @ToBeFixedForConfigurationCache
     def "publishes POM dependency with #versionType version for Gradle dependency with null version"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -78,6 +80,11 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
 
             group = 'group'
             version = '1.0'
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
 
             dependencies {
                 api $dependencyNotation
@@ -113,7 +120,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         "null"      | "group:'group', name:'projectA', version:null"
     }
 
-    @ToBeFixedForConfigurationCache
     void "defaultDependencies are included in published pom file"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -129,6 +135,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
             }
             configurations.implementation.defaultDependencies { deps ->
                 deps.add project.dependencies.create("org:default-dependency:1.0")
+            }
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
             dependencies {
                 implementation "org:explicit-dependency:1.0"
@@ -155,7 +165,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         repoModule.assertRuntimeDependencies('org:explicit-dependency:1.0')
     }
 
-    @ToBeFixedForConfigurationCache
     void "dependency mutations are reflected in published pom file"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -166,6 +175,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
             group = 'group'
             version = '1.0'
 
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
             dependencies {
                 api "org.test:dep1:1.0"
             }
@@ -196,7 +209,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         repoModule.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:1.0')
     }
 
-    @ToBeFixedForConfigurationCache
     def "publishes both dependencies when one has a classifier"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -207,6 +219,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
             group = 'group'
             version = '1.0'
 
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
             dependencies {
                 implementation "org:foo:1.0"
                 implementation "org:foo:1.0:classy"
@@ -254,7 +270,6 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "dependencies with multiple dependency artifacts are mapped to multiple dependency declarations in GMM"() {
         given:
         settingsFile << "rootProject.name = 'root'"
@@ -265,6 +280,10 @@ class MavenPublishDependenciesIntegTest extends AbstractMavenPublishIntegTest {
             group = 'group'
             version = '1.0'
 
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
             dependencies {
                 implementation "org:foo:1.0"
                 implementation("org:foo:1.0:classy") {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import spock.lang.Unroll
 
 class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJavaIntegTest {
 
-    @ToBeFixedForConfigurationCache
     def "can publish java-library with a feature"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -39,6 +37,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     outgoing.capability("org:optional-feature:\${version}")
                 }
                 compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -89,7 +92,6 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can group dependencies by feature"() {
         mavenRepo.module('org', 'optionaldep-g1', '1.0').publish()
         mavenRepo.module('org', 'optionaldep1-g2', '1.0').publish()
@@ -121,6 +123,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     outgoing.capability("org:optional-feature2:\${version}")
                 }
                 compileClasspath.extendsFrom(optionalFeature2Implementation)
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -173,7 +180,6 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
     }
 
     @Unroll("publish java-library with feature with additional artifact #id (#optionalFeatureFileName)")
-    @ToBeFixedForConfigurationCache
     def "publish java-library with feature with additional artifact"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -191,6 +197,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     outgoing.capability("org:optional-feature:\${version}")
                 }
                 compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -277,7 +288,6 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
 
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish java-library with a feature from a configuration with more than one outgoing variant"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -295,6 +305,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     outgoing.capability("org:optional-feature:\${version}")
                 }
                 compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -358,7 +373,6 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can publish java-library with a feature from a configuration with more than one outgoing variant and filter out variants"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -376,6 +390,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     outgoing.capability("org:optional-feature:\${version}")
                 }
                 compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -16,10 +16,7 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
-
 class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeaturesJavaIntegTest {
-    @ToBeFixedForConfigurationCache
     def "can publish java-library with feature using extension"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -30,6 +27,11 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
                 registerFeature("feature") {
                     usingSourceSet(sourceSets.main)
                 }
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {
@@ -79,7 +81,6 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "can update #prop after feature has been registered"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
 
@@ -90,6 +91,11 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
                 registerFeature("feature") {
                     usingSourceSet(sourceSets.main)
                 }
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.test.fixtures.maven.MavenJavaModule
 
 class MavenPublishJavaIntegTest extends AbstractMavenPublishJavaIntegTest {
@@ -78,10 +77,13 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishJavaIntegTest {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "a component's variant can be modified before publishing"() {
         given:
         createBuildScripts """
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
+            }
             dependencies {
                 api 'org:foo:1.0'
                 implementation 'org:bar:1.0'

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 import spock.lang.Issue
 
@@ -281,7 +280,6 @@ project(":project2") {
         }
     }
 
-    @ToBeFixedForConfigurationCache
     def "publish and resolve java-library with dependency on java-platform (named #platformName)"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
@@ -297,6 +295,8 @@ allprojects {
 
     group = "org.test"
     version = "1.0"
+
+    ${mavenTestRepository()}
 }
 
 project(":$platformName") {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishVersionRangeIntegTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
 
 class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
     def mavenModule = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
 
-    @ToBeFixedForConfigurationCache
     void "version range is mapped to maven syntax in published pom file"() {
         given:
         settingsFile << "rootProject.name = 'publishTest' "
@@ -42,6 +40,11 @@ class MavenPublishVersionRangeIntegTest extends AbstractMavenPublishIntegTest {
                         from components.java
                     }
                 }
+            }
+
+            tasks.compileJava {
+                // Avoid resolving the classpath when caching the configuration
+                classpath = files()
             }
 
             dependencies {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -139,6 +139,7 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
         def binaryAndSourcesInRepo = internalRepo.module("org.gradle.sample", artifactId, version).withModuleMetadata()
         def localRepo = maven(temporaryFolder.createDir("m2_repo"))
         def binaryAndSourcesLocal = localRepo.module("org.gradle.sample", artifactId, version).withModuleMetadata()
+
         when:
         args "-Dmaven.repo.local=${localRepo.rootDir.getAbsolutePath()}"
         succeeds "publish", "publishToMavenLocal"


### PR DESCRIPTION
Configuration cache causes Maven Publish to resolve
dependencies eagerly during configuration, so tests
must either:
- configure classpaths that do not depend on dependency resolution (as in 6a008fc91a28f72aaa54d79adf247fbaf1c99af0), or
- (when dependency resolution is required) declare repositories containing any required dependencies


