### PR TITLE
Remove old 7.6 release feature for 19

### DIFF
--- a/subprojects/launcher/src/main/resources/release-features.txt
+++ b/subprojects/launcher/src/main/resources/release-features.txt
@@ -1,1 +1,0 @@
- - Support for Java 19


### PR DESCRIPTION
This feature is part of 7.6 and is on the `release` branch. It shouldn't be here.