### PR TITLE
Adjust snippet for configuration cache

### DIFF
--- a/subprojects/docs/build.gradle
+++ b/subprojects/docs/build.gradle
@@ -812,9 +812,6 @@ tasks.named("docsTest") { task ->
             // Tests that can and has to be fixed to run with the configuration cache enabled.
             // Set the Gradle property runBrokenConfigurationCacheDocsTests=true to run tests from this list or any of the lists above.
             def testsToBeFixedForConfigurationCache = [
-                "snippet-dependency-management-customizing-resolution-capability-substitution-rule_groovy_capability_substitution.sample",
-                "snippet-dependency-management-customizing-resolution-capability-substitution-rule_kotlin_capability_substitution.sample",
-
                 "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_groovy_ivyComonentMetadataRule.sample",
                 "snippet-dependency-management-customizing-resolution-ivy-metadata-rule_kotlin_ivyComonentMetadataRule.sample",
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -12,6 +12,7 @@ Include only their name, impactful features should be called out separately belo
 We would like to thank the following community members for their contributions to this release of Gradle:
 
 [Björn Kautler](https://github.com/Vampire),
+[Clara Guerrero](https://github.com/cguerreros),
 [David Marin](https://github.com/dmarin),
 [Denis Buzmakov](https://github.com/bacecek),
 [Dmitry Pogrebnoy](https://github.com/DmitryPogrebnoy),

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/groovy/build.gradle
@@ -21,7 +21,9 @@ configurations.testCompileClasspath {
 
 tasks.register('resolve') {
     inputs.files(configurations.testCompileClasspath)
+
+    def files = configurations.testCompileClasspath.files
     doLast {
-        println configurations.testCompileClasspath.files.name
+        println files.name
     }
 }

--- a/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule/kotlin/build.gradle.kts
@@ -21,7 +21,9 @@ configurations.testCompileClasspath {
 
 tasks.register("resolve") {
     inputs.files(configurations.testCompileClasspath)
+
+    val files = configurations.testCompileClasspath.files
     doLast {
-        println(configurations.testCompileClasspath.files.map { it.name })
+        println(files.map { it.name })
     }
 }


### PR DESCRIPTION
Adjust the snippets/dependencyManagement/customizingResolution-capabilitySubstitutionRule sample for configuration cache

Fixes #21803
