### PR TITLE
De-incubate UntrackedTask annotation

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -275,12 +275,11 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     /**
      * Do not track the state of the task.
      *
-     * Instructs Gradle to treat the task as untracked.
+     * <p>Instructs Gradle to treat the task as untracked.
      *
      * @see org.gradle.api.tasks.UntrackedTask
      * @since 7.3
      */
-    @Incubating
     void doNotTrackState(String reasonNotToTrackState);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/UntrackedTask.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/UntrackedTask.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.tasks;
 
-import org.gradle.api.Incubating;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -44,7 +42,6 @@ import java.lang.annotation.Target;
  *
  * @since 7.3
  */
-@Incubating
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})


### PR DESCRIPTION
De-incubates `UntrackedTask` annotation and related `Task.doNotTrackState()`.