### PR TITLE
Align Kotlin snippet with the Groovy version

### DIFF
--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/consumer/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-attributeSubstitutionRule/kotlin/consumer/build.gradle.kts
@@ -30,9 +30,9 @@ configurations.all {
 // end::substitution_rule_alternative[]
 
 tasks.register("resolve") {
-    val classpath: Provider<out FileCollection> = configurations.runtimeClasspath
+    val classpath: FileCollection = configurations.runtimeClasspath.get()
     inputs.files(classpath)
     doLast {
-        println(classpath.get().files.map { it.name })
+        println(classpath.files.map { it.name })
     }
 }


### PR DESCRIPTION
And prefer to resolve (`get()`) configurations during the configuration phase based on the discussion around #21555.