### PR TITLE
Simplify FileSystemAccess API

### DIFF
--- a/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
+++ b/subprojects/build-cache-packaging/src/test/groovy/org/gradle/caching/internal/packaging/impl/AbstractTarBuildCacheEntryPackerSpec.groovy
@@ -53,10 +53,7 @@ abstract class AbstractTarBuildCacheEntryPackerSpec extends Specification {
         Map<String, FileSystemSnapshot> snapshots = treeDefs.collectEntries { treeDef ->
             FileSystemSnapshot result = FileSystemSnapshot.EMPTY
             if (treeDef.root != null) {
-                fileSystemAccess.read(treeDef.root.absolutePath) { snapshot ->
-                    //noinspection GrReassignedInClosureLocalVar
-                    result = snapshot
-                }
+                result = fileSystemAccess.read(treeDef.root.absolutePath)
             }
             return [(treeDef.name): result]
         }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/VirtualFileSystemExtensions.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/extensions/VirtualFileSystemExtensions.kt
@@ -23,5 +23,5 @@ import java.io.File
 
 internal
 fun FileSystemAccess.hashCodeOf(file: File): HashCode? =
-    readRegularFileContentHash(file.path) { hashCode -> hashCode }
+    readRegularFileContentHash(file.path)
         .orElse(null)

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/DefaultFileContentCacheFactory.java
@@ -111,9 +111,8 @@ public class DefaultFileContentCacheFactory implements FileContentCacheFactory, 
         @Override
         public V get(File file) {
             return locationCache.computeIfAbsent(file,
-                location -> fileSystemAccess.readRegularFileContentHash(
-                    location.getAbsolutePath(),
-                    contentHash -> contentCache.get(contentHash, key -> calculator.calculate(location, true))
+                location -> fileSystemAccess.readRegularFileContentHash(location.getAbsolutePath())
+                    .map(contentHash -> contentCache.get(contentHash, key -> calculator.calculate(location, true))
                 ).orElseGet(
                     () -> calculator.calculate(location, false)
                 ));

--- a/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/classpath/DefaultCachedClasspathTransformer.java
@@ -196,7 +196,7 @@ public class DefaultCachedClasspathTransformer implements CachedClasspathTransfo
     }
 
     private FileSystemLocationSnapshot snapshotOf(File file) {
-        return fileSystemAccess.read(file.getAbsolutePath(), s -> s);
+        return fileSystemAccess.read(file.getAbsolutePath());
     }
 
     private boolean shouldUseFromCache(File original) {

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/impl/DefaultFileCollectionSnapshotter.java
@@ -68,7 +68,7 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
         @Override
         public void visitCollection(FileCollectionInternal.Source source, Iterable<File> contents) {
             for (File file : contents) {
-                fileSystemAccess.read(file.getAbsolutePath(), roots::add);
+                roots.add(fileSystemAccess.read(file.getAbsolutePath()));
             }
         }
 
@@ -76,18 +76,15 @@ public class DefaultFileCollectionSnapshotter implements FileCollectionSnapshott
         public void visitFileTree(File root, PatternSet patterns, FileTreeInternal fileTree) {
             fileSystemAccess.read(
                 root.getAbsolutePath(),
-                new PatternSetSnapshottingFilter(patterns, stat),
-                snapshot -> {
-                    if (snapshot.getType() != FileType.Missing) {
-                        roots.add(snapshot);
-                    }
-                }
-            );
+                new PatternSetSnapshottingFilter(patterns, stat)
+            )
+                .filter(snapshot -> snapshot.getType() != FileType.Missing)
+                .map(roots::add);
         }
 
         @Override
         public void visitFileTreeBackedByFile(File file, FileTreeInternal fileTree, FileSystemMirroringFileTree sourceTree) {
-            fileSystemAccess.read(file.getAbsolutePath(), roots::add);
+            roots.add(fileSystemAccess.read(file.getAbsolutePath()));
             containsArchiveTrees = true;
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/cache/internal/DefaultFileContentCacheFactoryTest.groovy
@@ -37,6 +37,8 @@ import org.gradle.util.UsesNativeServices
 import org.junit.Rule
 import spock.lang.Specification
 
+import javax.annotation.Nullable
+
 @UsesNativeServices
 class DefaultFileContentCacheFactoryTest extends Specification {
     @Rule
@@ -97,7 +99,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         result == 12
 
         and:
-        1 * fileSystemAccess.readRegularFileContentHash(file.absolutePath, _) >> Optional.empty()
+        1 * fileSystemAccess.readRegularFileContentHash(file.absolutePath) >> Optional.empty()
         1 * calculator.calculate(file, false) >> 12
         0 * _
 
@@ -209,7 +211,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         result == 12
 
         and:
-        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), _) >> Optional.empty()
+        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath()) >> Optional.empty()
         1 * calculator.calculate(file, false) >> 12
         0 * _
 
@@ -221,7 +223,7 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         result == 10
 
         and:
-        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), _) >> Optional.empty()
+        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath()) >> Optional.empty()
         1 * calculator.calculate(file, false) >> 10
         0 * _
     }
