### PR TITLE
Warn explicitly if performance base version is wrong

### DIFF
--- a/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
+++ b/build-logic/performance-testing/src/main/kotlin/gradlebuild/performance/tasks/BuildCommitDistribution.kt
@@ -123,7 +123,11 @@ abstract class BuildCommitDistribution @Inject internal constructor(
     private
     fun copyToFinalDestination(checkoutDir: File) {
         val baseVersion = commitBaseline.get().substringBefore("-")
-        checkoutDir.resolve("subprojects/distributions-full/build/distributions/gradle-$baseVersion-bin.zip").copyTo(commitDistribution.asFile.get(), true)
+        val distribution = checkoutDir.resolve("subprojects/distributions-full/build/distributions/gradle-$baseVersion-bin.zip")
+        if (!distribution.isFile) {
+            throw IllegalStateException("${distribution.absolutePath} doesn't exist. Did you set the wrong base version?\n${distribution.parentFile.list()?.joinToString("\n")}")
+        }
+        distribution.copyTo(commitDistribution.asFile.get(), true)
     }
 
     private


### PR DESCRIPTION
Previously, if you use a wrong base version for performance baseline, e.g. `8.0-commit-X` is incorrectly set as `7.6-commit-X`, it fails with a vague error "gradle-7.6-bin.zip: The source file doesn't exist."

Now let's warn explictly in this case.

Example: https://builds.gradle.org/viewLog.html?buildId=56095009&