### PR TITLE
Recognize deleted locations and local state as outputs of task

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputUnpacker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/OutputUnpacker.java
@@ -73,6 +73,16 @@ public class OutputUnpacker extends PropertyVisitor.Adapter {
         }
     }
 
+    @Override
+    public void visitDestroyableProperty(Object value) {
+        hasDeclaredOutputs = true;
+    }
+
+    @Override
+    public void visitLocalStateProperty(Object value) {
+        hasDeclaredOutputs = true;
+    }
+
     public boolean hasDeclaredOutputs() {
         return hasDeclaredOutputs;
     }


### PR DESCRIPTION
We are currently re-running `Delete` tasks (such as `clean`) because `OutputUnpacker` does not recognize the removed outputs as outputs. Let's fix that.

Fixes https://github.com/gradle/gradle/issues/21856.