### PR TITLE
Revert to old warning behavior and ignore failing tests until a permanent fix is found

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/UnsafeConfigurationResolutionDeprecationIntegrationTest.groovy
@@ -20,8 +20,10 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.ToBeFixedForConfigurationCache
 import org.gradle.integtests.fixtures.UnsupportedWithConfigurationCache
 import org.gradle.util.GradleVersion
+import spock.lang.Ignore
 
 class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDependencyResolutionTest {
+    @Ignore("https://github.com/gradle/gradle/issues/22088")
     @ToBeFixedForConfigurationCache(because = "Task.getProject() during execution")
     def "configuration in another project can not be resolved"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
@@ -234,6 +236,7 @@ class UnsafeConfigurationResolutionDeprecationIntegrationTest extends AbstractDe
         succeeds(":resolve")
     }
 
+    @Ignore("https://github.com/gradle/gradle/issues/22088")
     def "fails when configuration is resolved while evaluating a different project"() {
         mavenRepo.module("test", "test-jar", "1.0").publish()
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -600,8 +600,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 // Error if we are executing in a user-managed thread.
                 throw new IllegalStateException("The configuration " + identityPath.toString() + " was resolved from a thread not managed by Gradle.");
             } else {
-                String docsLink = documentationRegistry.getDocumentationFor("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors");
-                throw new IllegalStateException(String.format("Resolution of the configuration " + identityPath.toString() + " was attempted from a context different than the project context. See: %s for more information.", docsLink));
+                DeprecationLogger.deprecateBehaviour("Resolution of the configuration " + identityPath.toString() + " was attempted from a context different than the project context. Have a look at the documentation to understand why this is a problem and how it can be resolved.")
+                        .willBeRemovedInGradle8()
+                        .withUserManual("viewing_debugging_dependencies", "sub:resolving-unsafe-configuration-resolution-errors")
+                        .nagUser();
+                return domainObjectContext.getModel().fromMutableState(p -> resolveExclusively(requestedState));
             }
         }
         return resolveExclusively(requestedState);

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ParallelStaleOutputIntegrationTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.GradleVersion
+import spock.lang.Ignore
 import spock.lang.Issue
 
 @Issue("https://github.com/gradle/gradle/issues/17812")
 class ParallelStaleOutputIntegrationTest extends AbstractIntegrationSpec {
+    @Ignore("https://github.com/gradle/gradle/issues/22088")
     def "fails when configuring tasks which do dependency resolution from non-project context in constructor"() {
         buildFile << """
             abstract class BadTask extends DefaultTask {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r73/DeprecationsCrossVersionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.tooling.r73
 
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import spock.lang.Ignore
 
 class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
     @TargetGradleVersion(">=7.3 <8.0")
@@ -67,6 +68,7 @@ class DeprecationsCrossVersionSpec extends ToolingApiSpecification {
         stdout.toString().contains("Deprecated Gradle features were used in this build")
     }
 
+    @Ignore("https://github.com/gradle/gradle/issues/22088")
     @TargetGradleVersion(">=8.0")
     def "fails when tooling model builder resolves configuration from a project other than its target post Gradle 8.0"() {
         settingsFile << """


### PR DESCRIPTION
Fixes #22088 

We need to revert this change so that `:docs:samplesMultiPage` will run, until a new version of Asciidoctor with a fix is ready.