### PR TITLE
Let `ValueSnapshotter` handle instances of `OpaqueComponentIdentifier`

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -1333,4 +1333,64 @@ dependencies {
         outputContains 'Transforming input.txt...'
         result.assertTaskExecuted ':summarize'
     }
+
+    def 'can use ListProperty of ComponentArtifactIdentifier as task input'() {
+        given:
+        def configurationCache = newConfigurationCacheFixture()
+        buildScript '''
+            plugins {
+                id 'java-library'
+            }
+
+            dependencies {
+                implementation(gradleApi())
+            }
+
+            @CacheableTask
+            abstract class PrintArtifactIds extends DefaultTask {
+
+                @Input
+                abstract ListProperty<ComponentArtifactIdentifier> getArtifactIds()
+
+                @OutputFile
+                abstract RegularFileProperty getOutputFile()
+
+                @TaskAction
+                def printArtifactIds() {
+                    outputFile.get().asFile.text = artifactIds.get().join('\\n')
+                }
+            }
+
+            tasks.register('printArtifactIds', PrintArtifactIds) {
+                artifactIds.addAll(
+                  configurations
+                      .compileClasspath
+                      .incoming.artifactView {
+                          attributes.attribute(Attribute.of('artifactType', String), 'jar')
+                      }.artifacts.resolvedArtifacts.map { artifacts ->
+                            artifacts.collect { it.id }
+                      }
+                )
+                outputFile = layout.buildDirectory.file('ids.txt')
+            }
+        '''
+
+        when:
+        configurationCacheRun ':printArtifactIds', '-s'
+
+        then:
+        configurationCache.assertStateStored()
+
+        and:
+        file('build/ids.txt').text.contains('(Gradle API)')
+
+        when:
+        configurationCacheRun ':printArtifactIds'
+
+        then:
+        configurationCache.assertStateLoaded()
+
+        and:
+        result.assertTaskSkipped ':printArtifactIds'
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementValueSnapshotterSerializerRegistry.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedComponentResultSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolvedVariantResultSerializer;
 import org.gradle.api.internal.artifacts.metadata.ComponentArtifactIdentifierSerializer;
+import org.gradle.api.internal.artifacts.metadata.ComponentFileArtifactIdentifierSerializer;
 import org.gradle.api.internal.artifacts.metadata.ModuleComponentFileArtifactIdentifierSerializer;
 import org.gradle.api.internal.artifacts.metadata.PublishArtifactLocalArtifactMetadataSerializer;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -44,6 +45,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.model.DefaultModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentFileArtifactIdentifier;
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
 import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata;
 import org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializer;
@@ -65,6 +67,7 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         OpaqueComponentArtifactIdentifier.class,
         DefaultModuleComponentArtifactIdentifier.class,
         ModuleComponentFileArtifactIdentifier.class,
+        ComponentFileArtifactIdentifier.class,
         ComponentIdentifier.class,
         AttributeContainer.class,
         ResolvedVariantResult.class,
@@ -93,6 +96,7 @@ public class DependencyManagementValueSnapshotterSerializerRegistry extends Defa
         register(OpaqueComponentArtifactIdentifier.class, new OpaqueComponentArtifactIdentifierSerializer());
         register(DefaultModuleComponentArtifactIdentifier.class, new ComponentArtifactIdentifierSerializer());
         register(ModuleComponentFileArtifactIdentifier.class, new ModuleComponentFileArtifactIdentifierSerializer());
+        register(ComponentFileArtifactIdentifier.class, new ComponentFileArtifactIdentifierSerializer());
         register(DefaultModuleComponentIdentifier.class, Cast.uncheckedCast(componentIdentifierSerializer));
         register(AttributeContainer.class, attributeContainerSerializer);
         ResolvedVariantResultSerializer resolvedVariantResultSerializer = new ResolvedVariantResultSerializer(componentIdentifierSerializer, attributeContainerSerializer);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializer.java
@@ -24,15 +24,18 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal;
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenUniqueSnapshotComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier;
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier;
+import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 import org.gradle.internal.serialize.AbstractSerializer;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.util.Path;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 
@@ -42,35 +45,45 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
     @Override
     public ComponentIdentifier read(Decoder decoder) throws IOException {
         byte id = decoder.readByte();
-
-        if (Implementation.ROOT_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            String projectName = decoder.readString();
-            return new DefaultProjectComponentIdentifier(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
-        } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath, projectPath, projectPath.getName());
-        } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path identityPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
-        } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
-            BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
-            Path identityPath = Path.path(decoder.readString());
-            Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, identityPath.getName());
-        } else if (Implementation.MODULE.getId() == id) {
-            return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString());
-        } else if (Implementation.SNAPSHOT.getId() == id) {
-            return new MavenUniqueSnapshotComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString(), decoder.readString());
-        } else if (Implementation.LIBRARY.getId() == id) {
-            return new DefaultLibraryBinaryIdentifier(decoder.readString(), decoder.readString(), decoder.readString());
-        } else if (Implementation.OPAQUE.getId() == id) {
-            return new OpaqueComponentArtifactIdentifier(new File(decoder.readString()));
+        Implementation implementation = Implementation.valueOf(id);
+        if (implementation == null) {
+            throw new IllegalArgumentException("Unable to find component identifier type with id: " + id);
         }
-
-        throw new IllegalArgumentException("Unable to find component identifier type with id: " + id);
+        switch (implementation) {
+            case ROOT_PROJECT: {
+                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+                String projectName = decoder.readString();
+                return new DefaultProjectComponentIdentifier(buildIdentifier, Path.ROOT, Path.ROOT, projectName);
+            }
+            case ROOT_BUILD_PROJECT: {
+                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+                Path projectPath = Path.path(decoder.readString());
+                return new DefaultProjectComponentIdentifier(buildIdentifier, projectPath, projectPath, projectPath.getName());
+            }
+            case OTHER_BUILD_ROOT_PROJECT: {
+                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+                Path identityPath = Path.path(decoder.readString());
+                return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, Path.ROOT, identityPath.getName());
+            }
+            case OTHER_BUILD_PROJECT: {
+                BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
+                Path identityPath = Path.path(decoder.readString());
+                Path projectPath = Path.path(decoder.readString());
+                return new DefaultProjectComponentIdentifier(buildIdentifier, identityPath, projectPath, identityPath.getName());
+            }
+            case MODULE:
+                return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString());
+            case SNAPSHOT:
+                return new MavenUniqueSnapshotComponentIdentifier(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), decoder.readString(), decoder.readString());
+            case LIBRARY:
+                return new DefaultLibraryBinaryIdentifier(decoder.readString(), decoder.readString(), decoder.readString());
+            case OPAQUE:
+                return new OpaqueComponentArtifactIdentifier(new File(decoder.readString()));
+            case OPAQUE_NOTATION:
+                return new OpaqueComponentIdentifier(readClassPathNotation(decoder));
+            default:
+                throw new IllegalArgumentException("Unsupported component identifier implementation: " + implementation);
+        }
     }
 
     @Override
