### PR TITLE
Clean up downloaded JDKs after test

### DIFF
--- a/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/jvm/toolchain/JavaToolchainDownloadSoakTest.groovy
@@ -71,4 +71,7 @@ class JavaToolchainDownloadSoakTest extends AbstractIntegrationSpec {
         } as FileFilter)
     }
 
+    def cleanup() {
+        executer.gradleUserHomeDir.file("jdks").deleteDir()
+    }
 }


### PR DESCRIPTION
Otherwise, when it fails, it will try to upload the whole directory to TeamCity, which exceeds the artifact size limit.
