### PR TITLE
Use `projectLayout` instead of `project`

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -812,11 +812,6 @@ tasks.named("docsTest") { task ->
             // Tests that can and has to be fixed to run with the configuration cache enabled.
             // Set the Gradle property runBrokenConfigurationCacheDocsTests=true to run tests from this list or any of the lists above.
             def testsToBeFixedForConfigurationCache = [
-                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle-caching.sample",
-                "snippet-build-cache-cacheable-bundle_groovy_cacheableBundle.sample",
-                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle-caching.sample",
-                "snippet-build-cache-cacheable-bundle_kotlin_cacheableBundle.sample",
-
                 "snippet-dependency-management-customizing-resolution-capability-substitution-rule_groovy_capability_substitution.sample",
                 "snippet-dependency-management-customizing-resolution-capability-substitution-rule_kotlin_capability_substitution.sample",
 

--- a/subprojects/docs/src/snippets/buildCache/cacheable-bundle/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/buildCache/cacheable-bundle/groovy/build.gradle
@@ -3,15 +3,21 @@ plugins {
 }
 
 // Fake NPM task that would normally execute npm with its provided arguments
-class NpmTask extends DefaultTask {
+abstract class NpmTask extends DefaultTask {
 
     @Input
     final ListProperty<String> args = project.objects.listProperty(String)
 
+    @Inject
+    abstract ProjectLayout getProjectLayout()
+
     @TaskAction
     void run() {
-        project.file("$project.buildDir/bundle.js").withOutputStream { stream ->
-            project.file("scripts").listFiles().sort().each {
+        def bundleFile = projectLayout.buildDirectory.file("bundle.js").get().asFile
+        def scriptsFiles = projectLayout.projectDirectory.dir("scripts").asFile.listFiles()
+
+        bundleFile.withOutputStream { stream ->
+            scriptsFiles.sort().each {
                 stream.write(it.bytes)
             }
         }
@@ -39,7 +45,10 @@ tasks.register('bundle', NpmTask) {
 
 tasks.register('printBundle') {
     dependsOn bundle
+
+    def projectLayout = layout
+
     doLast {
-        println file("$buildDir/bundle.js").text
+        println projectLayout.buildDirectory.file("bundle.js").get().asFile.text
     }
 }

--- a/subprojects/docs/src/snippets/buildCache/cacheable-bundle/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/buildCache/cacheable-bundle/kotlin/build.gradle.kts
@@ -8,10 +8,16 @@ abstract class NpmTask : DefaultTask() {
     @get:Input
     val args = project.objects.listProperty<String>()
 
+    @get:Inject
+    abstract val projectLayout: ProjectLayout
+
     @TaskAction
     fun run() {
-        project.file("${project.buildDir}/bundle.js").outputStream().use { stream ->
-            project.file("scripts").listFiles().sorted().forEach {
+        val bundleFile = projectLayout.buildDirectory.file("bundle.js").get().asFile
+        val scriptsFiles = projectLayout.projectDirectory.dir("scripts").asFile.listFiles()
+
+        bundleFile.outputStream().use { stream ->
+            scriptsFiles.sorted().forEach {
                 stream.write(it.readBytes())
             }
         }
@@ -39,7 +45,10 @@ tasks.register<NpmTask>("bundle") {
 
 tasks.register("printBundle") {
     dependsOn("bundle")
+
+    val projectLayout = layout
+
     doLast {
-        println(file("$buildDir/bundle.js").readText())
+        println(projectLayout.buildDirectory.file("bundle.js").get().asFile.readText())
     }
 }


### PR DESCRIPTION
In order to work under configuration cache, project property can not be accessed during execution.

Fixes #21800