### PR TITLE
Let init incubating mode generate included build logic build in `build-logic`

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -53,6 +53,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
         !targetDir.file(buildFile).exists()
 
         targetDir.file(incubating ? "build-logic" : "buildSrc").assertHasDescendants(
+            settingsFile,
             buildFile,
             "src/main/${dsl.id}/some.thing.${dsl.fileNameFor("${language}-common-conventions")}",
             "src/main/${dsl.id}/some.thing.${dsl.fileNameFor("${language}-application-conventions")}",

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MultiProjectJvmApplicationInitIntegrationTest.groovy
@@ -52,7 +52,7 @@ abstract class AbstractMultiProjectJvmApplicationInitIntegrationTest extends Abs
         targetDir.file(settingsFile).exists()
         !targetDir.file(buildFile).exists()
 
-        targetDir.file(incubating ? "gradle/plugins" : "buildSrc").assertHasDescendants(
+        targetDir.file(incubating ? "build-logic" : "buildSrc").assertHasDescendants(
             buildFile,
             "src/main/${dsl.id}/some.thing.${dsl.fileNameFor("${language}-common-conventions")}",
             "src/main/${dsl.id}/some.thing.${dsl.fileNameFor("${language}-application-conventions")}",

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SimpleGlobalFilesBuildSettingsDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/SimpleGlobalFilesBuildSettingsDescriptor.java
@@ -20,7 +20,7 @@ import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.buildinit.plugins.internal.modifiers.ModularizationOption;
 
 public class SimpleGlobalFilesBuildSettingsDescriptor implements BuildContentGenerator {
-    final static String PLUGINS_BUILD_LOCATION = "gradle/plugins";
+    final static String PLUGINS_BUILD_LOCATION = "build-logic";
 
     private final DocumentationRegistry documentationRegistry;
     private final BuildScriptBuilderFactory scriptBuilderFactory;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -113,7 +113,7 @@ The feature can be disabled with the [`incrementalAfterFailure`](javadoc/org/gra
 > 🐣 *This feature is incubating*.
 
 When generating builds with the `init` task and opting in to incubating features,
-Gradle now places convention plugins under the `gradle/plugins` directory instead of in `buildSrc`.
+Gradle now places convention plugins under the `build-logic` directory instead of in `buildSrc`.
 
 For more information about convention plugins, see [Convention Plugins](userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins).
 


### PR DESCRIPTION
Let init incubating mode generate included build logic build in `build-logic` instead of `gradle/plugins` as this path is reserved for future low ceremony precompiled script plugins.

Also add the missing generation of a settings script for build logic builds.

This PR is a follow up to 
* https://github.com/gradle/gradle/pull/21192