### PR TITLE
De-incubate Checkstyle properties

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins.quality;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -182,7 +181,6 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      *
      * @since 7.5
      */
-    @Incubating
     @Nested
     public Property<JavaLauncher> getJavaLauncher() {
         return javaLauncher;
@@ -425,7 +423,6 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      *
      * @since 7.5
      */
-    @Incubating
     @Optional
     @Input
     public Property<String> getMinHeapSize() {
@@ -440,7 +437,6 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      *
      * @since 7.5
      */
-    @Incubating
     @Optional
     @Input
     public Property<String> getMaxHeapSize() {


### PR DESCRIPTION
De-incubates `Checkstyle` task properties introduced in 7.5: `javaLauncher`, `minHeapSize`, `maxHeapSize`.