@@ -258,9 +260,9 @@ class DefaultFileContentCacheFactoryTest extends Specification {
         0 * _
     }
 
-    def snapshotRegularFile(File file, HashCode hashCode = TestHashCodes.hashCodeFrom(123)) {
-        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), _) >> { location, function ->
-            return Optional.ofNullable(function.apply(hashCode))
+    def snapshotRegularFile(File file, @Nullable HashCode hashCode = TestHashCodes.hashCodeFrom(123)) {
+        1 * fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath()) >> { location ->
+            return Optional.ofNullable(hashCode)
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -58,7 +58,6 @@ import java.io.File;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.gradle.internal.execution.fingerprint.InputFingerprinter.InputPropertyType.INCREMENTAL;
@@ -209,7 +208,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             super.visitIdentityInputs(visitor);
             // This is a performance hack. We could use the regular fingerprint of the input artifact, but that takes longer than
             // capturing the normalized path and the snapshot of the raw contents, so we are using these to determine the identity
-            FileSystemLocationSnapshot inputArtifactSnapshot = fileSystemAccess.read(inputArtifact.getAbsolutePath(), Function.identity());
+            FileSystemLocationSnapshot inputArtifactSnapshot = fileSystemAccess.read(inputArtifact.getAbsolutePath());
             visitor.visitInputProperty(INPUT_ARTIFACT_SNAPSHOT_PROPERTY_NAME, inputArtifactSnapshot::getHash);
         }
 

--- a/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
+++ b/subprojects/enterprise/src/main/java/org/gradle/internal/snapshot/impl/DefaultSnapshottingService.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.snapshot.impl;
 
 import org.gradle.internal.hash.HashCode;
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.Snapshot;
 import org.gradle.internal.snapshot.SnapshottingService;
 import org.gradle.internal.vfs.FileSystemAccess;
@@ -39,7 +38,7 @@ public class DefaultSnapshottingService implements SnapshottingService {
     @Override
     public Snapshot snapshotFor(Path filePath) {
         String absolutePath = filePath.toAbsolutePath().toString();
-        HashCode hash = fileSystemAccess.read(absolutePath, FileSystemLocationSnapshot::getHash);
+        HashCode hash = fileSystemAccess.read(absolutePath).getHash();
 
         return new DefaultSnapshot(hash);
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/DefaultOutputFilesRepositoryTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.cache.CacheDecorator
 import org.gradle.cache.PersistentCache
 import org.gradle.cache.internal.DefaultInMemoryCacheDecoratorFactory
-import org.gradle.internal.MutableReference
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.test.fixtures.file.CleanupTestDirectory
@@ -75,8 +74,6 @@ class DefaultOutputFilesRepositoryTest extends Specification {
     }
 
     private FileSystemLocationSnapshot snapshot(File file) {
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(file.getAbsolutePath(), result.&set)
-        return result.get()
+        return fileSystemAccess.read(file.getAbsolutePath())
     }
 }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/OutputSnapshotUtilTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/impl/OutputSnapshotUtilTest.groovy
@@ -17,8 +17,6 @@
 package org.gradle.internal.execution.history.impl
 
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.internal.MutableReference
-import org.gradle.internal.snapshot.FileSystemLocationSnapshot
 import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.internal.snapshot.SnapshotVisitorUtil
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -159,9 +157,7 @@ class OutputSnapshotUtilTest extends Specification {
 
     private FileSystemSnapshot snapshotOutput(File output) {
         virtualFileSystem.invalidateAll()
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(output.getAbsolutePath(), result.&set)
-        return result.get()
+        return fileSystemAccess.read(output.getAbsolutePath())
     }
 
     private static List<File> collectFiles(FileSystemSnapshot fileSystemSnapshots) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/CachingClassSetAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/CachingClassSetAnalyzer.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.compile.incremental.classpath;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData;
 import org.gradle.cache.Cache;
 import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.vfs.FileSystemAccess;
 
 import java.io.File;
@@ -39,10 +40,8 @@ public class CachingClassSetAnalyzer implements ClassSetAnalyzer {
 
     @Override
     public ClassSetAnalysisData analyzeClasspathEntry(final File classpathEntry) {
-        return fileSystemAccess.read(
-            classpathEntry.getAbsolutePath(),
-            snapshot -> cache.get(snapshot.getHash(), hash -> delegate.analyzeClasspathEntry(classpathEntry))
-        );
+        FileSystemLocationSnapshot snapshot = fileSystemAccess.read(classpathEntry.getAbsolutePath());
+        return cache.get(snapshot.getHash(), hash -> delegate.analyzeClasspathEntry(classpathEntry));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultSourceIncludesResolver.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultSourceIncludesResolver.java
@@ -348,9 +348,9 @@ public class DefaultSourceIncludesResolver implements SourceIncludesResolver {
             return contents.computeIfAbsent(includePath,
                 key -> {
                     File candidate = normalizeIncludePath(searchDir, includePath);
-                    return fileSystemAccess.readRegularFileContentHash(candidate.getAbsolutePath(),
-                            contentHash -> (CachedIncludeFile) new SystemIncludeFile(candidate, key, contentHash)
-                        ).orElse(MISSING_INCLUDE_FILE);
+                    return fileSystemAccess.readRegularFileContentHash(candidate.getAbsolutePath())
+                        .map(contentHash -> (CachedIncludeFile) new SystemIncludeFile(candidate, key, contentHash))
+                        .orElse(MISSING_INCLUDE_FILE);
                 });
         }
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
@@ -88,8 +88,8 @@ public class IncrementalCompileFilesFactory {
          * @return true if this source file requires recompilation, false otherwise.
          */
         private boolean visitSourceFile(File sourceFile) {
-            return fileSystemAccess.readRegularFileContentHash(sourceFile.getAbsolutePath(),
-                fileContent -> {
+            return fileSystemAccess.readRegularFileContentHash(sourceFile.getAbsolutePath())
+                .map(fileContent -> {
                     SourceFileState previousState = previous.getState(sourceFile);
 
                     if (previousState != null) {
@@ -120,8 +120,8 @@ public class IncrementalCompileFilesFactory {
                     }
                     return true;
                 })
-            // Skip things that aren't files
-            .orElse(false);
+                // Skip things that aren't files
+                .orElse(false);
         }
 
         private boolean graphHasNotChanged(File sourceFile, HashCode fileHash, SourceFileState previousState, Set<File> existingHeaders) {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessorTest.groovy
@@ -518,7 +518,7 @@ class IncrementalCompileProcessorTest extends Specification {
 
     private HashCode getContentHash(File file) {
         fileSystemAccess.write([file.absolutePath], {})
-        return fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath(), { it })
+        return fileSystemAccess.readRegularFileContentHash(file.getAbsolutePath())
             .orElse(new MissingFileSnapshot(file.getAbsolutePath(), file.getName(), AccessType.DIRECT).hash)
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/FileSystemAccess.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/vfs/FileSystemAccess.java
@@ -21,8 +21,6 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.SnapshottingFilter;
 
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Provides access to snapshots of the content and metadata of the file system.
@@ -38,19 +36,19 @@ public interface FileSystemAccess {
      *
      * @return the visitor function applied to the found snapshot.
      */
-    <T> Optional<T> readRegularFileContentHash(String location, Function<HashCode, T> visitor);
+    Optional<HashCode> readRegularFileContentHash(String location);
 
     /**
-     * Visits the hierarchy of files at the given location.
+     * Reads the hierarchy of files at the given location.
      */
-    <T> T read(String location, Function<FileSystemLocationSnapshot, T> visitor);
+    FileSystemLocationSnapshot read(String location);
 
     /**
      * Visits the hierarchy of files which match the filter at the given location.
      *
-     * The consumer is only called if something matches the filter.
+     * Returns empty {@link Optional} if filter doesn't match anything.
      */
-    void read(String location, SnapshottingFilter filter, Consumer<FileSystemLocationSnapshot> visitor);
+    Optional<FileSystemLocationSnapshot> read(String location, SnapshottingFilter filter);
 
     /**
      * Runs an action which potentially writes to the given locations.

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/PathNormalizationStrategyTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.fingerprint.impl
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.internal.MutableReference
 import org.gradle.internal.fingerprint.DirectorySensitivity
 import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.snapshot.CompositeFileSystemSnapshot
@@ -75,9 +74,7 @@ class PathNormalizationStrategyTest extends Specification {
     }
 
     private FileSystemLocationSnapshot snapshot(File file) {
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(file.absolutePath, result.&set)
-        return result.get()
+        return fileSystemAccess.read(file.absolutePath)
     }
 
     def "sensitivity NONE"() {

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/FileSystemSnapshotFilterTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.snapshot.impl
 
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.util.PatternSet
-import org.gradle.internal.MutableReference
 import org.gradle.internal.file.FileMetadata.AccessType
 import org.gradle.internal.file.impl.DefaultFileMetadata
 import org.gradle.internal.fingerprint.impl.PatternSetSnapshottingFilter
@@ -58,9 +57,7 @@ class FileSystemSnapshotFilterTest extends Specification {
         def subdir = dir1.createDir("subdir")
         def subdirFile1 = subdir.createFile("subdirFile1")
 
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(root.getAbsolutePath(), snapshottingFilter(new PatternSet()), result.&set)
-        def unfiltered = result.get()
+        def unfiltered = fileSystemAccess.read(root.getAbsolutePath(), snapshottingFilter(new PatternSet())).get()
 
         expect:
         filteredPaths(unfiltered, include("**/*2")) == [root, dir1, dirFile2, subdir, rootFile2] as Set
@@ -98,9 +95,7 @@ class FileSystemSnapshotFilterTest extends Specification {
         dir1.createFile("dirFile1")
         dir1.createFile("dirFile2")
 
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(root.getAbsolutePath(), snapshottingFilter(new PatternSet()), result.&set)
-        def unfiltered = result.get()
+        def unfiltered = fileSystemAccess.read(root.getAbsolutePath(), snapshottingFilter(new PatternSet())).get()
 
         when:
         def filtered = FileSystemSnapshotFilter.filterSnapshot(snapshottingFilter(include("**/*File*")).asSnapshotPredicate, unfiltered)

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/vfs/impl/AbstractFileSystemAccessTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.vfs.impl
 
 import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.internal.MutableReference
 import org.gradle.internal.file.FileException
 import org.gradle.internal.file.FileMetadata
 import org.gradle.internal.file.FileType
@@ -35,6 +34,7 @@ import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import spock.lang.Specification
 
+import javax.annotation.Nullable
 import java.nio.file.Path
 import java.util.function.Predicate
 
@@ -62,13 +62,13 @@ abstract class AbstractFileSystemAccessTest extends Specification {
     }
 
     FileSystemLocationSnapshot read(File file) {
-        return fileSystemAccess.read(file.absolutePath, { it })
+        return fileSystemAccess.read(file.absolutePath)
     }
 
+    @Nullable
     FileSystemLocationSnapshot read(File file, SnapshottingFilter filter) {
-        MutableReference<FileSystemLocationSnapshot> result = MutableReference.empty()
-        fileSystemAccess.read(file.absolutePath, filter, result.&set)
-        return result.get()
+        return fileSystemAccess.read(file.absolutePath, filter)
+            .orElse(null)
     }
 
     static class AllowingHasher implements FileHasher {


### PR DESCRIPTION
No need for passing functions that only get evaluated straight away on the results anyway.