@@ -81,50 +94,65 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
 
         Implementation implementation = resolveImplementation(value);
 
-        encoder.writeByte(implementation.getId());
+        encoder.writeByte(implementation.id);
 
-        if (implementation == Implementation.MODULE) {
-            ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) value;
-            encoder.writeString(moduleComponentIdentifier.getGroup());
-            encoder.writeString(moduleComponentIdentifier.getModule());
-            encoder.writeString(moduleComponentIdentifier.getVersion());
-        } else if (implementation == Implementation.SNAPSHOT) {
-            MavenUniqueSnapshotComponentIdentifier snapshotIdentifier = (MavenUniqueSnapshotComponentIdentifier) value;
-            encoder.writeString(snapshotIdentifier.getGroup());
-            encoder.writeString(snapshotIdentifier.getModule());
-            encoder.writeString(snapshotIdentifier.getVersion());
-            encoder.writeString(snapshotIdentifier.getTimestamp());
-        } else if (implementation == Implementation.ROOT_PROJECT) {
-            ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
-            BuildIdentifier build = projectComponentIdentifier.getBuild();
-            buildIdentifierSerializer.write(encoder, build);
-            encoder.writeString(projectComponentIdentifier.getProjectName());
-        } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
-            ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
-            BuildIdentifier build = projectComponentIdentifier.getBuild();
-            buildIdentifierSerializer.write(encoder, build);
-            encoder.writeString(projectComponentIdentifier.getProjectPath());
-        } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
-            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
-            BuildIdentifier build = projectComponentIdentifier.getBuild();
-            buildIdentifierSerializer.write(encoder, build);
-            encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
-        } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
-            DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
-            BuildIdentifier build = projectComponentIdentifier.getBuild();
-            buildIdentifierSerializer.write(encoder, build);
-            encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
-            encoder.writeString(projectComponentIdentifier.getProjectPath());
-        } else if (implementation == Implementation.LIBRARY) {
-            LibraryBinaryIdentifier libraryIdentifier = (LibraryBinaryIdentifier) value;
-            encoder.writeString(libraryIdentifier.getProjectPath());
-            encoder.writeString(libraryIdentifier.getLibraryName());
-            encoder.writeString(libraryIdentifier.getVariant());
-        } else if (implementation == Implementation.OPAQUE) {
-            OpaqueComponentArtifactIdentifier opaqueComponentIdentifier = (OpaqueComponentArtifactIdentifier) value;
-            encoder.writeString(opaqueComponentIdentifier.getFile().getPath());
-        } else {
-            throw new IllegalStateException("Unsupported implementation type: " + implementation);
+        switch (implementation) {
+            case MODULE:
+                ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) value;
+                encoder.writeString(moduleComponentIdentifier.getGroup());
+                encoder.writeString(moduleComponentIdentifier.getModule());
+                encoder.writeString(moduleComponentIdentifier.getVersion());
+                break;
+            case SNAPSHOT:
+                MavenUniqueSnapshotComponentIdentifier snapshotIdentifier = (MavenUniqueSnapshotComponentIdentifier) value;
+                encoder.writeString(snapshotIdentifier.getGroup());
+                encoder.writeString(snapshotIdentifier.getModule());
+                encoder.writeString(snapshotIdentifier.getVersion());
+                encoder.writeString(snapshotIdentifier.getTimestamp());
+                break;
+            case ROOT_PROJECT: {
+                ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
+                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
+                encoder.writeString(projectComponentIdentifier.getProjectName());
+                break;
+            }
+            case ROOT_BUILD_PROJECT: {
+                ProjectComponentIdentifier projectComponentIdentifier = (ProjectComponentIdentifier) value;
+                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
+                encoder.writeString(projectComponentIdentifier.getProjectPath());
+                break;
+            }
+            case OTHER_BUILD_ROOT_PROJECT: {
+                DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
+                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
+                encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
+                break;
+            }
+            case OTHER_BUILD_PROJECT: {
+                DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) value;
+                writeBuildIdentifierOf(projectComponentIdentifier, encoder);
+                encoder.writeString(projectComponentIdentifier.getIdentityPath().getPath());
+                encoder.writeString(projectComponentIdentifier.getProjectPath());
+                break;
+            }
+            case LIBRARY:
+                LibraryBinaryIdentifier libraryIdentifier = (LibraryBinaryIdentifier) value;
+                encoder.writeString(libraryIdentifier.getProjectPath());
+                encoder.writeString(libraryIdentifier.getLibraryName());
+                encoder.writeString(libraryIdentifier.getVariant());
+                break;
+            case OPAQUE: {
+                OpaqueComponentArtifactIdentifier opaqueIdentifier = (OpaqueComponentArtifactIdentifier) value;
+                encoder.writeString(opaqueIdentifier.getFile().getPath());
+                break;
+            }
+            case OPAQUE_NOTATION: {
+                OpaqueComponentIdentifier opaqueIdentifier = (OpaqueComponentIdentifier) value;
+                writeClassPathNotation(encoder, opaqueIdentifier.getClassPathNotation());
+                break;
+            }
+            default:
+                throw new IllegalStateException("Unsupported implementation type: " + implementation);
         }
     }
 
