### PR TITLE
Remove implicit test worker implementation dependencies for test suite tests

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -28,7 +28,6 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.plugins.JvmTestSuitePlugin;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
-import org.gradle.api.plugins.jvm.internal.DefaultJvmTestSuite;
 import org.gradle.buildinit.InsecureProtocolOption;
 import org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl;
 import org.gradle.internal.Cast;
@@ -1337,19 +1336,17 @@ public class BuildScriptBuilder {
         }
 
         public enum TestSuiteFramework {
-            JUNIT(new MethodInvocationExpression("useJUnit"), DefaultJvmTestSuite.Frameworks.JUNIT4, "JUnit4"),
-            JUNIT_PLATFORM(new MethodInvocationExpression("useJUnitJupiter"), DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER, "JUnit Jupiter"),
-            SPOCK(new MethodInvocationExpression("useSpock"), DefaultJvmTestSuite.Frameworks.SPOCK, "Spock"),
-            KOTLIN_TEST(new MethodInvocationExpression("useKotlinTest"), DefaultJvmTestSuite.Frameworks.KOTLIN_TEST, "Kotlin Test"),
-            TEST_NG(new MethodInvocationExpression("useTestNG"), DefaultJvmTestSuite.Frameworks.TESTNG, "TestNG");
+            JUNIT(new MethodInvocationExpression("useJUnit"), "JUnit4"),
+            JUNIT_PLATFORM(new MethodInvocationExpression("useJUnitJupiter"), "JUnit Jupiter"),
+            SPOCK(new MethodInvocationExpression("useSpock"), "Spock"),
+            KOTLIN_TEST(new MethodInvocationExpression("useKotlinTest"), "Kotlin Test"),
+            TEST_NG(new MethodInvocationExpression("useTestNG"), "TestNG");
 
             final String displayName;
             final MethodInvocationExpression method;
-            final DefaultJvmTestSuite.Frameworks framework;
 
-            TestSuiteFramework(MethodInvocationExpression method, DefaultJvmTestSuite.Frameworks framework, String displayName) {
+            TestSuiteFramework(MethodInvocationExpression method, String displayName) {
                 this.method = method;
-                this.framework = framework;
                 this.displayName = displayName;
             }
 

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
@@ -271,6 +271,8 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
                 break;
             case KOTLINTEST:
                 buildScriptBuilder.testImplementationDependency("Use the Kotlin JUnit 5 integration.", "org.jetbrains.kotlin:kotlin-test-junit5");
+                // TODO: Make this work with JUnit 5.6.0 again, see https://github.com/gradle/gradle/issues/13955
+                buildScriptBuilder.testImplementationDependency("Use the JUnit 5 integration.", "org.junit.jupiter:junit-jupiter-engine:" + libraryVersionProvider.getVersion("junit-jupiter"));
 
                 buildScriptBuilder.taskMethodInvocation(
                         "Use JUnit Platform for unit tests.",

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/JvmProjectInitDescriptor.java
@@ -271,8 +271,6 @@ public abstract class JvmProjectInitDescriptor extends LanguageLibraryProjectIni
                 break;
             case KOTLINTEST:
                 buildScriptBuilder.testImplementationDependency("Use the Kotlin JUnit 5 integration.", "org.jetbrains.kotlin:kotlin-test-junit5");
-                // TODO: Make this work with JUnit 5.6.0 again, see https://github.com/gradle/gradle/issues/13955
-                buildScriptBuilder.testImplementationDependency("Use the JUnit 5 integration.", "org.junit.jupiter:junit-jupiter-engine:" + libraryVersionProvider.getVersion("junit-jupiter"));
 
                 buildScriptBuilder.taskMethodInvocation(
                         "Use JUnit Platform for unit tests.",

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/LanguageLibraryProjectInitDescriptor.java
@@ -56,10 +56,7 @@ public abstract class LanguageLibraryProjectInitDescriptor implements LanguageSp
             case SPOCK:
                 return buildScriptBuilder.testing().spockSuite(name, libraryVersionProvider);
             case KOTLINTEST:
-                BuildScriptBuilder.SuiteSpec kotlinTestSuite = buildScriptBuilder.testing().kotlinTestSuite(name, libraryVersionProvider);
-                // TODO: Make this work with JUnit 5.6.0 again, see https://github.com/gradle/gradle/issues/13955
-                kotlinTestSuite.implementation("Use newer version of JUnit Engine for Kotlin Test", "org.junit.jupiter:junit-jupiter-engine:" + libraryVersionProvider.getVersion("junit-jupiter"));
-                return kotlinTestSuite;
+                return buildScriptBuilder.testing().kotlinTestSuite(name, libraryVersionProvider);
             case TESTNG:
                 return buildScriptBuilder.testing().testNG(name, libraryVersionProvider);
             case SCALATEST:

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/groovy/build.gradle
@@ -70,9 +70,9 @@ tasks.register('checkDependencies') {
     FileCollection functionalTestRuntimeClasspath = configurations.functionalTestRuntimeClasspath
 
     doLast {
-        assert testRuntimeClasspath.size() == 12
+        assert testRuntimeClasspath.size() == 13
         assert testRuntimeClasspath.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
-        assert integrationTestRuntimeClasspath.size() == 12
+        assert integrationTestRuntimeClasspath.size() == 13
         assert integrationTestRuntimeClasspath.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
         assert functionalTestRuntimeClasspath.size() == 3
         assert functionalTestRuntimeClasspath.any { it.name == "junit-4.13.2.jar" }

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-extracted/kotlin/build.gradle.kts
@@ -65,9 +65,9 @@ val checkDependencies by tasks.registering {
 
     dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(testRuntimeClasspath.files.size == 12)
+        assert(testRuntimeClasspath.files.size == 13)
         assert(testRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(integrationTestRuntimeClasspath.files.size == 12)
+        assert(integrationTestRuntimeClasspath.files.size == 13)
         assert(integrationTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
         assert(functionalTestRuntimeClasspath.files.size == 3)
         assert(functionalTestRuntimeClasspath.files.any { it.name == "junit-4.13.2.jar" })

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/groovy/build.gradle
@@ -53,9 +53,9 @@ tasks.register('checkDependencies') {
 
     dependsOn(integrationTestRuntimeClasspath, functionalTestRuntimeClasspath, testRuntimeClasspath)
     doLast {
-        assert testRuntimeClasspath.files.size() == 12
+        assert testRuntimeClasspath.files.size() == 13
         assert testRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
-        assert integrationTestRuntimeClasspath.files.size() == 12
+        assert integrationTestRuntimeClasspath.files.size() == 13
         assert integrationTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
         assert functionalTestRuntimeClasspath.files.size() == 3
         assert functionalTestRuntimeClasspath.files.any { it.name == "junit-4.13.2.jar" }

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each-matching/kotlin/build.gradle.kts
@@ -52,9 +52,9 @@ val checkDependencies by tasks.registering {
 
     dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(testRuntimeClasspath.files.size == 12)
+        assert(testRuntimeClasspath.files.size == 13)
         assert(testRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(integrationTestRuntimeClasspath.files.size == 12)
+        assert(integrationTestRuntimeClasspath.files.size == 13)
         assert(integrationTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
         assert(functionalTestRuntimeClasspath.files.size == 3)
         assert(functionalTestRuntimeClasspath.files.any { it.name == "junit-4.13.2.jar" })

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/groovy/build.gradle
@@ -51,11 +51,11 @@ tasks.register('checkDependencies') {
     def functionalTestRuntimeClasspath = configurations.getByName("functionalTestRuntimeClasspath")
     dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert testRuntimeClasspath.files.size() == 12
+        assert testRuntimeClasspath.files.size() == 13
         assert testRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
-        assert integrationTestRuntimeClasspath.files.size() == 12
+        assert integrationTestRuntimeClasspath.files.size() == 13
         assert integrationTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
-        assert functionalTestRuntimeClasspath.files.size() == 13
+        assert functionalTestRuntimeClasspath.files.size() == 14
         assert functionalTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" }
         assert functionalTestRuntimeClasspath.files.any { it.name == "commons-lang3-3.11.jar" }
     }

--- a/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/testing/test-suite-multi-configure-each/kotlin/build.gradle.kts
@@ -54,11 +54,11 @@ val checkDependencies by tasks.registering {
 
     dependsOn(testRuntimeClasspath, integrationTestRuntimeClasspath, functionalTestRuntimeClasspath)
     doLast {
-        assert(testRuntimeClasspath.files.size == 12)
+        assert(testRuntimeClasspath.files.size == 13)
         assert(testRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(integrationTestRuntimeClasspath.files.size == 12)
+        assert(integrationTestRuntimeClasspath.files.size == 13)
         assert(integrationTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
-        assert(functionalTestRuntimeClasspath.files.size == 13)
+        assert(functionalTestRuntimeClasspath.files.size == 14)
         assert(functionalTestRuntimeClasspath.files.any { it.name == "mockito-junit-jupiter-4.6.1.jar" })
         assert(functionalTestRuntimeClasspath.files.any { it.name == "commons-lang3-3.11.jar" })
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -83,7 +83,7 @@ public interface JvmTestSuite extends TestSuite, Buildable {
      * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Jupiter</a> testing framework.
      *
      * <p>
-     *     Gradle will provide the version of JUnit Jupiter to use. Defaults to version {@code 5.7.2}
+     *     Gradle will provide the version of JUnit Jupiter to use. Defaults to version {@code 5.8.2}
      * </p>
      */
     void useJUnitJupiter();
@@ -107,7 +107,7 @@ public interface JvmTestSuite extends TestSuite, Buildable {
     /**
      * Use the <a href="https://junit.org/junit4/">JUnit4</a> testing framework.
      * <p>
-     *     Gradle will provide the version of JUnit4 to use. Defaults to version {@code 4.13}
+     *     Gradle will provide the version of JUnit4 to use. Defaults to version {@code 4.13.2}
      * </p>
      */
     void useJUnit();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -105,35 +105,6 @@ public interface JvmTestSuite extends TestSuite, Buildable {
     void useJUnitJupiter(Provider<String> version);
 
     /**
-     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework.
-     *
-     * <p>
-     *     Gradle will provide the version of JUnit Platform to use. Defaults to version {@code 1.8.2}
-     * </p>
-     *
-     * @since 8.0
-     */
-    void useJUnitPlatform();
-
-    /**
-     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework with a specific version.
-     *
-     * @param version version of JUnit Platform to use
-     *
-     * @since 8.0
-     */
-    void useJUnitPlatform(String version);
-
-    /**
-     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework with a specific version.
-     *
-     * @param version provider supplying the version of JUnit Platform to use
-     *
-     * @since 8.0
-     */
-    void useJUnitPlatform(Provider<String> version);
-
-    /**
      * Use the <a href="https://junit.org/junit4/">JUnit4</a> testing framework.
      * <p>
      *     Gradle will provide the version of JUnit4 to use. Defaults to version {@code 4.13.2}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -105,6 +105,35 @@ public interface JvmTestSuite extends TestSuite, Buildable {
     void useJUnitJupiter(Provider<String> version);
 
     /**
+     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework.
+     *
+     * <p>
+     *     Gradle will provide the version of JUnit Platform to use. Defaults to version {@code 1.8.2}
+     * </p>
+     *
+     * @since 7.6
+     */
+    void useJUnitPlatform();
+
+    /**
+     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework with a specific version.
+     *
+     * @param version version of JUnit Platform to use
+     *
+     * @since 7.6
+     */
+    void useJUnitPlatform(String version);
+
+    /**
+     * Use the <a href="https://junit.org/junit5/docs/current/user-guide/">JUnit Platform</a> testing framework with a specific version.
+     *
+     * @param version provider supplying the version of JUnit Platform to use
+     *
+     * @since 7.6
+     */
+    void useJUnitPlatform(Provider<String> version);
+
+    /**
      * Use the <a href="https://junit.org/junit4/">JUnit4</a> testing framework.
      * <p>
      *     Gradle will provide the version of JUnit4 to use. Defaults to version {@code 4.13.2}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/JvmTestSuite.java
@@ -111,7 +111,7 @@ public interface JvmTestSuite extends TestSuite, Buildable {
      *     Gradle will provide the version of JUnit Platform to use. Defaults to version {@code 1.8.2}
      * </p>
      *
-     * @since 7.6
+     * @since 8.0
      */
     void useJUnitPlatform();
 
@@ -120,7 +120,7 @@ public interface JvmTestSuite extends TestSuite, Buildable {
      *
      * @param version version of JUnit Platform to use
      *
-     * @since 7.6
+     * @since 8.0
      */
     void useJUnitPlatform(String version);
 
@@ -129,7 +129,7 @@ public interface JvmTestSuite extends TestSuite, Buildable {
      *
      * @param version provider supplying the version of JUnit Platform to use
      *
-     * @since 7.6
+     * @since 8.0
      */
     void useJUnitPlatform(Provider<String> version);
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -16,14 +16,15 @@
 
 package org.gradle.api.plugins.jvm.internal;
 
-import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.Action;
 import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.dsl.DependencyAdder;
+import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyAdder;
+import org.gradle.api.internal.provider.DefaultProvider;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.testing.TestFramework;
@@ -46,73 +47,113 @@ import org.gradle.api.tasks.TaskDependency;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class DefaultJvmTestSuite implements JvmTestSuite {
-    public enum Frameworks {
-        JUNIT4("junit:junit", "4.13.2"),
-        JUNIT_JUPITER("org.junit.jupiter:junit-jupiter", "5.8.2"),
-        SPOCK("org.spockframework:spock-core", "2.1-groovy-3.0"),
-        KOTLIN_TEST("org.jetbrains.kotlin:kotlin-test-junit5", "1.7.10"),
-        TESTNG("org.testng:testng", "7.5"),
-        NONE(null, null);
 
-        @Nullable
-        private final String module;
-        @Nullable
-        private final String defaultVersion;
+    private static class Module {
+        private final String group;
+        private final String name;
+        private final String version;
 
-        Frameworks(@Nullable String module, @Nullable String defaultVersion) {
-            Preconditions.checkArgument(module != null && defaultVersion != null || module == null && defaultVersion == null, "Either module and version must both be null, or neither be null.");
-            this.module = module;
-            this.defaultVersion = defaultVersion;
+        public Module(String group, String name, @Nullable String version) {
+            this.group = group;
+            this.name = name;
+            this.version = version;
         }
 
-        @Nullable
+        public String getDefaultVersionNotation() {
+            return getNotationForVersion(version);
+        }
+
+        public String getNotationForVersion(@Nullable String specified) {
+            return group + ":" + name + (specified != null ?  ":" + specified : "");
+        }
+    }
+
+    // Should be the same as the version listed in the junit-bom corresponding to the default junit-jupiter version.
+    // Only used here for testing, but defined in this class to keep it near the default junit-jupiter version.
+    @VisibleForTesting
+    public static final String JUNIT_PLATFORM_DEFAULT_VERSION = "1.8.2";
+
+    @VisibleForTesting
+    public enum TestingFramework {
+        // When updating these versions, be sure to update the default versions noted in `JvmTestSuite` javadoc
+        JUNIT4("junit", "junit", "4.13.2"),
+        JUNIT_JUPITER("org.junit.jupiter", "junit-jupiter", "5.8.2", Collections.singletonList(
+            // junit-jupiter's BOM, junit-bom, specifies the platform version
+            new Module("org.junit.platform", "junit-platform-launcher", null)
+        )),
+        SPOCK("org.spockframework", "spock-core", "2.1-groovy-3.0"),
+        KOTLIN_TEST("org.jetbrains.kotlin", "kotlin-test-junit5", "1.7.10", Collections.singletonList(
+            // kotlin-test-junit5 depends on junit-jupiter, which in turn specifies the platform version
+            new Module("org.junit.platform", "junit-platform-launcher", null)
+        )),
+        TESTNG("org.testng", "testng", "7.5");
+
+        private final Module module;
+        private final List<Module> dependencies;
+
+        TestingFramework(String group, String name, String defaultVersion) {
+            this(group, name, defaultVersion, Collections.emptyList());
+        }
+
+        TestingFramework(String group, String name, String defaultVersion, List<Module> dependencies) {
+            this.module = new Module(group, name, defaultVersion);
+            this.dependencies = dependencies;
+        }
+
         public String getDefaultVersion() {
-            return defaultVersion;
+            return module.version;
         }
 
-        @Nullable
-        public String getDependency() {
-            return getDependency(getDefaultVersion());
-        }
-
-        @Nullable
-        public String getDependency(String version) {
-            if (null != module) {
-                return module + ":" + version;
-            } else {
-                return null;
+        public List<Dependency> getDependencies(String version, DependencyFactory dependencyFactory) {
+            List<Dependency> deps = new ArrayList<>(1 + dependencies.size());
+            deps.add(dependencyFactory.create(module.getNotationForVersion(version)));
+            for (Module dep : dependencies) {
+                // TODO: Should we separate these between implementation and runtime dependencies?
+                // Do we need junit-platform-launcher on the compile classpath or only during runtime?
+                deps.add(dependencyFactory.create(dep.getDefaultVersionNotation()));
             }
+            return deps;
         }
     }
 
     private static class VersionedTestingFramework {
-        private final Frameworks type;
+        private final TestingFramework framework;
         private final String version;
 
-        private VersionedTestingFramework(Frameworks type, String version) {
-            Preconditions.checkNotNull(version);
-            this.type = type;
+        private VersionedTestingFramework(TestingFramework framework, String version) {
+            this.framework = framework;
             this.version = version;
         }
+
+        public TestingFramework getFramework() {
+            return framework;
+        }
+
+        public List<Dependency> getDependencies(DependencyFactory dependencyFactory) {
+            return framework.getDependencies(version, dependencyFactory);
+        }
     }
-    private final static VersionedTestingFramework NO_OPINION = new VersionedTestingFramework(Frameworks.NONE, "unset");
 
     private final ExtensiblePolymorphicDomainObjectContainer<JvmTestSuiteTarget> targets;
     private final SourceSet sourceSet;
     private final String name;
+    private final DependencyFactory dependencyFactory;
     private final JvmComponentDependencies dependencies;
-    private boolean attachedDependencies;
-    private final Action<Void> attachDependencyAction;
+    private boolean attachedDependencies = false;
 
     protected abstract Property<VersionedTestingFramework> getVersionedTestingFramework();
 
     @Inject
     public DefaultJvmTestSuite(String name, DependencyFactory dependencyFactory, ConfigurationContainer configurations, SourceSetContainer sourceSets) {
         this.name = name;
+        this.dependencyFactory = dependencyFactory;
         this.sourceSet = sourceSets.create(getName());
 
         Configuration compileOnly = configurations.getByName(sourceSet.getCompileOnlyConfigurationName());
@@ -131,20 +172,13 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
             getObjectFactory().newInstance(DefaultDependencyAdder.class, annotationProcessor)
         );
 
-        this.attachedDependencies = false;
-        // This complexity is to keep the built-in test suite from automatically adding dependencies
-        // unless a user explicitly calls one of the useXXX methods
-        // Eventually, we should deprecate this behavior and provide a way for users to opt out
-        // We could then always add these dependencies.
-        this.attachDependencyAction = x -> attachDependenciesForTestFramework(dependencyFactory, dependencies.getImplementation());
-
         if (!name.equals(JvmTestSuitePlugin.DEFAULT_TEST_SUITE_NAME)) {
             useJUnitJupiter();
         } else {
             // for the built-in test suite, we don't express an opinion, so we will not add any dependencies
             // if a user explicitly calls useJUnit or useJUnitJupiter, the built-in test suite will behave like a custom one
             // and add dependencies automatically.
-            getVersionedTestingFramework().convention(NO_OPINION);
+            getVersionedTestingFramework().convention((VersionedTestingFramework) null);
         }
 
         addDefaultTestTarget();
@@ -152,43 +186,54 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
         // Until the values here can be finalized upon the user setting them (see the org.gradle.api.tasks.testing.Test#testFramework(Closure) method),
         // in Gradle 8, we will be executing the provider lambda used as the convention multiple times.  So make sure, within a Test Suite, that we
         // always return the same one via computeIfAbsent() against this map.
-        final Map<Frameworks, TestFramework> frameworkLookup = new HashMap<>(3);
+        final Map<TestingFramework, TestFramework> frameworkLookup = new HashMap<>(4);
 
         this.targets.withType(JvmTestSuiteTarget.class).configureEach(target -> {
             target.getTestTask().configure(task -> {
                 task.getTestFrameworkProperty().convention(getVersionedTestingFramework().map(vtf -> {
-                    switch(vtf.type) {
-                        case NONE: // fall-through
+                    switch(vtf.getFramework()) {
                         case JUNIT4:
-                            return frameworkLookup.computeIfAbsent(vtf.type, f -> new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter()));
+                            return frameworkLookup.computeIfAbsent(vtf.getFramework(), f -> new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), false));
                         case KOTLIN_TEST: // fall-through
                         case JUNIT_JUPITER: // fall-through
                         case SPOCK:
-                            return frameworkLookup.computeIfAbsent(vtf.type, f -> new JUnitPlatformTestFramework((DefaultTestFilter) task.getFilter()));
+                            return frameworkLookup.computeIfAbsent(vtf.getFramework(), f -> new JUnitPlatformTestFramework((DefaultTestFilter) task.getFilter(), false));
                         case TESTNG:
-                            return frameworkLookup.computeIfAbsent(vtf.type, f -> new TestNGTestFramework(task, task.getClasspath(), (DefaultTestFilter) task.getFilter(), getObjectFactory()));
+                            return frameworkLookup.computeIfAbsent(vtf.getFramework(), f -> new TestNGTestFramework(task, task.getClasspath(), (DefaultTestFilter) task.getFilter(), getObjectFactory()));
                         default:
                             throw new IllegalStateException("do not know how to handle " + vtf);
                     }
-                }));
+                    // In order to maintain compatibility for the default test suite, we need to load JUnit4 from the Gradle distribution
+                    // instead of including it in testImplementation.
+                    // TODO: In 8.0 should we switch getVersionedTestingFramework() to use JUNIT4 as a convention?
+                }).orElse(new DefaultProvider<>(() -> frameworkLookup.computeIfAbsent(null, f -> new JUnitTestFramework(task, (DefaultTestFilter) task.getFilter(), true)))));
             });
         });
     }
 
-    private void attachDependenciesForTestFramework(DependencyFactory dependencyFactory, DependencyAdder implementation) {
+    private void setFrameworkTo(TestingFramework framework, Provider<String> version) {
+        getVersionedTestingFramework().set(version.map(v -> new VersionedTestingFramework(framework, v)));
+
+        // This whole way of adding the implementation dependencies here is messed up. Once a user calls the useXXX method,
+        // they can't go back. Maybe that's no so terrible, except that we call useJunitJupiter() FOR ALL USER DEFINED TEST SUITES.
+        // This is a real problem. Users who want to use anything but JUnit Jupiter will always have the JUnit Jupiter
+        // on their classpath and will have to manually declare the implementation dependencies for the test framework
+        // they want to use.
+
+        // There is a nice-seeming solution: We could move the line below, `.getImplementation.bundle(...)`, into the constructor.
+        // This could seemingly work, except for if the configuration's dependencies ever get resolved early, before the user is
+        // able to call their useXXX method. If that happens, the provider gets resolved early, and the dependencies defined at
+        // that point are added to the configuration. Then, after the user calls their useXXX method, the provider is updated
+        // but the configuration never is. This is a problem with how we declare dependencies on configurations. We should be
+        // able to restrict users from resolving the configuration dependencies early OR make these dependencies even more lazy
+        // so that if dependencies are resolved early, the future changes in the lazy properties are still propagated to later resolutions.
+
+        // A concrete example of this occurs when using the Kotlin Gradle Plugin. See the function `configureKotlinTestDependency` added
+        // at the below linked commit. This resolves the dependencies before configuration-time is over, and would break an implementation
+        // where the below line is instead located in the constructor.
+        // See: https://github.com/JetBrains/kotlin/commit/4a172286217a1a7d4e7a7f0eb6a0bc53ebf56515
         if (!attachedDependencies) {
-            implementation.add(getVersionedTestingFramework().map(framework -> {
-                switch (framework.type) {
-                    case JUNIT4: // fall-through
-                    case JUNIT_JUPITER: // fall-through
-                    case SPOCK: // fall-through
-                    case TESTNG: // fall-through
-                    case KOTLIN_TEST:
-                        return dependencyFactory.create(framework.type.getDependency(framework.version));
-                    default:
-                        throw new IllegalStateException("do not know how to handle " + framework);
-                }
-            }));
+            this.dependencies.getImplementation().bundle(getVersionedTestingFramework().map(vtf -> vtf.getDependencies(dependencyFactory)));
             attachedDependencies = true;
         }
     }
@@ -228,7 +273,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useJUnit() {
-        useJUnit(Frameworks.JUNIT4.defaultVersion);
+        useJUnit(TestingFramework.JUNIT4.getDefaultVersion());
     }
 
     @Override
@@ -238,12 +283,12 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useJUnit(Provider<String> version) {
-        setFrameworkTo(Frameworks.JUNIT4, version);
+        setFrameworkTo(TestingFramework.JUNIT4, version);
     }
 
     @Override
     public void useJUnitJupiter() {
-        useJUnitJupiter(Frameworks.JUNIT_JUPITER.defaultVersion);
+        useJUnitJupiter(TestingFramework.JUNIT_JUPITER.getDefaultVersion());
     }
 
     @Override
@@ -253,12 +298,12 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useJUnitJupiter(Provider<String> version) {
-        setFrameworkTo(Frameworks.JUNIT_JUPITER, version);
+        setFrameworkTo(TestingFramework.JUNIT_JUPITER, version);
     }
 
     @Override
     public void useSpock() {
-        useSpock(Frameworks.SPOCK.defaultVersion);
+        useSpock(TestingFramework.SPOCK.getDefaultVersion());
     }
 
     @Override
@@ -268,12 +313,12 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useSpock(Provider<String> version) {
-        setFrameworkTo(Frameworks.SPOCK, version);
+        setFrameworkTo(TestingFramework.SPOCK, version);
     }
 
     @Override
     public void useKotlinTest() {
-        useKotlinTest(Frameworks.KOTLIN_TEST.defaultVersion);
+        useKotlinTest(TestingFramework.KOTLIN_TEST.getDefaultVersion());
     }
 
     @Override
@@ -283,12 +328,12 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useKotlinTest(Provider<String> version) {
-        setFrameworkTo(Frameworks.KOTLIN_TEST, version);
+        setFrameworkTo(TestingFramework.KOTLIN_TEST, version);
     }
 
     @Override
     public void useTestNG() {
-        useTestNG(Frameworks.TESTNG.defaultVersion);
+        useTestNG(TestingFramework.TESTNG.getDefaultVersion());
     }
 
     @Override
@@ -298,12 +343,7 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
 
     @Override
     public void useTestNG(Provider<String> version) {
-        setFrameworkTo(Frameworks.TESTNG, version);
-    }
-
-    private void setFrameworkTo(Frameworks framework, Provider<String> versionProvider) {
-        getVersionedTestingFramework().set(versionProvider.map(v -> new VersionedTestingFramework(framework, v)));
-        attachDependencyAction.execute(null);
+        setFrameworkTo(TestingFramework.TESTNG, version);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -207,18 +207,18 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
         getVersionedTestingFramework().set(version.map(v -> new VersionedTestingFramework(framework, v)));
 
         // This whole way of adding the dependencies here is messed up. Once a user calls the useXXX method, they can't
-        // go back. Maybe that's no so terrible, except that we call useJunitJupiter() FOR ALL USER DEFINED TEST SUITES.
-        // This is a real problem. Users who want to use anything but JUnit Jupiter will always have the JUnit Jupiter
-        // on their classpath and will have to manually declare the implementation dependencies for the test framework
+        // go back. This is fine except for that we call useJunitJupiter() FOR ALL USER DEFINED TEST SUITES.
+        // This is a real problem. Users who want to use anything but JUnit Jupiter will always have JUnit Jupiter on
+        // their classpath and will have to manually declare the implementation dependencies for the test framework
         // they want to use.
 
-        // There is a nice-seeming solution: We could move the lines below, `this.dependencies.getX().bundle(...)`,
-        // into the constructor. This could seemingly work, except for if the configuration's dependencies ever get
-        // realized early, before the user is able to call their useXXX method (Note: here we're talking about the
-        // configuration's dependencies, not the configuration itself). If that happens, the provider gets resolved
-        // early by the backing DomainObjectCollection and the result is cached
-        // (see `AbstractIterationOrderRetainingElementSource`). Then, after the user calls their useXXX method, the
-        // provider is updated but is never queried again.
+        // Consider this solution: We move the dependency provider declarations below, into the constructor. This works
+        // except for if the configurations' dependencies get realized early, before a useXXX method is called.
+        // Note, we're talking about the realizing a configuration's dependencies, not resolving its dependency graph.
+        // If a DependencySet is realized, its provider dependencies get resolved early by the backing
+        // DomainObjectCollection and the result is cached (see `AbstractIterationOrderRetainingElementSource`). Future
+        // calls to any useXXX would then be ignored since the collection would use the cached result instead of querying
+        // the provider.
 
         // There are two different solutions here: 1) Restrict users from realizing configuration dependencies early
         // OR 2) ensure that the DefaultDependencySet is aware of the changing nature of the dependency bundle

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/jvm/internal/DefaultJvmTestSuite.java
@@ -291,21 +291,6 @@ public abstract class DefaultJvmTestSuite implements JvmTestSuite {
     }
 
     @Override
-    public void useJUnitPlatform() {
-        useJUnitPlatform(TestingFramework.JUNIT_PLATFORM.getDefaultVersion());
-    }
-
-    @Override
-    public void useJUnitPlatform(String version) {
-        useJUnitPlatform(getProviderFactory().provider(() -> version));
-    }
-
-    @Override
-    public void useJUnitPlatform(Provider<String> version) {
-        setFrameworkTo(TestingFramework.JUNIT_PLATFORM, version);
-    }
-
-    @Override
     public void useJUnitJupiter() {
         useJUnitJupiter(TestingFramework.JUNIT_JUPITER.getDefaultVersion());
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -46,6 +46,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     private final JavaForkOptions options;
     private final Iterable<File> classPath;
     private final Iterable<File> modulePath;
+    private final List<String> testWorkerImplementationClasses;
     private final List<String> testWorkerImplementationModules;
     private final Action<WorkerProcessBuilder> buildConfigAction;
     private final ModuleRegistry moduleRegistry;
@@ -60,7 +61,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
 
     public ForkingTestClassProcessor(
         WorkerThreadRegistry workerThreadRegistry, WorkerProcessFactory workerFactory, WorkerTestClassProcessorFactory processorFactory, JavaForkOptions options,
-        Iterable<File> classPath, Iterable<File> modulePath, List<String> testWorkerImplementationModules,
+        Iterable<File> classPath, Iterable<File> modulePath, List<String> testWorkerImplementationClasses, List<String> testWorkerImplementationModules,
         Action<WorkerProcessBuilder> buildConfigAction, ModuleRegistry moduleRegistry, DocumentationRegistry documentationRegistry
     ) {
         this.workerThreadRegistry = workerThreadRegistry;
@@ -69,6 +70,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
         this.options = options;
         this.classPath = classPath;
         this.modulePath = modulePath;
+        this.testWorkerImplementationClasses = testWorkerImplementationClasses;
         this.testWorkerImplementationModules = testWorkerImplementationModules;
         this.buildConfigAction = buildConfigAction;
         this.moduleRegistry = moduleRegistry;
@@ -129,6 +131,11 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
     }
 
     List<URL> getTestWorkerImplementationClasspath() {
+        List<URL> workerImplementationClasses = new ArrayList<URL>();
+        for (String moduleName : testWorkerImplementationClasses) {
+            workerImplementationClasses.addAll(moduleRegistry.getExternalModule(moduleName).getImplementationClasspath().getAsURLs());
+        }
+
         return CollectionUtils.flattenCollections(URL.class,
             moduleRegistry.getModule("gradle-core-api").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getModule("gradle-worker-processes").getImplementationClasspath().getAsURLs(),
@@ -154,8 +161,8 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
             moduleRegistry.getExternalModule("native-platform").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("kryo").getImplementationClasspath().getAsURLs(),
             moduleRegistry.getExternalModule("commons-lang").getImplementationClasspath().getAsURLs(),
-            moduleRegistry.getExternalModule("junit").getImplementationClasspath().getAsURLs(),
-            moduleRegistry.getExternalModule("javax.inject").getImplementationClasspath().getAsURLs()
+            moduleRegistry.getExternalModule("javax.inject").getImplementationClasspath().getAsURLs(),
+            workerImplementationClasses
         );
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -89,7 +89,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert test.testFramework instanceof ${JUnitTestFramework.canonicalName}
                     assert configurations.testRuntimeClasspath.files.size() == 2
-                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-${DefaultJvmTestSuite.Frameworks.JUNIT4.getDefaultVersion()}.jar" }
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-${DefaultJvmTestSuite.TestingFramework.JUNIT4.getDefaultVersion()}.jar" }
                 }
             }
         """
@@ -177,8 +177,9 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn test
                 doLast {
                     assert test.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
-                    assert configurations.testRuntimeClasspath.files.size() == 7
-                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER.getDefaultVersion()}.jar" }
+                    assert configurations.testRuntimeClasspath.files.size() == 8
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
         """
@@ -206,7 +207,8 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn test
                 doLast {
                     assert test.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
-                    assert configurations.testRuntimeClasspath.files.size() == 8
+                    assert configurations.testRuntimeClasspath.files.size() == 9
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-platform-launcher-1.7.2.jar" }
                     assert configurations.testRuntimeClasspath.files.any { it.name == "junit-jupiter-5.7.2.jar" }
                 }
             }
@@ -237,7 +239,8 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn test
                 doLast {
                     assert test.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
-                    assert configurations.testRuntimeClasspath.files.size() == 8
+                    assert configurations.testRuntimeClasspath.files.size() == 9
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-platform-launcher-1.7.2.jar" }
                     assert configurations.testRuntimeClasspath.files.any { it.name == "junit-jupiter-5.7.2.jar" }
                 }
             }
@@ -264,8 +267,9 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn integTest
                 doLast {
                     assert integTest.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
-                    assert configurations.integTestRuntimeClasspath.files.size() == 7
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER.getDefaultVersion()}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.size() == 8
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
         """
@@ -302,15 +306,15 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
 
         where: // When testing a custom version, this should be a different version that the default
         testingFrameworkDeclaration  | testingFrameworkType       | testingFrameworkDep
-        'useJUnit()'                 | JUnitTestFramework         | "junit-${DefaultJvmTestSuite.Frameworks.JUNIT4.getDefaultVersion()}.jar"
+        'useJUnit()'                 | JUnitTestFramework         | "junit-${DefaultJvmTestSuite.TestingFramework.JUNIT4.getDefaultVersion()}.jar"
         'useJUnit("4.12")'           | JUnitTestFramework         | "junit-4.12.jar"
-        'useJUnitJupiter()'          | JUnitPlatformTestFramework | "junit-jupiter-${DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER.getDefaultVersion()}.jar"
+        'useJUnitJupiter()'          | JUnitPlatformTestFramework | "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar"
         'useJUnitJupiter("5.7.1")'   | JUnitPlatformTestFramework | "junit-jupiter-5.7.1.jar"
-        'useSpock()'                 | JUnitPlatformTestFramework | "spock-core-${DefaultJvmTestSuite.Frameworks.SPOCK.getDefaultVersion()}.jar"
+        'useSpock()'                 | JUnitPlatformTestFramework | "spock-core-${DefaultJvmTestSuite.TestingFramework.SPOCK.getDefaultVersion()}.jar"
         'useSpock("2.1-groovy-3.0")' | JUnitPlatformTestFramework | "spock-core-2.1-groovy-3.0.jar" // Not possible to test a different version from the default yet, since this is the first groovy 3.0 targeted release
-        'useKotlinTest()'            | JUnitPlatformTestFramework | "kotlin-test-junit5-${DefaultJvmTestSuite.Frameworks.KOTLIN_TEST.getDefaultVersion()}.jar"
+        'useKotlinTest()'            | JUnitPlatformTestFramework | "kotlin-test-junit5-${DefaultJvmTestSuite.TestingFramework.KOTLIN_TEST.getDefaultVersion()}.jar"
         'useKotlinTest("1.5.30")'    | JUnitPlatformTestFramework | "kotlin-test-junit5-1.5.30.jar"
-        'useTestNG()'                | TestNGTestFramework        | "testng-${DefaultJvmTestSuite.Frameworks.TESTNG.getDefaultVersion()}.jar"
+        'useTestNG()'                | TestNGTestFramework        | "testng-${DefaultJvmTestSuite.TestingFramework.TESTNG.getDefaultVersion()}.jar"
         'useTestNG("7.3.0")'         | TestNGTestFramework        | "testng-7.3.0.jar"
     }
 
@@ -373,8 +377,9 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 dependsOn integTest
                 doLast {
                     assert integTest.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
-                    assert configurations.integTestRuntimeClasspath.files.size() == 7
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER.getDefaultVersion()}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.size() == 8
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
             task checkConfigurationIsJUnit {
@@ -432,8 +437,9 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                     assert integTest.testFramework instanceof ${JUnitTestFramework.canonicalName}
 
                     // but test suite still adds JUnit Jupiter
-                    assert configurations.integTestRuntimeClasspath.files.size() == 7
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.Frameworks.JUNIT_JUPITER.getDefaultVersion()}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.size() == 8
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
         """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/TestSuitesIntegrationTest.groovy
@@ -178,7 +178,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert test.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
                     assert configurations.testRuntimeClasspath.files.size() == 8
-                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.testRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.TestingFramework.JUNIT_PLATFORM.getDefaultVersion()}.jar" }
                     assert configurations.testRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
@@ -268,7 +268,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert integTest.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
                     assert configurations.integTestRuntimeClasspath.files.size() == 8
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.TestingFramework.JUNIT_PLATFORM.getDefaultVersion()}.jar" }
                     assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
@@ -378,7 +378,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
                 doLast {
                     assert integTest.testFramework instanceof ${JUnitPlatformTestFramework.canonicalName}
                     assert configurations.integTestRuntimeClasspath.files.size() == 8
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.TestingFramework.JUNIT_PLATFORM.getDefaultVersion()}.jar" }
                     assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }
@@ -438,7 +438,7 @@ class TestSuitesIntegrationTest extends AbstractIntegrationSpec {
 
                     // but test suite still adds JUnit Jupiter
                     assert configurations.integTestRuntimeClasspath.files.size() == 8
-                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.JUNIT_PLATFORM_DEFAULT_VERSION}.jar" }
+                    assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-platform-launcher-${DefaultJvmTestSuite.TestingFramework.JUNIT_PLATFORM.getDefaultVersion()}.jar" }
                     assert configurations.integTestRuntimeClasspath.files.any { it.name == "junit-jupiter-${DefaultJvmTestSuite.TestingFramework.JUNIT_JUPITER.getDefaultVersion()}.jar" }
                 }
             }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testsuites/dependencies/TestSuitesKotlinDSLDependenciesIntegrationTest.groovy
@@ -848,7 +848,9 @@ class TestSuitesKotlinDSLDependenciesIntegrationTest extends AbstractIntegration
                 // Due to the named-args method being invoked, we are actually requesting a single dependency
                 val ${suiteName}Implementation = configurations.getByName("${suiteName}Implementation")
                 // We might get junit included too, dependending on the test suite, so filter it
-                val deps = ${suiteName}Implementation.dependencies.filter { it.name != "junit-jupiter" }
+                val deps = ${suiteName}Implementation.dependencies
+                            .filter { it.name != "junit-jupiter" }
+                            .filter { it.name != "junit-platform-launcher" }
                             .map { listOf(it.group, it.name, it.version ?: "null") }
                 doLast {
                     assert(deps.size == 1) { "expected 1 dependency, found " + (deps.size) + " dependencies" }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/TestFramework.java
@@ -57,8 +57,34 @@ public interface TestFramework extends Closeable {
     Action<WorkerProcessBuilder> getWorkerConfigurationAction();
 
     /**
-     * Returns a list of modules the test worker requires on the --module-path if it runs as a module.
+     * Returns a list of jars the test worker requires on the classpath.
+     * These dependencies are loaded from the Gradle distribution.
+     *
+     * @see #getUseImplementationDependencies()
+     */
+    @Internal
+    List<String> getTestWorkerImplementationClasses();
+
+    /**
+     * Returns a list of modules the test worker requires on the modulepath if it runs as a module.
+     * These dependencies are loaded from the Gradle distribution.
+     *
+     * @see #getUseImplementationDependencies()
      */
     @Internal
     List<String> getTestWorkerImplementationModules();
+
+    /**
+     * Whether the legacy behavior of loading test framework dependencies from the Gradle distribution
+     * is enabled. If true, jars and modules as specified by {@link #getTestWorkerImplementationClasses()}
+     * and {@link #getTestWorkerImplementationModules()} respectively are loaded from the Gradle distribution
+     * and placed on the test worker classpath and/or modulepath.
+     * <p>
+     * This functionality is legacy and will eventually be deprecated and removed. Test framework dependencies
+     * should be managed externally from the Gradle distribution, as is done by test suites.
+     *
+     * @return Whether test framework implementation dependencies should be loaded from the Gradle distribution.
+     */
+    @Internal
+    boolean getUseImplementationDependencies();
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AllExceptIgnoredTestRunnerBuilder.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AllExceptIgnoredTestRunnerBuilder.java
@@ -22,6 +22,7 @@ import org.junit.internal.builders.IgnoredBuilder;
 import org.junit.internal.builders.JUnit4Builder;
 import org.junit.runner.Runner;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.RunnerBuilder;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
@@ -42,6 +43,13 @@ public class AllExceptIgnoredTestRunnerBuilder extends AllDefaultPossibilitiesBu
         return new FallbackJUnit4Builder();
     }
 
+    /**
+     * Handles a weird case when there are duplicate JUint 4 jars on the classpath with differing
+     * versions. Specifically, when one version is below 4.4 and one is above. This case can occur
+     * when a user declares a JUnit dependency on the test classpath while Gradle also loads
+     * JUnit as a test framework implementation dependency. Note that JUnit4Builder extends
+     * {@link RunnerBuilder}, a class which was introduced in 4.5.
+     */
     private static class FallbackJUnit4Builder extends JUnit4Builder {
         @Override
         public Runner runnerForClass(Class<?> testClass) throws Throwable {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
@@ -17,26 +17,75 @@
 package org.gradle.api.internal.tasks.testing.junit;
 
 import org.gradle.api.internal.tasks.testing.TestSuiteExecutionException;
+import org.junit.internal.runners.InitializationError;
+import org.junit.internal.runners.JUnit38ClassRunner;
+import org.junit.internal.runners.JUnit4ClassRunner;
 import org.junit.runner.Description;
 import org.junit.runner.Request;
+import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
+import org.junit.runners.AllTests;
 
 import java.util.List;
 
 public class IgnoredTestDescriptorProvider {
     List<Description> getAllDescriptions(Description description, String className) {
-        final AllExceptIgnoredTestRunnerBuilder allExceptIgnoredTestRunnerBuilder = new AllExceptIgnoredTestRunnerBuilder();
         try {
             final Class<?> testClass = description.getClass().getClassLoader().loadClass(className);
-            Runner runner = allExceptIgnoredTestRunnerBuilder.runnerForClass(testClass);
-            if (runner == null) {
-                //fall back to default runner
-                runner = Request.aClass(testClass).getRunner();
-            }
+            Runner runner = getRunner(testClass);
             final Description runnerDescription = runner.getDescription();
             return runnerDescription.getChildren();
         } catch (Throwable throwable) {
             throw new TestSuiteExecutionException(String.format("Unable to process Ignored class %s.", className), throwable);
         }
+    }
+
+    Runner getRunner(Class<?> testClass) throws Throwable {
+        try {
+            final AllExceptIgnoredTestRunnerBuilder allExceptIgnoredTestRunnerBuilder = new AllExceptIgnoredTestRunnerBuilder();
+            Runner runner = allExceptIgnoredTestRunnerBuilder.runnerForClass(testClass);
+            if (runner == null) {
+                // Fall back to default runner
+                runner = Request.aClass(testClass).getRunner();
+            }
+            return runner;
+        } catch (NoClassDefFoundError e) {
+            return getRunnerLegacy(testClass);
+        }
+    }
+
+    /**
+     * Prior to JUnit 4.5, the {@code RunnerBuilder} class did not exist, and so we cannot use the {@link AllExceptIgnoredTestRunnerBuilder}.
+     * Therefore, we manually construct the runner ourselves the same way it was done in 4.4.
+     *
+     * @see <a href="https://github.com/junit-team/junit4/commit/67e3edf20613b1278f4be05353b31b5129e21882">The relevant commit</a>
+     */
+    Runner getRunnerLegacy(Class<?> testClass) throws Throwable {
+        RunWith annotation = testClass.getAnnotation(RunWith.class);
+        if (annotation != null) {
+            Class<? extends Runner> runnerClass = annotation.value();
+            try {
+                return runnerClass.getConstructor(Class.class).newInstance(testClass);
+            } catch (NoSuchMethodException e) {
+                String simpleName = runnerClass.getSimpleName();
+                throw new InitializationError("Custom runner class " + simpleName +
+                    " should have a public constructor with signature " + simpleName + "(Class testClass)");
+            }
+        } else if (hasSuiteMethod(testClass)) {
+            return new AllTests(testClass);
+        } else if (junit.framework.TestCase.class.isAssignableFrom(testClass)) {
+            return new JUnit38ClassRunner(testClass);
+        } else {
+            return new JUnit4ClassRunner(testClass);
+        }
+    }
+
+    public boolean hasSuiteMethod(Class<?> testClass) {
+        try {
+            testClass.getMethod("suite");
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+        return true;
     }
 }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.internal.tasks.testing.TestSuiteExecutionException;
 import org.junit.internal.runners.InitializationError;
 import org.junit.internal.runners.JUnit38ClassRunner;
@@ -29,7 +30,7 @@ import org.junit.runners.AllTests;
 import java.util.List;
 
 public class IgnoredTestDescriptorProvider {
-    List<Description> getAllDescriptions(Description description, String className) {
+    public static List<Description> getAllDescriptions(Description description, String className) {
         try {
             final Class<?> testClass = description.getClass().getClassLoader().loadClass(className);
             Runner runner = getRunner(testClass);
@@ -40,7 +41,7 @@ public class IgnoredTestDescriptorProvider {
         }
     }
 
-    Runner getRunner(Class<?> testClass) throws Throwable {
+    private static Runner getRunner(Class<?> testClass) throws Throwable {
         try {
             final AllExceptIgnoredTestRunnerBuilder allExceptIgnoredTestRunnerBuilder = new AllExceptIgnoredTestRunnerBuilder();
             Runner runner = allExceptIgnoredTestRunnerBuilder.runnerForClass(testClass);
@@ -60,7 +61,9 @@ public class IgnoredTestDescriptorProvider {
      *
      * @see <a href="https://github.com/junit-team/junit4/commit/67e3edf20613b1278f4be05353b31b5129e21882">The relevant commit</a>
      */
-    Runner getRunnerLegacy(Class<?> testClass) throws Throwable {
+    @VisibleForTesting
+    @SuppressWarnings("deprecation")
+    static Runner getRunnerLegacy(Class<?> testClass) throws Throwable {
         RunWith annotation = testClass.getAnnotation(RunWith.class);
         if (annotation != null) {
             Class<? extends Runner> runnerClass = annotation.value();
@@ -80,7 +83,7 @@ public class IgnoredTestDescriptorProvider {
         }
     }
 
-    public boolean hasSuiteMethod(Class<?> testClass) {
+    private static boolean hasSuiteMethod(Class<?> testClass) {
         try {
             testClass.getMethod("suite");
         } catch (NoSuchMethodException e) {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestEventAdapter.java
@@ -135,9 +135,8 @@ public class JUnitTestEventAdapter extends RunListener {
     }
 
     private void processIgnoredClass(Description description) throws Exception {
-        IgnoredTestDescriptorProvider provider = new IgnoredTestDescriptorProvider();
         String className = className(description);
-        for (Description childDescription : provider.getAllDescriptions(description, className)) {
+        for (Description childDescription : IgnoredTestDescriptorProvider.getAllDescriptions(description, className)) {
             testIgnored(childDescription);
         }
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -41,9 +41,11 @@ public class JUnitTestFramework implements TestFramework {
     private JUnitOptions options;
     private JUnitDetector detector;
     private final DefaultTestFilter filter;
+    private final boolean useImplementationDependencies;
 
-    public JUnitTestFramework(Test testTask, DefaultTestFilter filter) {
+    public JUnitTestFramework(Test testTask, DefaultTestFilter filter, boolean useImplementationDependencies) {
         this.filter = filter;
+        this.useImplementationDependencies = useImplementationDependencies;
         options = new JUnitOptions();
         detector = new JUnitDetector(new ClassFileExtractionManager(testTask.getTemporaryDirFactory()));
     }
@@ -69,8 +71,18 @@ public class JUnitTestFramework implements TestFramework {
     }
 
     @Override
+    public List<String> getTestWorkerImplementationClasses() {
+        return Collections.singletonList("junit");
+    }
+
+    @Override
     public List<String> getTestWorkerImplementationModules() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public boolean getUseImplementationDependencies() {
+        return useImplementationDependencies;
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -38,15 +38,27 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.List;
 
 @UsedByScanPlugin("test-retry")
 public class JUnitPlatformTestFramework implements TestFramework {
     private final JUnitPlatformOptions options;
     private final DefaultTestFilter filter;
+    private final boolean useImplementationDependencies;
 
+    // Used by org.gradle.test-retry plugin.
+    // TODO: Update plugin to pass in correct value for useImplementationDependencies when copying the framework
+    // Or better yet, make it so the plugin doesn't need to access internal APIs.
+    @Deprecated
+    @SuppressWarnings("unused")
     public JUnitPlatformTestFramework(DefaultTestFilter filter) {
+        this(filter, true);
+    }
+
+    public JUnitPlatformTestFramework(DefaultTestFilter filter, boolean useImplementationDependencies) {
         this.filter = filter;
+        this.useImplementationDependencies = useImplementationDependencies;
         this.options = new JUnitPlatformOptions();
     }
 
@@ -71,8 +83,18 @@ public class JUnitPlatformTestFramework implements TestFramework {
     }
 
     @Override
+    public List<String> getTestWorkerImplementationClasses() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<String> getTestWorkerImplementationModules() {
         return ImmutableList.of("junit-platform-engine", "junit-platform-launcher", "junit-platform-commons");
+    }
+
+    @Override
+    public boolean getUseImplementationDependencies() {
+        return useImplementationDependencies;
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -132,7 +132,7 @@ public class TestNGTestFramework implements TestFramework {
     }
 
     /**
-     * Use reflection to load {@link org.testng.xml.XmlSuite.FailurePolicy}, added in TestNG 6.9.12
+     * Use reflection to load {@code org.testng.xml.XmlSuite.FailurePolicy}, added in TestNG 6.9.12
      * @return reference to class, if exists.
      * @throws ClassNotFoundException if using older TestNG version.
      */
@@ -167,8 +167,21 @@ public class TestNGTestFramework implements TestFramework {
     }
 
     @Override
+    public List<String> getTestWorkerImplementationClasses() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<String> getTestWorkerImplementationModules() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public boolean getUseImplementationDependencies() {
+        // We have no (default) implementation dependencies (see above).
+        // The user must add their TestNG dependency to the test's runtimeClasspath themselves
+        // or preferably use test suites where the dependencies are automatically managed.
+        return false;
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -197,7 +197,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
         forkOptions.setExecutable(null);
         modularity = getObjectFactory().newInstance(DefaultModularitySpec.class);
         javaLauncher = getObjectFactory().property(JavaLauncher.class);
-        testFramework = getObjectFactory().property(TestFramework.class).convention(new JUnitTestFramework(this, (DefaultTestFilter) getFilter()));
+        testFramework = getObjectFactory().property(TestFramework.class).convention(new JUnitTestFramework(this, (DefaultTestFilter) getFilter(), true));
     }
 
     @Inject
@@ -1040,7 +1040,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @since 3.5
      */
     public void useJUnit(Action<? super JUnitOptions> testFrameworkConfigure) {
-        useTestFramework(new JUnitTestFramework(this, (DefaultTestFilter) getFilter()), testFrameworkConfigure);
+        useTestFramework(new JUnitTestFramework(this, (DefaultTestFilter) getFilter(), true), testFrameworkConfigure);
     }
 
     /**
@@ -1072,7 +1072,7 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
      * @since 4.6
      */
     public void useJUnitPlatform(Action<? super JUnitPlatformOptions> testFrameworkConfigure) {
-        useTestFramework(new JUnitPlatformTestFramework((DefaultTestFilter) getFilter()), testFrameworkConfigure);
+        useTestFramework(new JUnitPlatformTestFramework((DefaultTestFilter) getFilter(), true), testFrameworkConfigure);
     }
 
     /**

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProviderTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/IgnoredTestDescriptorProviderTest.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing.junit
+
+import junit.framework.TestCase
+import junit.framework.TestSuite
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.internal.runners.InitializationError
+import org.junit.internal.runners.JUnit38ClassRunner
+import org.junit.internal.runners.JUnit4ClassRunner
+import org.junit.internal.runners.SuiteMethod
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runner.Runner
+import org.junit.runner.notification.RunNotifier
+import spock.lang.Specification
+
+import java.lang.annotation.IncompleteAnnotationException
+
+/**
+ * Tests {@link IgnoredTestDescriptorProvider}.
+ */
+class IgnoredTestDescriptorProviderTest extends Specification {
+
+    def "can get individual test descriptions for ignored test classes"() {
+        expect:
+        describe(RunWithSpec.class)*.getDisplayName() == ["CHILD(SUITE)"]
+        describe(SuiteMethodSpec.class)*.getDisplayName() == ["testSomething(org.gradle.api.internal.tasks.testing.junit.IgnoredTestDescriptorProviderTest\$TestCaseSpec)"]
+        describe(TestCaseSpec.class)*.getDisplayName() == ["testSomething(org.gradle.api.internal.tasks.testing.junit.IgnoredTestDescriptorProviderTest\$TestCaseSpec)"]
+        describe(JUnit4Spec.class)*.getDisplayName() == ["doTest(org.gradle.api.internal.tasks.testing.junit.IgnoredTestDescriptorProviderTest\$JUnit4Spec)"]
+    }
+
+    private List<Description> describe(Class<?> testClass) {
+        IgnoredTestDescriptorProvider.getAllDescriptions(Description.createSuiteDescription(testClass), testClass.getName())
+    }
+
+    @SuppressWarnings
+    def "can get @RunWith runner through legacy means"() {
+        expect:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(RunWithSpec.class) instanceof CustomRunner
+
+        when:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(EmptyRunWithSpec.class)
+
+        then:
+        thrown IncompleteAnnotationException
+
+        when:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(MissingConstructorRunWithSpec.class)
+
+        then:
+        thrown InitializationError
+    }
+
+    def "can get SuiteMethod runner through legacy means"() {
+        expect:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(SuiteMethodSpec.class) instanceof SuiteMethod
+    }
+
+    def "can get JUnit 3 runner through legacy means"() {
+        expect:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(TestCaseSpec.class) instanceof JUnit38ClassRunner
+    }
+
+    def "can get JUnit 4 runner through legacy means"() {
+        expect:
+        IgnoredTestDescriptorProvider.getRunnerLegacy(JUnit4Spec.class) instanceof JUnit4ClassRunner
+    }
+
+    @Ignore
+    @RunWith(CustomRunner.class)
+    static class RunWithSpec {
+        void doTest() {}
+    }
+
+    @Ignore
+    @RunWith()
+    static class EmptyRunWithSpec {
+        void doTest() {}
+    }
+
+    @Ignore
+    @RunWith(MissingConstructorRunner.class)
+    static class MissingConstructorRunWithSpec {
+        void doTest() {}
+    }
+
+    @Ignore
+    static class SuiteMethodSpec {
+        static TestSuite suite() {
+            return new SuiteMethodSuite()
+        }
+        void doTest() {}
+    }
+
+    static class SuiteMethodSuite extends TestSuite {
+        SuiteMethodSuite() {
+            super(TestCaseSpec.class)
+        }
+    }
+
+    @Ignore
+    static class TestCaseSpec extends TestCase {
+        void testSomething() {}
+    }
+
+    @Ignore
+    static class JUnit4Spec {
+        @Test
+        void doTest() {}
+    }
+
+    static class CustomRunner extends Runner {
+        CustomRunner(Class<?> clazz) {}
+
+        @Override
+        Description getDescription() {
+            Description desc = Description.createSuiteDescription("SUITE")
+            desc.addChild(Description.createTestDescription("SUITE", "CHILD"))
+            return desc
+        }
+
+        @Override
+        void run(RunNotifier notifier) {}
+    }
+
+    static class MissingConstructorRunner extends Runner {
+        @Override
+        Description getDescription() {
+            return Description.createSuiteDescription("DESCRIPTION")
+        }
+
+        @Override
+        void run(RunNotifier notifier) {}
+    }
+}


### PR DESCRIPTION
Partially, kinda, doesn't really fix, but works towards fixing #13955

* Removes loading of `junit-platform` dependencies from the Gradle distribution when using test suites with `useJUnitJupiter()`.
  * These dependencies are still loaded from the distribution when executing a standalone, non-suite-associated `Test` task with `useJUnitPlatform()`.
  * For test-suite-associated tests in the default case or those which explicitly declare `useJUnitJupiter`, adds `junit-platform` dependencies to the test's `implementation` configuration so that the dependencies are fetched via dependency-management.
* Removes implicit `junit` dependency added to all test workers.
  * Instead only includes the implicit dependency when using junit tests with non-suite-associated tests with `useJUnit()` or the default case where no `useXXX` method is called.

In the future, we will want to disable the current behavior of loading implicit dependencies for standalone `Test` tasks. Though, this will need to wait until we de-incubate test suites.

- [x] Add `IgnoredTestDescriptorProvider` unit tests
- [x] Update the long block of comments with new information, post-investigation (the one about resolving dependencies early)
