### PR TITLE
Set docsTest timeout to 45 minutes

### DIFF
--- a/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
+++ b/build-logic/lifecycle/src/main/kotlin/gradlebuild.lifecycle.gradle.kts
@@ -37,6 +37,8 @@ val soakTest = "soakTest"
 
 val smokeTest = "smokeTest"
 
+val docsTest = "docs:docsTest"
+
 setupTimeoutMonitorOnCI()
 setupGlobalState()
 
@@ -59,6 +61,7 @@ fun setupTimeoutMonitorOnCI() {
 fun determineTimeoutMillis() = when {
     isRequestedTask(compileAllBuild) || isRequestedTask(sanityCheck) || isRequestedTask(quickTest) -> Duration.ofMinutes(30).toMillis()
     isRequestedTask(smokeTest) -> Duration.ofHours(1).plusMinutes(30).toMillis()
+    isRequestedTask(docsTest) -> Duration.ofMinutes(45).toMillis()
     else -> Duration.ofHours(2).plusMinutes(45).toMillis()
 }
 


### PR DESCRIPTION
The default timeout for "stacktrace dumper" is 2h45m. Let's set this value to 45m for docsTest.
