### PR TITLE
Allow Provider#zip combiner to return null

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -224,11 +224,11 @@ public interface Provider<T> {
      * </p>
      *
      * @param right the second provider to combine with
-     * @param combiner the combiner of values
+     * @param combiner the combiner of values. May return {@code null}, in which case the provider
+     * will have no value.
      * @param <U> the type of the second provider
      * @param <R> the type of the result of the combiner
      * @return a combined provider
-     *
      * @since 6.6
      */
     <U, R> Provider<R> zip(Provider<U> right, BiFunction<? super T, ? super U, ? extends R> combiner);

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ProviderFactory.java
@@ -295,17 +295,19 @@ public interface ProviderFactory {
      * Returns a provider which value will be computed by combining a provider value with another
      * provider value using the supplied combiner function.
      *
+     * <p>
      * If the supplied providers represents a task or the output of a task, the resulting provider
      * will carry the dependency information.
+     * </p>
      *
      * @param first the first provider to combine with
      * @param second the second provider to combine with
-     * @param combiner the combiner of values
+     * @param combiner the combiner of values. May return {@code null}, in which case the provider
+     * will have no value.
      * @param <A> the type of the first provider
      * @param <B> the type of the second provider
      * @param <R> the type of the result of the combiner
      * @return a combined provider
-     *
      * @since 6.6
      */
     <A, B, R> Provider<R> zip(Provider<A> first, Provider<B> second, BiFunction<? super A, ? super B, ? extends R> combiner);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultProjectLayoutTest.groovy
@@ -177,7 +177,7 @@ class DefaultProjectLayoutTest extends Specification {
     }
 
     def "can resolve directory relative to build directory"() {
-        def pathProvider = withValues("a", "b")
+        def pathProvider = withValues("a", "b", "c")
 
         expect:
         def dir = layout.buildDirectory.dir("sub-dir")
@@ -188,17 +188,17 @@ class DefaultProjectLayoutTest extends Specification {
         provider.present
 
         def dir1 = provider.get()
-        dir1.getAsFile() == projectDir.file("build/a")
+        dir1.getAsFile() == projectDir.file("build/b")
 
         def dir2 = provider.get()
-        dir2.getAsFile() == projectDir.file("build/b")
+        dir2.getAsFile() == projectDir.file("build/c")
 
-        dir1.getAsFile() == projectDir.file("build/a")
-        dir2.getAsFile() == projectDir.file("build/b")
+        dir1.getAsFile() == projectDir.file("build/b")
+        dir2.getAsFile() == projectDir.file("build/c")
     }
 
     def "can resolve regular file relative to build directory"() {
-        def pathProvider = withValues("a", "b")
+        def pathProvider = withValues("a", "b", "c")
 
         expect:
         def file = layout.buildDirectory.file("child")
@@ -209,13 +209,13 @@ class DefaultProjectLayoutTest extends Specification {
         provider.present
 
         def file1 = provider.get()
-        file1.getAsFile() == projectDir.file("build/a")
+        file1.getAsFile() == projectDir.file("build/b")
 
         def file2 = provider.get()
-        file2.getAsFile() == projectDir.file("build/b")
+        file2.getAsFile() == projectDir.file("build/c")
 
-        file1.getAsFile() == projectDir.file("build/a")
-        file2.getAsFile() == projectDir.file("build/b")
+        file1.getAsFile() == projectDir.file("build/b")
+        file2.getAsFile() == projectDir.file("build/c")
     }
 
     def "directories are equal when their paths are equal"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
@@ -112,6 +112,7 @@ class DefaultProviderFactoryTest extends Specification implements ProviderAssert
 
         then:
         !zipped.isPresent()
+        zipped.getOrNull() == null
     }
 
     def "can zip two providers of arbitrary types"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
@@ -21,8 +21,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
-import java.util.concurrent.atomic.AtomicReference
-
 import static org.gradle.api.internal.provider.ProviderTestUtil.withProducer
 import static org.gradle.api.internal.provider.ProviderTestUtil.withValues
 
@@ -93,22 +91,18 @@ class DefaultProviderFactoryTest extends Specification implements ProviderAssert
     }
 
     def "can zip two providers and use null to remove the value, and it is live"() {
-        def reference = new AtomicReference<String>("initial")
-        def provider = providerFactory.provider(reference::get)
+        def provider = withValues("accepted", "accepted", "rejected", "rejected")
         def second = providerFactory.provider { "value" }
 
         when:
         def zipped = providerFactory.zip(provider, second) { s1, s2 ->
-            s1 == "initial" ? "$s1 $s2" : null
+            s1 == "accepted" ? "$s1 $s2" : null
         }
 
         then:
         zipped instanceof Provider
         zipped.isPresent()
-        zipped.get() == "initial value"
-
-        when:
-        reference.set("changed")
+        zipped.get() == "accepted value"
 
         then:
         !zipped.isPresent()

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderFactoryTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
+import java.util.concurrent.atomic.AtomicReference
+
 import static org.gradle.api.internal.provider.ProviderTestUtil.withProducer
 import static org.gradle.api.internal.provider.ProviderTestUtil.withValues
 
@@ -75,6 +77,41 @@ class DefaultProviderFactoryTest extends Specification implements ProviderAssert
         then:
         zipped instanceof Provider
         zipped.get() == 'Big black cat'
+    }
+
+    def "can zip two providers and use null to remove the value"() {
+        def not = providerFactory.provider { "not" }
+        def important = providerFactory.provider { "important" }
+
+        when:
+        def zipped = providerFactory.zip(not, important) { s1, s2 -> null }
+
+        then:
+        zipped instanceof Provider
+        !zipped.isPresent()
+        zipped.getOrNull() == null
+    }
+
+    def "can zip two providers and use null to remove the value, and it is live"() {
+        def reference = new AtomicReference<String>("initial")
+        def provider = providerFactory.provider(reference::get)
+        def second = providerFactory.provider { "value" }
+
+        when:
+        def zipped = providerFactory.zip(provider, second) { s1, s2 ->
+            s1 == "initial" ? "$s1 $s2" : null
+        }
+
+        then:
+        zipped instanceof Provider
+        zipped.isPresent()
+        zipped.get() == "initial value"
+
+        when:
+        reference.set("changed")
+
+        then:
+        !zipped.isPresent()
     }
 
     def "can zip two providers of arbitrary types"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/WithSideEffectProviderTest.groovy
@@ -186,7 +186,9 @@ class WithSideEffectProviderTest extends ProviderSpec<Integer> {
         def zippedSideEffect = Mock(ValueSupplier.SideEffect)
         def leftWithSideEffect = Providers.ofNullable(leftValue).withSideEffect(leftSideEffect)
         def rightWithSideEffect = Providers.ofNullable(rightValue).withSideEffect(rightSideEffect)
-        def zipped = leftWithSideEffect.zip(rightWithSideEffect) { a, b -> a + b } as ProviderInternal<Integer>
+        def zipped = leftWithSideEffect.zip(rightWithSideEffect) { a, b ->
+            a == Integer.MAX_VALUE ? null : (a + b)
+        } as ProviderInternal<Integer>
         def provider = zipped.withSideEffect(zippedSideEffect)
 
         when:
@@ -211,11 +213,12 @@ class WithSideEffectProviderTest extends ProviderSpec<Integer> {
         0 * _
 
         where:
-        description      | leftValue | leftRuns | rightValue | rightRuns | expectedResult
-        "both have"      | 23        | 1        | 88         | 1         | 23 + 88
-        "only left has"  | 23        | 0        | null       | 0         | null
-        "only right has" | null      | 0        | 88         | 0         | null
-        "none have"      | null      | 0        | null       | 0         | null
+        description                            | leftValue         | leftRuns | rightValue | rightRuns | expectedResult
+        "both have"                            | 23                | 1        | 88         | 1         | 23 + 88
+        "both have (but zip provider missing)" | Integer.MAX_VALUE | 0        | 88         | 0         | null
+        "only left has"                        | 23                | 0        | null       | 0         | null
+        "only right has"                       | null              | 0        | 88         | 0         | null
+        "none have"                            | null              | 0        | null       | 0         | null
     }
 
     def "carries the side effect in the execution time value for a provider of a fixed value"() {


### PR DESCRIPTION
This seems like a harmless change, though it does make computing presence slightly more expensive when both the left and right provider are present.

Fixes #22075