### PR TITLE
Remove `decorate*Exception` from `UnitOfWork`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyErrorIntegrationTest.groovy
@@ -98,7 +98,12 @@ The following types/formats are supported:
 
             ExecutionFailure failure = inTestDirectory().withTasks('copy').runWithFailure()
             failure.assertHasDescription("Execution failed for task ':copy'.")
-            failure.assertHasCause("Cannot fingerprint input file property 'rootSpec\$1': java.nio.file.AccessDeniedException: ${dir}")
+            failure.assertHasDocumentedCause("Cannot access input property 'rootSpec\$1' of task ':copy'. " +
+                "Accessing unreadable inputs or outputs is not supported. " +
+                "Declare the task as untracked by using Task.doNotTrackState(). " +
+                "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details."
+            )
+            failure.assertHasCause("java.nio.file.AccessDeniedException: ${dir}")
         } finally {
             dir.permissions = oldPermissions
         }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyPermissionsIntegrationTest.groovy
@@ -280,17 +280,17 @@ class CopyPermissionsIntegrationTest extends AbstractIntegrationSpec implements 
 
         when:
         executer.withStackTraceChecksDisabled()
-        runAndFail "copy", "--info"
+        runAndFail "copy"
         then:
-        outputContains("Cannot access output property 'destinationDir' of task ':copy'")
         expectUnreadableCopyDestinationFailure()
+        failureHasCause(expectedError(unreadableOutput))
 
         cleanup:
         unreadableOutput.makeReadable()
 
         where:
         type        | create              | expectedError
-        'file'      | { it.createFile() } | { "java.io.UncheckedIOException: Failed to create MD5 hash for file '${it.absolutePath}' as it does not exist." }
+        'file'      | { it.createFile() } | { "Failed to create MD5 hash for file '${it.absolutePath}' as it does not exist." }
         'directory' | { it.createDir() }  | { "java.nio.file.AccessDeniedException: ${it.absolutePath}" }
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopySpecIntegrationSpec.groovy
@@ -238,6 +238,7 @@ class CopySpecIntegrationSpec extends AbstractIntegrationSpec implements Unreada
         runAndFail "copy"
         then:
         expectUnreadableCopyDestinationFailure()
