### PR TITLE
Do not resolve FileCollections in non-file task inputs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InputParameterUtils.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.properties;
 
 import groovy.lang.GString;
 import org.gradle.api.Task;
-import org.gradle.api.file.FileCollection;
 import org.gradle.util.internal.DeferredUtil;
 
 import javax.annotation.Nullable;
@@ -44,9 +43,6 @@ public class InputParameterUtils {
     private static Object finalizeValue(@Nullable Object unpacked) {
         if (unpacked instanceof GString) {
             return unpacked.toString();
-        }
-        if (unpacked instanceof FileCollection) {
-            return ((FileCollection) unpacked).getFiles();
         }
         return unpacked;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -175,12 +175,12 @@ class DefaultTaskInputsTest extends Specification {
     }
 
     def inputPropertyCanBeNestedCallableAndClosure() {
-        def files = [new File('file')] as Set
+        def value = Mock(Object)
         when:
-        inputs.property('a', { { { files } } as Callable })
+        inputs.property('a', { { { value } } as Callable })
 
         then:
-        inputProperties() == [a: files]
+        inputProperties() == [a: value]
     }
 
     def "GString input property values are evaluated to avoid serialization issues"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.api.internal.tasks
 
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.TaskOutputsInternal
 import org.gradle.api.internal.file.TestFiles
@@ -175,23 +174,10 @@ class DefaultTaskInputsTest extends Specification {
         inputProperties() == [a: 'value']
     }
 
-    def canRegisterInputPropertyUsingAFileCollection() {
-        def files = [new File('file')] as Set
-
-        when:
-        inputs.property('a', [getFiles: { files }] as FileCollection)
-
-        then:
-        inputProperties() == [a: files]
-    }
-
     def inputPropertyCanBeNestedCallableAndClosure() {
         def files = [new File('file')] as Set
-        def fileCollection = [getFiles: { files }] as FileCollection
-        def callable = {fileCollection} as Callable
-
         when:
-        inputs.property('a', { callable })
+        inputs.property('a', { { { files } } as Callable })
 
         then:
         inputProperties() == [a: files]


### PR DESCRIPTION
`FileCollection` instances should not show up as regular `@Input` properties.
