### PR TITLE
Generify UnitOfWork

### DIFF
--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/fingerprint/ConfigurationCacheFingerprintWriter.kt
@@ -332,7 +332,7 @@ class ConfigurationCacheFingerprintWriter(
         }
     }
 
-    override fun onExecute(work: UnitOfWork, relevantBehaviors: EnumSet<InputBehavior>) {
+    override fun onExecute(work: UnitOfWork<*>, relevantBehaviors: EnumSet<InputBehavior>) {
         captureWorkInputs(work, relevantBehaviors)
     }
 
@@ -342,7 +342,7 @@ class ConfigurationCacheFingerprintWriter(
     }
 
     private
-    fun captureWorkInputs(work: UnitOfWork, relevantInputBehaviors: EnumSet<InputBehavior>) {
+    fun captureWorkInputs(work: UnitOfWork<*>, relevantInputBehaviors: EnumSet<InputBehavior>) {
         captureWorkInputs(work.displayName) { visitStructure ->
             work.visitRegularInputs(object : InputVisitor {
                 override fun visitInputFileProperty(propertyName: String, behavior: InputBehavior, value: InputFileValueSupplier) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -135,10 +135,10 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
     }
 
     private TaskExecuterResult executeIfValid(TaskInternal task, TaskStateInternal state, TaskExecutionContext context, TaskExecution work) {
-        ExecutionEngine.Request request = executionEngine.createRequest(work);
+        ExecutionEngine.Request<Void> request = executionEngine.createRequest(work);
         context.getTaskExecutionMode().getRebuildReason().ifPresent(request::forceNonIncremental);
         request.withValidationContext(context.getValidationContext());
-        Result result = request.execute();
+        Result<Void> result = request.execute();
         result.getExecution().ifSuccessfulOrElse(
             success -> state.setOutcome(convertOutcome(success.getOutcome())),
             failure -> state.setOutcome(new TaskExecutionException(task, failure))

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TaskExecution.java
@@ -91,7 +91,7 @@ import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.REL
 import static org.gradle.internal.work.AsyncWorkTracker.ProjectLockRetention.RELEASE_PROJECT_LOCKS;
 
 @SuppressWarnings("deprecation")
-public class TaskExecution implements UnitOfWork {
+public class TaskExecution implements UnitOfWork<Void> {
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecution.class);
     private static final SnapshotTaskInputsBuildOperationType.Details SNAPSHOT_TASK_INPUTS_DETAILS = new SnapshotTaskInputsBuildOperationType.Details() {
     };
@@ -152,7 +152,7 @@ public class TaskExecution implements UnitOfWork {
     }
 
     @Override
-    public WorkOutput execute(ExecutionRequest executionRequest) {
+    public WorkOutput<Void> execute(ExecutionRequest executionRequest) {
         FileCollection previousFiles = executionRequest.getPreviouslyProducedOutputs()
             .<FileCollection>map(previousOutputs -> new PreviousOutputFileCollection(task, fileCollectionFactory, previousOutputs))
             .orElseGet(fileCollectionFactory::empty);
@@ -160,14 +160,14 @@ public class TaskExecution implements UnitOfWork {
         outputs.setPreviousOutputFiles(previousFiles);
         try {
             WorkResult didWork = executeWithPreviousOutputFiles(executionRequest.getInputChanges().orElse(null));
-            return new WorkOutput() {
+            return new WorkOutput<Void>() {
                 @Override
                 public WorkResult getDidWork() {
                     return didWork;
                 }
 
                 @Override
-                public Object getOutput() {
+                public Void getOutput() {
                     return null;
                 }
             };
@@ -177,7 +177,7 @@ public class TaskExecution implements UnitOfWork {
     }
 
     @Override
-    public Object loadAlreadyProducedOutput(File workspace) {
+    public Void loadAlreadyProducedOutput(File workspace) {
         return null;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/DefaultWorkValidationWarningRecorder.java
@@ -37,7 +37,7 @@ public class DefaultWorkValidationWarningRecorder implements ValidateStep.Valida
     private final AtomicInteger workWithFailuresCount = new AtomicInteger();
 
     @Override
-    public void recordValidationWarnings(UnitOfWork work, Collection<TypeValidationProblem> warnings) {
+    public void recordValidationWarnings(UnitOfWork<?> work, Collection<TypeValidationProblem> warnings) {
         workWithFailuresCount.incrementAndGet();
 
         ImmutableSet<String> uniqueWarnings = warnings.stream().map(warning -> convertToSingleLine(renderMinimalInformationAbout(warning, true, false))).collect(ImmutableSet.toImmutableSet());

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultWorkInputListeners.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/DefaultWorkInputListeners.java
@@ -43,7 +43,7 @@ public class DefaultWorkInputListeners implements WorkInputListeners {
     }
 
     @Override
-    public void broadcastFileSystemInputsOf(UnitOfWork work, EnumSet<InputBehavior> relevantBehaviors) {
+    public void broadcastFileSystemInputsOf(UnitOfWork<?> work, EnumSet<InputBehavior> relevantBehaviors) {
         broadcaster.getSource().onExecute(work, relevantBehaviors);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -174,7 +174,6 @@ import org.gradle.internal.execution.steps.RemoveUntrackedExecutionStateStep;
 import org.gradle.internal.execution.steps.ResolveChangesStep;
 import org.gradle.internal.execution.steps.ResolveInputChangesStep;
 import org.gradle.internal.execution.steps.SkipUpToDateStep;
-import org.gradle.internal.execution.steps.Step;
 import org.gradle.internal.execution.steps.StoreExecutionStateStep;
 import org.gradle.internal.execution.steps.TimeoutStep;
 import org.gradle.internal.execution.steps.UpToDateResult;
@@ -739,16 +738,16 @@ class DependencyManagementBuildScopeServices {
         // @formatter:on
     }
 
-    private static class NoOpCachingStateStep<C extends ValidationFinishedContext> implements Step<C, CachingResult> {
-        private final Step<? super CachingContext, ? extends UpToDateResult> delegate;
+    private static class NoOpCachingStateStep<C extends ValidationFinishedContext> implements CachingResult.Step<C> {
+        private final UpToDateResult.Step<? super CachingContext> delegate;
 
-        public NoOpCachingStateStep(Step<? super CachingContext, ? extends UpToDateResult> delegate) {
+        public NoOpCachingStateStep(UpToDateResult.Step<? super CachingContext> delegate) {
             this.delegate = delegate;
         }
 
         @Override
-        public CachingResult execute(UnitOfWork work, ValidationFinishedContext context) {
-            UpToDateResult result = delegate.execute(work, new CachingContext() {
+        public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
+            UpToDateResult<T> result = delegate.execute(work, new CachingContext() {
                 @Override
                 public CachingState getCachingState() {
                     return CachingState.NOT_DETERMINED;
@@ -804,7 +803,7 @@ class DependencyManagementBuildScopeServices {
                     return context.getBeforeExecutionState();
                 }
             });
-            return new CachingResult() {
+            return new CachingResult<T>() {
                 @Override
                 public CachingState getCachingState() {
                     return CachingState.NOT_DETERMINED;
@@ -826,7 +825,7 @@ class DependencyManagementBuildScopeServices {
                 }
 
                 @Override
-                public Try<Execution> getExecution() {
+                public Try<Execution<T>> getExecution() {
                     return result.getExecution();
                 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvocationFactory.java
@@ -108,7 +108,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         ProjectInternal producerProject = determineProducerProject(subject);
         TransformationWorkspaceServices workspaceServices = determineWorkspaceServices(producerProject);
 
-        UnitOfWork execution;
+        UnitOfWork<TransformationResult> execution;
         if (producerProject == null) {
             execution = new ImmutableTransformerExecution(
                 transformer,
@@ -234,7 +234,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         }
     }
 
-    private abstract static class AbstractTransformerExecution implements UnitOfWork {
+    private abstract static class AbstractTransformerExecution implements UnitOfWork<TransformationResult> {
         protected final Transformer transformer;
         protected final File inputArtifact;
         private final ArtifactTransformDependencies dependencies;
@@ -274,7 +274,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
         }
 
         @Override
-        public WorkOutput execute(ExecutionRequest executionRequest) {
+        public WorkOutput<TransformationResult> execute(ExecutionRequest executionRequest) {
             artifactTransformListener.beforeTransformerInvocation(transformer, subject);
             try {
                 return executeWithinTransformerListener(executionRequest);
@@ -283,7 +283,7 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
             }
         }
 
-        private WorkOutput executeWithinTransformerListener(ExecutionRequest executionRequest) {
+        private WorkOutput<TransformationResult> executeWithinTransformerListener(ExecutionRequest executionRequest) {
             TransformationResult result = buildOperationExecutor.call(new CallableBuildOperation<TransformationResult>() {
                 @Override
                 public TransformationResult call(BuildOperationContext context) {
@@ -303,21 +303,21 @@ public class DefaultTransformerInvocationFactory implements TransformerInvocatio
                 }
             });
 
-            return new WorkOutput() {
+            return new WorkOutput<TransformationResult>() {
                 @Override
                 public WorkResult getDidWork() {
                     return WorkResult.DID_WORK;
                 }
 
                 @Override
-                public Object getOutput() {
+                public TransformationResult getOutput() {
                     return result;
                 }
             };
         }
 
         @Override
-        public Object loadAlreadyProducedOutput(File workspace) {
+        public TransformationResult loadAlreadyProducedOutput(File workspace) {
             TransformationResultSerializer resultSerializer = new TransformationResultSerializer(getOutputDir(workspace));
             return resultSerializer.readResultsFile(getResultsFile(workspace));
         }

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/UnitOfWorkBuilder.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/UnitOfWorkBuilder.groovy
@@ -146,12 +146,12 @@ class UnitOfWorkBuilder {
         final String uniqueId
     }
 
-    UnitOfWork build() {
+    UnitOfWork<String> build() {
         Map<String, OutputPropertySpec> outputFileSpecs = Maps.transformEntries(outputFiles, { key, value -> outputFileSpec(value) })
         Map<String, OutputPropertySpec> outputDirSpecs = Maps.transformEntries(outputDirs, { key, value -> outputDirectorySpec(value) })
         Map<String, OutputPropertySpec> outputs = outputFileSpecs + outputDirSpecs
 
-        return new UnitOfWork() {
+        return new UnitOfWork<String>() {
             boolean executed
 
             @Override
@@ -175,24 +175,24 @@ class UnitOfWorkBuilder {
             }
 
             @Override
-            UnitOfWork.WorkOutput execute(UnitOfWork.ExecutionRequest executionRequest) {
+            UnitOfWork.WorkOutput<String> execute(UnitOfWork.ExecutionRequest executionRequest) {
                 def didWork = work.get()
                 executed = true
-                return new UnitOfWork.WorkOutput() {
+                return new UnitOfWork.WorkOutput<String>() {
                     @Override
                     UnitOfWork.WorkResult getDidWork() {
                         return didWork
                     }
 
                     @Override
-                    Object getOutput() {
+                    String getOutput() {
                         return loadAlreadyProducedOutput(executionRequest.workspace)
                     }
                 }
             }
 
             @Override
-            Object loadAlreadyProducedOutput(File workspace) {
+            String loadAlreadyProducedOutput(File workspace) {
                 return "output"
             }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/ExecutionEngine.java
@@ -30,9 +30,9 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 
 public interface ExecutionEngine {
-    Request createRequest(UnitOfWork work);
+    <T> Request<T> createRequest(UnitOfWork<T> work);
 
-    interface Request {
+    interface Request<T> {
         /**
          * Force the re-execution of the unit of work, disabling optimizations
          * like up-to-date checks, build cache and incremental execution.
@@ -48,7 +48,7 @@ public interface ExecutionEngine {
          * Execute the unit of work using available optimizations like
          * up-to-date checks, build cache and incremental execution.
          */
-        Result execute();
+        Result<T> execute();
 
         /**
          * Load the unit of work from the given cache, or defer its execution.
@@ -57,11 +57,11 @@ public interface ExecutionEngine {
          * Otherwise, the execution is wrapped in a not-yet-complete {@link Deferrable} to be evaluated later.
          * The work is looked up by its {@link UnitOfWork.Identity identity} in the given cache.
          */
-        <T> Deferrable<Try<T>> executeDeferred(Cache<Identity, Try<T>> cache);
+        Deferrable<Try<T>> executeDeferred(Cache<Identity, Try<T>> cache);
     }
 
-    interface Result {
-        Try<Execution> getExecution();
+    interface Result<T> {
+        Try<Execution<T>> getExecution();
 
         CachingState getCachingState();
 
@@ -83,7 +83,7 @@ public interface ExecutionEngine {
         Optional<AfterExecutionState> getAfterExecutionState();
     }
 
-    interface Execution {
+    interface Execution<T> {
         /**
          * Get how the outputs have been produced.
          */
@@ -93,9 +93,8 @@ public interface ExecutionEngine {
          * Get the object representing the produced output.
          * The type of value returned here depends on the {@link UnitOfWork} implmenetation.
          */
-        // TODO Parametrize UnitOfWork with this generated result
         @Nullable
-        Object getOutput();
+        T getOutput();
     }
 
     /**

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputSnapshotter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/OutputSnapshotter.java
@@ -25,7 +25,7 @@ public interface OutputSnapshotter {
     /**
      * Takes a snapshot of the outputs of a work.
      */
-    ImmutableSortedMap<String, FileSystemSnapshot> snapshotOutputs(UnitOfWork work, File workspace)
+    ImmutableSortedMap<String, FileSystemSnapshot> snapshotOutputs(UnitOfWork<?> work, File workspace)
         throws OutputFileSnapshottingException;
 
     class OutputFileSnapshottingException extends RuntimeException {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/UnitOfWork.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-public interface UnitOfWork extends Describable {
+public interface UnitOfWork<T> extends Describable {
     /**
      * Determine the identity of the work unit that uniquely identifies it
      * among the other work units of the same type in the current build.
@@ -62,7 +62,7 @@ public interface UnitOfWork extends Describable {
     /**
      * Executes the work synchronously.
      */
-    WorkOutput execute(ExecutionRequest executionRequest);
+    WorkOutput<T> execute(ExecutionRequest executionRequest);
 
     /**
      * Parameter object for {@link #execute(ExecutionRequest)}.
@@ -91,7 +91,7 @@ public interface UnitOfWork extends Describable {
     /**
      * The result of executing the user code.
      */
-    interface WorkOutput {
+    interface WorkOutput<T> {
         /**
          * Whether any significant amount of work has happened while executing the user code.
          * <p>
@@ -103,7 +103,7 @@ public interface UnitOfWork extends Describable {
          * Implementation-specific output of executing the user code.
          */
         @Nullable
-        Object getOutput();
+        T getOutput();
     }
 
     enum WorkResult {
@@ -117,7 +117,7 @@ public interface UnitOfWork extends Describable {
      * or loaded from cache.
      */
     @Nullable
-    Object loadAlreadyProducedOutput(File workspace);
+    T loadAlreadyProducedOutput(File workspace);
 
     /**
      * Returns the {@link WorkspaceProvider} to allocate a workspace to execution this work in.

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkInputListener.java
@@ -34,5 +34,5 @@ public interface WorkInputListener {
      * @param work the identity of the unit of work to be executed
      * @param relevantBehaviors the file system inputs relevant to the task execution
      */
-    void onExecute(UnitOfWork work, EnumSet<InputBehavior> relevantBehaviors);
+    void onExecute(UnitOfWork<?> work, EnumSet<InputBehavior> relevantBehaviors);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkInputListeners.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/WorkInputListeners.java
@@ -34,5 +34,5 @@ public interface WorkInputListeners {
 
     void removeListener(WorkInputListener listener);
 
-    void broadcastFileSystemInputsOf(UnitOfWork work, EnumSet<InputBehavior> relevantBehaviors);
+    void broadcastFileSystemInputsOf(UnitOfWork<?> work, EnumSet<InputBehavior> relevantBehaviors);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultOutputSnapshotter.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/DefaultOutputSnapshotter.java
@@ -33,7 +33,7 @@ public class DefaultOutputSnapshotter implements OutputSnapshotter {
     }
 
     @Override
-    public ImmutableSortedMap<String, FileSystemSnapshot> snapshotOutputs(UnitOfWork work, File workspace) {
+    public ImmutableSortedMap<String, FileSystemSnapshot> snapshotOutputs(UnitOfWork<?> work, File workspace) {
         ImmutableSortedMap.Builder<String, FileSystemSnapshot> builder = ImmutableSortedMap.naturalOrder();
         work.visitOutputs(workspace, new UnitOfWork.OutputVisitor() {
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AfterExecutionResult.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AfterExecutionResult.java
@@ -16,13 +16,19 @@
 
 package org.gradle.internal.execution.steps;
 
+import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.AfterExecutionState;
 
 import java.util.Optional;
 
-public interface AfterExecutionResult extends Result {
+public interface AfterExecutionResult<T> extends Result<T> {
     /**
      * State after execution, or {@link Optional#empty()} if work is untracked.
      */
     Optional<AfterExecutionState> getAfterExecutionState();
+
+    interface Step<C extends Context> extends org.gradle.internal.execution.steps.Step<C, AfterExecutionResult<?>> {
+        @Override
+        <T> AfterExecutionResult<T> execute(UnitOfWork<T> work, C context);
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AssignWorkspaceStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/AssignWorkspaceStep.java
@@ -27,15 +27,15 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 import java.io.File;
 import java.util.Optional;
 
-public class AssignWorkspaceStep<C extends IdentityContext, R extends Result> implements Step<C, R> {
-    private final Step<? super WorkspaceContext, ? extends R> delegate;
+public class AssignWorkspaceStep<C extends IdentityContext> implements CachingResult.Step<C> {
+    private final CachingResult.Step<? super WorkspaceContext> delegate;
 
-    public AssignWorkspaceStep(Step<? super WorkspaceContext, ? extends R> delegate) {
+    public AssignWorkspaceStep(CachingResult.Step<? super WorkspaceContext> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
         WorkspaceProvider workspaceProvider = work.getWorkspaceProvider();
         return workspaceProvider.withWorkspace(context.getIdentity().getUniqueId(), (workspace, history) -> delegate.execute(work, new WorkspaceContext() {
             @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildOperationStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/BuildOperationStep.java
@@ -23,7 +23,7 @@ import org.gradle.internal.operations.CallableBuildOperation;
 
 import java.util.function.Function;
 
-public abstract class BuildOperationStep<C extends Context, R extends Result> implements Step<C, R> {
+public abstract class BuildOperationStep<C extends Context, R extends Result<?>> implements Step<C, R> {
     private final BuildOperationExecutor buildOperationExecutor;
 
     protected BuildOperationStep(BuildOperationExecutor buildOperationExecutor) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingResult.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CachingResult.java
@@ -17,9 +17,18 @@
 package org.gradle.internal.execution.steps;
 
 import org.gradle.internal.execution.ExecutionEngine;
+import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.caching.CachingState;
 
-public interface CachingResult extends UpToDateResult, ExecutionEngine.Result {
+public interface CachingResult<T> extends UpToDateResult<T>, ExecutionEngine.Result<T> {
 
     CachingState getCachingState();
+
+    interface Step<C extends Context> extends org.gradle.internal.execution.steps.Step<C, CachingResult<?>> {
+        @Override
+        <T> CachingResult<T> execute(UnitOfWork<T> work, C context);
+    }
+
+    interface DeferredExecutionAwareStep<C extends Context> extends org.gradle.internal.execution.steps.DeferredExecutionAwareStep<C, CachingResult<?>>, Step<C> {
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CancelExecutionStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CancelExecutionStep.java
@@ -20,20 +20,20 @@ import org.gradle.api.BuildCancelledException;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.execution.UnitOfWork;
 
-public class CancelExecutionStep<C extends Context, R extends Result> implements Step<C, R> {
+public class CancelExecutionStep<C extends Context> implements Result.Step<C> {
     private final BuildCancellationToken cancellationToken;
-    private final Step<? super C, ? extends R> delegate;
+    private final Result.Step<? super C> delegate;
 
     public CancelExecutionStep(
         BuildCancellationToken cancellationToken,
-        Step<? super C, ? extends R> delegate
+        Result.Step<? super C> delegate
     ) {
         this.cancellationToken = cancellationToken;
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> Result<T> execute(UnitOfWork<T> work, C context) {
         Thread thread = Thread.currentThread();
         Runnable interrupt = thread::interrupt;
         try {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/CreateOutputsStep.java
@@ -25,17 +25,17 @@ import java.io.File;
 
 import static org.gradle.util.internal.GFileUtils.mkdirs;
 
-public class CreateOutputsStep<C extends ChangingOutputsContext, R extends Result> implements Step<C, R> {
+public class CreateOutputsStep<C extends ChangingOutputsContext> implements Result.Step<C> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateOutputsStep.class);
 
-    private final Step<? super C, ? extends R> delegate;
+    private final Result.Step<? super C> delegate;
 
-    public CreateOutputsStep(Step<? super C, ? extends R> delegate) {
+    public CreateOutputsStep(Result.Step<? super C> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> Result<T> execute(UnitOfWork<T> work, C context) {
         work.visitOutputs(context.getWorkspace(), new UnitOfWork.OutputVisitor() {
             @Override
             public void visitOutputProperty(String propertyName, TreeType type, UnitOfWork.OutputFileValueSupplier value) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/DeferredExecutionAwareStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/DeferredExecutionAwareStep.java
@@ -22,6 +22,6 @@ import org.gradle.internal.Try;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.UnitOfWork.Identity;
 
-public interface DeferredExecutionAwareStep<C extends Context, R extends Result> extends Step<C, R> {
-    <T> Deferrable<Try<T>> executeDeferred(UnitOfWork work, C context, Cache<Identity, Try<T>> cache);
+public interface DeferredExecutionAwareStep<C extends Context, R extends Result<?>> extends Step<C, R> {
+    <T> Deferrable<Try<T>> executeDeferred(UnitOfWork<T> work, C context, Cache<Identity, Try<T>> cache);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentifyStep.java
@@ -30,27 +30,27 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-public class IdentifyStep<C extends ExecutionRequestContext, R extends Result> implements DeferredExecutionAwareStep<C, R> {
-    private final DeferredExecutionAwareStep<? super IdentityContext, R> delegate;
+public class IdentifyStep<C extends ExecutionRequestContext> implements CachingResult.DeferredExecutionAwareStep<C> {
+    private final CachingResult.DeferredExecutionAwareStep<? super IdentityContext> delegate;
 
     public IdentifyStep(
-        DeferredExecutionAwareStep<? super IdentityContext, R> delegate
+        CachingResult.DeferredExecutionAwareStep<? super IdentityContext> delegate
     ) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
         return delegate.execute(work, createIdentityContext(work, context));
     }
 
     @Override
-    public <T> Deferrable<Try<T>> executeDeferred(UnitOfWork work, C context, Cache<Identity, Try<T>> cache) {
+    public <T> Deferrable<Try<T>> executeDeferred(UnitOfWork<T> work, C context, Cache<Identity, Try<T>> cache) {
         return delegate.executeDeferred(work, createIdentityContext(work, context), cache);
     }
 
     @Nonnull
-    private IdentityContext createIdentityContext(UnitOfWork work, C context) {
+    private IdentityContext createIdentityContext(UnitOfWork<?> work, C context) {
         InputFingerprinter.Result inputs = work.getInputFingerprinter().fingerprintInputProperties(
             ImmutableSortedMap.of(),
             ImmutableSortedMap.of(),

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentityCacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/IdentityCacheStep.java
@@ -24,21 +24,21 @@ import org.gradle.internal.execution.ExecutionEngine.Execution;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.UnitOfWork.Identity;
 
-public class IdentityCacheStep<C extends IdentityContext, R extends Result> implements DeferredExecutionAwareStep<C, R> {
+public class IdentityCacheStep<C extends IdentityContext> implements CachingResult.DeferredExecutionAwareStep<C> {
 
-    private final Step<? super IdentityContext, ? extends R> delegate;
+    private final CachingResult.Step<? super IdentityContext> delegate;
 
-    public IdentityCacheStep(Step<? super IdentityContext, ? extends R> delegate) {
+    public IdentityCacheStep(CachingResult.Step<? super IdentityContext> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
         return delegate.execute(work, context);
     }
 
     @Override
-    public <T> Deferrable<Try<T>> executeDeferred(UnitOfWork work, C context, Cache<Identity, Try<T>> cache) {
+    public <T> Deferrable<Try<T>> executeDeferred(UnitOfWork<T> work, C context, Cache<Identity, Try<T>> cache) {
         Identity identity = context.getIdentity();
         Try<T> cachedOutput = cache.getIfPresent(identity);
         if (cachedOutput != null) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadPreviousExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/LoadPreviousExecutionStateStep.java
@@ -28,15 +28,15 @@ import org.gradle.internal.snapshot.ValueSnapshot;
 import java.io.File;
 import java.util.Optional;
 
-public class LoadPreviousExecutionStateStep<C extends WorkspaceContext, R extends Result> implements Step<C, R> {
-    private final Step<? super PreviousExecutionContext, ? extends R> delegate;
+public class LoadPreviousExecutionStateStep<C extends WorkspaceContext> implements CachingResult.Step<C> {
+    private final CachingResult.Step<? super PreviousExecutionContext> delegate;
 
-    public LoadPreviousExecutionStateStep(Step<? super PreviousExecutionContext, ? extends R> delegate) {
+    public LoadPreviousExecutionStateStep(CachingResult.Step<? super PreviousExecutionContext> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
         Identity identity = context.getIdentity();
         Optional<PreviousExecutionState> previousExecutionState = context.getHistory()
             .flatMap(history -> history.load(identity.getUniqueId()));

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RecordOutputsStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RecordOutputsStep.java
@@ -19,21 +19,21 @@ package org.gradle.internal.execution.steps;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.history.OutputFilesRepository;
 
-public class RecordOutputsStep<C extends Context, R extends AfterExecutionResult> implements Step<C, R> {
+public class RecordOutputsStep<C extends Context> implements AfterExecutionResult.Step<C> {
     private final OutputFilesRepository outputFilesRepository;
-    private final Step<? super C, ? extends R> delegate;
+    private final AfterExecutionResult.Step<? super C> delegate;
 
     public RecordOutputsStep(
         OutputFilesRepository outputFilesRepository,
-        Step<? super C, ? extends R> delegate
+        AfterExecutionResult.Step<? super C> delegate
     ) {
         this.outputFilesRepository = outputFilesRepository;
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
-        R result = delegate.execute(work, context);
+    public <T> AfterExecutionResult<T> execute(UnitOfWork<T> work, C context) {
+        AfterExecutionResult<T> result = delegate.execute(work, context);
         result.getAfterExecutionState()
             .ifPresent(afterExecutionState -> outputFilesRepository.recordOutputs(afterExecutionState.getOutputFilesProducedByWork().values()));
         return result;

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemoveUntrackedExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/RemoveUntrackedExecutionStateStep.java
@@ -18,18 +18,18 @@ package org.gradle.internal.execution.steps;
 
 import org.gradle.internal.execution.UnitOfWork;
 
-public class RemoveUntrackedExecutionStateStep<C extends WorkspaceContext, R extends AfterExecutionResult> implements Step<C, R> {
-    private final Step<? super C, ? extends R> delegate;
+public class RemoveUntrackedExecutionStateStep<C extends WorkspaceContext> implements CachingResult.Step<C> {
+    private final CachingResult.Step<? super C> delegate;
 
     public RemoveUntrackedExecutionStateStep(
-        Step<? super C, ? extends R> delegate
+        CachingResult.Step<? super C> delegate
     ) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
-        R result = delegate.execute(work, context);
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
+        CachingResult<T> result = delegate.execute(work, context);
         context.getHistory()
             .ifPresent(history -> {
                 if (!result.getAfterExecutionState().isPresent()) {

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ResolveInputChangesStep.java
@@ -35,17 +35,17 @@ import java.util.Optional;
 
 import static org.gradle.internal.execution.UnitOfWork.ExecutionBehavior.NON_INCREMENTAL;
 
-public class ResolveInputChangesStep<C extends IncrementalChangesContext, R extends Result> implements Step<C, R> {
+public class ResolveInputChangesStep<C extends IncrementalChangesContext> implements AfterExecutionResult.Step<C> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveInputChangesStep.class);
 
-    private final Step<? super InputChangesContext, ? extends R> delegate;
+    private final AfterExecutionResult.Step<? super InputChangesContext> delegate;
 
-    public ResolveInputChangesStep(Step<? super InputChangesContext, ? extends R> delegate) {
+    public ResolveInputChangesStep(AfterExecutionResult.Step<? super InputChangesContext> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> AfterExecutionResult<T> execute(UnitOfWork<T> work, C context) {
         Optional<InputChangesInternal> inputChanges = determineInputChanges(work, context);
         return delegate.execute(work, new InputChangesContext() {
             @Override
@@ -110,7 +110,7 @@ public class ResolveInputChangesStep<C extends IncrementalChangesContext, R exte
         });
     }
 
-    private static Optional<InputChangesInternal> determineInputChanges(UnitOfWork work, IncrementalChangesContext context) {
+    private static Optional<InputChangesInternal> determineInputChanges(UnitOfWork<?> work, IncrementalChangesContext context) {
         if (work.getExecutionBehavior() == NON_INCREMENTAL) {
             return Optional.empty();
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/Result.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/Result.java
@@ -22,7 +22,7 @@ import org.gradle.internal.execution.UnitOfWork;
 
 import java.time.Duration;
 
-public interface Result {
+public interface Result<T> {
 
     /**
      * The elapsed wall clock time of executing the actual work, i.e. the time it took to execute the
@@ -43,5 +43,10 @@ public interface Result {
      */
     Duration getDuration();
 
-    Try<Execution> getExecution();
+    Try<Execution<T>> getExecution();
+
+    interface Step<C extends Context> extends org.gradle.internal.execution.steps.Step<C, Result<?>> {
+        @Override
+        <T> Result<T> execute(UnitOfWork<T> work, C context);
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/Step.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/Step.java
@@ -18,6 +18,6 @@ package org.gradle.internal.execution.steps;
 
 import org.gradle.internal.execution.UnitOfWork;
 
-public interface Step<C extends Context, R extends Result> {
-    R execute(UnitOfWork work, C context);
+public interface Step<C extends Context, R extends Result<?>> {
+    <T> R execute(UnitOfWork<T> work, C context);
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/StoreExecutionStateStep.java
@@ -22,18 +22,18 @@ import org.gradle.internal.execution.history.changes.ChangeDetectorVisitor;
 import org.gradle.internal.execution.history.changes.OutputFileChanges;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 
-public class StoreExecutionStateStep<C extends PreviousExecutionContext, R extends AfterExecutionResult> implements Step<C, R> {
-    private final Step<? super C, ? extends R> delegate;
+public class StoreExecutionStateStep<C extends PreviousExecutionContext> implements AfterExecutionResult.Step<C> {
+    private final AfterExecutionResult.Step<? super C> delegate;
 
     public StoreExecutionStateStep(
-        Step<? super C, ? extends R> delegate
+        AfterExecutionResult.Step<? super C> delegate
     ) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
-        R result = delegate.execute(work, context);
+    public <T> AfterExecutionResult<T> execute(UnitOfWork<T> work, C context) {
+        AfterExecutionResult<T> result = delegate.execute(work, context);
         context.getHistory()
             .ifPresent(history -> result.getAfterExecutionState()
                 .ifPresent(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/TimeoutStep.java
@@ -26,16 +26,16 @@ import org.gradle.internal.operations.CurrentBuildOperationRef;
 import java.time.Duration;
 import java.util.Optional;
 
-public class TimeoutStep<C extends Context, R extends Result> implements Step<C, R> {
+public class TimeoutStep<C extends Context> implements Result.Step<C> {
 
     private final TimeoutHandler timeoutHandler;
     private final CurrentBuildOperationRef currentBuildOperationRef;
-    private final Step<? super C, ? extends R> delegate;
+    private final Result.Step<? super C> delegate;
 
     public TimeoutStep(
         TimeoutHandler timeoutHandler,
         CurrentBuildOperationRef currentBuildOperationRef,
-        Step<? super C, ? extends R> delegate
+        Result.Step<? super C> delegate
     ) {
         this.timeoutHandler = timeoutHandler;
         this.currentBuildOperationRef = currentBuildOperationRef;
@@ -43,7 +43,7 @@ public class TimeoutStep<C extends Context, R extends Result> implements Step<C,
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> Result<T> execute(UnitOfWork<T> work, C context) {
         Optional<Duration> timeoutProperty = work.getTimeout();
         if (timeoutProperty.isPresent()) {
             Duration timeout = timeoutProperty.get();
@@ -56,7 +56,7 @@ public class TimeoutStep<C extends Context, R extends Result> implements Step<C,
         }
     }
 
-    private R executeWithTimeout(UnitOfWork work, C context, Duration timeout) {
+    private <T> Result<T> executeWithTimeout(UnitOfWork<T> work, C context, Duration timeout) {
         Timeout taskTimeout = timeoutHandler.start(Thread.currentThread(), timeout, work, currentBuildOperationRef.get());
         try {
             return executeWithoutTimeout(work, context);
@@ -70,7 +70,7 @@ public class TimeoutStep<C extends Context, R extends Result> implements Step<C,
         }
     }
 
-    private R executeWithoutTimeout(UnitOfWork work, C context) {
+    private <T> Result<T> executeWithoutTimeout(UnitOfWork<T> work, C context) {
         return delegate.execute(work, context);
     }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/UpToDateResult.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/UpToDateResult.java
@@ -18,10 +18,11 @@ package org.gradle.internal.execution.steps;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.caching.internal.origin.OriginMetadata;
+import org.gradle.internal.execution.UnitOfWork;
 
 import java.util.Optional;
 
-public interface UpToDateResult extends AfterExecutionResult {
+public interface UpToDateResult<T> extends AfterExecutionResult<T> {
     /**
      * A list of messages describing the first few reasons encountered that caused the work to be executed.
      * An empty list means the work was up-to-date and hasn't been executed.
@@ -32,4 +33,9 @@ public interface UpToDateResult extends AfterExecutionResult {
      * If a previously produced output was reused in some way, the reused output's origin metadata is returned.
      */
     Optional<OriginMetadata> getReusedOutputOriginMetadata();
+
+    interface Step<C extends Context> extends org.gradle.internal.execution.steps.Step<C, UpToDateResult<?>> {
+        @Override
+        <T> UpToDateResult<T> execute(UnitOfWork<T> work, C context);
+    }
 }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsFinishedStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsFinishedStep.java
@@ -18,21 +18,20 @@ package org.gradle.internal.execution.steps.legacy;
 
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.steps.CachingContext;
-import org.gradle.internal.execution.steps.Result;
-import org.gradle.internal.execution.steps.Step;
+import org.gradle.internal.execution.steps.UpToDateResult;
 
 /**
  * This is a temporary measure for Gradle tasks to track a legacy measurement of all input snapshotting together.
  */
-public class MarkSnapshottingInputsFinishedStep<C extends CachingContext, R extends Result> implements Step<C, R> {
-    private final Step<? super C, ? extends R> delegate;
+public class MarkSnapshottingInputsFinishedStep<C extends CachingContext> implements UpToDateResult.Step<C> {
+    private final UpToDateResult.Step<? super C> delegate;
 
-    public MarkSnapshottingInputsFinishedStep(Step<? super C, ? extends R> delegate) {
+    public MarkSnapshottingInputsFinishedStep(UpToDateResult.Step<? super C> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> UpToDateResult<T> execute(UnitOfWork<T> work, C context) {
         work.markLegacySnapshottingInputsFinished(context.getCachingState());
         return delegate.execute(work, context);
     }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsStartedStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/legacy/MarkSnapshottingInputsStartedStep.java
@@ -17,22 +17,21 @@
 package org.gradle.internal.execution.steps.legacy;
 
 import org.gradle.internal.execution.UnitOfWork;
+import org.gradle.internal.execution.steps.CachingResult;
 import org.gradle.internal.execution.steps.Context;
-import org.gradle.internal.execution.steps.Result;
-import org.gradle.internal.execution.steps.Step;
 
 /**
  * This is a temporary measure for Gradle tasks to track a legacy measurement of all input snapshotting together.
  */
-public class MarkSnapshottingInputsStartedStep<C extends Context, R extends Result> implements Step<C, R> {
-    private final Step<? super C, ? extends R> delegate;
+public class MarkSnapshottingInputsStartedStep<C extends Context> implements CachingResult.Step<C> {
+    private final CachingResult.Step<? super C> delegate;
 
-    public MarkSnapshottingInputsStartedStep(Step<? super C, ? extends R> delegate) {
+    public MarkSnapshottingInputsStartedStep(CachingResult.Step<? super C> delegate) {
         this.delegate = delegate;
     }
 
     @Override
-    public R execute(UnitOfWork work, C context) {
+    public <T> CachingResult<T> execute(UnitOfWork<T> work, C context) {
         work.markLegacySnapshottingInputsStarted();
         try {
             return delegate.execute(work, context);

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignWorkspaceStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/AssignWorkspaceStepTest.groovy
@@ -20,13 +20,18 @@ package org.gradle.internal.execution.steps
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.workspace.WorkspaceProvider
 
-class AssignWorkspaceStepTest extends StepSpec<IdentityContext> {
-    def delegateResult = Mock(Result)
+class AssignWorkspaceStepTest extends StepSpec<IdentityContext, CachingResult.Step> {
+    def delegateResult = Mock(CachingResult)
     def step = new AssignWorkspaceStep<>(delegate)
 
     @Override
     protected IdentityContext createContext() {
         Stub(IdentityContext)
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def "delegates with assigned workspace"() {
@@ -42,7 +47,7 @@ class AssignWorkspaceStepTest extends StepSpec<IdentityContext> {
             def actionResult = action.executeInWorkspace(workspace, null)
             return actionResult
         }
-        1 * delegate.execute(work, _ as WorkspaceContext) >> { UnitOfWork work, WorkspaceContext context ->
+        1 * delegate.execute(work, _ as WorkspaceContext) >> { UnitOfWork<?> work, WorkspaceContext context ->
             assert context.workspace == workspace
             return delegateResult
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/BuildCacheStepTest.groovy
@@ -36,7 +36,7 @@ import java.time.Duration
 import static org.gradle.internal.execution.ExecutionEngine.Execution
 import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.FROM_CACHE
 
-class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements SnapshotterFixture {
+class BuildCacheStepTest extends StepSpec<IncrementalChangesContext, AfterExecutionResult.Step> implements SnapshotterFixture {
     def buildCacheController = Mock(BuildCacheController)
 
     def beforeExecutionState = Stub(BeforeExecutionState)
@@ -55,6 +55,11 @@ class BuildCacheStepTest extends StepSpec<IncrementalChangesContext> implements 
     @Override
     protected IncrementalChangesContext createContext() {
         Stub(IncrementalChangesContext)
+    }
+
+    @Override
+    protected AfterExecutionResult.Step createDelegate() {
+        Mock(AfterExecutionResult.Step)
     }
 
     def "loads from cache"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CancelExecutionStepTest.groovy
@@ -19,10 +19,15 @@ package org.gradle.internal.execution.steps
 import org.gradle.api.BuildCancelledException
 import org.gradle.initialization.DefaultBuildCancellationToken
 
-class CancelExecutionStepTest extends ContextInsensitiveStepSpec {
+class CancelExecutionStepTest extends ContextInsensitiveStepSpec<Result.Step> {
     def cancellationToken = new DefaultBuildCancellationToken()
-    def step = new CancelExecutionStep<Context, Result>(cancellationToken, delegate)
+    def step = new CancelExecutionStep<Context>(cancellationToken, delegate)
     def delegateResult = Mock(Result)
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
+    }
 
     def "executes normally when cancellation is not requested"() {
         when:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CaptureStateAfterExecutionStepTest.groovy
@@ -39,7 +39,7 @@ import java.time.Duration
 
 import static org.gradle.internal.snapshot.DirectorySnapshotBuilder.EmptyDirectoryHandlingStrategy.INCLUDE_EMPTY_DIRS
 
-class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
+class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext, Result.Step> {
 
     def buildInvocationScopeId = UniqueId.generate()
     def outputSnapshotter = Mock(OutputSnapshotter)
@@ -54,6 +54,11 @@ class CaptureStateAfterExecutionStepTest extends StepSpec<InputChangesContext> {
             getInputProperties() >> ImmutableSortedMap.of()
             getInputFileProperties() >> ImmutableSortedMap.of()
         }
+    }
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
     }
 
     def "no state is captured if before execution state is unavailable"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupStaleOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CleanupStaleOutputsStepTest.groovy
@@ -25,7 +25,7 @@ import org.gradle.internal.file.Deleter
 import org.gradle.internal.file.TreeType
 import spock.lang.Shared
 
-class CleanupStaleOutputsStepTest extends StepSpec<WorkspaceContext> {
+class CleanupStaleOutputsStepTest extends StepSpec<WorkspaceContext, CachingResult.Step> {
     def cleanupRegistry = Mock(BuildOutputCleanupRegistry)
     def deleter = Mock(Deleter)
     def outputChangeListener = Mock(OutputChangeListener)
@@ -44,11 +44,16 @@ class CleanupStaleOutputsStepTest extends StepSpec<WorkspaceContext> {
         outputFilesRepository,
         delegate)
 
-    def delegateResult = Mock(Result)
+    def delegateResult = Mock(CachingResult)
 
     @Override
     protected WorkspaceContext createContext() {
         Stub(WorkspaceContext)
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def "#description is cleaned up: #cleanedUp"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ContextInsensitiveStepSpec.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ContextInsensitiveStepSpec.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.execution.steps
 
-class ContextInsensitiveStepSpec extends StepSpec<Context> {
+abstract class ContextInsensitiveStepSpec<D extends Step<Context, ? extends Result<?>>> extends StepSpec<Context, D> {
     @Override
     protected Context createContext() {
         Stub(Context)

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/CreateOutputsStepTest.groovy
@@ -20,12 +20,17 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.file.TreeType
 
-class CreateOutputsStepTest extends StepSpec<ChangingOutputsContext> {
+class CreateOutputsStepTest extends StepSpec<ChangingOutputsContext, Result.Step> {
     def step = new CreateOutputsStep<>(delegate)
 
     @Override
     protected ChangingOutputsContext createContext() {
         Stub(ChangingOutputsContext)
+    }
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
     }
 
     def "outputs are created"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ExecuteStepTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.UP_
 import static org.gradle.internal.execution.UnitOfWork.WorkResult.DID_NO_WORK
 import static org.gradle.internal.execution.UnitOfWork.WorkResult.DID_WORK
 
-class ExecuteStepTest extends StepSpec<ChangingOutputsContext> {
+class ExecuteStepTest extends StepSpec<ChangingOutputsContext, Result.Step> {
     def workspace = Mock(File)
     def previousOutputs = ImmutableSortedMap.of()
     def previousExecutionState = Stub(PreviousExecutionState) {
@@ -41,6 +41,11 @@ class ExecuteStepTest extends StepSpec<ChangingOutputsContext> {
     @Override
     protected ChangingOutputsContext createContext() {
         Stub(ChangingOutputsContext)
+    }
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
     }
 
     def setup() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -24,14 +24,19 @@ import org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.snapshot.ValueSnapshot
 
-class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
-    def delegateResult = Mock(Result)
+class IdentifyStepTest extends StepSpec<ExecutionRequestContext, CachingResult.DeferredExecutionAwareStep> {
+    def delegateResult = Mock(CachingResult)
     def inputFingerprinter = Mock(InputFingerprinter)
     def step = new IdentifyStep<>(delegate)
 
     @Override
     protected ExecutionRequestContext createContext() {
         Stub(ExecutionRequestContext)
+    }
+
+    @Override
+    protected CachingResult.DeferredExecutionAwareStep createDelegate() {
+        Mock(CachingResult.DeferredExecutionAwareStep)
     }
 
     def "delegates with assigned workspace"() {
@@ -59,7 +64,7 @@ class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
             ImmutableSet.of()
         )
 
-        1 * delegate.execute(work, _ as IdentityContext) >> { UnitOfWork work, IdentityContext delegateContext ->
+        1 * delegate.execute(work, _ as IdentityContext) >> { UnitOfWork<?> work, IdentityContext delegateContext ->
             assert delegateContext.inputProperties as Map == ["input": inputSnapshot]
             assert delegateContext.inputFileProperties as Map == ["input-files": inputFilesFingerprint]
             delegateResult

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentityCacheStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentityCacheStepTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.internal.execution.UnitOfWork
 
 import static org.gradle.internal.execution.ExecutionEngine.Execution
 
-class IdentityCacheStepTest extends StepSpec<IdentityContext> {
+class IdentityCacheStepTest extends StepSpec<IdentityContext, CachingResult.Step> {
     Cache<UnitOfWork.Identity, Try<Object>> cache = new ManualEvictionInMemoryCache<>()
 
     def step = new IdentityCacheStep<>(delegate)
@@ -31,6 +31,11 @@ class IdentityCacheStepTest extends StepSpec<IdentityContext> {
     @Override
     protected IdentityContext createContext() {
         Stub(IdentityContext)
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def "executes when no cached output exists"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RecordOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RecordOutputsStepTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.internal.execution.steps
 import org.gradle.internal.execution.history.AfterExecutionState
 import org.gradle.internal.execution.history.OutputFilesRepository
 
-class RecordOutputsStepTest extends ContextInsensitiveStepSpec implements SnapshotterFixture {
+class RecordOutputsStepTest extends ContextInsensitiveStepSpec<AfterExecutionResult.Step> implements SnapshotterFixture {
     def outputFilesRepository = Mock(OutputFilesRepository)
     def step = new RecordOutputsStep<>(outputFilesRepository, delegate)
 
@@ -27,6 +27,11 @@ class RecordOutputsStepTest extends ContextInsensitiveStepSpec implements Snapsh
     def outputFilesProducedByWork = snapshotsOf(output: outputFile)
 
     def delegateResult = Mock(AfterExecutionResult)
+
+    @Override
+    protected AfterExecutionResult.Step createDelegate() {
+        Mock(AfterExecutionResult.Step)
+    }
 
     def "outputs are recorded after execution"() {
         when:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemovePreviousOutputsStepTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.internal.snapshot.FileSystemSnapshot
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 
-class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext> implements SnapshotterFixture {
+class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext, Result.Step> implements SnapshotterFixture {
     @Rule
     TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
     def previousExecutionState = Mock(PreviousExecutionState)
@@ -43,6 +43,11 @@ class RemovePreviousOutputsStepTest extends StepSpec<ChangingOutputsContext> imp
     @Override
     protected ChangingOutputsContext createContext() {
         Stub(ChangingOutputsContext)
+    }
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
     }
 
     def "deletes only the previous outputs"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemoveUntrackedExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/RemoveUntrackedExecutionStateStepTest.groovy
@@ -18,15 +18,20 @@ package org.gradle.internal.execution.steps
 
 import org.gradle.internal.execution.history.ExecutionHistoryStore
 
-class RemoveUntrackedExecutionStateStepTest extends StepSpec<PreviousExecutionContext> {
+class RemoveUntrackedExecutionStateStepTest extends StepSpec<PreviousExecutionContext, CachingResult.Step> {
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
     def step = new RemoveUntrackedExecutionStateStep(delegate)
-    def delegateResult = Mock(AfterExecutionResult)
+    def delegateResult = Mock(CachingResult)
 
     @Override
     protected PreviousExecutionContext createContext() {
         Stub(PreviousExecutionContext)
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def "removes untracked outputs"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveCachingStateStepTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.caching.internal.controller.BuildCacheController
 import org.gradle.internal.execution.caching.CachingDisabledReason
 import org.gradle.internal.execution.caching.CachingDisabledReasonCategory
 
-class ResolveCachingStateStepTest extends StepSpec<ValidationFinishedContext> {
+class ResolveCachingStateStepTest extends StepSpec<ValidationFinishedContext, UpToDateResult.Step> {
 
     def buildCache = Mock(BuildCacheController)
     def step = new ResolveCachingStateStep(buildCache, true, delegate)
@@ -29,6 +29,11 @@ class ResolveCachingStateStepTest extends StepSpec<ValidationFinishedContext> {
     @Override
     protected ValidationFinishedContext createContext() {
         Stub(ValidationFinishedContext)
+    }
+
+    @Override
+    protected UpToDateResult.Step createDelegate() {
+        Mock(UpToDateResult.Step)
     }
 
     def "build cache disabled reason is reported when build cache is disabled"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveInputChangesStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ResolveInputChangesStepTest.groovy
@@ -20,17 +20,22 @@ import org.gradle.internal.execution.UnitOfWork
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges
 import org.gradle.internal.execution.history.changes.InputChangesInternal
 
-class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext> {
+class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext, AfterExecutionResult.Step> {
 
     def step = new ResolveInputChangesStep<>(delegate)
     def changes = Mock(ExecutionStateChanges)
     def optionalChanges = Optional.of(changes)
     def inputChanges = Mock(InputChangesInternal)
-    def result = Mock(Result)
+    def result = Mock(AfterExecutionResult)
 
     @Override
     protected IncrementalChangesContext createContext() {
         Stub(IncrementalChangesContext)
+    }
+
+    @Override
+    protected AfterExecutionResult.Step createDelegate() {
+        Mock(AfterExecutionResult.Step)
     }
 
     def "resolves input changes when required"() {
@@ -41,7 +46,7 @@ class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext> {
         _ * context.changes >> optionalChanges
         1 * changes.createInputChanges() >> inputChanges
         1 * inputChanges.incremental >> true
-        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork work, InputChangesContext context ->
+        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork<?> work, InputChangesContext context ->
             assert context.inputChanges.get() == inputChanges
             return result
         }
@@ -55,7 +60,7 @@ class ResolveInputChangesStepTest extends StepSpec<IncrementalChangesContext> {
         def returnedResult = step.execute(work, context)
         then:
         _ * work.executionBehavior >> UnitOfWork.ExecutionBehavior.NON_INCREMENTAL
-        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork work, InputChangesContext context ->
+        1 * delegate.execute(work, _ as InputChangesContext) >> { UnitOfWork<?> work, InputChangesContext context ->
             assert context.inputChanges == Optional.empty()
             return result
         }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipEmptyWorkStepTest.groovy
@@ -34,7 +34,7 @@ import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.EXE
 import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.SHORT_CIRCUITED
 import static org.gradle.internal.execution.UnitOfWork.InputBehavior.PRIMARY
 
-class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
+class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext, CachingResult.Step> {
     def outputChangeListener = Mock(OutputChangeListener)
     def workInputListeners = Mock(WorkInputListeners)
     def outputsCleaner = Mock(OutputsCleaner)
@@ -61,6 +61,11 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
             getInputProperties() >> { knownInputProperties }
             getInputFileProperties() >> { knownInputFileProperties }
         }
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def setup() {
@@ -126,7 +131,7 @@ class SkipEmptyWorkStepTest extends StepSpec<PreviousExecutionContext> {
         1 * sourceFileFingerprint.empty >> false
 
         then:
-        1 * delegate.execute(work, _ as PreviousExecutionContext) >> { UnitOfWork work, PreviousExecutionContext delegateContext ->
+        1 * delegate.execute(work, _ as PreviousExecutionContext) >> { UnitOfWork<?> work, PreviousExecutionContext delegateContext ->
             assert delegateContext.inputProperties as Map == ["known": knownSnapshot]
             assert delegateContext.inputFileProperties as Map == ["known-file": knownFileFingerprint, "source-file": sourceFileFingerprint]
             return delegateResult

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/SkipUpToDateStepTest.groovy
@@ -28,13 +28,18 @@ import org.gradle.internal.execution.history.changes.ExecutionStateChanges
 import static org.gradle.internal.execution.ExecutionEngine.Execution
 import static org.gradle.internal.execution.ExecutionEngine.ExecutionOutcome.UP_TO_DATE
 
-class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext> {
+class SkipUpToDateStepTest extends StepSpec<IncrementalChangesContext, AfterExecutionResult.Step> {
     def step = new SkipUpToDateStep<>(delegate)
     def changes = Mock(ExecutionStateChanges)
 
     @Override
     protected IncrementalChangesContext createContext() {
         Stub(IncrementalChangesContext)
+    }
+
+    @Override
+    protected AfterExecutionResult.Step createDelegate() {
+        Mock(AfterExecutionResult.Step)
     }
 
     def "skips when outputs are up to date"() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StepSpec.groovy
@@ -27,7 +27,7 @@ import spock.lang.Specification
 
 import java.util.function.Consumer
 
-abstract class StepSpec<C extends Context> extends Specification {
+abstract class StepSpec<C extends Context, D extends Step<C, ? extends Result<?>>> extends Specification {
     @Shared @ClassRule
     final TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance(getClass())
     final buildOperationExecutor = new TestBuildOperationExecutor()
@@ -36,11 +36,12 @@ abstract class StepSpec<C extends Context> extends Specification {
     final identity = Stub(UnitOfWork.Identity) {
         getUniqueId() >> ":test"
     }
-    final delegate = Mock(DeferredExecutionAwareStep)
     final work = Stub(UnitOfWork)
-    final C context = createContext()
+    final context = createContext()
+    final delegate = createDelegate()
 
     abstract protected C createContext()
+    abstract protected D createDelegate()
 
     def setup() {
         _ * context.identity >> identity

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/StoreExecutionStateStepTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 
 import static org.gradle.internal.execution.ExecutionEngine.Execution
 
-class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> implements SnapshotterFixture {
+class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext, AfterExecutionResult.Step> implements SnapshotterFixture {
     def executionHistoryStore = Mock(ExecutionHistoryStore)
 
     def originMetadata = Mock(OriginMetadata)
@@ -44,12 +44,17 @@ class StoreExecutionStateStepTest extends StepSpec<BeforeExecutionContext> imple
     def outputFile = file("output.txt").text = "output"
     def outputFilesProducedByWork = snapshotsOf(output: outputFile)
 
-    def step = new StoreExecutionStateStep<PreviousExecutionContext, AfterExecutionResult>(delegate)
+    def step = new StoreExecutionStateStep<>(delegate)
     def delegateResult = Mock(AfterExecutionResult)
 
     @Override
     protected BeforeExecutionContext createContext() {
         Stub(BeforeExecutionContext)
+    }
+
+    @Override
+    protected AfterExecutionResult.Step createDelegate() {
+        Mock(AfterExecutionResult.Step)
     }
 
     def setup() {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/TimeoutStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/TimeoutStepTest.groovy
@@ -26,12 +26,17 @@ import org.gradle.internal.operations.OperationIdentifier
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
-class TimeoutStepTest extends ContextInsensitiveStepSpec {
+class TimeoutStepTest extends ContextInsensitiveStepSpec<Result.Step> {
     def timeoutHandler = Mock(TimeoutHandler)
     def buildOperationRef = new DefaultBuildOperationRef(new OperationIdentifier(1), new OperationIdentifier(2))
     def currentBuildOperationRef = new CurrentBuildOperationRef()
     def step = new TimeoutStep<>(timeoutHandler, currentBuildOperationRef, delegate)
     def delegateResult = Mock(Result)
+
+    @Override
+    protected Result.Step createDelegate() {
+        Mock(Result.Step)
+    }
 
     def "negative timeout is reported"() {
         when:

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/ValidateStepTest.groovy
@@ -30,12 +30,12 @@ import static org.gradle.internal.reflect.validation.Severity.WARNING
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.convertToSingleLine
 import static org.gradle.internal.reflect.validation.TypeValidationProblemRenderer.renderMinimalInformationAbout
 
-class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements ValidationMessageChecker {
+class ValidateStepTest extends StepSpec<BeforeExecutionContext, CachingResult.Step> implements ValidationMessageChecker {
 
     def warningReporter = Mock(ValidateStep.ValidationWarningRecorder)
     def virtualFileSystem = Mock(VirtualFileSystem)
     def step = new ValidateStep<>(virtualFileSystem, warningReporter, delegate)
-    def delegateResult = Mock(Result)
+    def delegateResult = Mock(CachingResult)
 
     @Override
     protected BeforeExecutionContext createContext() {
@@ -43,6 +43,11 @@ class ValidateStepTest extends StepSpec<BeforeExecutionContext> implements Valid
         return Stub(BeforeExecutionContext) {
             getValidationContext() >> validationContext
         }
+    }
+
+    @Override
+    protected CachingResult.Step createDelegate() {
+        Mock(CachingResult.Step)
     }
 
     def "executes work when there are no violations"() {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/AccessorsClassPath.kt
@@ -89,7 +89,7 @@ class ProjectAccessorsClassPathGenerator @Inject constructor(
                 workspaceProvider
             )
             val result = executionEngine.createRequest(work).execute()
-            result.execution.get().output as AccessorsClassPath
+            result.execution.get().output
         }
     }
 
@@ -111,7 +111,7 @@ class GenerateProjectAccessors(
     private val fileCollectionFactory: FileCollectionFactory,
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider
-) : UnitOfWork {
+) : UnitOfWork<AccessorsClassPath> {
 
     companion object {
         const val PROJECT_SCHEMA_INPUT_PROPERTY = "projectSchema"
@@ -120,7 +120,7 @@ class GenerateProjectAccessors(
         const val CLASSES_OUTPUT_PROPERTY = "classes"
     }
 
-    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput {
+    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput<AccessorsClassPath> {
         val workspace = executionRequest.workspace
         withAsynchronousIO(project) {
             buildAccessorsFor(
@@ -130,7 +130,7 @@ class GenerateProjectAccessors(
                 binDir = getClassesOutputDir(workspace)
             )
         }
-        return object : UnitOfWork.WorkOutput {
+        return object : UnitOfWork.WorkOutput<AccessorsClassPath> {
             override fun getDidWork() = UnitOfWork.WorkResult.DID_WORK
 
             override fun getOutput() = loadAlreadyProducedOutput(workspace)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/accessors/PluginAccessorsClassPath.kt
@@ -121,7 +121,7 @@ class GeneratePluginAccessors(
     private val fileCollectionFactory: FileCollectionFactory,
     private val inputFingerprinter: InputFingerprinter,
     private val workspaceProvider: KotlinDslWorkspaceProvider
-) : UnitOfWork {
+) : UnitOfWork<AccessorsClassPath> {
 
     companion object {
         const val BUILD_SRC_CLASSLOADER_INPUT_PROPERTY = "buildSrcClassLoader"
@@ -129,7 +129,7 @@ class GeneratePluginAccessors(
         const val CLASSES_OUTPUT_PROPERTY = "classes"
     }
 
-    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput {
+    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput<AccessorsClassPath> {
         val workspace = executionRequest.workspace
         kotlinScriptClassPathProviderOf(rootProject).run {
             withAsynchronousIO(rootProject) {
@@ -140,7 +140,7 @@ class GeneratePluginAccessors(
                 )
             }
         }
-        return object : UnitOfWork.WorkOutput {
+        return object : UnitOfWork.WorkOutput<AccessorsClassPath> {
             override fun getDidWork() = UnitOfWork.WorkResult.DID_WORK
 
             override fun getOutput() = loadAlreadyProducedOutput(workspace)

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptEvaluator.kt
@@ -336,7 +336,7 @@ class CompileKotlinScript(
     private val workspaceProvider: KotlinDslWorkspaceProvider,
     private val fileCollectionFactory: FileCollectionFactory,
     private val inputFingerprinter: InputFingerprinter
-) : UnitOfWork {
+) : UnitOfWork<File> {
 
     override fun visitIdentityInputs(
         visitor: InputVisitor
@@ -372,15 +372,15 @@ class CompileKotlinScript(
         return UnitOfWork.Identity { identityHash }
     }
 
-    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput {
+    override fun execute(executionRequest: UnitOfWork.ExecutionRequest): UnitOfWork.WorkOutput<File> {
         val workspace = executionRequest.workspace
         compileTo(classesDir(workspace))
         return workOutputFor(workspace)
     }
 
     private
-    fun workOutputFor(workspace: File): UnitOfWork.WorkOutput =
-        object : UnitOfWork.WorkOutput {
+    fun workOutputFor(workspace: File): UnitOfWork.WorkOutput<File> =
+        object : UnitOfWork.WorkOutput<File> {
             override fun getDidWork() = UnitOfWork.WorkResult.DID_WORK
             override fun getOutput() = loadAlreadyProducedOutput(workspace)
         }
@@ -388,7 +388,7 @@ class CompileKotlinScript(
     override fun getDisplayName(): String =
         "Kotlin DSL script compilation ($templateId)"
 
-    override fun loadAlreadyProducedOutput(workspace: File): Any =
+    override fun loadAlreadyProducedOutput(workspace: File) =
         classesDir(workspace)
 
     override fun getWorkspaceProvider() = workspaceProvider.scripts

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/continuous/AccumulateBuildInputsListener.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/continuous/AccumulateBuildInputsListener.java
@@ -42,7 +42,7 @@ public class AccumulateBuildInputsListener implements WorkInputListener {
     }
 
     @Override
-    public void onExecute(UnitOfWork work, EnumSet<InputBehavior> relevantBehaviors) {
+    public void onExecute(UnitOfWork<?> work, EnumSet<InputBehavior> relevantBehaviors) {
         Set<String> taskInputs = new LinkedHashSet<>();
         Set<FilteredTree> filteredFileTreeTaskInputs = new LinkedHashSet<>();
         work.visitRegularInputs(new InputVisitor() {


### PR DESCRIPTION
This way we can return implementation-specific outputs from the execution engine.