### PR TITLE
Require exclusive access to build agent host for performance tests

### DIFF
--- a/.teamcity/src/main/kotlin/common/extensions.kt
+++ b/.teamcity/src/main/kotlin/common/extensions.kt
@@ -74,10 +74,19 @@ fun Requirements.requiresArch(os: Os, arch: Arch) {
     }
 }
 
-fun Requirements.requiresNoEc2Agent() {
+fun Requirements.requiresNotEc2Agent() {
     doesNotContain("teamcity.agent.name", "ec2")
     // US region agents have name "EC2-XXX"
     doesNotContain("teamcity.agent.name", "EC2")
+}
+
+/**
+ * We have some "shared" host where a Linux build agent and a Windows build agent
+ * both run on the same bare metal. Some builds require exclusive access to the
+ * hardware resources (e.g. performance test).
+ */
+fun Requirements.requiresNotSharedHost() {
+    doesNotContain("agent.host.type", "shared")
 }
 
 /**

--- a/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
+++ b/.teamcity/src/main/kotlin/common/performance-test-extensions.kt
@@ -31,7 +31,8 @@ fun BuildType.applyPerformanceTestSettings(os: Os = Os.LINUX, arch: Arch = Arch.
     """.trimIndent()
     detectHangingBuilds = false
     requirements {
-        requiresNoEc2Agent()
+        requiresNotEc2Agent()
+        requiresNotSharedHost()
     }
     params {
         param("env.JPROFILER_HOME", os.jprofilerHome)

--- a/.teamcity/src/main/kotlin/configurations/Gradleception.kt
+++ b/.teamcity/src/main/kotlin/configurations/Gradleception.kt
@@ -4,7 +4,7 @@ import common.buildToolGradleParameters
 import common.customGradle
 import common.dependsOn
 import common.gradleWrapper
-import common.requiresNoEc2Agent
+import common.requiresNotEc2Agent
 import common.skipConditionally
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildSteps
 import jetbrains.buildServer.configs.kotlin.v2019_2.RelativeId
@@ -24,7 +24,7 @@ class Gradleception(model: CIBuildModel, stage: Stage, bundleGroovy4: Boolean = 
 
     requirements {
         // Gradleception is a heavy build which runs ~40m on EC2 agents but only ~20m on Hetzner agents
-        requiresNoEc2Agent()
+        requiresNotEc2Agent()
     }
 
     features {

--- a/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
+++ b/.teamcity/src/main/kotlin/configurations/SmokeTests.kt
@@ -1,7 +1,7 @@
 package configurations
 
 import common.JvmCategory
-import common.requiresNoEc2Agent
+import common.requiresNotEc2Agent
 import common.toCapitalized
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.parallelTests
 import model.CIBuildModel
@@ -23,7 +23,7 @@ class SmokeTests(model: CIBuildModel, stage: Stage, testJava: JvmCategory, task:
 
     requirements {
         // Smoke tests is usually heavy and the build time is twice on EC2 agents
-        requiresNoEc2Agent()
+        requiresNotEc2Agent()
     }
 
     applyTestDefaults(

--- a/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
+++ b/.teamcity/src/main/kotlin/promotion/BasePromotionBuildType.kt
@@ -19,7 +19,7 @@ package promotion
 import common.BuildToolBuildJvm
 import common.Os
 import common.paramsForBuildToolBuild
-import common.requiresNoEc2Agent
+import common.requiresNotEc2Agent
 import common.requiresOs
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildType
@@ -37,7 +37,7 @@ abstract class BasePromotionBuildType(vcsRootId: String, cleanCheckout: Boolean 
 
         requirements {
             requiresOs(Os.LINUX)
-            requiresNoEc2Agent()
+            requiresNotEc2Agent()
         }
 
         paramsForBuildToolBuild(BuildToolBuildJvm, Os.LINUX)


### PR DESCRIPTION
We are trying to run a Linux build agent and Windows build agent on a same bare metal (aka. shared host). Add requirements for performance tests since they require exclusive access.

The change on the infrastructure side: https://github.com/gradle/dev-infrastructure/commit/e0993ee83b0e3e4f9772349cd63d719ab690b013