### PR TITLE
Fix getter generation for String constant fields

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -39,11 +39,9 @@ import javax.annotation.Nullable;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -124,10 +122,9 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
          * We only add getters for `public static final String` constants. This is because in
          * the converted classes only contain these kinds of constants.
          *
-         * This is a mapping of the synthesized accessor name to the name of the backing field,
-         * i.e. "getFOO" -> "FOO"
+         * This is a Set of field names for which we will generate accessor methods.
          */
-        private Map<String, String> missingStaticStringConstantGetters = new HashMap<String, String>();
+        private Set<String> missingStaticStringConstantGetters = new HashSet<>();
         private Set<String> booleanGetGetters = new HashSet<String>();
         private Set<String> booleanFields = new HashSet<String>();
         private Set<String> booleanIsGetters = new HashSet<String>();
@@ -148,7 +145,7 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
         @Override
         public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
             if (((access & PUBLIC_STATIC_FINAL) == PUBLIC_STATIC_FINAL) && Type.getDescriptor(String.class).equals(desc)) {
-                missingStaticStringConstantGetters.put("get" + name, name);
+                missingStaticStringConstantGetters.add(name);
             }
             if (((access & Opcodes.ACC_PRIVATE) > 0) && !isStatic(access) && (Type.getDescriptor(boolean.class).equals(desc))) {
                 booleanFields.add(name);
@@ -158,9 +155,7 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-            if (missingStaticStringConstantGetters.containsKey(name)) {
-                missingStaticStringConstantGetters.remove(name);
-            }
+            missingStaticStringConstantGetters.remove(name.substring("get".length()));
             if (((access & Opcodes.ACC_PUBLIC) > 0) && !isStatic(access) && Type.getMethodDescriptor(Type.BOOLEAN_TYPE).equals(desc)) {
                 PropertyAccessorType accessorType = PropertyAccessorType.fromName(name);
                 if (accessorType != null) {
@@ -308,13 +303,13 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
         }
 
         private void addStaticStringConstantGetters() {
-            for (Map.Entry<String, String> constant : missingStaticStringConstantGetters.entrySet()) {
+            for (String fieldName : missingStaticStringConstantGetters) {
                 MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
-                    constant.getKey(),
+                    "get" + fieldName,
                     Type.getMethodDescriptor(Type.getType(String.class)), null, null);
                 mv.visitCode();
                 // accommodate cases where the RHS of the String constant is a method, not a hard-coded String
-                mv.visitFieldInsn(Opcodes.GETSTATIC, className, constant.getValue(), Type.getDescriptor(String.class));
+                mv.visitFieldInsn(Opcodes.GETSTATIC, className, fieldName, Type.getDescriptor(String.class));
                 mv.visitInsn(Opcodes.ARETURN);
                 mv.visitMaxs(1, 0);
                 mv.visitEnd();

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -310,7 +310,8 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
                     constant.getKey(),
                     Type.getMethodDescriptor(Type.getType(String.class)), null, null);
                 mv.visitCode();
-                mv.visitLdcInsn(constant.getValue());
+                // accommodate cases where the RHS of the String constant is a method, not a hard-coded String
+                mv.visitFieldInsn(Opcodes.GETSTATIC, className, constant.getKey().substring("get".length()), Type.getDescriptor(String.class));
                 mv.visitInsn(Opcodes.ARETURN);
                 mv.visitMaxs(1, 0);
                 mv.visitEnd();

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -123,6 +123,9 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
         /**
          * We only add getters for `public static final String` constants. This is because in
          * the converted classes only contain these kinds of constants.
+         *
+         * This is a mapping of the synthesized accessor name to the name of the backing field,
+         * i.e. "getFOO" -> "FOO"
          */
         private Map<String, String> missingStaticStringConstantGetters = new HashMap<String, String>();
         private Set<String> booleanGetGetters = new HashSet<String>();
@@ -145,7 +148,7 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
         @Override
         public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
             if (((access & PUBLIC_STATIC_FINAL) == PUBLIC_STATIC_FINAL) && Type.getDescriptor(String.class).equals(desc)) {
-                missingStaticStringConstantGetters.put("get" + name, (String) value);
+                missingStaticStringConstantGetters.put("get" + name, name);
             }
             if (((access & Opcodes.ACC_PRIVATE) > 0) && !isStatic(access) && (Type.getDescriptor(boolean.class).equals(desc))) {
                 booleanFields.add(name);
@@ -311,7 +314,7 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
                     Type.getMethodDescriptor(Type.getType(String.class)), null, null);
                 mv.visitCode();
                 // accommodate cases where the RHS of the String constant is a method, not a hard-coded String
-                mv.visitFieldInsn(Opcodes.GETSTATIC, className, constant.getKey().substring("get".length()), Type.getDescriptor(String.class));
+                mv.visitFieldInsn(Opcodes.GETSTATIC, className, constant.getValue(), Type.getDescriptor(String.class));
                 mv.visitInsn(Opcodes.ARETURN);
                 mv.visitMaxs(1, 0);
                 mv.visitEnd();

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
@@ -78,18 +78,28 @@ class MixInLegacyTypesClassLoaderTest extends Specification {
             class JavaPluginConvention {
                 public static final String SOME_CONST = "Value";
                 public static final String SOME_CONST_WITH_GETTER = "Other Value";
+                public static final String SOME_CONST_WITH_RHS_EXPRESSION = doSomething("Derived Value");
+                public static final String SOME_CONST_WITH_RHS_EXPRESSION_AND_GETTER = doSomething("Other Derived Value");
 
                 public static String getSomeStuff() { return SOME_CONST; }
                 public static String getSOME_CONST_WITH_GETTER() { return SOME_CONST_WITH_GETTER; }
+                public static String getSOME_CONST_WITH_RHS_EXPRESSION_AND_GETTER() { return SOME_CONST_WITH_RHS_EXPRESSION_AND_GETTER; }
                 String _prop;
                 String getProp() { return _prop; }
                 void setProp(String value) { _prop = value; }
-                String doSomething(String arg) { return arg; }
+
+                private static String doSomething(String arg) { return arg; }
             }
         """)
 
         when:
         original.getMethod("getSOME_CONST")
+
+        then:
+        thrown java.lang.NoSuchMethodException
+
+        when:
+        original.getMethod("getSOME_CONST_WITH_RHS_EXPRESSION")
 
         then:
         thrown java.lang.NoSuchMethodException
@@ -105,6 +115,12 @@ class MixInLegacyTypesClassLoaderTest extends Specification {
 
         cl.SOME_CONST_WITH_GETTER == "Other Value"
         cl.getSOME_CONST_WITH_GETTER() == "Other Value"
+
+        cl.SOME_CONST_WITH_RHS_EXPRESSION == "Derived Value"
+        cl.getSOME_CONST_WITH_RHS_EXPRESSION() == "Derived Value"
+
+        cl.SOME_CONST_WITH_RHS_EXPRESSION_AND_GETTER == "Other Derived Value"
+        cl.getSOME_CONST_WITH_RHS_EXPRESSION_AND_GETTER() == "Other Derived Value"
     }
 
     def "add getters for booleans"() {


### PR DESCRIPTION
 - Previously, the value of the String field was duplicated as the return value of the getter.  This fails when the constant value was null, i.e. if the RHS is a method call
 - Instead rewire the getter to return the value of the field

Note this blocks #22133 