+        failureHasCause("java.io.IOException: Cannot snapshot ${pipe}: not a regular file")
 
         cleanup:
         pipe.delete()

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UnreadableCopyDestinationFixture.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UnreadableCopyDestinationFixture.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 @SelfType(AbstractIntegrationSpec)
 trait UnreadableCopyDestinationFixture {
-    private static final String COPY_UNREADABLE_DESTINATION_FAILURE = "Cannot access a file in the destination directory (see --info log for details). " +
+    private static final String COPY_UNREADABLE_DESTINATION_FAILURE = "Cannot access a file in the destination directory. " +
         "Copying to a directory which contains unreadable content is not supported. " +
         "Declare the task as untracked by using Task.doNotTrackState(). " +
         "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details."

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/UntrackedTaskIntegrationTest.groovy
@@ -218,15 +218,14 @@ class UntrackedTaskIntegrationTest extends AbstractIntegrationSpec implements Di
 
         when:
         executer.withStackTraceChecksDisabled()
-        runAndFail "producer", "--info"
+        runAndFail "producer"
         then:
         executedAndNotSkipped(":producer")
-        outputContains("Cannot access output property 'outputDir' of task ':producer'")
-        outputContains("java.io.UncheckedIOException: java.nio.file.AccessDeniedException: ${unreadableDir.absolutePath}")
-        failure.assertHasDocumentedCause("Cannot access output property 'outputDir' of task ':producer' (see --info log for details). " +
+        failure.assertHasDocumentedCause("Cannot access output property 'outputDir' of task ':producer'. " +
             "Accessing unreadable inputs or outputs is not supported. " +
             "Declare the task as untracked by using Task.doNotTrackState(). " +
             "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details.")
+        failureHasCause("java.nio.file.AccessDeniedException: ${unreadableDir.absolutePath}")
 
         cleanup:
         unreadableDir.setReadable(true)
@@ -249,14 +248,14 @@ class UntrackedTaskIntegrationTest extends AbstractIntegrationSpec implements Di
 
         when:
         executer.withStackTraceChecksDisabled()
-        runAndFail "producer", "--info"
+        runAndFail "producer"
         then:
         executedAndNotSkipped(":producer")
-        outputContains("Cannot access output property 'outputDir' of task ':producer'")
-        failure.assertHasDocumentedCause("Cannot access output property 'outputDir' of task ':producer' (see --info log for details). " +
+        failure.assertHasDocumentedCause("Cannot access output property 'outputDir' of task ':producer'. " +
             "Accessing unreadable inputs or outputs is not supported. " +
             "Declare the task as untracked by using Task.doNotTrackState(). " +
             "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details.")
+        failureHasCause("java.io.IOException: Cannot snapshot ${namedPipe}: not a regular file")
     }
 
     @Requires(TestPrecondition.FILE_PERMISSIONS)
@@ -277,14 +276,13 @@ class UntrackedTaskIntegrationTest extends AbstractIntegrationSpec implements Di
 
         when:
         executer.withStackTraceChecksDisabled()
-        runAndFail "consumer", "--info"
+        runAndFail "consumer"
         then:
-        outputContains("Cannot access input property 'inputDir' of task ':consumer'")
-        outputContains("java.io.UncheckedIOException: java.nio.file.AccessDeniedException: ${unreadableDir.absolutePath}")
-        failure.assertHasDocumentedCause("Cannot access input property 'inputDir' of task ':consumer' (see --info log for details). " +
+        failure.assertHasDocumentedCause("Cannot access input property 'inputDir' of task ':consumer'. " +
             "Accessing unreadable inputs or outputs is not supported. " +
             "Declare the task as untracked by using Task.doNotTrackState(). " +
             "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details.")
+        failureHasCause("java.nio.file.AccessDeniedException: ${unreadableDir.absolutePath}")
 
         cleanup:
         unreadableDir.setReadable(true)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -354,25 +354,24 @@ public class TaskExecution implements UnitOfWork {
         if (!(cause instanceof UncheckedIOException || cause instanceof org.gradle.api.UncheckedIOException)) {
             return UncheckedException.throwAsUncheckedException(cause);
         }
-        LOGGER.info("Cannot access {} property '{}' of {}", propertyType, propertyName, getDisplayName(), cause);
         boolean isDestinationDir = propertyName.equals("destinationDir");
         DocumentedFailure.Builder builder = DocumentedFailure.builder();
         if (isDestinationDir && task instanceof Copy) {
-            builder.withSummary("Cannot access a file in the destination directory (see --info log for details).")
+            builder.withSummary("Cannot access a file in the destination directory.")
                 .withContext("Copying to a directory which contains unreadable content is not supported.")
                 .withAdvice("Declare the task as untracked by using Task.doNotTrackState().");
         } else if (isDestinationDir && task instanceof Sync) {
-            builder.withSummary("Cannot access a file in the destination directory (see --info log for details).")
+            builder.withSummary("Cannot access a file in the destination directory.")
                 .withContext("Syncing to a directory which contains unreadable content is not supported.")
                 .withAdvice("Use a Copy task with Task.doNotTrackState() instead.");
         } else {
-            builder.withSummary(String.format("Cannot access %s property '%s' of %s (see --info log for details).",
+            builder.withSummary(String.format("Cannot access %s property '%s' of %s.",
                     propertyType, propertyName, getDisplayName()))
                 .withContext("Accessing unreadable inputs or outputs is not supported.")
                 .withAdvice("Declare the task as untracked by using Task.doNotTrackState().");
         }
         return builder.withUserManual("more_about_tasks", "disable-state-tracking")
-            .build();
+            .build(cause);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -320,7 +320,7 @@ public class TaskExecution implements UnitOfWork {
                         inputFileProperty.getLineEndingNormalization(),
                         inputFileProperty::getPropertyFiles));
             } catch (InputFingerprinter.InputFileFingerprintingException e) {
-                throw decorateSnapshottingException("input", e.getPropertyName(), e.getCause());
+                throw decorateSnapshottingException("input", inputFileProperty.getPropertyName(), e.getCause());
             }
         }
     }
@@ -338,7 +338,7 @@ public class TaskExecution implements UnitOfWork {
                         new OutputFileValueSupplier(outputFile, property.getPropertyFiles())
                     );
                 } catch (OutputSnapshotter.OutputFileSnapshottingException e) {
-                    throw decorateSnapshottingException("output", e.getPropertyName(), e.getCause());
+                    throw decorateSnapshottingException("output", property.getPropertyName(), e.getCause());
                 }
             }
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -20,11 +20,9 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.Describable;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.FileNormalizer;
-import org.gradle.internal.execution.OutputSnapshotter.OutputFileSnapshottingException;
 import org.gradle.internal.execution.caching.CachingDisabledReason;
 import org.gradle.internal.execution.caching.CachingState;
 import org.gradle.internal.execution.fingerprint.InputFingerprinter;
