### PR TITLE
Fail if executable does not exist

### DIFF
--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -148,6 +148,11 @@ Groovy has been updated to https://groovy-lang.org/changelogs/changelog-3.0.12.h
 
 PMD has been updated to https://pmd.github.io/pmd-6.48.0/pmd_release_notes.html[PMD 6.48.0].
 
+==== Configuring a non-existing executable now fails
+
+When configuring an executable explicitly for link:{groovyDslPath}/org.gradle.api.tasks.compile.ForkOptions.html#org.gradle.api.tasks.compile.ForkOptions:executable[`JavaCompile`] or link:{groovyDslPath}/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:executable[`Test`] tasks, Gradle will now emit an error if this executable does not exist.
+In the past, the task would be executed with the default toolchain or JVM running the build.
+
 === Deprecations
 
 [[dependency_factory_renamed]]

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/JavaCompile.java
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
@@ -258,6 +259,8 @@ public class JavaCompile extends AbstractCompile implements HasCompileOptions {
                     // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
                     File parentJavaHome = executable.getParentFile().getParentFile();
                     return new SpecificInstallationToolchainSpec(objectFactory, parentJavaHome);
+                } else {
+                    throw new InvalidUserDataException("The configured executable does not exist (" + executable.getAbsolutePath() + ")");
                 }
             }
         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.compile
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec
 import org.gradle.internal.jvm.Jvm
@@ -58,6 +59,20 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
         then:
         def e = thrown(IllegalStateException)
         e.message == "Must not use `executable` property on `ForkOptions` together with `javaCompiler` property"
+    }
+
+    def "fails if custom executable does not exist"() {
+        def javaCompile = project.tasks.create("compileJava", JavaCompile)
+        def invalidjavac = "invalidjavac"
+
+        when:
+        javaCompile.options.forkOptions.executable = invalidjavac
+        javaCompile.createSpec()
+
+        then:
+        def e = thrown(InvalidUserDataException)
+        e.message.contains("The configured executable does not exist")
+        e.message.contains(invalidjavac)
     }
 
     def 'uses release property combined with toolchain compiler'() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/tasks/testing/Test.java
@@ -22,6 +22,7 @@ import groovy.lang.DelegatesTo;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -1280,6 +1281,8 @@ public class Test extends AbstractTestTask implements JavaForkOptions, PatternFi
                 // Relying on the layout of the toolchain distribution: <JAVA HOME>/bin/<executable>
                 File parentJavaHome = executable.getParentFile().getParentFile();
                 return new SpecificInstallationToolchainSpec(getObjectFactory(), parentJavaHome);
+            } else {
+                throw new InvalidUserDataException("The configured executable does not exist (" + executable.getAbsolutePath() + ")");
             }
         }
 

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/tasks/testing/TestTest.groovy
@@ -16,11 +16,12 @@
 
 package org.gradle.api.tasks.testing
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import spock.lang.Specification
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 
-class TestTest extends Specification {
+class TestTest extends AbstractProjectBuilderSpec {
 
     def 'javaLauncher is annotated with @Nested and @Optional'() {
         given:
@@ -29,5 +30,19 @@ class TestTest extends Specification {
         expect:
         launcherMethod.isAnnotationPresent(Nested)
         launcherMethod.isAnnotationPresent(Optional)
+    }
+
+    def 'fails if custom executable does not exist'() {
+        def testTask = project.tasks.create("test", Test)
+        def invalidJava = "invalidjava"
+
+        when:
+        testTask.executable = invalidJava
+        testTask.javaVersion
+
+        then:
+        def e = thrown(InvalidUserDataException)
+        e.message.contains("The configured executable does not exist")
+        e.message.contains(invalidJava)
     }
 }


### PR DESCRIPTION
When configuring the executable on JavaCompile or Test, if it points to a non-existing file, Gradle now fails with an error.

Fixes #21758