### PR TITLE
Let configuration cache errors surface to the top

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
@@ -55,7 +55,7 @@ class ConfigurationCacheDependencyResolutionFailuresIntegrationTest extends Abst
         configurationCacheFails 'test'
 
         then:
-        failure.assertHasDescription "Configuration cache state could not be cached: field 'files' from type 'Bean': error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfiguration'"
+        failure.assertHasDescription "Configuration cache state could not be cached: field `files` of `Bean` bean found in field `__bean__` of task `:test` of type `Test`: error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfiguration'"
         topLevelCause() == "> Could not resolve all files for configuration ':implementation'."
     }
 

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionFailuresIntegrationTest.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+class ConfigurationCacheDependencyResolutionFailuresIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    def 'nested dependency resolution failures are surfaced to the top'() {
+        given:
+        def emptyRepo = createDir('empty')
+        buildFile '''
+
+            configurations {
+                implementation
+            }
+
+            dependencies {
+                implementation 'non:existent:1.0'
+            }
+
+            repositories {
+                maven { url = uri('${emptyRepo.uri}') }
+            }
+
+            class Bean {
+                @InputFiles FileCollection files
+            }
+
+            abstract class Test extends DefaultTask {
+                @Nested abstract Property<Bean> getBean()
+                @TaskAction def test() { assert false }
+            }
+
+            tasks.register('test', Test) {
+                bean = new Bean().tap {
+                    files = configurations.implementation
+                }
+            }
+        '''
+
+        when:
+        configurationCacheFails 'test'
+
+        then:
+        failure.assertHasDescription "Configuration cache state could not be cached: field 'files' from type 'Bean': error writing value of type 'org.gradle.api.internal.artifacts.configurations.DefaultConfiguration'"
+        topLevelCause() == "> Could not resolve all files for configuration ':implementation'."
+    }
+
+    String topLevelCause() {
+        failure.error.with {
+            def firstCauseIndex = indexOf('>')
+            assert firstCauseIndex > 0
+            def endOfLine = indexOf('\n', firstCauseIndex)
+            assert endOfLine > firstCauseIndex
+            substring(firstCauseIndex, endOfLine)
+        }
+    }
+}

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheDependencyResolutionIntegrationTest.groovy
@@ -1368,7 +1368,7 @@ dependencies {
                       .incoming.artifactView {
                           attributes.attribute(Attribute.of('artifactType', String), 'jar')
                       }.artifacts.resolvedArtifacts.map { artifacts ->
-                            artifacts.collect { it.id }
+                          artifacts.collect { it.id }
                       }
                 )
                 outputFile = layout.buildDirectory.file('ids.txt')

--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProblemReportingIntegrationTest.groovy
@@ -167,7 +167,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
         }
@@ -184,7 +184,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
         }
@@ -225,7 +225,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
             totalProblemsCount = 2
@@ -245,7 +245,7 @@ class ConfigurationCacheProblemReportingIntegrationTest extends AbstractConfigur
         failure.assertHasFailures(1)
         failure.assertHasFileName("Build file '${buildFile.absolutePath}'")
         failure.assertHasLineNumber(4)
-        failure.assertHasDescription("Configuration cache state could not be cached: field 'prop' from type 'BrokenTaskType': error writing value of type 'BrokenSerializable'")
+        failure.assertHasDescription("Configuration cache state could not be cached: field `prop` of task `:broken` of type `BrokenTaskType`: error writing value of type 'BrokenSerializable'")
         failure.assertHasCause("BOOM")
         problems.assertResultHasProblems(failure) {
             totalProblemsCount = 2

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheException.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheException.kt
@@ -35,10 +35,7 @@ interface ConfigurationCacheThrowable
 class ConfigurationCacheError internal constructor(
     error: String,
     cause: Throwable? = null
-) : ConfigurationCacheThrowable, Exception(
-    "Configuration cache state could not be cached: $error",
-    cause
-)
+) : ConfigurationCacheThrowable, Exception(error, cause)
 
 
 @Contextual

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
@@ -35,7 +35,7 @@ interface ProblemsListener {
             throw error
         }
         throw ConfigurationCacheError(
-            "${propertyDescriptionFor(trace)}: ${StructuredMessage.build(message)}",
+            "Configuration cache state could not be cached: $trace: ${StructuredMessage.build(message)}",
             error.maybeUnwrapInvocationTargetException()
         )
     }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/problems/ProblemsListener.kt
