### PR TITLE
Relax expectations causing test to become flaky 

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
@@ -18,12 +18,10 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.GradleVersion
-import spock.lang.Ignore
 import spock.lang.Issue
 
 @Issue("https://github.com/gradle/gradle/issues/17812")
 class ParallelStaleOutputIntegrationTest extends AbstractIntegrationSpec {
-    @Ignore("https://github.com/gradle/gradle-private/issues/3579")
     def "fails when configuring tasks which do dependency resolution from non-project context in constructor"() {
         buildFile << """
             abstract class BadTask extends DefaultTask {
@@ -83,6 +81,15 @@ class ParallelStaleOutputIntegrationTest extends AbstractIntegrationSpec {
 
         expect:
         fails("a:foo", "b:foo", "--parallel")
-        result.assertHasErrorOutput("Resolution of the configuration :a:myconf was attempted from a context different than the project context. See: https://docs.gradle.org/${GradleVersion.current().version}/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more information.")
+
+        // We just need to assert that the build fails with the right error message here, it doesn't matter which task is the first to fail,
+        // allowing either failure to pass the test should reduce flakiness on CI.
+        if (result.error.contains("Could not create task ':a:bar'.")) {
+            result.assertHasErrorOutput("Resolution of the configuration :a:myconf was attempted from a context different than the project context. See: https://docs.gradle.org/${GradleVersion.current().version}/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more information.")
+        } else if (result.error.contains("Could not create task ':b:bar'.")) {
+            result.assertHasErrorOutput("Resolution of the configuration :b:myconf was attempted from a context different than the project context. See: https://docs.gradle.org/${GradleVersion.current().version}/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors for more information.")
+        } else {
+            throw new AssertionError("Unexpected task failure in test, see error output.")
+        }
     }
 }


### PR DESCRIPTION
Allow for either task to fail in the expectations - either should be considered test success.  It only matters that whichever task we attempt to create first outputs the proper error message.

Fixes: https://github.com/gradle/gradle-private/issues/3579, causing [this flaky behavior](https://ge.gradle.org/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia/Shanghai&tests.container=org.gradle.integtests.ParallelStaleOutputIntegrationTest&tests.test=fails%20when%20configuring%20tasks%20which%20do%20dependency%20resolution%20from%20non-project%20context%20in%20constructor)