### PR TITLE
Make MappingProvider extend TransformBackedProvider

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractMinimalProvider.java
@@ -35,7 +35,8 @@ public abstract class AbstractMinimalProvider<T> implements ProviderInternal<T>,
 
     @Override
     public <S> ProviderInternal<S> map(final Transformer<? extends S, ? super T> transformer) {
-        return new TransformBackedProvider<>(transformer, this);
+        // Could do a better job of inferring the type
+        return new TransformBackedProvider<>(null, this, transformer);
     }
 
     @Override

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
@@ -131,11 +131,11 @@ class WithSideEffectProviderTest extends ProviderSpec<Integer> {
         0 * _
 
         where:
-        description                 | wrap
-        "Provider.map"              | { p, m -> p.map(m) }
-        "Provider.flatMap"          | { p, m -> p.flatMap { Providers.of(m.call(it)) } }
-        "TransformerBackedProvider" | { p, m -> new TransformBackedProvider(m, p) }
-        "MappingProvider"           | { p, m -> new MappingProvider(Integer, p, m) }
+        description               | wrap
+        "Provider.map"            | { p, m -> p.map(m) }
+        "Provider.flatMap"        | { p, m -> p.flatMap { Providers.of(m.call(it)) } }
+        "TransformBackedProvider" | { p, m -> new TransformBackedProvider(null, p, m) }
+        "MappingProvider"         | { p, m -> new MappingProvider(Integer, p, m) }
     }
 
     def "runs the side effect when changing provider is flat-mapped to a provider with side effect"() {


### PR DESCRIPTION
`MappingProvider` and `TransformBackedProvider` serve the same purpose, with the only difference that `MappingProvider` has a stricter usage contract.

This PR refactors `MappingProvider` making it extend `TransformBackProvider` and explicitly referencing usage contract points in the implementation.