### PR TITLE
Make TaskContainer Extensible

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -157,7 +157,7 @@ import java.util.Set;
  * Parallel execution can be enabled by the <code>--parallel</code> flag when the build is initiated.
  * In parallel mode, the tasks of different projects (i.e. in a multi project build) are able to be executed in parallel.
  */
-public interface Task extends Comparable<Task>, ExtensionAware {
+public interface Task extends Comparable<Task>, ExtensionAware, Named {
     String TASK_NAME = "name";
 
     String TASK_DESCRIPTION = "description";

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -17,9 +17,9 @@ package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.ExtensiblePolymorphicDomainObjectContainer;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
-import org.gradle.api.PolymorphicDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -36,7 +36,7 @@ import java.util.Map;
  * {@code tasks} property in your build script.</p>
  */
 @HasInternalProtocol
-public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainObjectContainer<Task> {
+public interface TaskContainer extends TaskCollection<Task>, ExtensiblePolymorphicDomainObjectContainer<Task> {
     /**
      * <p>Locates a task by path. You can supply a task name, a relative path, or an absolute path. Relative paths are
      * interpreted relative to the project for this container. This method returns null if no task with the given path

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -284,7 +284,7 @@ tasks.configure {
 
         expect:
         fails()
-        failure.assertHasCause("Could not set unknown property 'unknown' for task set of type $DefaultTaskContainer.name.")
+        failure.assertHasCause("Could not set unknown property 'unknown' for task container of type $DefaultTaskContainer.name.")
     }
 
     def "reports invoke unknown method from polymorphic container configure closure"() {
@@ -297,7 +297,7 @@ tasks.configure {
 
         expect:
         fails()
-        failure.assertHasCause("Could not find method unknown() for arguments [12] on task set of type ${DefaultTaskContainer.name}.")
+        failure.assertHasCause("Could not find method unknown() for arguments [12] on task container of type ${DefaultTaskContainer.name}.")
     }
 
     def "can read property from polymorphic container configure closure outer scope"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -22,6 +22,7 @@ import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Namer;
+import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.Actions;
@@ -43,6 +44,10 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
 
     protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, Named.Namer.forType(type), callbackActionDecorator);
+    }
+
+    protected AbstractNamedDomainObjectContainer(DefaultNamedDomainObjectSet<? super T> collection, CollectionFilter<T> filter, Instantiator instantiator, Namer<? super T> namer) {
+        super(collection, filter, instantiator, namer);
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
@@ -17,10 +17,11 @@ package org.gradle.api.internal;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Namer;
+import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.internal.Cast;
 import org.gradle.internal.Transformers;
 import org.gradle.internal.metaobject.AbstractDynamicObject;
@@ -40,6 +41,10 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
 
     protected AbstractPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
         super(type, instantiator, namer, callbackDecorator);
+    }
+
+    protected AbstractPolymorphicDomainObjectContainer(DefaultNamedDomainObjectSet<? super T> collection, CollectionFilter<T> filter, Instantiator instantiator, Namer<? super T> namer) {
+        super(collection, filter, instantiator, namer);
     }
 
     protected abstract <U extends T> U doCreate(String name, Class<U> type);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -21,6 +21,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Namer;
+import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
@@ -44,6 +45,12 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
 
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Instantiator elementInstantiator, CollectionCallbackActionDecorator callbackDecorator) {
         this(type, instantiator, elementInstantiator, Named.Namer.forType(type), callbackDecorator);
+    }
+
+    protected DefaultPolymorphicDomainObjectContainer(DefaultNamedDomainObjectSet<? super T> collection, CollectionFilter<T> filter, Instantiator instantiator, Instantiator elementInstantiator) {
+        super(collection, filter, instantiator, Named.Namer.forType(filter.getType()));
+        this.namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<>(filter.getType(), "this container");
+        this.elementInstantiator = elementInstantiator;
     }
 
     private DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Instantiator elementInstantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskCollection.java
@@ -24,7 +24,7 @@ import org.gradle.api.NamedDomainObjectCollectionSchema;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultNamedDomainObjectSet;
+import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.MutationGuard;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.plugins.DslObject;
@@ -43,21 +43,20 @@ import java.util.Map;
 
 import static org.gradle.api.reflect.TypeOf.typeOf;
 
-public class DefaultTaskCollection<T extends Task> extends DefaultNamedDomainObjectSet<T> implements TaskCollection<T> {
-    private static final Task.Namer NAMER = new Task.Namer();
-
+public class DefaultTaskCollection<T extends Task> extends DefaultPolymorphicDomainObjectContainer<T> implements TaskCollection<T> {
     protected final ProjectInternal project;
 
     private final MutationGuard parentMutationGuard;
 
     public DefaultTaskCollection(Class<T> type, Instantiator instantiator, ProjectInternal project, MutationGuard parentMutationGuard, CollectionCallbackActionDecorator decorator) {
-        super(type, instantiator, NAMER, decorator);
+        super(type, instantiator, instantiator, decorator);
         this.project = project;
         this.parentMutationGuard = parentMutationGuard;
     }
 
+    @SuppressWarnings("unused") // See #filtered(CollectionFilter)
     public DefaultTaskCollection(DefaultTaskCollection<? super T> collection, CollectionFilter<T> filter, Instantiator instantiator, ProjectInternal project, MutationGuard parentMutationGuard) {
-        super(collection, filter, instantiator, NAMER);
+        super(collection, filter, instantiator, instantiator);
         this.project = project;
         this.parentMutationGuard = parentMutationGuard;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -493,7 +493,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
-    public TaskContainerInternal configure(Closure configureClosure) {
+    public DefaultTaskContainer configure(Closure configureClosure) {
         return ConfigureUtil.configureSelf(configureClosure, this, new NamedDomainObjectContainerConfigureDelegate(configureClosure, this));
     }
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/TaskContainerDelegate.kt
@@ -22,6 +22,7 @@ import org.gradle.api.Action
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.NamedDomainObjectCollectionSchema
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Namer
 import org.gradle.api.Rule
 import org.gradle.api.Task
@@ -242,4 +243,16 @@ abstract class TaskContainerDelegate : TaskContainer {
 
     override fun remove(element: Task): Boolean =
         delegate.remove(element)
+
+    override fun <U : Task?> registerFactory(type: Class<U>, factory: NamedDomainObjectFactory<out U>) {
+        delegate.registerFactory(type, factory)
+    }
+
+    override fun <U : Task?> registerFactory(type: Class<U>, factory: Closure<out U>) {
+        delegate.registerFactory(type, factory)
+    }
+
+    override fun <U : Task?> registerBinding(type: Class<U>, implementationType: Class<out U>) {
+        delegate.registerBinding(type, implementationType)
+    }
 }


### PR DESCRIPTION
Currently, we cannot register interfaces and default implementations for Tasks.
We want to be able to do this for the Test task




