### PR TITLE
Add internal build operations to provide finer tracking of task input/output fingerprinting

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTree.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTree.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class BuildOperationTree {
 
@@ -53,4 +54,7 @@ public class BuildOperationTree {
         });
     }
 
+    static List<Map<String, ?>> serializeToTraceEvents(List<BuildOperationRecord> roots) {
+        return roots.stream().flatMap(it -> it.toSerializableTraceEvents().stream()).collect(Collectors.toList());
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -137,7 +137,7 @@ public class ExecutionGradleServices {
         Supplier<OutputsCleaner> skipEmptyWorkOutputsCleanerSupplier = () -> new OutputsCleaner(deleter, buildOutputCleanupRegistry::isOutputOwnedByBuild, buildOutputCleanupRegistry::isOutputOwnedByBuild);
         // @formatter:off
         return new DefaultExecutionEngine(documentationRegistry,
-            new IdentifyStep<>(
+            new IdentifyStep<>(buildOperationExecutor,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadPreviousExecutionStateStep<>(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -719,7 +719,7 @@ class DependencyManagementBuildScopeServices {
         UniqueId fixedUniqueId = UniqueId.from("dhwwyv4tqrd43cbxmdsf24wquu");
         // @formatter:off
         return new DefaultExecutionEngine(documentationRegistry,
-            new IdentifyStep<>(
+            new IdentifyStep<>(buildOperationExecutor,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadPreviousExecutionStateStep<>(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -25,17 +25,22 @@ import org.gradle.internal.execution.UnitOfWork.Identity;
 import org.gradle.internal.execution.WorkValidationContext;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.snapshot.ValueSnapshot;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> implements DeferredExecutionAwareStep<C, R> {
+public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> extends BuildOperationStep<C, R> implements DeferredExecutionAwareStep<C, R> {
     private final DeferredExecutionAwareStep<? super IdentityContext, R> delegate;
 
     public IdentifyStep(
+        BuildOperationExecutor buildOperationExecutor,
         DeferredExecutionAwareStep<? super IdentityContext, R> delegate
     ) {
+        super(buildOperationExecutor);
         this.delegate = delegate;
     }
 
@@ -51,42 +56,65 @@ public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> i
 
     @Nonnull
     private IdentityContext createIdentityContext(UnitOfWork work, C context) {
-        InputFingerprinter.Result inputs = work.getInputFingerprinter().fingerprintInputProperties(
-            ImmutableSortedMap.of(),
-            ImmutableSortedMap.of(),
-            ImmutableSortedMap.of(),
-            ImmutableSortedMap.of(),
-            work::visitIdentityInputs
+        return operation(operationContext -> {
+                InputFingerprinter.Result inputs = work.getInputFingerprinter().fingerprintInputProperties(
+                    ImmutableSortedMap.of(),
+                    ImmutableSortedMap.of(),
+                    ImmutableSortedMap.of(),
+                    ImmutableSortedMap.of(),
+                    work::visitIdentityInputs
+                );
+                ImmutableSortedMap<String, ValueSnapshot> identityInputProperties = inputs.getValueSnapshots();
+                ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = inputs.getFileFingerprints();
+
+                Identity identity = work.identify(identityInputProperties, identityInputFileProperties);
+                operationContext.setResult(Operation.Result.INSTANCE);
+                return new IdentityContext() {
+                    @Override
+                    public Optional<String> getNonIncrementalReason() {
+                        return context.getNonIncrementalReason();
+                    }
+
+                    @Override
+                    public WorkValidationContext getValidationContext() {
+                        return context.getValidationContext();
+                    }
+
+                    @Override
+                    public ImmutableSortedMap<String, ValueSnapshot> getInputProperties() {
+                        return identityInputProperties;
+                    }
+
+                    @Override
+                    public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> getInputFileProperties() {
+                        return identityInputFileProperties;
+                    }
+
+                    @Override
+                    public Identity getIdentity() {
+                        return identity;
+                    }
+                };
+
+            },
+            BuildOperationDescriptor
+                .displayName("Identify " + work.getDisplayName())
+                .details(Operation.Details.INSTANCE)
         );
-        ImmutableSortedMap<String, ValueSnapshot> identityInputProperties = inputs.getValueSnapshots();
-        ImmutableSortedMap<String, CurrentFileCollectionFingerprint> identityInputFileProperties = inputs.getFileFingerprints();
+    }
 
-        Identity identity = work.identify(identityInputProperties, identityInputFileProperties);
-        return new IdentityContext() {
-            @Override
-            public Optional<String> getNonIncrementalReason() {
-                return context.getNonIncrementalReason();
-            }
+    /*
+     * This operation is only used here temporarily. Should be replaced with a more stable operation in the long term.
+     */
+    public interface Operation extends BuildOperationType<Operation.Details, Operation.Result> {
+        interface Details {
+            Details INSTANCE = new Details() {
+            };
+        }
 
-            @Override
-            public WorkValidationContext getValidationContext() {
-                return context.getValidationContext();
-            }
-
-            @Override
-            public ImmutableSortedMap<String, ValueSnapshot> getInputProperties() {
-                return identityInputProperties;
-            }
-
-            @Override
-            public ImmutableSortedMap<String, CurrentFileCollectionFingerprint> getInputFileProperties() {
-                return identityInputFileProperties;
-            }
-
-            @Override
-            public Identity getIdentity() {
-                return identity;
-            }
-        };
+        interface Result {
+            Result INSTANCE = new Result() {
+            };
+        }
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.internal.snapshot.ValueSnapshot
 class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
     def delegateResult = Mock(Result)
     def inputFingerprinter = Mock(InputFingerprinter)
-    def step = new IdentifyStep<>(delegate)
+    def step = new IdentifyStep<>(buildOperationExecutor, delegate)
 
     @Override
     protected ExecutionRequestContext createContext() {


### PR DESCRIPTION
Also adds support for producing a trace of build operations in the Event Trace format, openable with various interactive visualization tools, such as `chrome://tracing`.