### PR TITLE
Bump version for removing validation warnings to 9.0

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -48,7 +48,7 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
                 .collect(Collectors.joining()));
         warnings.forEach(warning -> DeprecationLogger.deprecateBehaviour(convertToSingleLine(renderMinimalInformationAbout(warning, false, false)))
             .withContext("Execution optimizations are disabled to ensure correctness.")
-            .willBeRemovedInGradle8()
+            .willBeRemovedInGradle9()
             .withUserManual(warning.getUserManualReference().getId(), warning.getUserManualReference().getSection())
             .nagUser()
         );

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultNodeValidator.java
@@ -66,7 +66,7 @@ public class DefaultNodeValidator implements NodeValidator {
                 String warning = convertToSingleLine(renderMinimalInformationAbout(problem, false, false));
                 DeprecationLogger.deprecateBehaviour(warning)
                     .withContext("Execution optimizations are disabled to ensure correctness.")
-                    .willBeRemovedInGradle8()
+                    .willBeRemovedInGradle9()
                     .withUserManual(userManualReference.getId(), userManualReference.getSection())
                     .nagUser();
             });

--- a/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
+++ b/subprojects/model-core/src/testFixtures/groovy/org/gradle/internal/reflect/validation/ValidationMessageChecker.groovy
@@ -435,7 +435,7 @@ trait ValidationMessageChecker {
         String asSingleLine = convertToSingleLine(message)
         String deprecationMessage = asSingleLine + (asSingleLine.endsWith(" ") ? '' : ' ') +
             "This behavior has been deprecated. " +
-            "This behavior is scheduled to be removed in Gradle 8.0. " +
+            "This behavior is scheduled to be removed in Gradle 9.0. " +
             "Execution optimizations are disabled to ensure correctness. " +
             "See https://docs.gradle.org/current/userguide/${docId}.html#${section} for more details."
         executer.expectDocumentedDeprecationWarning(deprecationMessage)


### PR DESCRIPTION
We changed all warnings for 8.0 into errors already, the warnings from the 8.x line should be turned into errors in 9.0.

Fixes #21648.