@@ -141,6 +169,19 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
     @Override
     public int hashCode() {
         return Objects.hashCode(super.hashCode(), buildIdentifierSerializer);
+    }
+
+    private static void writeClassPathNotation(Encoder encoder, DependencyFactoryInternal.ClassPathNotation classPathNotation) throws IOException {
+        encoder.writeSmallInt(classPathNotation.ordinal());
+    }
+
+    private static DependencyFactoryInternal.ClassPathNotation readClassPathNotation(Decoder decoder) throws IOException {
+        int ordinal = decoder.readSmallInt();
+        return DependencyFactoryInternal.ClassPathNotation.values()[ordinal];
+    }
+
+    private void writeBuildIdentifierOf(ProjectComponentIdentifier projectComponentIdentifier, Encoder encoder) throws IOException {
+        buildIdentifierSerializer.write(encoder, projectComponentIdentifier.getBuild());
     }
 
     private Implementation resolveImplementation(ComponentIdentifier value) {
@@ -166,22 +207,37 @@ public class ComponentIdentifierSerializer extends AbstractSerializer<ComponentI
             return Implementation.LIBRARY;
         } else if (value instanceof OpaqueComponentArtifactIdentifier) {
             return Implementation.OPAQUE;
+        } else if (value instanceof OpaqueComponentIdentifier) {
+            return Implementation.OPAQUE_NOTATION;
         } else {
             throw new IllegalArgumentException("Unsupported component identifier class: " + value.getClass());
         }
     }
 
     private enum Implementation {
-        MODULE(1), ROOT_PROJECT(2), ROOT_BUILD_PROJECT(3), OTHER_BUILD_ROOT_PROJECT(4), OTHER_BUILD_PROJECT(5), LIBRARY(6), SNAPSHOT(7), OPAQUE(8);
+        MODULE(1),
+        ROOT_PROJECT(2),
+        ROOT_BUILD_PROJECT(3),
+        OTHER_BUILD_ROOT_PROJECT(4),
+        OTHER_BUILD_PROJECT(5),
+        LIBRARY(6),
+        SNAPSHOT(7),
+        OPAQUE(8),
+        OPAQUE_NOTATION(9);
+
+        @Nullable
+        public static Implementation valueOf(int id) {
+            Implementation[] values = values();
+            if (id >= values[0].id && id <= values[values.length - 1].id) {
+                return values[id - 1];
+            }
+            return null;
+        }
 
         private final byte id;
 
         Implementation(int id) {
             this.id = (byte) id;
-        }
-
-        private byte getId() {
-            return id;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentFileArtifactIdentifierSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/metadata/ComponentFileArtifactIdentifierSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.metadata;
+
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentIdentifierSerializer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.IvyArtifactNameSerializer;
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
+import org.gradle.internal.component.model.IvyArtifactName;
+import org.gradle.internal.serialize.Decoder;
+import org.gradle.internal.serialize.Encoder;
+import org.gradle.internal.serialize.Serializer;
+
+public class ComponentFileArtifactIdentifierSerializer implements Serializer<ComponentFileArtifactIdentifier> {
+    private final ComponentIdentifierSerializer componentIdentifierSerializer = new ComponentIdentifierSerializer();
+
+    @Override
+    public void write(Encoder encoder, ComponentFileArtifactIdentifier value) throws Exception {
+        componentIdentifierSerializer.write(encoder, value.getComponentIdentifier());
+        Object rawFileName = value.getRawFileName();
+        if (rawFileName instanceof IvyArtifactName) {
+            encoder.writeBoolean(true);
+            IvyArtifactNameSerializer.INSTANCE.write(encoder, (IvyArtifactName) rawFileName);
+        } else {
+            encoder.writeBoolean(false);
+            encoder.writeString((String) rawFileName);
+        }
+    }
+
+    @Override
+    public ComponentFileArtifactIdentifier read(Decoder decoder) throws Exception {
+        ModuleComponentIdentifier componentIdentifier = (ModuleComponentIdentifier) componentIdentifierSerializer.read(decoder);
+        if (decoder.readBoolean()) {
+            IvyArtifactName fileName = IvyArtifactNameSerializer.INSTANCE.read(decoder);
+            return new ComponentFileArtifactIdentifier(componentIdentifier, fileName);
+        } else {
+            String fileName = decoder.readString();
+            return new ComponentFileArtifactIdentifier(componentIdentifier, fileName);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/ComponentFileArtifactIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/ComponentFileArtifactIdentifier.java
@@ -26,13 +26,16 @@ public class ComponentFileArtifactIdentifier implements ComponentArtifactIdentif
     private final Object fileName;
 
     public ComponentFileArtifactIdentifier(ComponentIdentifier componentId, String fileName) {
-        this.componentId = componentId;
-        this.fileName = fileName;
+        this(componentId, (Object) fileName);
     }
 
-    public ComponentFileArtifactIdentifier(ComponentIdentifier componentIdentifier, IvyArtifactName artifactName) {
-        this.componentId = componentIdentifier;
-        this.fileName = artifactName;
+    public ComponentFileArtifactIdentifier(ComponentIdentifier componentId, IvyArtifactName artifactName) {
+        this(componentId, (Object) artifactName);
+    }
+
+    ComponentFileArtifactIdentifier(ComponentIdentifier componentId, Object fileName) {
+        this.componentId = componentId;
+        this.fileName = fileName;
     }
 
     @Override
@@ -42,6 +45,10 @@ public class ComponentFileArtifactIdentifier implements ComponentArtifactIdentif
 
     public String getFileName() {
         return fileName.toString();
+    }
+
+    public Object getRawFileName() {
+        return fileName;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentIdentifierSerializerTest.groovy
@@ -21,9 +21,11 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
+import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier
 import org.gradle.internal.component.local.model.OpaqueComponentArtifactIdentifier
+import org.gradle.internal.component.local.model.OpaqueComponentIdentifier
 import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.util.Path
 
@@ -132,6 +134,20 @@ class ComponentIdentifierSerializerTest extends SerializerSpec {
         result.displayName == file.name
         result.file == file
         result.componentIdentifier == identifier
+        result == identifier
+    }
+
+    def "serialize OpaqueComponentIdentifier"() {
+        given:
+        def notation = DependencyFactoryInternal.ClassPathNotation.GRADLE_API
+        def identifier = new OpaqueComponentIdentifier(notation)
+
+        when:
+        def result = serialize(identifier, serializer)
+
+        then:
+        result.displayName == notation.displayName
+        result.classPathNotation == notation
         result == identifier
     }
 }

--- a/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions-integ-tests/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
     @Override
     int getMaxDistributionSizeBytes() {
-        return 48 * 1024 * 1024
+        return 49 * 1024 * 1024
     }
 
     @Override

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
@@ -41,17 +41,18 @@ public final class DefaultTaskOperationDescriptor extends DefaultOperationDescri
     private final Supplier<PluginIdentifier> originPlugin;
 
     public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath) {
-        super(descriptor, parent);
-        this.taskPath = taskPath;
-        this.dependencies = unsupportedMethodExceptionThrowingSupplier(DEPENDENCIES_METHOD);
-        this.originPlugin = unsupportedMethodExceptionThrowingSupplier(ORIGIN_PLUGIN_METHOD);
+        this(descriptor, parent, taskPath, unsupportedDependencies(), unsupportedOriginPlugin());
     }
 
     public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath, Set<OperationDescriptor> dependencies, @Nullable PluginIdentifier originPlugin) {
+        this(descriptor, parent, taskPath, Suppliers.ofInstance(dependencies), Suppliers.ofInstance(originPlugin));
+    }
+
+    private DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath, Supplier<Set<OperationDescriptor>> dependencies, Supplier<PluginIdentifier> originPlugin) {
         super(descriptor, parent);
         this.taskPath = taskPath;
-        this.dependencies = Suppliers.ofInstance(dependencies);
-        this.originPlugin = Suppliers.ofInstance(originPlugin);
+        this.dependencies = dependencies;
+        this.originPlugin = originPlugin;
     }
 
     @Override
@@ -68,6 +69,14 @@ public final class DefaultTaskOperationDescriptor extends DefaultOperationDescri
     @Nullable
     public PluginIdentifier getOriginPlugin() {
         return originPlugin.get();
+    }
+
+    private static Supplier<PluginIdentifier> unsupportedOriginPlugin() {
+        return unsupportedMethodExceptionThrowingSupplier(ORIGIN_PLUGIN_METHOD);
+    }
+
+    private static Supplier<Set<OperationDescriptor>> unsupportedDependencies() {
+        return unsupportedMethodExceptionThrowingSupplier(DEPENDENCIES_METHOD);
     }
 
     private static <T> Supplier<T> unsupportedMethodExceptionThrowingSupplier(final String method) {


### PR DESCRIPTION
So it's possible to use dependency resolution results involving _opaque_ identifiers derived from `gradleApi()`, `gradleTestKit()`, `localGroovy()` and `gradleKotlinDsl()` as task inputs.