### PR TITLE
Upgrade the spock version used in samples/snippets

### DIFF
--- a/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
+++ b/build-logic/build-update-utils/src/main/kotlin/gradlebuild/buildutils/tasks/UpdateInitPluginTemplateVersionFile.kt
@@ -63,7 +63,7 @@ abstract class UpdateInitPluginTemplateVersionFile : DefaultTask() {
         findLatest("groovy", "org.codehaus.groovy:groovy:[3.0,4.0)", versionProperties)
         findLatest("junit", "junit:junit:(4.0,)", versionProperties)
         findLatest("junit-jupiter", "org.junit.jupiter:junit-jupiter-api:(5,)", versionProperties)
-        findLatest("testng", "org.testng:testng:(6.0,)", versionProperties)
+        findLatest("testng", "org.testng:testng:(6.0,7.6.0)", versionProperties) // TestNG 7.6.0 and above require JDK 11; see https://groups.google.com/g/testng-users/c/BAFB1vk-kok
         findLatest("slf4j", "org.slf4j:slf4j-api:(1.7,)", versionProperties)
 
         // Starting with ScalaTest 3.1.0, the third party integration were moved out of the main JAR
@@ -71,7 +71,7 @@ abstract class UpdateInitPluginTemplateVersionFile : DefaultTask() {
         findLatest("scalatestplus-junit", "org.scalatestplus:junit-4-12_${versionProperties["scala"]}:(3.1,)", versionProperties)
 
         val groovyVersion = VersionNumber.parse(versionProperties["groovy"] as String)
-        versionProperties["spock"] = "2.1-groovy-${groovyVersion.major}.${groovyVersion.minor}"
+        versionProperties["spock"] = "2.2-groovy-${groovyVersion.major}.${groovyVersion.minor}"
 
         findLatest("guava", "com.google.guava:guava:(20,)", versionProperties)
         findLatest("commons-math", "org.apache.commons:commons-math3:latest.release", versionProperties)

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -1,16 +1,16 @@
 #Generated file, please do not edit - Version values used in build-init templates
 commons-math=3.6.1
 commons-text=1.9
-groovy=3.0.12
+groovy=3.0.13
 guava=31.1-jre
 junit-jupiter=5.9.0
 junit=4.13.2
-kotlin=1.7.20-Beta
-scala-library=2.13.8
+kotlin=1.7.20-RC
+scala-library=2.13.9
 scala-xml=1.2.0
 scala=2.13
 scalatest=3.2.13
 scalatestplus-junit=3.2.2.0
-slf4j=1.7.36
-spock=2.1-groovy-3.0
+slf4j=2.0.1
+spock=2.2-groovy-3.0
 testng=7.5

--- a/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/multi-project-with-convention-plugins/groovy/buildSrc/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
-    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
 }
 

--- a/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/publishing-convention-plugins/groovy/convention-plugins/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 dependencies {
     implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.2'
-    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
 }
 

--- a/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/configurationCache/testKit/groovy/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
 }
 

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/groovy/url-verifier-plugin/build.gradle
@@ -48,13 +48,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    testImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     testImplementation 'org.spockframework:spock-core'
 
-    integrationTestImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    integrationTestImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     integrationTestImplementation 'org.spockframework:spock-core'
 
-    functionalTestImplementation platform("org.spockframework:spock-bom:2.1-groovy-3.0")
+    functionalTestImplementation platform("org.spockframework:spock-bom:2.2-groovy-3.0")
     functionalTestImplementation 'org.spockframework:spock-core'
 }
 

--- a/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/developingPlugins/testingPlugins/kotlin/url-verifier-plugin/build.gradle.kts
@@ -48,13 +48,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
+    testImplementation(platform("org.spockframework:spock-bom:2.2-groovy-3.0"))
     testImplementation("org.spockframework:spock-core")
 
-    "integrationTestImplementation"(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
+    "integrationTestImplementation"(platform("org.spockframework:spock-bom:2.2-groovy-3.0"))
     "integrationTestImplementation"("org.spockframework:spock-core")
 
-    "functionalTestImplementation"(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
+    "functionalTestImplementation"(platform("org.spockframework:spock-bom:2.2-groovy-3.0"))
     "functionalTestImplementation"("org.spockframework:spock-core")
 }
 


### PR DESCRIPTION
Also upgrade the version used by the init plugin.

Also limit TestNG to < 7.6, as it requires JDK 11

Extracted from #20038 