### PR TITLE
Restore TAPI compatibility with Java 6 and old Gradle versions

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/internal/TextUtil.java
@@ -19,11 +19,14 @@ package org.gradle.util.internal;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.SystemProperties;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -116,11 +119,152 @@ public class TextUtil {
     }
 
     /**
+     * Checks if a String is whitespace, empty ("") or null.
+     * <p>
+     * This function was copied from Apache Commons-Lang to restore TAPI compatibility
+     * with Java 6 on old Gradle versions because StringUtils require SQLException which
+     * is absent from Java 6.
+     */
+    public static boolean isBlank(String str) {
+        int strLen;
+        if (str == null || (strLen = str.length()) == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Capitalizes a String changing the first letter to title case as
+     * per {@link Character#toTitleCase(char)}. No other letters are changed.
+     * <p>
+     * This function was copied from Apache Commons-Lang to restore TAPI compatibility
+     * with Java 6 on old Gradle versions because StringUtils require SQLException which
+     * is absent from Java 6.
+     */
+    public static String capitalize(String str) {
+        if (str == null || str.length() == 0) {
+            return str;
+        }
+        return Character.toTitleCase(str.charAt(0)) + str.substring(1);
+    }
+
+    /**
      * Escapes the toString() representation of {@code obj} for use in a literal string.
      * This is useful for interpolating variables into script strings, as well as in other situations.
      */
     public static String escapeString(Object obj) {
-        return obj == null ? null : StringEscapeUtils.escapeJava(obj.toString());
+        return obj == null ? null : escapeJavaStyleString(obj.toString(), false, false);
+    }
+
+    /**
+     * This function was copied from Apache Commons-Lang to restore TAPI compatibility
+     * with Java 6 on old Gradle versions because StringUtils require SQLException which
+     * is absent from Java 6.
+     */
+    private static String escapeJavaStyleString(String str, boolean escapeSingleQuotes, boolean escapeForwardSlash) {
+        if (str == null) {
+            return null;
+        }
+        try {
+            StringWriter writer = new StringWriter(str.length() * 2);
+            escapeJavaStyleString(writer, str, escapeSingleQuotes, escapeForwardSlash);
+            return writer.toString();
+        } catch (IOException ioe) {
+            // this should never ever happen while writing to a StringWriter
+            throw new UncheckedIOException(ioe);
+        }
+    }
+
+
+    private static void escapeJavaStyleString(
+        Writer out, String str, boolean escapeSingleQuote,
+        boolean escapeForwardSlash
+    ) throws IOException {
+        if (out == null) {
+            throw new IllegalArgumentException("The Writer must not be null");
+        }
+        if (str == null) {
+            return;
+        }
+        int sz;
+        sz = str.length();
+        for (int i = 0; i < sz; i++) {
+            char ch = str.charAt(i);
+
+            // handle unicode
+            if (ch > 0xfff) {
+                out.write("\\u" + hex(ch));
+            } else if (ch > 0xff) {
+                out.write("\\u0" + hex(ch));
+            } else if (ch > 0x7f) {
+                out.write("\\u00" + hex(ch));
+            } else if (ch < 32) {
+                switch (ch) {
+                    case '\b':
+                        out.write('\\');
+                        out.write('b');
+                        break;
+                    case '\n':
+                        out.write('\\');
+                        out.write('n');
+                        break;
+                    case '\t':
+                        out.write('\\');
+                        out.write('t');
+                        break;
+                    case '\f':
+                        out.write('\\');
+                        out.write('f');
+                        break;
+                    case '\r':
+                        out.write('\\');
+                        out.write('r');
+                        break;
+                    default:
+                        if (ch > 0xf) {
+                            out.write("\\u00" + hex(ch));
+                        } else {
+                            out.write("\\u000" + hex(ch));
+                        }
+                        break;
+                }
+            } else {
+                switch (ch) {
+                    case '\'':
+                        if (escapeSingleQuote) {
+                            out.write('\\');
+                        }
+                        out.write('\'');
+                        break;
+                    case '"':
+                        out.write('\\');
+                        out.write('"');
+                        break;
+                    case '\\':
+                        out.write('\\');
+                        out.write('\\');
+                        break;
+                    case '/':
+                        if (escapeForwardSlash) {
+                            out.write('\\');
+                        }
+                        out.write('/');
+                        break;
+                    default:
+                        out.write(ch);
+                        break;
+                }
+            }
+        }
+    }
+
+    private static String hex(char ch) {
+        return Integer.toHexString(ch).toUpperCase(Locale.ENGLISH);
     }
 
     /**
@@ -200,7 +344,6 @@ public class TextUtil {
      *
      * @param s string to be made lowercase
      * @return a lowercase string that ignores locale
-     *
      * @see <a href="https://issues.gradle.org/browse/GRADLE-3470">GRADLE-3470</a>
      * @see <a href="https://haacked.com/archive/2012/07/05/turkish-i-problem-and-why-you-should-care.aspx/">Turkish i problem</a>
      */

--- a/subprojects/build-option/build.gradle.kts
+++ b/subprojects/build-option/build.gradle.kts
@@ -8,6 +8,7 @@ gradlebuildJava.usedInWorkers()
 
 dependencies {
     implementation(project(":cli"))
+    implementation(project(":base-services"))
 
     implementation(project(":base-annotations"))
     implementation(libs.commonsLang)

--- a/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
+++ b/subprojects/build-option/src/main/java/org/gradle/internal/buildoption/Origin.java
@@ -16,8 +16,8 @@
 
 package org.gradle.internal.buildoption;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.cli.CommandLineArgumentException;
+import org.gradle.util.internal.TextUtil;
 
 public abstract class Origin {
     protected String source;
@@ -41,7 +41,7 @@ public abstract class Origin {
     }
 
     String hintMessage(String hint) {
-        if (StringUtils.isBlank(hint)) {
+        if (TextUtil.isBlank(hint)) {
             return "";
         }
         return String.format(" (%s)", hint);

--- a/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/deprecation/DeprecatedFeatureUsage.java
@@ -17,7 +17,6 @@
 package org.gradle.internal.deprecation;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
 import org.gradle.internal.featurelifecycle.FeatureUsage;
 
 import javax.annotation.Nullable;
@@ -145,7 +144,7 @@ public class DeprecatedFeatureUsage extends FeatureUsage {
     }
 
     private void append(StringBuilder outputBuilder, String message) {
-        if (!StringUtils.isEmpty(message)) {
+        if (message != null && message.length() > 0) {
             outputBuilder.append(" ").append(message);
         }
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingConfigurationBuildOptions.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.logging;
 
-import org.apache.commons.lang.StringUtils;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
@@ -200,7 +199,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
 
         @Override
         public void applyTo(String value, LoggingConfiguration settings, Origin origin) {
-            String consoleValue = StringUtils.capitalize(TextUtil.toLowerCaseLocaleSafe(value));
+            String consoleValue = TextUtil.capitalize(TextUtil.toLowerCaseLocaleSafe(value));
             try {
                 ConsoleOutput consoleOutput = ConsoleOutput.valueOf(consoleValue);
                 settings.setConsoleOutput(consoleOutput);
@@ -221,7 +220,7 @@ public class LoggingConfigurationBuildOptions extends BuildOptionSet<LoggingConf
         @Override
         public void applyTo(String value, LoggingConfiguration settings, final Origin origin) {
             try {
-                settings.setWarningMode(WarningMode.valueOf(StringUtils.capitalize(TextUtil.toLowerCaseLocaleSafe(value))));
+                settings.setWarningMode(WarningMode.valueOf(TextUtil.capitalize(TextUtil.toLowerCaseLocaleSafe(value))));
             } catch (IllegalArgumentException e) {
                 origin.handleInvalidValue(value);
             }


### PR DESCRIPTION
This is required since `DefaultGradleVersion` makes use of deprecation logging facilities. This dragged Apache Commons Lang `StringUtils` which dragged `javax.sql.SQLException` which is not available on Java 6.

See https://ge.gradle.org/s/kaqqzlgw332si/tests/:tooling-api:embeddedIntegTest/org.gradle.integtests.tooling.ToolingApiClientCurrentJdkCompatibilityTest/tapi%20client%20can%20run%20build%20action%20with%20Gradle%20and%20Java%20combination%20%5BgradleDaemonJdkVersion:%201.6,%20gradleVersion:%202.14.1,%20%230%5D?focused-execution=1&top-execution=1#L69 for an example failure

This PR is a follow up to https://github.com/gradle/gradle/pull/21843