### PR TITLE
Disable IntelliJ inspection for <p> in Javadocs

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -13,6 +13,7 @@
       </extension>
     </inspection_tool>
     <inspection_tool class="FoldExpressionIntoStream" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="JavadocBlankLines" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="NewMethodNamingConvention" enabled="true" level="ERROR" enabled_by_default="true">
       <extension name="InstanceMethodNamingConvention" enabled="true">


### PR DESCRIPTION
Disable warning for blank lines in Javadocs that should be `<p>` instead. We have a large number of Javadocs where this is messed up, especially in internal types, and the validation marks all of these locations with warnings, adding noise.

If we later want to enable this validation, we should do so by fixing all the existing violations, too.