### PR TITLE
Disable TaskOptionsSpec when parallel

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ GradleContextualExecuter.isParallel() }) // --parallel option unavailable
-@IgnoreIf({ GradleContextualExecuter.isConfigCache() }) // --configuration-cache option unavailables
 class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def defineTaskWithProfileOption() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
-@IgnoreIf({ GradleContextualExecuter.isParallel() }) // --parallel option unavailable
+@IgnoreIf({ GradleContextualExecuter.isConfigCache() || GradleContextualExecuter.isParallel() }) // --parallel or configuration-cache options unavailable
 class TaskOptionsSpec extends AbstractIntegrationSpec {
 
     def defineTaskWithProfileOption() {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/cli/TaskOptionsSpec.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import spock.lang.IgnoreIf
 
+@IgnoreIf({ GradleContextualExecuter.isParallel() }) // --parallel option unavailable
 @IgnoreIf({ GradleContextualExecuter.isConfigCache() }) // --configuration-cache option unavailables
 class TaskOptionsSpec extends AbstractIntegrationSpec {
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes failing nightly test run.

### Context
Failing tests are bad.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`


### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
