### PR TITLE
Merge release into master

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/FinalizerTaskIntegrationTest.groovy
@@ -331,7 +331,6 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/21325")
-    @Ignore("https://github.com/gradle/gradle-private/issues/3574")
     def "finalizer can have dependencies that are not reachable from first discovered finalized task and reachable from second discovered finalized task"() {
         buildFile '''
             task classes(type: BreakingTask) {
@@ -394,9 +393,9 @@ class FinalizerTaskIntegrationTest extends AbstractIntegrationSpec {
             result.assertTaskOrder any(':jarOne', ':shadowJar'), ':jar', ':copyJars'
         }
         2.times {
-            fails 'entry', '-PshadowJar.broken'
-            // jar may or may not run
-            result.assertTaskOrder ':jarOne', ':classes', ':shadowJar'
+            fails 'entry', '-PshadowJar.broken', '--continue'
+            result.assertTasksExecuted ':classes', ':jar', ':shadowJar', ':jarOne'
+            result.assertTaskOrder any(':jarOne', ':shadowJar'), ':jar'
         }
         2.times {
             succeeds 'jarOne', 'lifecycleTwo'

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -27,14 +27,14 @@ import org.gradle.api.specs.Specs;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 
 import java.util.AbstractCollection;
-import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -143,8 +143,8 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
 
     private void doAddEntryNodes(SortedSet<? extends Node> nodes, int ordinal) {
         scheduledNodes = null;
-        final Deque<Node> queue = new ArrayDeque<>();
-        final OrdinalGroup group = ordinalNodeAccess.group(ordinal);
+        LinkedList<Node> queue = new LinkedList<>();
+        OrdinalGroup group = ordinalNodeAccess.group(ordinal);
 
         for (Node node : nodes) {
             node.maybeInheritOrdinalAsDependency(group);
@@ -156,7 +156,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         discoverNodeRelationships(queue);
     }
 
-    private void discoverNodeRelationships(Deque<Node> queue) {
+    private void discoverNodeRelationships(LinkedList<Node> queue) {
         Set<Node> visiting = new HashSet<>();
         while (!queue.isEmpty()) {
             Node node = queue.getFirst();
@@ -185,9 +185,10 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
                 for (Node successor : node.getHardSuccessors()) {
                     successor.maybeInheritOrdinalAsDependency(node.getGroup());
                 }
-                for (Node successor : node.getDependencySuccessorsInReverseOrder()) {
+                ListIterator<Node> insertPoint = queue.listIterator();
+                for (Node successor : node.getDependencySuccessors()) {
                     if (!visiting.contains(successor)) {
-                        queue.addFirst(successor);
+                        insertPoint.add(successor);
                     }
                 }
             } else {
@@ -222,6 +223,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
                 entryNodes,
                 finalizers
             ).run();
+            finalizers.clear();
         }
     }
 
@@ -232,7 +234,7 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         }
         if (finalizedPlan == null) {
             dependencyResolver.clear();
-            // TODO - make an immutable copy of the contents to pass to the finalized plan, and to return from
+            // Should make an immutable copy of the contents to pass to the finalized plan and also to use in this instance
             finalizedPlan = new DefaultFinalizedExecutionPlan(displayName, ordinalNodeAccess, outputHierarchy, destroyableHierarchy, lockCoordinator, scheduledNodes, continueOnFailure, this, completionHandler);
         }
         return finalizedPlan;
@@ -290,9 +292,18 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
         if (scheduledNodes == null) {
             throw new IllegalStateException("Nodes have node been scheduled yet.");
         }
+        for (Node node : scheduledNodes) {
+            if (node instanceof TaskNode) {
+                // The task for a node can be attached lazily
+                // Ensure the task is available if the caller happens to need it.
+                // It would be better for callers to not touch nodes directly, but instead take some immutable snapshot here
+                ((TaskNode) node).getTask();
+            }
+        }
         return new ScheduledNodes() {
-            // Hold a reference to the plan, as the field is discard when the plan completes
+            // Hold a reference to the plan, as the field is discarded when the plan completes
             final ImmutableList<Node> plan = scheduledNodes;
+
             @Override
             public void visitNodes(Consumer<List<Node>> visitor) {
                 visitor.accept(plan);
@@ -347,8 +358,8 @@ public class DefaultExecutionPlan implements ExecutionPlan, QueryableExecutionPl
             return true;
         }
 
-        public TaskNode get(Task task) {
-            TaskNode taskNode = taskMapping.get(task);
+        public LocalTaskNode get(Task task) {
+            LocalTaskNode taskNode = taskMapping.get(task);
             if (taskNode == null) {
                 throw new IllegalStateException("Task is not part of the execution plan, no dependency information is available.");
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultFinalizedExecutionPlan.java
@@ -16,6 +16,8 @@
 
 package org.gradle.execution.plan;
 
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.SetMultimap;
 import org.gradle.api.Action;
 import org.gradle.api.BuildCancelledException;
 import org.gradle.api.NonNullApi;
@@ -107,6 +109,13 @@ public class DefaultFinalizedExecutionPlan implements WorkSource<Node>, Finalize
         this.continueOnFailure = continueOnFailure;
         this.contents = contents;
         this.completionHandler = completionHandler;
+
+        SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups = LinkedHashMultimap.create();
+        for (Node node : scheduledNodes) {
+            if (node.getFinalizerGroup() != null) {
+                node.getFinalizerGroup().scheduleMembers(reachableGroups);
+            }
+        }
 
         for (int i = 0; i < scheduledNodes.size(); i++) {
             Node node = scheduledNodes.get(i);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DetermineExecutionPlanAction.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,10 +95,14 @@ class DetermineExecutionPlanAction {
         return createOrdinalRelationshipsAndCollectNodes();
     }
 
+    /**
+     * Create the finalizer group for each finalizer and propagate these groups down to all dependencies.
+     */
     private void updateFinalizerGroups() {
         if (finalizers.isEmpty()) {
             return;
         }
+
         // Collect the finalizers and their dependencies so that each node is ordered before all of its dependencies
         LinkedList<Node> nodes = new LinkedList<>();
         Set<Node> visiting = new HashSet<>();
@@ -121,10 +126,10 @@ class DetermineExecutionPlanAction {
                 nodes.addFirst(node);
             }
         }
+
         for (Node node : nodes) {
-            node.updateGroupOfFinalizer();
+            node.maybeInheritFinalizerGroups();
         }
-        finalizers.clear();
     }
 
     private void processEntryNodes() {
@@ -165,7 +170,8 @@ class DetermineExecutionPlanAction {
                     addFinalizerToQueue(visitingSegmentCounter++, finalizer);
                 }
 
-                for (Node successor : node.getAllSuccessorsInReverseOrder()) {
+                ListIterator<NodeInVisitingSegment> insertPoint = nodeQueue.listIterator();
+                for (Node successor : node.getAllSuccessors()) {
                     if (visitingNodes.containsEntry(successor, currentSegment)) {
                         if (!walkedShouldRunAfterEdges.isEmpty()) {
                             //remove the last walked should run after edge and restore state from before walking it
@@ -182,7 +188,7 @@ class DetermineExecutionPlanAction {
                             onOrderingCycle(successor, node);
                         }
                     }
-                    nodeQueue.addFirst(new NodeInVisitingSegment(successor, currentSegment));
+                    insertPoint.add(new NodeInVisitingSegment(successor, currentSegment));
                 }
                 path.push(node);
             } else {
@@ -203,6 +209,7 @@ class DetermineExecutionPlanAction {
             createOrdinalRelationships(node, scheduledNodes);
             scheduledNodes.add(node);
         }
+
         nodeMapping.addAll(ordinalNodeAccess.getAllNodes());
         return scheduledNodes.build();
     }
@@ -338,7 +345,7 @@ class DetermineExecutionPlanAction {
     /**
      * Walk the properties of the task to determine if it is a destroyer or a producer (or neither).
      */
-    private TaskClassifier classifyTask(TaskNode taskNode) {
+    private TaskClassifier classifyTask(LocalTaskNode taskNode) {
         TaskClassifier taskClassifier = new TaskClassifier();
         TaskInternal task = taskNode.getTask();
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ExecutionPlan.java
@@ -50,7 +50,7 @@ public interface ExecutionPlan extends Describable, Closeable {
     void addEntryTasks(Collection<? extends Task> tasks);
 
     /**
-     * Returns the current contents of this plan. Note that this may change.
+     * Returns a snapshot of the current contents of this plan. Note that this plan is mutable, so the contents may later change.
      */
     QueryableExecutionPlan getContents();
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/FinalizerGroup.java
@@ -16,11 +16,13 @@
 
 package org.gradle.execution.plan;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.SetMultimap;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -32,6 +34,7 @@ import java.util.function.Consumer;
  * The set of nodes reachable from a particular finalizer node.
  */
 public class FinalizerGroup extends HasFinalizers {
+    private static final MemberSuccessors DO_NOT_BLOCK = new DoNotBlock();
     private final TaskNode node;
     private final NodeGroup delegate;
     private final Set<Node> members = new LinkedHashSet<>();
@@ -39,6 +42,7 @@ public class FinalizerGroup extends HasFinalizers {
     private OrdinalGroup ordinal;
     @Nullable
     private ElementSuccessors successors;
+    private boolean finalizedNodeHasStarted;
 
     public FinalizerGroup(TaskNode node, NodeGroup delegate) {
         this.ordinal = delegate.asOrdinal();
@@ -95,28 +99,13 @@ public class FinalizerGroup extends HasFinalizers {
     }
 
     @Override
-    public Collection<Node> getSuccessorsFor(Node node) {
-        assert members.contains(node) : "Node " + node + " is not part of the finalizer group of " + this.node;
-        if (successors == null) {
-            successors = createSuccessors();
+    public Iterable<? extends Node> getSuccessorsFor(Node node) {
+        // If the node is the finalizer for this group, it should wait for all the finalized nodes
+        if (isFinalizerNode(node)) {
+            return getFinalizedNodes();
+        } else {
+            return Collections.emptyList();
         }
-        return successors.successorsFor(node);
-    }
-
-    @Override
-    public Collection<Node> getSuccessorsInReverseOrderFor(Node node) {
-        List<Node> successors = new ArrayList<>(getSuccessorsFor(node));
-        Collections.reverse(successors);
-        return successors;
-    }
-
-    private ElementSuccessors createSuccessors() {
-        for (Node finalizedNode : getFinalizedNodes()) {
-            if (members.contains(finalizedNode)) {
-                return new FinalizesMembers();
-            }
-        }
-        return new DoesNotFinalizeMembers();
     }
 
     private static boolean memberCanStartAtAnyTime(Node node) {
@@ -130,16 +119,16 @@ public class FinalizerGroup extends HasFinalizers {
 
     @Override
     public void addMember(Node node) {
+        assert successors == null;
         members.add(node);
         delegate.addMember(node);
-        successors = null;
     }
 
     @Override
     public void removeMember(Node node) {
+        assert successors == null;
         members.remove(node);
         delegate.removeMember(node);
-        successors = null;
     }
 
     public void visitAllMembers(Consumer<Node> visitor) {
@@ -157,29 +146,93 @@ public class FinalizerGroup extends HasFinalizers {
         }
     }
 
+    public boolean isCanCancelSelf() {
+        if (node.allDependenciesComplete() && !node.allDependenciesSuccessful()) {
+            // Finalizer won't run, so there's no point running its dependencies
+            return true;
+        }
+        // Don't cancel if any finalized node has started
+        return !finalizedNodeHasStarted;
+    }
+
     @Override
-    public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
-        if (!isFinalizerNode(node) && memberCanStartAtAnyTime(node)) {
-            // Is not the finalizer and is reachable from an entry point, so can start
-            return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+    public void onNodeStart(Node finalizer, Node node) {
+        if (isFinalizerNode(finalizer) && !finalizedNodeHasStarted && getFinalizedNodes().contains(node)) {
+            finalizedNodeHasStarted = true;
+        }
+    }
+
+    public void scheduleMembers(SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {
+        Set<Node> finalizedNodesToBlockOn = findFinalizedNodesThatDoNotIntroduceACycle(reachableGroups);
+        WaitForNodesToComplete waitForFinalizers = new WaitForNodesToComplete(finalizedNodesToBlockOn);
+
+        // Determine the finalized nodes that are also members
+        Set<Node> blockedFinalizedMembers = new HashSet<>(getFinalizedNodes());
+        blockedFinalizedMembers.removeAll(finalizedNodesToBlockOn);
+        blockedFinalizedMembers.retainAll(members);
+
+        if (blockedFinalizedMembers.isEmpty()) {
+            // When there are no members that are also finalized, then all members are blocked by the finalizer nodes that don't introduce a cycle
+            successors = node -> waitForFinalizers;
+            return;
         }
 
-        // Wait for all finalized nodes, potentially excluding some finalized nodes that are also members of this group
-        Collection<Node> successors = getSuccessorsFor(node);
-        if (successors.isEmpty()) {
-            // All finalized nodes are also members and none can start early
-            return checkPeersCompleteFor(node);
-        }
-        boolean isAnyExecuted = false;
-        for (Node finalized : successors) {
-            if (!finalized.isComplete()) {
-                return Node.DependenciesState.NOT_COMPLETE;
+        // For each member, determine which finalized node to wait for
+        ImmutableMap.Builder<Node, MemberSuccessors> blockingNodesBuilder = ImmutableMap.builder();
+        for (Node member : members) {
+            if (isFinalizerNode(member) || memberCanStartAtAnyTime(member)) {
+                continue;
             }
-            isAnyExecuted |= finalized.isExecuted();
+            if (blockedFinalizedMembers.contains(member)) {
+                if (!finalizedNodesToBlockOn.isEmpty()) {
+                    blockingNodesBuilder.put(member, waitForFinalizers);
+                } else {
+                    blockingNodesBuilder.put(member, new WaitForFinalizedNodesToBecomeActive(Collections.singleton(member)));
+                }
+            } else {
+                // Wait for the finalized nodes that don't introduce a cycle
+                Set<Node> blockOn = new LinkedHashSet<>(finalizedNodesToBlockOn);
+                for (Node finalizedMember : blockedFinalizedMembers) {
+                    if (!dependsOn(finalizedMember, member)) {
+                        blockOn.add(finalizedMember);
+                    }
+                }
+                if (blockOn.isEmpty()) {
+                    blockingNodesBuilder.put(member, new WaitForFinalizedNodesToBecomeActive(blockedFinalizedMembers));
+                } else {
+                    blockingNodesBuilder.put(member, new WaitForNodesToComplete(blockOn));
+                }
+            }
         }
-        // All relevant finalized nodes have completed
-        // Can run if any finalized node executed or if this node is reachable from an entry point
-        if (isAnyExecuted || delegate.isReachableFromEntryPoint()) {
+        ImmutableMap<Node, MemberSuccessors> blockingNodes = blockingNodesBuilder.build();
+        successors = node -> blockingNodes.get(node);
+    }
+
+    private Set<Node> findFinalizedNodesThatDoNotIntroduceACycle(SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {
+        // The members of this group have an implicit dependency on each finalized node of this group.
+        // When a finalizer node is a member of some other group, then it in turn has an implicit dependency on the finalized nodes of that group.
+        // This can introduce a cycle. So, determine all the groups reachable from the finalizers of this group via these relationships
+        // and check for cycles
+        Set<Node> nodesWithNoCycle = new HashSet<>(getFinalizedNodes().size());
+        for (Node finalizedNode : getFinalizedNodes()) {
+            if (!hasACycle(finalizedNode, reachableGroups)) {
+                nodesWithNoCycle.add(finalizedNode);
+            }
+        }
+        return nodesWithNoCycle;
+    }
+
+    @Override
+    public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
+        MemberSuccessors waitingFor = getNodesThatBlock(node);
+        Node.DependenciesState state = waitingFor.successorsComplete();
+        if (state != null) {
+            return state;
+        }
+
+        // All relevant finalized nodes have completed but none have executed
+        // Can run the finalized node is reachable from an entry point
+        if (delegate.isReachableFromEntryPoint()) {
             return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
         }
 
@@ -193,112 +246,138 @@ public class FinalizerGroup extends HasFinalizers {
         }
     }
 
-    /**
-     * Determines the state for a member node that is also a finalized node, in the case where all finalized nodes are also member nodes
-     * and none can start for some other reason.
-     *
-     * The approach is to defer execution until one of the member nodes is "activated", that is, it can start if its membership in this
-     * group is ignored.
-     */
-    private Node.DependenciesState checkPeersCompleteFor(Node node) {
-        // If some other member has already completed, then allow all other members to start.
-        for (Node member : members) {
-            if (member.isComplete()) {
-                return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
-            }
+    private MemberSuccessors getNodesThatBlock(Node node) {
+        if (isFinalizerNode(node)) {
+            return new WaitForNodesToComplete(getFinalizedNodes());
         }
-
-        HasFinalizers hasFinalizers = (HasFinalizers) node.getGroup();
-        for (FinalizerGroup group : hasFinalizers.getFinalizerGroups()) {
-            if (group == this) {
-                continue;
-            }
-            if (group.isActivated(node)) {
-                return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
-            }
+        if (memberCanStartAtAnyTime(node)) {
+            return DO_NOT_BLOCK;
         }
-
-        return Node.DependenciesState.NOT_COMPLETE;
+        return successors.getNodesThatBlock(node);
     }
 
-    private boolean isActivated(Node node) {
-        // A node is active when it is the finalizer of this group and is ready to start
-        if (node == this.node) {
-            return checkSuccessorsCompleteFor(node) == Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+    private boolean dependsOn(Node fromNode, Node toNode) {
+        Set<Node> seen = new HashSet<>();
+        List<Node> queue = new ArrayList<>();
+        Iterables.addAll(queue, fromNode.getHardSuccessors());
+        while (!queue.isEmpty()) {
+            Node node = queue.remove(0);
+            if (node == toNode) {
+                return true;
+            }
+            if (!seen.add(node)) {
+                continue;
+            }
+            Iterables.addAll(queue, node.getHardSuccessors());
         }
         return false;
+    }
+
+    private boolean hasACycle(Node finalized, SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {
+        if (!(finalized.getGroup() instanceof HasFinalizers) || finalized.getGroup().isReachableFromEntryPoint()) {
+            // Is not a member of a finalizer group or will not be blocked
+            return false;
+        }
+        HasFinalizers groups = (HasFinalizers) finalized.getGroup();
+        for (FinalizerGroup finalizerGroup : groups.getFinalizerGroups()) {
+            if (reachableGroups(finalizerGroup, reachableGroups).contains(this)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<FinalizerGroup> reachableGroups(FinalizerGroup fromGroup, SetMultimap<FinalizerGroup, FinalizerGroup> reachableGroups) {
+        if (!reachableGroups.containsKey(fromGroup)) {
+            Set<Node> seen = new HashSet<>();
+            List<Node> queue = new ArrayList<>(fromGroup.getFinalizedNodes());
+            while (!queue.isEmpty()) {
+                Node node = queue.remove(0);
+                if (!seen.add(node)) {
+                    continue;
+                }
+                if (node.getGroup().isReachableFromEntryPoint()) {
+                    continue;
+                }
+                if (node.getGroup() instanceof HasFinalizers) {
+                    HasFinalizers groups = (HasFinalizers) node.getGroup();
+                    for (FinalizerGroup finalizerGroup : groups.getFinalizerGroups()) {
+                        reachableGroups.put(fromGroup, finalizerGroup);
+                        queue.addAll(finalizerGroup.getFinalizedNodes());
+                    }
+                }
+                Iterables.addAll(queue, node.getHardSuccessors());
+            }
+        }
+        return reachableGroups.get(fromGroup);
     }
 
     private boolean isFinalizerNode(Node node) {
         return node == this.node;
     }
 
-    private abstract class ElementSuccessors {
-        public Set<Node> successorsFor(Node node) {
-            // If the node is the finalizer for this group, it should wait for all the finalized nodes
-            if (isFinalizerNode(node)) {
-                return getFinalizedNodes();
-            }
-
-            // If the node is reachable from an entry point, it can start at any time
-            if (memberCanStartAtAnyTime(node)) {
-                return Collections.emptySet();
-            }
-
-            return getFilteredSuccessorsFor(node);
-        }
-
-        protected abstract Set<Node> getFilteredSuccessorsFor(Node node);
+    private interface ElementSuccessors {
+        MemberSuccessors getNodesThatBlock(Node node);
     }
 
-    private class DoesNotFinalizeMembers extends ElementSuccessors {
+    private interface MemberSuccessors {
+        /**
+         * @return null when all successors have completed but none have executed
+         */
+        @Nullable
+        Node.DependenciesState successorsComplete();
+    }
+
+    private static class DoNotBlock implements MemberSuccessors {
         @Override
-        protected Set<Node> getFilteredSuccessorsFor(Node node) {
-            // None of the finalized nodes are members of the group -> so all members should wait for all the finalized nodes
-            return getFinalizedNodes();
+        public Node.DependenciesState successorsComplete() {
+            return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
         }
     }
 
-    private class FinalizesMembers extends ElementSuccessors {
-        private final Set<Node> finalizedNodesThatCanStartAtAnyTime;
-        private final Set<Node> membersThatAreDeferred;
+    private static class WaitForNodesToComplete implements MemberSuccessors {
+        private final Set<Node> nodes;
 
-        public FinalizesMembers() {
-            Set<Node> successors = getFinalizedNodes();
-            finalizedNodesThatCanStartAtAnyTime = new LinkedHashSet<>(successors.size());
-            List<Node> queue = new ArrayList<>();
-            for (Node successor : successors) {
-                if (!members.contains(successor)) {
-                    finalizedNodesThatCanStartAtAnyTime.add(successor);
-                } else if (memberCanStartAtAnyTime(successor)) {
-                    finalizedNodesThatCanStartAtAnyTime.add(successor);
-                } else {
-                    queue.add(successor);
+        public WaitForNodesToComplete(Set<Node> nodes) {
+            this.nodes = nodes;
+        }
+
+        @Nullable
+        @Override
+        public Node.DependenciesState successorsComplete() {
+            boolean isAnyExecuted = false;
+            for (Node node : nodes) {
+                if (!node.isComplete()) {
+                    return Node.DependenciesState.NOT_COMPLETE;
+                }
+                isAnyExecuted |= node.isExecuted();
+            }
+            // All relevant finalized nodes have completed
+            if (isAnyExecuted) {
+                return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+            }
+            return null;
+        }
+    }
+
+    private static class WaitForFinalizedNodesToBecomeActive implements MemberSuccessors {
+        private final Set<Node> nodes;
+
+        public WaitForFinalizedNodesToBecomeActive(Set<Node> nodes) {
+            this.nodes = nodes;
+        }
+
+        @Nullable
+        @Override
+        public Node.DependenciesState successorsComplete() {
+            for (Node node : nodes) {
+                for (FinalizerGroup finalizerGroup : ((HasFinalizers) node.getGroup()).getFinalizerGroups()) {
+                    if (finalizerGroup.finalizedNodeHasStarted) {
+                        return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
+                    }
                 }
             }
-
-            // TODO - a better option would be to split FinalizerGroup into several types, eg so that there are implementations for members that should start
-            // early, those that should be deferred, etc. Then the general purpose inheritance mechanism can be used instead of traversing the dependencies here
-            membersThatAreDeferred = new HashSet<>();
-            while (!queue.isEmpty()) {
-                Node node = queue.remove(0);
-                if (!membersThatAreDeferred.add(node)) {
-                    continue;
-                }
-                queue.addAll(0, node.getDependencySuccessors());
-            }
-        }
-
-        @Override
-        protected Set<Node> getFilteredSuccessorsFor(Node node) {
-            // If the node is not finalized by this group,  it should wait for all the finalized nodes
-            if (!membersThatAreDeferred.contains(node)) {
-                return getFinalizedNodes();
-            }
-
-            // The node is also finalized by this group, so it should wait for those finalized nodes that can start at any time
-            return finalizedNodesThatCanStartAtAnyTime;
+            return Node.DependenciesState.NOT_COMPLETE;
         }
     }
-
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/HasFinalizers.java
@@ -35,7 +35,7 @@ abstract class HasFinalizers extends NodeGroup {
         List<FinalizerGroup> queue = new ArrayList<>(groups);
         while (!queue.isEmpty()) {
             FinalizerGroup group = queue.remove(0);
-            if (isTriggered(group)) {
+            if (!group.isCanCancelSelf()) {
                 // Has started running at least one finalized node, so cannot cancel
                 return false;
             }
@@ -49,19 +49,5 @@ abstract class HasFinalizers extends NodeGroup {
             // Else, have already traversed this group
         }
         return true;
-    }
-
-    private boolean isTriggered(FinalizerGroup group) {
-        Node finalizer = group.getNode();
-        if (finalizer.allDependenciesComplete() && !finalizer.allDependenciesSuccessful()) {
-            // Finalizer won't run, so there's no point running its dependencies
-            return false;
-        }
-        for (Node node : group.getFinalizedNodes()) {
-            if (node.isExecuting() || node.isExecuted()) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/NodeGroup.java
@@ -79,20 +79,6 @@ public abstract class NodeGroup {
         return Collections.emptyList();
     }
 
-    /**
-     * Returns the sequence of nodes which must complete before the given node can start. The given node must belong to this group.
-     * The returned sequence is not exhaustive, i.e. it doesn't mean that the given node can start even if all nodes in it are
-     * completed.
-     *
-     * The returned sequence is a reverse of the result of {@link #getSuccessorsFor(Node)}.
-     *
-     * @param node the node to check successors for
-     * @see #getSuccessorsFor(Node)
-     */
-    public Iterable<? extends Node> getSuccessorsInReverseOrderFor(Node node) {
-        return Collections.emptyList();
-    }
-
     public Node.DependenciesState checkSuccessorsCompleteFor(Node node) {
         return Node.DependenciesState.COMPLETE_AND_SUCCESSFUL;
     }
@@ -108,4 +94,7 @@ public abstract class NodeGroup {
     }
 
     public abstract NodeGroup withOrdinalGroup(OrdinalGroup newOrdinal);
+
+    public void onNodeStart(Node finalizer, Node node) {
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -96,16 +96,6 @@ public abstract class TaskNode extends Node {
         );
     }
 
-    @Override
-    public Iterable<Node> getAllSuccessorsInReverseOrder() {
-        return Iterables.concat(
-            super.getAllSuccessorsInReverseOrder(),
-            getDependencyNodes().getMustSuccessors().descendingSet(),
-            getGroup().getSuccessorsInReverseOrderFor(this),
-            shouldSuccessors.descendingSet()
-        );
-    }
-
     public abstract TaskInternal getTask();
 
     protected void deprecateLifecycleHookReferencingNonLocalTask(String hookName, Node taskNode) {
@@ -115,8 +105,8 @@ public abstract class TaskNode extends Node {
     }
 
     @Override
-    public void updateGroupOfFinalizer() {
-        super.updateGroupOfFinalizer();
+    public void maybeInheritFinalizerGroups() {
+        super.maybeInheritFinalizerGroups();
         if (!getFinalizingSuccessors().isEmpty()) {
             // This node is a finalizer, decorate the current group to add finalizer behaviour
             NodeGroup oldGroup = getGroup();

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -886,6 +886,24 @@ class DefaultExecutionPlanParallelTest extends AbstractExecutionPlanSpec {
         assertAllWorkComplete()
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/21975")
+    def "handles task failure when a finalizer is a dependency of and finalized by another node"() {
+        Task finalizer1 = createTask("finalizer1")
+        Task finalizer2 = task("finalizer2", finalizedBy: [finalizer1])
+        Task dep = task("dep", failure: new RuntimeException("broken"))
+        Task entry = task("entry", finalizedBy: [finalizer2], dependsOn: [dep])
+        relationships(finalizer1, dependsOn: [finalizer2])
+
+        when:
+        addToGraphAndPopulate(entry)
+
+        then:
+        executionPlan.tasks as List == [dep, entry, finalizer2, finalizer1]
+        reachableFromEntryPoint == [true, true, false, false]
+        assertTaskReady(dep)
+        assertAllWorkComplete()
+    }
+
     def "assigns task to first ordinal group it is reachable from when task is entry task multiple times"() {
         given:
         Task finalizer1 = task("finalizer1", type: Async)

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanTest.groovy
@@ -471,23 +471,7 @@ class DefaultExecutionPlanTest extends AbstractExecutionPlanSpec {
         addToGraphAndPopulate([entryPoint])
 
         then:
-        // TODO(mlopatkin) A potential execution order that was working in 7.4:
-        //   executionPlan.tasks as List == [entryPoint, finalizerDepA, finalizerDepB, finalizerB, finalizerA]
-        // It somewhat violates a finalizer constraint: "only run dependencies of a finalizer after completing a finalized task"
-        // To satisfy that, finalizerDepA should run after finalizerDepB, and finalizerDepB should run after finalizerDepA.
-        // Obviously, both constraints cannot be satisfied at once.
-        // There is an alternative reading though. The entryPoint is finalized by finalizerA, and we started to execute
-        // finalizerA's dependencies; finalizerDepA happen to be finalized by finalizerB, so we schedule it and its dependency after
-        // finalizerDepA. Then we complete everything with finalizerA. This reading is somewhat similar to the case where finalizerDepA
-        // is reachable from the entry point.
-        def e = thrown CircularReferenceException
-        e.message == TextUtil.toPlatformLineSeparators("""Circular dependency between the following tasks:
-:finalizerDepA
-\\--- :finalizerDepB
-     \\--- :finalizerDepA (*)
-
-(*) - details omitted (listed previously)
-""")
+        executes(entryPoint, finalizerDepA, finalizerDepB, finalizerB, finalizerA)
     }
 
     def "cannot add task with circular reference"() {

--- a/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/authoring-builds/working_with_files.adoc
@@ -313,7 +313,7 @@ Relative paths are resolved relative to the project directory, while absolute pa
 
 [CAUTION]
 ====
-Never use `new File(relative path)` because this creates a path relative to the current working directory (CWD). Gradle can make no guarantees about the location of the CWD, which means builds that rely on it may break at any time.
+Never use `new File(relative path)` unless passed to `file()` or `files()` or `from()` or other methods being defined in terms of `file()` or `files()`. Otherwise this creates a path relative to the current working directory (CWD). Gradle can make no guarantees about the location of the CWD, which means builds that rely on it may break at any time.
 ====
 
 Here are some examples of using the `file()` method with different types of argument:
@@ -352,7 +352,7 @@ Learn about all the supported argument types in the reference guide.
 
 [CAUTION]
 ====
-Although the `files()` method accepts `File` instances, never use `new File(relative path)` with it because this creates a path relative to the current working directory (CWD). Gradle can make no guarantees about the location of the CWD, which means builds that rely on it may break at any time.
+`files()` properly handle relative paths and `File(relative path)` instances, resolving them relative to the project directory.
 ====
 
 As with the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method covered in the <<#sec:single_file_paths,previous section>>, all relative paths are evaluated relative to the current project directory. The following example demonstrates some of the variety of argument types you can use — strings, `File` instances, a list and a `{javaApi}/java/nio/file/Path.html[Path]`:


### PR DESCRIPTION
We fix the conflict in the wrapper version by using the wrapper from `master`. The latest nightly from master seems to cause some build failures: 
- One when running asciidoctor: https://ge.gradle.org/s/xmil4pe7mda6q/failure?focused-exception-line=0-1-0#1 
```
Execution failed for task ':docs:samplesMultiPage'.
 > Resolution of the configuration :docs:detachedConfiguration6 was attempted from a context different than the project context.
```
- Publishing the build scan fails sometimes fails with a concurrent modification exception: https://builds.gradle.org/buildConfiguration/Gradle_Master_Check_CheckLinks/56206710
```
11:01:58   A build scan cannot be produced as an error occurred gathering build data.
11:01:58   Please report this problem via https://gradle.com/help/plugin and include the following via copy/paste:
11:01:58   
11:01:58   ----------
11:01:58   Gradle version: 8.0-20220916221043+0000
11:01:58   Plugin version: 3.11.1
11:01:58   
11:01:58   java.util.ConcurrentModificationException
11:01:58     at com.google.common.collect.Iterators$5.computeNext(Iterators.java:672)
11:01:58     at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146)
11:01:58     at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:141)
11:01:58     at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
11:01:58     at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
11:01:58     at com.google.common.collect.Iterators$ConcatenatedIterator.getTopMetaIterator(Iterators.java:1379)
11:01:58     at com.google.common.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1395)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer.taskIdentifiesOf(BuildOperationFiringBuildWorkPreparer.java:163)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer.access$100(BuildOperationFiringBuildWorkPreparer.java:52)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer$PopulateWorkGraph$1.toPlannedTask(BuildOperationFiringBuildWorkPreparer.java:131)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer$PopulateWorkGraph$1.lambda$toPlannedTasks$0(BuildOperationFiringBuildWorkPreparer.java:120)
11:01:58     at org.gradle.execution.plan.DefaultExecutionPlan$1.visitNodes(DefaultExecutionPlan.java:298)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer$PopulateWorkGraph$1.toPlannedTasks(BuildOperationFiringBuildWorkPreparer.java:117)
11:01:58     at org.gradle.internal.build.BuildOperationFiringBuildWorkPreparer$PopulateWorkGraph$1.getTaskPlan(BuildOperationFiringBuildWorkPreparer.java:112)
11:01:58     at com.gradle.scan.plugin.internal.b.w.f.a(SourceFile:53)
11:01:58     at com.gradle.scan.plugin.internal.l.a.f.a(SourceFile:12)
11:01:58     at com.gradle.scan.plugin.internal.l.a$c.finished(SourceFile:154)
11:01:58     at com.gradle.scan.plugin.internal.l.a.a(SourceFile:65)
11:01:58     at com.gradle.scan.plugin.internal.l.m.a(SourceFile:56)
11:01:58     at com.gradle.scan.plugin.internal.l.c.a(SourceFile:100)
11:01:58     at com.gradle.scan.plugin.internal.l.g.a(SourceFile:51)
11:01:58     at com.gradle.scan.plugin.internal.q.a$a.a(SourceFile:31)
11:01:58     at com.gradle.scan.plugin.internal.q.a$a.a(SourceFile:20)
11:01:58     at com.gradle.scan.plugin.internal.q.a.c(SourceFile:67)