### PR TITLE
Allow checking if Java installation matches current JVM

### DIFF
--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultGroovyJavaJointCompileSpecFactoryTest.groovy
@@ -53,6 +53,7 @@ class DefaultGroovyJavaJointCompileSpecFactoryTest extends Specification {
         JavaInstallationMetadata metadata = Mock(JavaInstallationMetadata)
         metadata.languageVersion >> JavaLanguageVersion.of(version)
         metadata.installationPath >> TestFiles.fileFactory().dir(javaHome)
+        metadata.isCurrentJvm() >> (Jvm.current().javaHome == javaHome)
 
         CompileOptions options = new CompileOptions(Mock(ObjectFactory))
         options.fork = fork

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/AbstractJavaCompileSpecFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.internal.Factory;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaInstallationMetadata;
 
 import javax.annotation.Nullable;
@@ -60,15 +59,11 @@ public abstract class AbstractJavaCompileSpecFactory<T extends JavaCompileSpec> 
         if (compileOptions.isFork()) {
             return getForkingSpec();
         } else {
-            if (isCurrentVmOurToolchain()) {
+            if (toolchain.isCurrentJvm()) {
                 return getDefaultSpec();
             }
             return getForkingSpec();
         }
-    }
-
-    boolean isCurrentVmOurToolchain() {
-        return toolchain.getInstallationPath().getAsFile().equals(Jvm.current().getJavaHome());
     }
 
     abstract protected T getCommandLineSpec();

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/DefaultJavaCompileSpecFactoryTest.groovy
@@ -34,6 +34,7 @@ class DefaultJavaCompileSpecFactoryTest extends Specification {
         if (toolchainHome != null) {
             toolchain = Mock(JavaToolchain)
             toolchain.installationPath >> TestFiles.fileFactory().dir(toolchainHome)
+            toolchain.isCurrentJvm() >> (Jvm.current().javaHome == toolchainHome)
             toolchain.languageVersion >> JavaLanguageVersion.of(8)
         }
         DefaultJavaCompileSpecFactory factory = new DefaultJavaCompileSpecFactory(options, toolchain)
@@ -51,7 +52,7 @@ class DefaultJavaCompileSpecFactoryTest extends Specification {
         false | null       | false             | false                 | null
         true  | null       | true              | false                 | null
         true  | "X"        | false             | true                  | null
-        true | "X" | true | false | File.createTempDir()
+        true  | "X"        | true              | false                 | File.createTempDir()
         false | null       | false             | false                 | Jvm.current().javaHome
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
@@ -77,4 +77,13 @@ public interface JavaInstallationMetadata {
      */
     @Internal
     Directory getInstallationPath();
+
+    /**
+     * Returns true if this installation corresponds to the currently running JVM.
+     *
+     * @since 8.0
+     */
+    @Internal
+    @Incubating
+    boolean isCurrentJvm();
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/JavaInstallationMetadata.java
@@ -79,7 +79,7 @@ public interface JavaInstallationMetadata {
     Directory getInstallationPath();
 
     /**
-     * Returns true if this installation corresponds to the currently running JVM.
+     * Returns true if this installation corresponds to the build JVM.
      *
      * @since 8.0
      */

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaToolchain.java
@@ -120,6 +120,7 @@ public class JavaToolchain implements Describable, JavaInstallationMetadata {
     }
 
     @Internal
+    @Override
     public boolean isCurrentJvm() {
         return javaHome.getAsFile().equals(Jvm.current().getJavaHome());
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
@@ -54,6 +54,7 @@ class JavaToolchainTest extends Specification {
     }
 
     def "installation metadata identifies whether it is a #description JVM"() {
+        def javaHome = new File(javaHomePath).absolutePath
         def metadata = Mock(JvmInstallationMetadata) {
             getJavaHome() >> Paths.get(javaHome)
             getLanguageVersion() >> Jvm.current().javaVersion
@@ -68,7 +69,7 @@ class JavaToolchainTest extends Specification {
         installationMetadata.isCurrentJvm() == isCurrentJvm
 
         where:
-        description   | isCurrentJvm | javaHome
+        description   | isCurrentJvm | javaHomePath
         "current"     | true         | Jvm.current().javaHome.toString()
         "not current" | false        | "/some/path"
     }

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaToolchainTest.groovy
@@ -17,11 +17,15 @@
 package org.gradle.jvm.toolchain.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmInstallationMetadata
 import org.gradle.internal.operations.BuildOperationProgressEventEmitter
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JvmImplementation
 import spock.lang.Specification
+
+import java.nio.file.Paths
 
 class JavaToolchainTest extends Specification {
     def "java version is reported as specified in metadata"() {
@@ -47,5 +51,25 @@ class JavaToolchainTest extends Specification {
         "1.8.0_292" | "1.8.0_292-b10" | "25.292-b10" | 8
         "11.0.11"   | "11.0.9+11"     | "11.0.9+11"  | 11
         "16"        | "16+36"         | "16+36"      | 16
+    }
+
+    def "installation metadata identifies whether it is a #description JVM"() {
+        def metadata = Mock(JvmInstallationMetadata) {
+            getJavaHome() >> Paths.get(javaHome)
+            getLanguageVersion() >> Jvm.current().javaVersion
+        }
+
+        when:
+        def javaToolchain = new JavaToolchain(metadata, Stub(JavaCompilerFactory), Stub(ToolchainToolFactory), TestFiles.fileFactory(), Stub(JavaToolchainInput), Stub(BuildOperationProgressEventEmitter))
+        def installationMetadata = javaToolchain as JavaInstallationMetadata
+
+        then:
+        installationMetadata.installationPath.toString() == javaHome
+        installationMetadata.isCurrentJvm() == isCurrentJvm
+
+        where:
+        description   | isCurrentJvm | javaHome
+        "current"     | true         | Jvm.current().javaHome.toString()
+        "not current" | false        | "/some/path"
     }
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/internal/tasks/scala/DefaultScalaJavaJointCompileSpecFactoryTest.groovy
@@ -37,6 +37,7 @@ class DefaultScalaJavaJointCompileSpecFactoryTest extends Specification {
         JavaInstallationMetadata metadata = Mock(JavaInstallationMetadata)
         metadata.languageVersion >> JavaLanguageVersion.of(version)
         metadata.installationPath >> TestFiles.fileFactory().dir(javaHome)
+        metadata.isCurrentJvm() >> (Jvm.current().javaHome == javaHome)
 
         CompileOptions options = new CompileOptions(Mock(ObjectFactory))
         options.fork = fork

--- a/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/scala/compile/internal/ScalaCompileOptionsConfigurerTest.groovy
@@ -133,6 +133,9 @@ class ScalaCompileOptionsConfigurerTest extends Specification {
 
             @Override
             Directory getInstallationPath() { return null }
+
+            @Override
+            boolean isCurrentJvm() { return false }
         }
     }
 }


### PR DESCRIPTION
Ability to check if Java installation matches the current JVM execution the build is required for determining the forking options when executing tasks such as `JavaCompile`. This can also be useful for task and plugin authors to determine if something can be run more efficiently in-process rather than forking a new JVM.

This was already implemented before, but the method was not available on the `JavaInstallationMetadata` interface.

This PR is related to https://github.com/gradle/gradle/pull/22108