### PR TITLE
Fix failing promotion jobs

### DIFF
--- a/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
+++ b/build-logic/publishing/src/main/kotlin/gradlebuild.publish-public-libraries.gradle.kts
@@ -211,6 +211,18 @@ fun publishNormalizedToLocalRepository() {
             builtBy(localPublish)
         }
     }
+
+    if (signArtifacts) {
+        // Otherwise we get
+        // ask ':tooling-api:publishGradleDistributionPublicationToRemoteRepository' uses this output of task ':tooling-api:signLocalPublication'
+        // without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
+        tasks.named("publishGradleDistributionPublicationToRemoteRepository") {
+            dependsOn("signLocalPublication")
+        }
+        tasks.named("publishLocalPublicationToLocalRepository") {
+            dependsOn("signGradleDistributionPublication")
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
By setting explicit dependency between publish and sign tasks.

Example: 

- https://ge.gradle.org/s/6snt5ua3mpn2q/failure#1
- https://ge.gradle.org/s/mykbtsror5lb4/failure#1

