### PR TITLE
ProviderFactory: add gradlePropertiesPrefixedBy

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/inputs/undeclared/UndeclaredBuildInputsIntegrationTest.groovy
@@ -786,6 +786,53 @@ class UndeclaredBuildInputsIntegrationTest extends AbstractConfigurationCacheInt
         }
     }
 
+    def "build logic can read Gradle properties with prefix"() {
+        def configurationCache = newConfigurationCacheFixture()
+        buildFile("""
+            def ciVars = providers.gradlePropertiesPrefixedBy("some.property.")
+            ciVars.get().forEach((k, v) -> {
+                println("Configuration: \$k = \$v")
+            })
+
+            tasks.register("print") {
+                doLast {
+                    ciVars.get().forEach((k, v) -> {
+                        println("Execution: \$k = \$v")
+                    })
+                }
+            }
+        """)
+
+        when:
+        configurationCacheRun("-Psome.property.1=1", "-Dsome.property.2=2", "print")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("Configuration: some.property.1 = 1")
+        outputDoesNotContain("Configuration: some.property.2 = 2")
+        problems.assertResultHasProblems(result) {
+            withNoInputs()
+        }
+
+        when:
+        configurationCacheRun("-Psome.property.1=1", "print")
+
+        then:
+        configurationCache.assertStateLoaded()
+        outputContains("Execution: some.property.1 = 1")
+
+        when:
+        configurationCacheRun("-Psome.property.1=1", "-Psome.property.2=2", "print")
+
+        then:
+        configurationCache.assertStateStored()
+        outputContains("Configuration: some.property.1 = 1")
+        outputContains("Configuration: some.property.2 = 2")
+        problems.assertResultHasProblems(result) {
+            withNoInputs()
+        }
+    }
+
     def "system properties overwritten in build logic are not inputs to prefixed system properties"() {
         def configurationCache = newConfigurationCacheFixture()
         buildFile("""

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -39,6 +39,7 @@ import org.gradle.api.internal.provider.ValueSourceProviderFactory
 import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource
 import org.gradle.api.internal.provider.sources.EnvironmentVariablesPrefixedByValueSource
 import org.gradle.api.internal.provider.sources.FileContentValueSource
+import org.gradle.api.internal.provider.sources.GradlePropertiesPrefixedByValueSource
 import org.gradle.api.internal.provider.sources.GradlePropertyValueSource
 import org.gradle.api.internal.provider.sources.SystemPropertiesPrefixedByValueSource
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource
@@ -286,6 +287,9 @@ class ConfigurationCacheFingerprintWriter(
                 }
             }
             is GradlePropertyValueSource.Parameters -> {
+                // The set of Gradle properties is already an input
+            }
+            is GradlePropertiesPrefixedByValueSource.Parameters -> {
                 // The set of Gradle properties is already an input
             }
             is SystemPropertyValueSource.Parameters -> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -157,6 +157,28 @@ public interface ProviderFactory {
     Provider<String> gradleProperty(Provider<String> propertyName);
 
     /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the Gradle properties with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the system property names
+     * @return The provider. Never returns null.
+     * @since 7.6
+     */
+    @Incubating
+    Provider<Map<String, String>> gradlePropertiesPrefixedBy(String variableNamePrefix);
+
+    /**
+     * Creates a {@link Provider} whose value is a name-to-value map of the Gradle properties with the names starting with the given prefix.
+     * The prefix comparison is case-sensitive. The returned map is immutable.
+     *
+     * @param variableNamePrefix The prefix of the system property names
+     * @return The provider. Never returns null.
+     * @since 7.6
+     */
+    @Incubating
+    Provider<Map<String, String>> gradlePropertiesPrefixedBy(Provider<String> variableNamePrefix);
+
+    /**
      * Allows lazy access to the contents of the given file.
      *
      * When the file contents are read at configuration time the file is automatically considered

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -162,7 +162,7 @@ public interface ProviderFactory {
      *
      * @param variableNamePrefix The prefix of the system property names
      * @return The provider. Never returns null.
-     * @since 7.6
+     * @since 8.0
      */
     @Incubating
     Provider<Map<String, String>> gradlePropertiesPrefixedBy(String variableNamePrefix);
@@ -173,7 +173,7 @@ public interface ProviderFactory {
      *
      * @param variableNamePrefix The prefix of the system property names
      * @return The provider. Never returns null.
-     * @since 7.6
+     * @since 8.0
      */
     @Incubating
     Provider<Map<String, String>> gradlePropertiesPrefixedBy(Provider<String> variableNamePrefix);

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -160,7 +160,7 @@ public interface ProviderFactory {
      * Creates a {@link Provider} whose value is a name-to-value map of the Gradle properties with the names starting with the given prefix.
      * The prefix comparison is case-sensitive. The returned map is immutable.
      *
-     * @param variableNamePrefix The prefix of the system property names
+     * @param variableNamePrefix The prefix of the Gradle property names
      * @return The provider. Never returns null.
      * @since 8.0
      */
@@ -171,7 +171,7 @@ public interface ProviderFactory {
      * Creates a {@link Provider} whose value is a name-to-value map of the Gradle properties with the names starting with the given prefix.
      * The prefix comparison is case-sensitive. The returned map is immutable.
      *
-     * @param variableNamePrefix The prefix of the system property names
+     * @param variableNamePrefix The prefix of the Gradle property names
      * @return The provider. Never returns null.
      * @since 8.0
      */

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -11,6 +11,7 @@ Include only their name, impactful features should be called out separately belo
 -->
 We would like to thank the following community members for their contributions to this release of Gradle:
 
+[Andrei Nevedomskii](https://github.com/monosoul),
 [Björn Kautler](https://github.com/Vampire),
 [Clara Guerrero](https://github.com/cguerreros),
 [David Marin](https://github.com/dmarin),

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultProviderFactory.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.provider.sources.EnvironmentVariableValueSource;
 import org.gradle.api.internal.provider.sources.EnvironmentVariablesPrefixedByValueSource;
 import org.gradle.api.internal.provider.sources.FileBytesValueSource;
 import org.gradle.api.internal.provider.sources.FileTextValueSource;
+import org.gradle.api.internal.provider.sources.GradlePropertiesPrefixedByValueSource;
 import org.gradle.api.internal.provider.sources.GradlePropertyValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertiesPrefixedByValueSource;
 import org.gradle.api.internal.provider.sources.SystemPropertyValueSource;
@@ -141,6 +142,19 @@ public class DefaultProviderFactory implements ProviderFactory {
         return of(
             GradlePropertyValueSource.class,
             spec -> spec.getParameters().getPropertyName().set(propertyName)
+        );
+    }
+
+    @Override
+    public Provider<Map<String, String>> gradlePropertiesPrefixedBy(String variableNamePrefix) {
+        return gradlePropertiesPrefixedBy(Providers.of(variableNamePrefix));
+    }
+
+    @Override
+    public Provider<Map<String, String>> gradlePropertiesPrefixedBy(Provider<String> variableNamePrefix) {
+        return of(
+            GradlePropertiesPrefixedByValueSource.class,
+            spec -> spec.getParameters().getPrefix().set(variableNamePrefix)
         );
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/GradlePropertiesPrefixedByValueSource.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/sources/GradlePropertiesPrefixedByValueSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider.sources;
+
+import org.gradle.api.internal.properties.GradleProperties;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class GradlePropertiesPrefixedByValueSource extends MapWithPrefixedKeysValueSource<GradlePropertiesPrefixedByValueSource.Parameters> {
+    public interface Parameters extends MapWithPrefixedKeysValueSource.Parameters {
+    }
+
+    @Inject
+    protected abstract GradleProperties getGradleProperties();
+
+    @Override
+    protected Stream<Map.Entry<String, String>> itemsToFilter() {
+        return getGradleProperties().mergeProperties(new HashMap<>()).entrySet().stream()
+            .filter(e -> e.getValue() instanceof String)
+            .map(e -> {
+                Map.Entry<String, ?> untypedEntry = e;
+                @SuppressWarnings("unchecked")
+                Map.Entry<String, String> stringEntry = (Map.Entry<String, String>) untypedEntry;
+                return stringEntry;
+            });
+    }
+}


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #21876

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
At the moment [ProviderFactory](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java) provides no way to get a list of Gradle properties by a prefix, while there are `systemPropertiesPrefixedBy` and `environmentVariablesPrefixedBy`.

Because of that `ProviderFactory` can't really be considered as an alternative to using project.properties when adopting [configuration cache](https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements).

~No tests just yet, as this is more of a PoC.~ The solution is kinda lazy, I just call `GradleProperties.mergeProperties()` with an empty map to get a map of properties and then filter it similar to `SystemPropertiesPrefixedByValueSource`.

~If there are no objections to this implementation, I'll add tests.~

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
