### PR TITLE
Parameterize Gradleception configuration to conditionally build with …

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -17,10 +17,10 @@ import model.Stage
  * Build a Gradle distribution (dogfood-first) and use this distribution to build a distribution again (dogfood-second).
  * Use `dogfood-second` to run `test sanityCheck`.
  */
-class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(stage = stage, init = {
-    id("${model.projectId}_Gradleception")
-    name = "Gradleception - Java8 Linux"
-    description = "Builds Gradle with the version of Gradle which is currently under development (twice)"
+class Gradleception(model: CIBuildModel, stage: Stage, bundleGroovy4: Boolean = false) : BaseGradleBuildType(stage = stage, init = {
+    if (bundleGroovy4) id("${model.projectId}_GradleceptionWithGroovy4") else id("${model.projectId}_Gradleception")
+    name = if (bundleGroovy4) "Gradleception - Groovy 4.x Java8 Linux" else "Gradleception - Java8 Linux"
+    description = "Builds Gradle with the version of Gradle which is currently under development (twice)" + if (bundleGroovy4) " - bundling Groovy 4" else ""
 
     requirements {
         // Gradleception is a heavy build which runs ~40m on EC2 agents but only ~20m on Hetzner agents
@@ -48,7 +48,11 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
     val dogfoodTimestamp1 = "19800101010101+0000"
     val dogfoodTimestamp2 = "19800202020202+0000"
     val buildScanTagForType = buildScanTag("Gradleception")
-    val defaultParameters = (buildToolGradleParameters() + listOf(buildScanTagForType) + "-Porg.gradle.java.installations.auto-download=false").joinToString(separator = " ")
+    val buildScanTagForGroovy4 = buildScanTag("Groovy4")
+    val buildScanTags = if (bundleGroovy4) listOf(buildScanTagForType, buildScanTagForGroovy4) else listOf(buildScanTagForType)
+    val bundleGroovy4SysProp =  "-DbundleGroovy4=true"
+    val maybeBundleGroovy4SysProp = if (bundleGroovy4) bundleGroovy4SysProp else ""
+    val defaultParameters = (buildToolGradleParameters() + buildScanTags + maybeBundleGroovy4SysProp + "-Porg.gradle.java.installations.auto-download=false").joinToString(separator = " ")
 
     params {
         // Override the default commit id so the build steps produce reproducible distribution
@@ -59,7 +63,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(sta
         model,
         this,
         ":distributions-full:install",
-        extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType",
+        extraParameters = "-Pgradle_installPath=dogfood-first-for-hash -PignoreIncomingBuildReceipt=true -PbuildTimestamp=$dogfoodTimestamp1 $buildScanTagForType $maybeBundleGroovy4SysProp",
         extraSteps = {
             script {
                 name = "CALCULATE_MD5_VERSION_FOR_DOGFOODING_DISTRIBUTION"

--- a/.teamcity/src/main/kotlin/model/CIBuildModel.kt
+++ b/.teamcity/src/main/kotlin/model/CIBuildModel.kt
@@ -74,6 +74,7 @@ data class CIBuildModel(
             specificBuilds = listOf(
                 SpecificBuild.BuildDistributions,
                 SpecificBuild.Gradleception,
+                SpecificBuild.GradleceptionWithGroovy4,
                 SpecificBuild.CheckLinks,
                 SpecificBuild.SmokeTestsMaxJavaVersion,
                 SpecificBuild.SantaTrackerSmokeTests,
@@ -350,6 +351,11 @@ enum class SpecificBuild {
     Gradleception {
         override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
             return Gradleception(model, stage)
+        }
+    },
+    GradleceptionWithGroovy4 {
+        override fun create(model: CIBuildModel, stage: Stage): BaseGradleBuildType {
+            return Gradleception(model, stage, true)
         }
     },
     CheckLinks {


### PR DESCRIPTION
…Groovy 4; add to Pull Request Feedback stage

To prepare for the Groovy 4 upgrade, @big-guy and I decided to parameterize the gradle/gradle build to optionally build with Groovy 4.  This change creates a duplicate Gradleception job, but passes in the "magic" sysprop `bundleGroovy4=true`.  The build will react to this property and bundle Groovy 4 jars instead of Groovy 3.

I tested this job config in the `experimental` branch and it appears to be working.

* Build dependency chain [example](https://builds.gradle.org/buildConfiguration/Gradle_Experimental_Check_GradleceptionWithGroovy4/56265700?hideProblemsFromDependencies=false&hideTestsFromDependencies=false).
* Resulting [build scan](https://ge.gradle.org/s/wxl27hmxkthhe), tagged with `Gradleception` _and_ `Groovy 4.x`.

Extracted from #20038 

