### PR TITLE
Fix TestLauncher task ordering 

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -29,6 +29,7 @@ import org.gradle.internal.resources.ResourceLockCoordinationService;
 import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -110,6 +111,11 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         entryNodes.addAll(nodes);
         scheduledNodes = ImmutableList.copyOf(nodes);
         nodeMapping.addAll(nodes);
+    }
+
+    @Override
+    public void addEntryTask(Task task) {
+        addEntryTasks(Collections.singletonList(task));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -38,6 +38,15 @@ public interface ExecutionPlan extends Describable, Closeable {
 
     void setScheduledNodes(Collection<? extends Node> nodes);
 
+    /**
+     * Adds an entry task to the execution plan. If called multiple times then execution plan follows the method invocation order.
+     *
+     */
+    void addEntryTask(Task task);
+
+    /**
+     * Adds entry tasks to the execution plan. No ordering can be assumed between the elements of the target collection. If called multiple times then execution plan follows the method invocation order.
+     */
     void addEntryTasks(Collection<? extends Task> tasks);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java
@@ -36,7 +36,6 @@ import org.gradle.internal.model.StateTransitionControllerFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -259,7 +258,7 @@ public class DefaultBuildLifecycleController implements BuildLifecycleController
         @Override
         public void addEntryTasks(List<? extends Task> tasks) {
             for (Task task : tasks) {
-                plan.addEntryTasks(Collections.singletonList(task));
+                plan.addEntryTask(task);
             }
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -2049,7 +2049,7 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
 
     private void addToGraph(Task... tasks) {
         for (final def task in tasks) {
-            executionPlan.addEntryTasks([task])
+            executionPlan.addEntryTask(task)
         }
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -58,12 +58,12 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
 
     @Override
     public void applyTasksTo(Context context, ExecutionPlan plan) {
-        final Set<Task> allTestTasksToRun = new LinkedHashSet<>();
-        allTestTasksToRun.addAll(configureBuildForTestDescriptors(context, testExecutionRequest));
-        allTestTasksToRun.addAll(configureBuildForInternalJvmTestRequest(context.getGradle(), testExecutionRequest));
-        allTestTasksToRun.addAll(configureBuildForTestTasks(context, testExecutionRequest));
-        configureTestTasks(allTestTasksToRun);
-        plan.addEntryTasks(allTestTasksToRun);
+        final Set<Task> allTasksToRun = new LinkedHashSet<>();
+        allTasksToRun.addAll(configureBuildForTestDescriptors(context, testExecutionRequest));
+        allTasksToRun.addAll(configureBuildForInternalJvmTestRequest(context.getGradle(), testExecutionRequest));
+        allTasksToRun.addAll(configureBuildForTestTasks(context, testExecutionRequest));
+        configureTestTasks(allTasksToRun);
+        plan.addEntryTasks(allTasksToRun);
     }
 
     private void configureTestTasks(Set<Task> tasks) {
@@ -92,7 +92,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
 
     private List<Task> configureBuildForTestDescriptors(Context context, TestExecutionRequestAction testExecutionRequest) {
         Map<String, List<InternalJvmTestRequest>> taskAndTests = testExecutionRequest.getTaskAndTests();
-        List<Task> testTasksToRun = new ArrayList<>();
+        List<Task> tasksToRun = new ArrayList<>();
         for (final Map.Entry<String, List<InternalJvmTestRequest>> entry : taskAndTests.entrySet()) {
             String testTaskPath = entry.getKey();
             for (Test testTask : queryTestTasks(context, testTaskPath)) {
@@ -100,7 +100,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
                     final TestFilter filter = testTask.getFilter();
                     filter.includeTest(jvmTestRequest.getClassName(), jvmTestRequest.getMethodName());
                 }
-                testTasksToRun.add(testTask);
+                tasksToRun.add(testTask);
             }
         }
 
@@ -109,7 +109,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
                 InternalTestSpec testSpec = (InternalTestSpec) taskSpec;
                 Set<Test> tasks = queryTestTasks(context, taskSpec.getTaskPath());
                 for (Test task : tasks) {
-                    testTasksToRun.add(task);
+                    tasksToRun.add(task);
                     DefaultTestFilter filter = (DefaultTestFilter) task.getFilter();
                     for (String cls : testSpec.getClasses()) {
                         filter.includeCommandLineTest(cls, null);
@@ -126,11 +126,11 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
                     }
                 }
             } else {
-                testTasksToRun.addAll(queryTasks(context, taskSpec.getTaskPath()));
+                tasksToRun.addAll(queryTasks(context, taskSpec.getTaskPath()));
             }
         }
 
-        return testTasksToRun;
+        return tasksToRun;
     }
 
     private List<Test> configureBuildForTestTasks(Context context, TestExecutionRequestAction testExecutionRequest) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -64,7 +64,7 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
         allTasksToRun.addAll(configureBuildForTestTasks(context, testExecutionRequest));
         configureTestTasks(allTasksToRun);
         for (Task task : allTasksToRun) {
-            plan.addEntryTasks(Collections.singletonList(task));
+            plan.addEntryTask(task);
         }
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TestExecutionBuildConfigurationAction.java
@@ -63,7 +63,9 @@ class TestExecutionBuildConfigurationAction implements EntryTaskSelector {
         allTasksToRun.addAll(configureBuildForInternalJvmTestRequest(context.getGradle(), testExecutionRequest));
         allTasksToRun.addAll(configureBuildForTestTasks(context, testExecutionRequest));
         configureTestTasks(allTasksToRun);
-        plan.addEntryTasks(allTasksToRun);
+        for (Task task : allTasksToRun) {
+            plan.addEntryTasks(Collections.singletonList(task));
+        }
     }
 
     private void configureTestTasks(Set<Task> tasks) {

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/TestExecutionBuildTaskSchedulerTest.groovy
@@ -98,6 +98,7 @@ class TestExecutionBuildTaskSchedulerTest extends Specification {
         then:
         0 * buildProjectRegistry.allProjects
         _ * executionPlan.addEntryTasks({ args -> assert args.size() == 0 })
+        _ * executionPlan.addEntryTask({ args -> assert args.size() == 0 })
     }
 
     def "sets test filter with information from #requestType"() {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTaskExecutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r76/TestLauncherTaskExecutionCrossVersionSpec.groovy
@@ -206,18 +206,23 @@ class TestLauncherTaskExecutionCrossVersionSpec extends ToolingApiSpecification 
         setup:
         buildFile << '''
             tasks.register('setupTest')
+            tasks.register('cleanupTest')
         '''
 
         when:
-        withConnection { connection ->
+        withConnection { ProjectConnection connection ->
             TestLauncher testLauncher = connection.newTestLauncher()
             collectOutputs(testLauncher)
-            testLauncher.forTasks("setupTest").withTestsFor(s -> s.forTaskPath(":test").includeMethod('MyTest', 'pass'))
-            testLauncher.run()
+
+            testLauncher.forTasks("setupTest")
+                        .withTestsFor(s -> s.forTaskPath(":test")
+                        .includeMethod('MyTest', 'pass'))
+                        .forTasks("cleanupTest")
+                        .run()
         }
 
         then:
-        tasksExecutedInOrder(':setupTest', ':test')
+        tasksExecutedInOrder(':setupTest', ':test', ':cleanupTest')
 
         when:
         withConnection { connection ->


### PR DESCRIPTION
Follow-up for #21530.

#21530, in fact, did not solve the task ordering issue and the related [integration test](https://github.com/gradle/gradle/pull/21530/files#diff-d682461e97bb8ccdebc1c40482301079c99ce638375ddd294b60f5af8d37d990R205) was broken. In the test, two Gradle builds were executed and the assertion checked the ordering of the tasks in the output. Since `stdout` was not reset between the Gradle builds the test accidentally passed.

The actual task ordering issue was due to the fact that `TestExecutionBuildConfigurationAction` did not define priority between entry tasks: https://github.com/gradle/gradle/pull/21530/files#diff-e4cfba351ba696ee854d33a7fdf546c4cead1a051a315e9e25b0240e9dfa20c8R66. The solution is to add the entry tasks one by one to the execution plan, just like it happens for the [command line](https://github.com/gradle/gradle/blob/37eab673b0336e2cfe50e973d64c6aa717b9fa4b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildLifecycleController.java#L261-L263).