### PR TITLE
De-incubate getThreads for Pmd task and extension

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -481,7 +481,6 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
      * @since 7.5
      */
     @Input
-    @Incubating
     public Property<Integer> getThreads() {
         return threads;
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.plugins.quality;
 
-import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -240,7 +239,6 @@ public class PmdExtension extends CodeQualityExtension {
      *
      * @since 7.5
      */
-    @Incubating
     public Property<Integer> getThreads() {
         return threads;
     }


### PR DESCRIPTION
De-incubates an input property for controlling the number of threads for the `Pmd` task and `PmdExtension`.