### PR TITLE
Support skipping all dependency builds

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -42,7 +42,10 @@ import java.util.Locale
 fun BuildSteps.customGradle(init: GradleBuildStep.() -> Unit, custom: GradleBuildStep.() -> Unit): GradleBuildStep =
     GradleBuildStep(init)
         .apply(custom)
-        .also { step(it) }
+        .also {
+            step(it)
+            it.skipConditionally()
+        }
 
 /**
  * Adds a [Gradle build step](https://confluence.jetbrains.com/display/TCDL/Gradle)
@@ -164,6 +167,13 @@ fun BuildSteps.checkCleanM2AndAndroidUserHome(os: Os = Os.LINUX) {
         } else {
             checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/repository") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.m2/.gradle-enterprise") + checkCleanDirUnixLike("%teamcity.agent.jvm.user.home%/.android", false)
         }
+        skipConditionally()
+    }
+}
+
+fun BuildStep.skipConditionally() {
+    conditions {
+        doesNotEqual("skip.build", "true")
     }
 }
 
@@ -233,6 +243,7 @@ fun BuildType.killProcessStep(stepName: String, os: Os, arch: Arch = Arch.AMD64)
             name = stepName
             executionMode = BuildStep.ExecutionMode.ALWAYS
             scriptContent = "\"${javaHome(BuildToolBuildJvm, os, arch)}/bin/java\" build-logic/cleanup/src/main/java/gradlebuild/cleanup/services/KillLeakingJavaProcesses.java $stepName"
+            skipConditionally()
         }
     }
 }

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -74,6 +74,7 @@ fun BuildSteps.killGradleProcessesStep(os: Os) {
         name = "KILL_GRADLE_PROCESSES"
         executionMode = BuildStep.ExecutionMode.ALWAYS
         scriptContent = os.killAllGradleProcesses
+        skipConditionally()
     }
 }
 
@@ -87,6 +88,7 @@ fun BuildSteps.substDirOnWindows(os: Os) {
                 subst p: /d
                 subst p: "%teamcity.build.checkoutDir%"
             """.trimIndent()
+            skipConditionally()
         }
         cleanBuildLogicBuild("P:/build-logic-commons")
         cleanBuildLogicBuild("P:/build-logic")
@@ -99,6 +101,7 @@ fun BuildSteps.removeSubstDirOnWindows(os: Os) {
             name = "REMOVE_VIRTUAL_DISK_FOR_PERF_TEST"
             executionMode = BuildStep.ExecutionMode.ALWAYS
             scriptContent = """dir p: && subst p: /d"""
+            skipConditionally()
         }
         cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic-commons")
         cleanBuildLogicBuild("%teamcity.build.checkoutDir%/build-logic")
@@ -120,5 +123,6 @@ private fun BuildSteps.cleanBuildLogicBuild(buildDir: String) {
             buildToolGradleParameters() +
                 buildScanTag("PerformanceTest")
             ).joinToString(separator = " ")
+        skipConditionally()
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -13,6 +13,7 @@ import common.dependsOn
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
+import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -100,6 +101,7 @@ fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: Strin
             name = "GRADLE_RUNNER"
             tasks = "clean $gradleTasks"
             gradleParams = parameters
+            skipConditionally()
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/TestPerformanceTest.kt
@@ -22,6 +22,7 @@ import common.buildToolGradleParameters
 import common.checkCleanM2AndAndroidUserHome
 import common.gradleWrapper
 import common.individualPerformanceTestArtifactRules
+import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
@@ -39,6 +40,7 @@ class TestPerformanceTest(model: CIBuildModel, stage: Stage) : BaseGradleBuildTy
                 tasks +
                     buildToolGradleParameters(isContinue = false)
                 ).joinToString(separator = " ")
+            skipConditionally()
         }
     }
 

--- a/.teamcity/src/main/kotlin/projects/CheckProject.kt
+++ b/.teamcity/src/main/kotlin/projects/CheckProject.kt
@@ -41,6 +41,13 @@ class CheckProject(
             allowEmpty = true,
             description = "The extra gradle parameters you want to pass to all dependencies of this build, e.g. `-PrerunAllTests` or `--no-build-cache`"
         )
+        text(
+            "reverse.dep.*.skip.build",
+            "",
+            display = ParameterDisplay.NORMAL,
+            allowEmpty = true,
+            description = "Set to 'true' if you want to skip all dependency builds"
+        )
     }
 
     var prevStage: Stage? = null


### PR DESCRIPTION
Even though we have adhoc job to run a specific build, there're some use cases we want to run a normal build but without its dependencies.

For example:

- I may want to run a normal performance test without dependencies.
- I want to quickly publish a nightly without running QuickFeedback.

This commit adds an extra `reverse.dep.*.skip.build` parameter. When set, all the dependency builds will be added into queue but eventually skipped.

We have a dedicated build to specify the gradle build tasks and parameters, but it's kind of cumbersome because people need to find out the tasks/parameters in build log and copy/paste them. After this change, you just need to rerun the build with the `reverse.dep.*.skip.build=true` and all dependencies are ignored automatically.

