### PR TITLE
CompileAllProduction -> CompileAll

### DIFF
--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -123,6 +123,5 @@ private fun BuildSteps.cleanBuildLogicBuild(buildDir: String) {
             buildToolGradleParameters() +
                 buildScanTag("PerformanceTest")
             ).joinToString(separator = " ")
-        skipConditionally()
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/CompileAll.kt
+++ b/.teamcity/src/main/kotlin/configurations/CompileAll.kt
@@ -3,10 +3,10 @@ package configurations
 import model.CIBuildModel
 import model.Stage
 
-class CompileAllProduction(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
+class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
     id(buildTypeId(model))
-    name = "Compile All Production"
-    description = "Compiles all production source code and warms up the build cache"
+    name = "Compile All"
+    description = "Compiles all production/test source code and warms up the build cache"
 
     features {
         publishBuildStatusToGithub(model)

--- a/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/src/main/kotlin/configurations/GradleBuildConfigurationDefaults.kt
@@ -13,7 +13,6 @@ import common.dependsOn
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
-import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildFeatures
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -97,11 +96,10 @@ fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: Strin
         ).joinToString(separator = " ")
 
     steps {
-        gradleWrapper {
+        gradleWrapper(this@gradleRunnerStep) {
             name = "GRADLE_RUNNER"
             tasks = "clean $gradleTasks"
             gradleParams = parameters
-            skipConditionally()
         }
     }
 }
@@ -124,7 +122,7 @@ fun applyDefaults(
 
     buildType.steps {
         extraSteps()
-        checkCleanM2AndAndroidUserHome(os)
+        checkCleanM2AndAndroidUserHome(os, buildType)
     }
 
     applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
@@ -158,7 +156,7 @@ fun applyTestDefaults(
 
     buildType.steps {
         extraSteps()
-        checkCleanM2AndAndroidUserHome(os)
+        checkCleanM2AndAndroidUserHome(os, buildType)
     }
 
     applyDefaultDependencies(model, buildType, dependsOnQuickFeedbackLinux)
@@ -173,9 +171,9 @@ fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, dependsO
             dependsOn(RelativeId(stageTriggerId(model, StageName.QUICK_FEEDBACK_LINUX_ONLY)))
         }
     }
-    if (buildType !is CompileAllProduction) {
+    if (buildType !is CompileAll) {
         buildType.dependencies {
-            compileAllDependency(CompileAllProduction.buildTypeId(model))
+            compileAllDependency(CompileAll.buildTypeId(model))
         }
     }
 }

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -5,6 +5,7 @@ import common.customGradle
 import common.dependsOn
 import common.gradleWrapper
 import common.requiresNoEc2Agent
+import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
@@ -96,4 +97,5 @@ fun BuildSteps.localGradle(init: GradleBuildStep.() -> Unit): GradleBuildStep =
     customGradle(init) {
         param("ui.gradleRunner.gradle.wrapper.useWrapper", "false")
         buildFile = ""
+        skipConditionally()
     }

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -13,7 +13,7 @@ import common.toCapitalized
 import configurations.BaseGradleBuildType
 import configurations.BuildDistributions
 import configurations.CheckLinks
-import configurations.CompileAllProduction
+import configurations.CompileAll
 import configurations.ConfigCacheDocsTest
 import configurations.FlakyTestQuarantine
 import configurations.FunctionalTest
@@ -334,7 +334,7 @@ const val GRADLE_BUILD_SMOKE_TEST_NAME = "gradleBuildSmokeTest"
 enum class SpecificBuild {
     CompileAll {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
-            return CompileAllProduction(model, stage)
+            return CompileAll(model, stage)
         }
     },
     SanityCheck {

--- a/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
+++ b/.teamcity/src/main/kotlin/util/RerunFlakyTest.kt
@@ -29,7 +29,7 @@ import common.functionalTestExtraParameters
 import common.functionalTestParameters
 import common.gradleWrapper
 import common.killProcessStep
-import configurations.CompileAllProduction
+import configurations.CompileAll
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParameterDisplay
@@ -65,6 +65,7 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
         }
         killProcessStep("KILL_PROCESSES_STARTED_BY_GRADLE", os, arch)
     }
+
     steps {
         checkCleanM2AndAndroidUserHome(os)
     }
@@ -108,6 +109,6 @@ class RerunFlakyTest(os: Os, arch: Arch = Arch.AMD64) : BuildType({
     }
 
     dependencies {
-        compileAllDependency(CompileAllProduction.buildTypeId("Check"))
+        compileAllDependency(CompileAll.buildTypeId("Check"))
     }
 })


### PR DESCRIPTION
Because of a historical reason, `CompileAll` was named `CompileAllProduction`, but it actually compile all code, not only production code.

Also, because all builds have artifact dependencies on CompileAll, it should not be skipped by `build.skip=true`.
