### PR TITLE
Make archive naming snippet work with gradle cache configuration

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -848,9 +848,6 @@ tasks.named("docsTest") { task ->
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_groovy_exclude-transitive-for-dependency.sample",
                 "snippet-dependency-management-managing-transitive-dependencies-exclude-for-dependency_kotlin_exclude-transitive-for-dependency.sample",
 
-                "snippet-files-archive-naming_groovy_archiveNaming.sample",
-                "snippet-files-archive-naming_kotlin_archiveNaming.sample",
-
                 "snippet-files-archives-changed-base-name_groovy_zipWithArchivesBaseName.sample",
                 "snippet-files-archives-changed-base-name_kotlin_zipWithArchivesBaseName.sample",
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -15,8 +15,9 @@ We would like to thank the following community members for their contributions t
 [Björn Kautler](https://github.com/Vampire)
 [Ricardo Jiang](https://github.com/RicardoJiang)
 [Dmitry Pogrebnoy](https://github.com/DmitryPogrebnoy),
-[Siddardha Bezawada](https://github.com/SidB3)
-[Stephen Topley](https://github.com/stopley)
+[Siddardha Bezawada](https://github.com/SidB3),
+[Stephen Topley](https://github.com/stopley),
+[Gabriel Rodriguez](https://github.com/gabrielrodriguez2746)
 
 ## Upgrade instructions
 

--- a/subprojects/docs/src/snippets/files/archiveNaming/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/files/archiveNaming/groovy/build.gradle
@@ -7,11 +7,11 @@ version = 1.0
 
 tasks.register('myZip', Zip) {
     from 'somedir'
-
+    File projectDir = layout.projectDirectory.asFile
     doLast {
         println archiveFileName.get()
-        println relativePath(destinationDirectory)
-        println relativePath(archiveFile)
+        println projectDir.relativePath(destinationDirectory.get().asFile)
+        println projectDir.relativePath(archiveFile.get().asFile)
     }
 }
 // end::zip-task[]

--- a/subprojects/docs/src/snippets/files/archiveNaming/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/files/archiveNaming/kotlin/build.gradle.kts
@@ -7,11 +7,11 @@ version = "1.0"
 
 tasks.register<Zip>("myZip") {
     from("somedir")
-
+    val projectDir = layout.projectDirectory.asFile
     doLast {
         println(archiveFileName.get())
-        println(relativePath(destinationDirectory))
-        println(relativePath(archiveFile))
+        println(destinationDirectory.get().asFile.relativeTo(projectDir))
+        println(archiveFile.get().asFile.relativeTo(projectDir))
     }
 }
 // end::zip-task[]


### PR DESCRIPTION
Fixes #21812
