### PR TITLE
Relax ZipSlip check

### DIFF
--- a/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/ZipSlip.java
+++ b/subprojects/wrapper-shared/src/main/java/org/gradle/util/internal/ZipSlip.java
@@ -43,8 +43,19 @@ public class ZipSlip {
         return name.isEmpty()
             || name.startsWith("/")
             || name.startsWith("\\")
-            || name.contains("..")
+            || containsDirectoryNavigation(name)
             || (name.contains(":") && isWindows());
+    }
+
+    private static boolean containsDirectoryNavigation(String name) {
+        if (!name.contains("..")) {
+            return false;
+        }
+        // We have a .. but if not before a file separator or at the end, it is OK
+        return name.endsWith("\\..")
+            || name.contains("..\\")
+            || name.endsWith("/..")
+            || name.contains("../");
     }
 
     private static boolean isWindows() {

--- a/subprojects/wrapper-shared/src/test/groovy/org/gradle/util/internal/ZipSlipTest.groovy
+++ b/subprojects/wrapper-shared/src/test/groovy/org/gradle/util/internal/ZipSlipTest.groovy
@@ -36,14 +36,18 @@ class ZipSlipTest extends Specification {
         !isUnsafeZipEntryName(safePath)
 
         where:
-        unsafePath | safePath
-        "/"        | "foo/"
-        "\\"       | "foo\\"
-        "/foo"     | "foo"
-        "\\foo"    | "foo"
-        "foo/.."   | "foo/bar"
-        "foo\\.."  | "foo\\bar"
-        "C:/foo"   | "foo"
+        unsafePath     | safePath
+        "/"            | "foo/"
+        "\\"           | "foo\\"
+        "/foo"         | "foo"
+        "\\foo"        | "foo"
+        "foo/.."       | "foo/bar"
+        "foo\\.."      | "foo\\bar"
+        "C:/foo"       | "foo"
+        "../foo"       | "..foo"
+        "..\\foo"      | "..foo"
+        "foo/../bar"   | "foo/..bar"
+        "foo\\..\\bar" | "foo\\..bar"
     }
 
     private static boolean isWindows() {

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -54,7 +54,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         // wrapper needs to be small. Let's check it's smaller than some arbitrary 'small' limit
-        file("gradle/wrapper/gradle-wrapper.jar").length() < 60 * 1024
+        file("gradle/wrapper/gradle-wrapper.jar").length() < 61 * 1024
     }
 
     def "generated wrapper scripts for given version from command-line"() {
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("53018fb29b1af30cb2776fd1ddfede2d1a60bb541d00750cbbb0e40e7c61226b")
+        Hashing.sha256().hashFile(file("first/gradle/wrapper/gradle-wrapper.jar")) == HashCode.fromString("d2d670ead532ad47bf5bacae8aa8d8fb9e6b7c2aa992524931a416f121db1e63")
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash


### PR DESCRIPTION
A .. in a file name is legal, what is not OK is having it with a file path separator after or at the end of the entry name after a file path separator.

Fixes #21465
