### PR TITLE
Reduce number of file changes for soak test on macOS

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/vfs/FileSystemWatchingSoakTest.groovy
@@ -152,7 +152,7 @@ class FileSystemWatchingSoakTest extends DaemonIntegrationSpec implements FileSy
         if (os.windows) {
             return 200
         } else if (os.macOsX) {
-            return 500
+            return 150
         } else {
             return 1000
         }


### PR DESCRIPTION
Any higher number causes an overflow on my (wolfs) M1 mac for `file watching works with multiple builds on the same daemon`. This may also solve some issues on CI: gradle/gradle-private#3577.

Fixes gradle/gradle-private#3577.