### PR TITLE
Finalize `ProjectLayout.buildDirectory` when writing to the configuration cache

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheLifecyclePluginIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheLifecyclePluginIntegrationTest.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import groovy.transform.CompileStatic
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+class ConfigurationCacheLifecyclePluginIntegrationTest  extends AbstractConfigurationCacheIntegrationTest {
+
+    def 'buildDirectory is finalized when writing to the cache'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        def buildDirName = 'my-build-dir'
+        def buildDir = file(buildDirName)
+        buildFile """
+
+            plugins { id 'lifecycle-base' }
+
+            @$CompileStatic.name
+            abstract class MyBuildService implements $BuildService.name<${BuildServiceParameters.name}.None> {
+                String myBuildDir(Project project) {
+                    return '$buildDir.name'
+                }
+            }
+
+            @$CompileStatic.name
+            final class MyTransformer implements Transformer<String, MyBuildService> {
+                private final Project project
+
+                MyTransformer(Project project) {
+                    this.project = project
+                }
+
+                String transform(MyBuildService it) {
+                    return it.myBuildDir(project)
+                }
+            }
+
+            // lifecycle-base plugin registers layout.buildDirectory as a build output
+            def service = gradle.sharedServices.registerIfAbsent('my', MyBuildService, {})
+            layout.buildDirectory.set(
+                layout.projectDirectory.dir(
+                    service.map(new MyTransformer(project))
+                )
+            )
+        """
+
+        when:
+        buildDir.mkdir()
+        configurationCacheRun 'clean'
+
+        then:
+        configurationCache.assertStateStored()
+
+        and:
+        buildDir.assertDoesNotExist()
+
+        when:
+        buildDir.mkdir()
+        configurationCacheRun 'clean'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        buildDir.assertDoesNotExist()
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -203,7 +203,7 @@ class ConfigurationCacheState(
         withDebugFrame({ "Work Graph" }) {
             val scheduledNodes = build.scheduledWork
             val relevantProjects = getRelevantProjectsFor(scheduledNodes, gradle.serviceOf())
-            writeRelevantProjects(relevantProjects)
+            writeRelevantProjectRegistrations(relevantProjects)
             writeProjectStates(gradle, relevantProjects)
             writeRequiredBuildServicesOf(gradle, buildTreeState)
             writeWorkGraphOf(gradle, scheduledNodes)
@@ -226,7 +226,7 @@ class ConfigurationCacheState(
             }
         }
 
-        readRelevantProjects(build)
+        readRelevantProjectRegistrations(build)
 
         build.registerProjects()
 
@@ -635,21 +635,21 @@ class ConfigurationCacheState(
     }
 
     private
-    fun Encoder.writeRelevantProjects(relevantProjects: List<ProjectState>) {
+    fun Encoder.writeRelevantProjectRegistrations(relevantProjects: List<ProjectState>) {
         writeCollection(relevantProjects) { project ->
-            writeProjectState(project)
+            writeProjectRegistration(project)
         }
     }
 
     private
-    fun Decoder.readRelevantProjects(build: ConfigurationCacheBuild) {
+    fun Decoder.readRelevantProjectRegistrations(build: ConfigurationCacheBuild) {
         readCollection {
-            readProjectState(build)
+            readProjectRegistration(build)
         }
     }
 
     private
-    fun Encoder.writeProjectState(project: ProjectState) {
+    fun Encoder.writeProjectRegistration(project: ProjectState) {
         val mutableModel = project.mutableModel
         writeString(mutableModel.path)
         writeFile(mutableModel.projectDir)
@@ -657,7 +657,7 @@ class ConfigurationCacheState(
     }
 
     private
-    fun Decoder.readProjectState(build: ConfigurationCacheBuild) {
+    fun Decoder.readProjectRegistration(build: ConfigurationCacheBuild) {
         val projectPath = readString()
         val projectDir = readFile()
         val buildDir = readFile()


### PR DESCRIPTION
So its value cannot be changed after having been written to the cache.

As part of the change, the writing of registered build outputs has been moved to happen after all `buildDirectory` properties have been finalized.
