### PR TITLE
Reduce iterations of performance tests

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidStudioPerformanceTest.groovy
@@ -41,8 +41,8 @@ class RealLifeAndroidStudioPerformanceTest extends AbstractCrossVersionPerforman
         testProject.configure(runner)
         AndroidTestProject.useStableAgpVersion(runner)
         AndroidTestProject.useStableKotlinVersion(runner)
-        runner.warmUpRuns = 40
-        runner.runs = 40
+        runner.warmUpRuns = 20
+        runner.runs = 20
         // AGP 7.3 requires Gradle 7.4
         runner.minimumBaseVersion = "7.4"
         runner.setupAndroidStudioSync()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/AbstractIncrementalExecutionPerformanceTest.groovy
@@ -24,13 +24,13 @@ class AbstractIncrementalExecutionPerformanceTest extends AbstractCrossVersionPe
 
     def setup() {
         runner.useToolingApi = true
-        if (OperatingSystem.current().windows) {
-            // Reduce the number of iterations on Windows, since the performance tests take 3 times as long.
-            runner.warmUpRuns = 5
-            runner.runs = 20
-        } else {
+        if (OperatingSystem.current().linux) {
             runner.warmUpRuns = 10
             runner.runs = 40
+        } else {
+            // Reduce the number of iterations on Windows and macOS, since the performance tests are slower there
+            runner.warmUpRuns = 5
+            runner.runs = 20
         }
     }
 


### PR DESCRIPTION
We observed bottlenecks in performance tests, esp. on mac agents. Let's try to reduce them.
