### PR TITLE
Add the variant identity to the seenArtifacts key

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -41,18 +41,22 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                 variant('api1') {
                     attribute('custom', 'c1')
                     capability('cap1')
+                    artifact("api1-c1-cap1")
                 }
                 variant('api2') {
                     attribute('custom', 'c2')
                     capability('cap1')
+                    artifact("api2-c2-cap1")
                 }
                 variant('runtime1') {
                     attribute('custom2', 'c1')
                     capability('cap2')
+                    artifact("runtime1-c1-cap2")
                 }
                 variant('runtime2') {
                     attribute('custom2', 'c2')
                     capability('cap2')
+                    artifact("runtime2-c2-cap2")
                 }
             }
         }
@@ -81,7 +85,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         when:
         repositoryInteractions {
             'org:test:1.0' {
-                expectResolve()
+                allowAll()
             }
         }
         succeeds 'checkDeps'
@@ -91,9 +95,11 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             root(":", ":test:") {
                 module('org:test:1.0') {
                     variant('api1', ['org.gradle.status': MultipleVariantSelectionIntegrationTest.defaultStatus(), custom: 'c1'])
+                    artifact([classifier: 'api1-c1-cap1'])
                 }
                 module('org:test:1.0') {
                     variant('runtime2', ['org.gradle.status': MultipleVariantSelectionIntegrationTest.defaultStatus(), custom2: 'c2'])
+                    artifact([classifier: 'runtime2-c2-cap2'])
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesConflictResolutionIntegrationTest.groovy
@@ -209,9 +209,11 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
                 variant('runtimeAlt') {
                     capability('org', 'testB', '1.0')
                     capability('special')
+                    artifact('runtime-special')
                 }
                 variant('runtimeOptional') {
                     capability('optional')
+                    artifact('runtime-optional')
                 }
             }
         }
@@ -245,7 +247,7 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
         when:
         repositoryInteractions {
             'org:testB:1.0' {
-                expectResolve()
+                allowAll()
             }
         }
         run ":checkDeps"
@@ -254,9 +256,13 @@ class CapabilitiesConflictResolutionIntegrationTest extends AbstractModuleDepend
 
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:testB:1.0:runtimeAlt').byConflictResolution("On capability org:testB we want runtimeAlt with 'special'")
+                module('org:testB:1.0:runtimeAlt') {
+                    artifact([classifier: 'runtime-special'])
+                }.byConflictResolution("On capability org:testB we want runtimeAlt with 'special'")
                 module('org:testB:1.0:runtimeAlt')
-                module('org:testB:1.0:runtimeOptional')
+                module('org:testB:1.0:runtimeOptional') {
+                    artifact([classifier: 'runtime-optional'])
+                }
             }
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitorTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice
+
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.DisplayName
+import org.gradle.internal.component.external.model.ImmutableCapability
+import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
+import spock.lang.Specification
+
+class ResolvedArtifactCollectingVisitorTest extends Specification {
+
+    def "variants with different capabilities are collected"() {
+        given:
+        def visitor = new ResolvedArtifactCollectingVisitor()
+        def componentIdentifier = Mock(ComponentIdentifier) {
+            getDisplayName() >> "example"
+        }
+        def variantName = Mock(DisplayName) {
+            getDisplayName() >> "variant"
+            getCapitalizedDisplayName() >> "Variant"
+        }
+        def artifactIdentifier = new ComponentFileArtifactIdentifier(componentIdentifier, "out")
+        def projectCapability = new ImmutableCapability("group", "project", "1.0")
+        def testFixturesCapability = new ImmutableCapability("group", "project-test-fixtures", "1.0")
+        def artifact = Mock(ResolvableArtifact) {
+            getId() >> artifactIdentifier
+        }
+
+        when:
+        visitor.visitArtifact(variantName, ImmutableAttributes.EMPTY, [projectCapability], artifact)
+        visitor.visitArtifact(variantName, ImmutableAttributes.EMPTY, [testFixturesCapability], artifact)
+
+        then:
+        visitor.getArtifacts().size() == 2
+    }
+}


### PR DESCRIPTION
In `ResolvedArtifactCollectingVisitor`, the artifacts are identified by `ResolvableArtifact.getId()`, so in case of `ComponentFileArtifactIdentifier` the artifact is identified by the `componentId` and `fileName` which could be the same for artifacts in the same module (the same `ProjectComponentIdentifier`) and producing the same `fileName` (but the path is different).

The problem exists only for artifacts with different capabilities as a node in the dependency graph has to have all the artifacts attributes matching, but they could have different capabilites, and so it's important to use the capability when identifying the artifact.

This change adds the variant attributes and capabilites as part of the key in `ResolvedArtifactCollectingVisitor` to solve this case.

Fixes #18458