### PR TITLE
Adds nagging for destinationDir property in AbstractCompile task

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileTaskIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 
 class JavaCompileTaskIntegrationTest extends AbstractIntegrationSpec {
-    def "task does nothing when no configuration applied"() {
+    def "task does nothing when only minimal configuration applied"() {
         buildFile << """
             // No plugins applied
             task compile(type: JavaCompile)

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/tasks/compile/JavaCompileTest.groovy
@@ -127,7 +127,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and sets release"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.setDestinationDir(new File("tmp"))
+        javaCompile.destinationDirectory = new File("tmp")
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)
@@ -151,7 +151,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
     @Issue('https://bugs.openjdk.java.net/browse/JDK-8139607')
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and does not set release for Java 9"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.setDestinationDir(new File("tmp"))
+        javaCompile.destinationDirectory = new File("tmp")
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)
@@ -174,7 +174,7 @@ class JavaCompileTest extends AbstractProjectBuilderSpec {
 
     def "spec is configured using the toolchain compiler in-process using the current jvm as toolchain and set source and target compatibility"() {
         def javaCompile = project.tasks.create("compileJava", JavaCompile)
-        javaCompile.setDestinationDir(new File("tmp"))
+        javaCompile.destinationDirectory = new File("tmp")
         def javaHome = Jvm.current().javaHome
         def metadata = Mock(JavaInstallationMetadata)
         def compiler = Mock(JavaCompiler)

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -282,7 +282,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         processResources.destinationDir == resourcesDir
 
         def compileJava = project.tasks['compileCustomJava']
-        compileJava.destinationDir == classesDir
+        compileJava.destinationDirectory.get().getAsFile() == classesDir
     }
 
     def "sourceSet reflect changes to tasks configuration"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -290,7 +290,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.options.generatedSourceOutputDirectory.asFile.orNull == new File(project.buildDir, 'generated/sources/annotationProcessor/java/main')
         task.options.annotationProcessorGeneratedSourcesDirectory == task.options.generatedSourceOutputDirectory.asFile.orNull
         task.options.headerOutputDirectory.asFile.orNull == new File(project.buildDir, 'generated/sources/headers/java/main')
-        task.destinationDir == project.sourceSets.main.java.destinationDirectory.get().asFile
+        task.destinationDirectory.get().getAsFile() == project.sourceSets.main.java.destinationDirectory.get().asFile
         task.source.files == project.sourceSets.main.java.files
 
         when:
@@ -320,7 +320,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task.options.generatedSourceOutputDirectory.asFile.orNull == new File(project.buildDir, 'generated/sources/annotationProcessor/java/test')
         task.options.annotationProcessorGeneratedSourcesDirectory == task.options.generatedSourceOutputDirectory.asFile.orNull
         task.options.headerOutputDirectory.asFile.orNull == new File(project.buildDir, 'generated/sources/headers/java/test')
-        task.destinationDir == project.sourceSets.test.java.destinationDirectory.get().asFile
+        task.destinationDirectory.get().getAsFile() == project.sourceSets.test.java.destinationDirectory.get().asFile
         task.source.files == project.sourceSets.test.java.files
 
         when:

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
@@ -61,8 +61,7 @@ class ScalaCompileTest extends AbstractConventionTaskTest {
         def compile = getCompile()
 
         expect:
-        compile.getDestinationDir() == null
-        compile.getDestinationDirectory().getOrNull() == null
+        !compile.getDestinationDirectory().isPresent()
         compile.getSourceCompatibility() == null
         compile.getTargetCompatibility() == null
         compile.getSource().isEmpty()


### PR DESCRIPTION
- Getters and setters now warn about removal in Gradle 9, not 8.
- Tests updated to use replacement property wherever possible.
- BackwardCompatibilityOutputDirectoryCOnvention moved out of AbstractCompile task into JavaBasePlugin, where it is applied to all compile tasks.

<!--- The issue this PR addresses -->
Fixes #22110 