@@ -17,9 +17,11 @@
 package org.gradle.configurationcache.problems
 
 import org.gradle.configurationcache.ConfigurationCacheError
+import org.gradle.configurationcache.ConfigurationCacheThrowable
 import org.gradle.configurationcache.extensions.maybeUnwrapInvocationTargetException
 import org.gradle.internal.service.scopes.EventScope
 import org.gradle.internal.service.scopes.Scopes
+import java.io.IOException
 
 
 @EventScope(Scopes.BuildTree::class)
@@ -28,6 +30,10 @@ interface ProblemsListener {
     fun onProblem(problem: PropertyProblem)
 
     fun onError(trace: PropertyTrace, error: Exception, message: StructuredMessageBuilder) {
+        // Let IO and configuration cache exceptions surface to the top.
+        if (error is IOException || error is ConfigurationCacheThrowable) {
+            throw error
+        }
         throw ConfigurationCacheError(
             "${propertyDescriptionFor(trace)}: ${StructuredMessage.build(message)}",
             error.maybeUnwrapInvocationTargetException()

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyWriter.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/beans/BeanPropertyWriter.kt
@@ -19,13 +19,11 @@ package org.gradle.configurationcache.serialization.beans
 import com.google.common.primitives.Primitives.wrap
 import org.gradle.api.internal.GeneratedSubclasses
 import org.gradle.api.internal.IConventionAware
-import org.gradle.configurationcache.ConfigurationCacheProblemsException
 import org.gradle.configurationcache.extensions.uncheckedCast
 import org.gradle.configurationcache.problems.PropertyKind
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.WriteContext
 import org.gradle.configurationcache.serialization.withDebugFrame
-import java.io.IOException
 import java.lang.reflect.Field
 
 
@@ -98,10 +96,6 @@ suspend fun WriteContext.writeNextProperty(name: String, value: Any?, kind: Prop
     withPropertyTrace(kind, name) {
         try {
             write(value)
-        } catch (passThrough: IOException) {
-            throw passThrough
-        } catch (passThrough: ConfigurationCacheProblemsException) {
-            throw passThrough
         } catch (error: Exception) {
             onError(error) {
                 when {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/CachedEnvironmentStateCodec.kt
@@ -16,7 +16,6 @@
 
 package org.gradle.configurationcache.serialization.codecs
 
-import org.gradle.configurationcache.ConfigurationCacheProblemsException
 import org.gradle.configurationcache.problems.PropertyTrace
 import org.gradle.configurationcache.serialization.Codec
 import org.gradle.configurationcache.serialization.ReadContext
@@ -25,7 +24,6 @@ import org.gradle.configurationcache.serialization.readList
 import org.gradle.configurationcache.serialization.withPropertyTrace
 import org.gradle.configurationcache.serialization.writeCollection
 import org.gradle.configurationcache.services.EnvironmentChangeTracker
-import java.io.IOException
 
 
 internal
@@ -40,10 +38,6 @@ object CachedEnvironmentStateCodec : Codec<EnvironmentChangeTracker.CachedEnviro
                 try {
                     write(update.key)
                     write(update.value)
-                } catch (passThrough: IOException) {
-                    throw passThrough
-                } catch (passThrough: ConfigurationCacheProblemsException) {
-                    throw passThrough
                 } catch (error: Exception) {
                     onError(error) {
                         text("failed to write system property ")


### PR DESCRIPTION
Instead of wrapping them so the original cause of an error, say a dependency resolution failure, is clearly reported.

Fixes https://github.com/gradle/gradle/issues/21783