-import org.gradle.internal.execution.fingerprint.InputFingerprinter.InputFileFingerprintingException;
 import org.gradle.internal.execution.history.OverlappingOutputs;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.execution.workspace.WorkspaceProvider;
@@ -296,20 +294,6 @@ public interface UnitOfWork extends Describable {
         default void visitLocalState(File localStateRoot) {}
 
         default void visitDestroyable(File destroyableRoot) {}
-    }
-
-    /**
-     * Decorate input file fingerprinting errors when appropriate.
-     */
-    default RuntimeException decorateInputFileFingerprintingException(InputFileFingerprintingException ex) {
-        return ex;
-    }
-
-    /**
-     * Decorate output file fingerprinting errors when appropriate.
-     */
-    default RuntimeException decorateOutputFileSnapshottingException(OutputFileSnapshottingException ex) {
-        return ex;
     }
 
     /**

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStep.java
@@ -129,22 +129,18 @@ public class CaptureStateAfterExecutionStep<C extends InputChangesContext> exten
     private AfterExecutionState captureStateAfterExecution(UnitOfWork work, BeforeExecutionContext context, BeforeExecutionState beforeExecutionState, Duration duration) {
         return operation(
             operationContext -> {
-                try {
-                    Timer timer = Time.startTimer();
-                    ImmutableSortedMap<String, FileSystemSnapshot> outputsProducedByWork = captureOutputs(work, context, beforeExecutionState);
-                    long snapshotOutputDuration = timer.getElapsedMillis();
+                Timer timer = Time.startTimer();
+                ImmutableSortedMap<String, FileSystemSnapshot> outputsProducedByWork = captureOutputs(work, context, beforeExecutionState);
+                long snapshotOutputDuration = timer.getElapsedMillis();
 
-                    // The origin execution time is recorded as “work duration” + “output snapshotting duration”,
-                    // As this is _roughly_ the amount of time that is avoided by reusing the outputs,
-                    // which is currently the _only_ thing this value is used for.
-                    Duration originExecutionTime = duration.plus(Duration.ofMillis(snapshotOutputDuration));
-                    OriginMetadata originMetadata = new OriginMetadata(buildInvocationScopeId.asString(), originExecutionTime);
-                    AfterExecutionState afterExecutionState = new DefaultAfterExecutionState(beforeExecutionState, outputsProducedByWork, originMetadata, false);
-                    operationContext.setResult(Operation.Result.INSTANCE);
-                    return afterExecutionState;
-                } catch (OutputSnapshotter.OutputFileSnapshottingException e) {
-                    throw work.decorateOutputFileSnapshottingException(e);
-                }
+                // The origin execution time is recorded as “work duration” + “output snapshotting duration”,
+                // As this is _roughly_ the amount of time that is avoided by reusing the outputs,
+                // which is currently the _only_ thing this value is used for.
+                Duration originExecutionTime = duration.plus(Duration.ofMillis(snapshotOutputDuration));
+                OriginMetadata originMetadata = new OriginMetadata(buildInvocationScopeId.asString(), originExecutionTime);
+                AfterExecutionState afterExecutionState = new DefaultAfterExecutionState(beforeExecutionState, outputsProducedByWork, originMetadata, false);
+                operationContext.setResult(Operation.Result.INSTANCE);
+                return afterExecutionState;
             },
             BuildOperationDescriptor
                 .displayName("Snapshot outputs after executing " + work.getDisplayName())

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -85,8 +85,7 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
         step.execute(work, context)
         then:
         def ex = thrown RuntimeException
-        ex.cause == failure
-        ex.message == "Wrapper"
+        ex == failure
         assertOperation(ex)
 
         1 * outputChangeListener.invalidateCachesFor([])
@@ -100,7 +99,6 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
             _ * detectedOverlappingOutputs >> Optional.empty()
         })
         1 * outputSnapshotter.snapshotOutputs(work, _) >> { throw failure }
-        _ * work.decorateOutputFileSnapshottingException(_) >> { OutputSnapshotter.OutputFileSnapshottingException e -> throw new RuntimeException("Wrapper", e) }
         0 * _
     }
 

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateBeforeExecutionStepTest.groovy
@@ -163,8 +163,7 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
 
         then:
         def ex = thrown RuntimeException
-        ex.cause == failure
-        ex.message == "Wrapper"
+        ex == failure
 
         _ * context.inputProperties >> ImmutableSortedMap.of()
         _ * context.inputFileProperties >> ImmutableSortedMap.of()
@@ -176,7 +175,6 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
             _
         ) >> { throw failure }
         interaction { snapshotState() }
-        _ * work.decorateInputFileFingerprintingException(_) >> { InputFingerprinter.InputFileFingerprintingException e -> throw new RuntimeException("Wrapper", e) }
         0 * _
 
         assertOperation(ex)
@@ -189,14 +187,12 @@ class CaptureStateBeforeExecutionStepTest extends StepSpec<BeforeExecutionContex
 
         then:
         def ex = thrown RuntimeException
-        ex.cause == failure
-        ex.message == "Wrapper"
+        ex == failure
 
         _ * context.inputProperties >> ImmutableSortedMap.of()
         _ * context.inputFileProperties >> ImmutableSortedMap.of()
         1 * outputSnapshotter.snapshotOutputs(work, _) >> { throw failure }
         interaction { snapshotState() }
-        _ * work.decorateOutputFileSnapshottingException(_) >> { OutputSnapshotter.OutputFileSnapshottingException e -> throw new RuntimeException("Wrapper", e) }
         0 * _
 
         assertOperation(ex)

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/SyncTaskIntegrationTest.groovy
@@ -458,13 +458,13 @@ class SyncTaskIntegrationTest extends AbstractIntegrationSpec {
 
         when:
         executer.withStackTraceChecksDisabled()
-        runAndFail "sync", "--info"
+        runAndFail "sync"
         then:
-        outputContains("Cannot access output property 'destinationDir' of task ':sync'")
-        failure.assertHasDocumentedCause("Cannot access a file in the destination directory (see --info log for details). " +
+        failure.assertHasDocumentedCause("Cannot access a file in the destination directory. " +
             "Syncing to a directory which contains unreadable content is not supported. " +
             "Use a Copy task with Task.doNotTrackState() instead. " +
             "See https://docs.gradle.org/current/userguide/more_about_tasks.html#disable-state-tracking for more details.")
+        failureHasCause("Failed to create MD5 hash for file '${unreadableOutput}' as it does not exist.")
 
         cleanup:
         unreadableOutput.makeReadable()

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DocumentedFailure.java
@@ -18,6 +18,7 @@ package org.gradle.internal.deprecation;
 
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException;
+import org.gradle.internal.exceptions.Contextual;
 
 import javax.annotation.Nullable;
 
@@ -56,17 +57,30 @@ public class DocumentedFailure {
         }
 
         public GradleException build() {
+            return build(null);
+        }
+
+        public GradleException build(@Nullable Throwable cause) {
             StringBuilder outputBuilder = new StringBuilder(summary);
             append(outputBuilder, contextualAdvice);
             append(outputBuilder, advice);
             append(outputBuilder, documentation.consultDocumentationMessage());
-            return new GradleException(outputBuilder.toString());
+            return cause == null
+                ? new GradleException(outputBuilder.toString())
+                : new DocumentedExceptionWithCause(outputBuilder.toString(), cause);
         }
 
         private static void append(StringBuilder outputBuilder, @Nullable String message) {
             if (!StringUtils.isEmpty(message)) {
                 outputBuilder.append(" ").append(message);
             }
+        }
+    }
+
+    @Contextual
+    public static class DocumentedExceptionWithCause extends GradleException {
+        public DocumentedExceptionWithCause(String message, @Nullable Throwable cause) {
+            super(message, cause);
         }
     }
 }


### PR DESCRIPTION
We can capture and decorate the exceptions directly in `TaskExecution`.

This also improves the error messages for unreadable input/output files so you don't need to check the info log any more.