### PR TITLE
Fix `-x` when the main build uses a settings plugin built by an included build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -139,6 +139,14 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry {
         }
     }
 
+    @Nullable
+    @Override
+    public BuildProjectRegistry findProjectsFor(BuildIdentifier buildIdentifier) {
+        synchronized (lock) {
+            return projectsByBuild.get(buildIdentifier);
+        }
+    }
+
     @Override
     public <T> T allowUncontrolledAccessToAnyProject(Factory<T> factory) {
         return workerLeaseService.allowUncontrolledAccessToAnyProject(factory);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectStateRegistry.java
@@ -25,6 +25,7 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.service.scopes.Scopes;
 import org.gradle.internal.service.scopes.ServiceScope;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
 
@@ -53,6 +54,12 @@ public interface ProjectStateRegistry {
      * Locates the state objects for all projects of the given build.
      */
     BuildProjectRegistry projectsFor(BuildIdentifier buildIdentifier) throws IllegalArgumentException;
+
+    /**
+     * Locates the state objects for all projects of the given build, or {@code null} if these are not available yet.
+     */
+    @Nullable
+    BuildProjectRegistry findProjectsFor(BuildIdentifier buildIdentifier);
 
     /**
      * Registers the projects of a build.

--- a/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/selection/DefaultBuildTaskSelector.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Task;
 import org.gradle.api.internal.project.ProjectState;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
 import org.gradle.configuration.project.BuiltInCommand;
 import org.gradle.execution.ProjectSelectionException;
 import org.gradle.execution.TaskSelection;
@@ -55,6 +56,10 @@ public class DefaultBuildTaskSelector implements BuildTaskSelector {
 
     @Override
     public Filter resolveExcludedTaskName(BuildState defaultBuild, String taskName) {
+        if (!defaultBuild.isProjectsLoaded()) {
+            // Too early to resolve excludes
+            return new Filter(defaultBuild, Specs.satisfyNone());
+        }
         TaskSelector.SelectionContext selection = sanityCheckPath(taskName, "excluded tasks");
         ProjectResolutionResult resolutionResult = resolveProject(selection, selection.getOriginalPath(), defaultBuild);
         return new Filter(resolutionResult.build, new LazyFilter(selection, resolutionResult));

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -99,6 +99,11 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     }
 
     @Override
+    public boolean isProjectsLoaded() {
+        return getProjectStateRegistry().findProjectsFor(getBuildIdentifier()) != null;
+    }
+
+    @Override
     public void ensureProjectsConfigured() {
         getBuildController().configureProjects();
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildState.java
@@ -70,6 +70,11 @@ public interface BuildState {
     void ensureProjectsLoaded();
 
     /**
+     * Have the projects been loaded, ie has {@link #ensureProjectsLoaded()} already completed for this build?
+     */
+    boolean isProjectsLoaded();
+
+    /**
      * Ensures all projects in this build are configured, if not already done.
      */
     void ensureProjectsConfigured();

--- a/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/selection/DefaultBuildTaskSelectorTest.groovy
@@ -267,6 +267,7 @@ class DefaultBuildTaskSelectorTest extends Specification {
         def defaultProjectState = Mock(ProjectState)
         def rootProjectState = Mock(ProjectState)
 
+        build.projectsLoaded >> true
         build.mutableModel >> gradle
         gradle.defaultProject >> defaultProject
         defaultProject.owner >> defaultProjectState


### PR DESCRIPTION

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
