### PR TITLE
CCH22-19: Adjust the snippets/java/customDirs sample for cc #21816

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -870,9 +870,6 @@ tasks.named("docsTest") { task ->
                 "snippet-java-cross-compilation_groovy_java7CrossCompilation.sample",
                 "snippet-java-cross-compilation_kotlin_java7CrossCompilation.sample",
 
-                "snippet-java-custom-dirs_groovy_javaCustomReportDirs.sample",
-                "snippet-java-custom-dirs_kotlin_javaCustomReportDirs.sample",
-
                 "snippet-java-fixtures_groovy_javaTestFixtures.sample",
                 "snippet-java-fixtures_kotlin_javaTestFixtures.sample",
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -13,6 +13,7 @@ We would like to thank the following community members for their contributions t
 [Herbert von Broeuschmeul](https://github.com/HvB),
 [Björn Kautler](https://github.com/Vampire)
 [Siddardha Bezawada](https://github.com/SidB3)
+[Stephen Topley](https://github.com/stopley)
 
 ## Upgrade instructions
 

--- a/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/java/customDirs/groovy/build.gradle
@@ -52,9 +52,13 @@ reporting.baseDir = "my-reports"
 testResultsDirName = "$buildDir/my-test-results"
 
 tasks.register('showDirs') {
+    def rootDir = project.rootDir
+    def reportsDir = project.reportsDir
+    def testResultsDir = project.testResultsDir
+
     doLast {
-        logger.quiet(rootDir.toPath().relativize(project.reportsDir.toPath()).toString())
-        logger.quiet(rootDir.toPath().relativize(project.testResultsDir.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(reportsDir.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(testResultsDir.toPath()).toString())
     }
 }
 // end::custom-report-dirs[]

--- a/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/java/customDirs/kotlin/build.gradle.kts
@@ -55,9 +55,13 @@ reporting.baseDir = file("my-reports")
 project.setProperty("testResultsDirName", "$buildDir/my-test-results")
 
 tasks.register("showDirs") {
+    val rootDir = project.rootDir
+    val reportsDir = project.reporting.baseDirectory
+    val testResultsDir = project.java.testResultsDir
+
     doLast {
-        logger.quiet(rootDir.toPath().relativize((project.property("reportsDir") as File).toPath()).toString())
-        logger.quiet(rootDir.toPath().relativize((project.property("testResultsDir") as File).toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(reportsDir.get().asFile.toPath()).toString())
+        logger.quiet(rootDir.toPath().relativize(testResultsDir.get().asFile.toPath()).toString())
     }
 }
 // end::custom-report-dirs[]


### PR DESCRIPTION
Fixes #21816

This change moves the references to the Project object out of the execution phase, to make the task compatible with the configuration cache.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
