### PR TITLE
Ensure `ProgressLoggingFixture` build service is fully initialized

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ProgressLoggingFixture.groovy
@@ -89,6 +89,10 @@ class ProgressLoggingFixture extends InitScriptExecuterFixture {
                 private LoggingOutput loggingOutput
 
                 OutputProgressService() {
+                    // Ensure parameters.outputFile is set before adding ourselves as a listener
+                    if (!parameters.outputFile.present) {
+                        throw new IllegalStateException("parameters.outputFile is not set")
+                    }
                     loggingOutput = objects.newInstance(InternalServices).loggingOutput
                     loggingOutput.addOutputEventListener(this)
                 }


### PR DESCRIPTION
Before registering it as a listener as it could start receiving events from a separate thread immediatelly.