### PR TITLE
De-incubate java launcher for scala tasks

### DIFF
--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -208,7 +208,6 @@ public class ScalaDoc extends SourceTask {
      * Optional JavaLauncher for toolchain support
      * @since 7.2
      */
-    @Incubating
     @Internal
     public Property<JavaLauncher> getJavaLauncher() {
         return javaLauncher;

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -208,7 +208,8 @@ public class ScalaDoc extends SourceTask {
      * Optional JavaLauncher for toolchain support
      * @since 7.2
      */
-    @Internal
+    @Nested
+    @Optional
     public Property<JavaLauncher> getJavaLauncher() {
         return javaLauncher;
     }

--- a/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -147,7 +147,6 @@ public abstract class AbstractScalaCompile extends AbstractCompile implements Ha
      * @return the java launcher property
      * @since 7.2
      */
-    @Incubating
     @Nested
     @Optional
     public Property<JavaLauncher> getJavaLauncher() {


### PR DESCRIPTION
De-incubating `getJavaLauncher` on `ScalaDoc` and `AbstractScalaCompile` tasks