### PR TITLE
Disable stacktrace check for MavenPublishS3ErrorsIntegrationTest

### DIFF
--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
@@ -35,6 +35,7 @@ class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest 
     def setup() {
         executer.withArgument('-d')
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")
+        executer.withStackTraceChecksDisabled()
     }
 
     def "should fail with an authentication error"() {


### PR DESCRIPTION
We sporadically get errors like:

```
java.lang.AssertionError: Standard output line 1034 contains an unexpected stack trace:
  at com.amazonaws.internal.EC2ResourceFetcher.doReadResource(EC2ResourceFetcher.java:100)
  ...
```

This is not what the test focuses on. Let's disable the stacktrace checking for this test.
