### PR TITLE
Remove ec2 requirement for configuration cache test

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -27,14 +27,6 @@ class FunctionalTest(
     this.id(id)
     val testTasks = getTestTaskName(testCoverage, subprojects)
 
-    if (name.contains("(configuration-cache)")) {
-        requirements {
-            doesNotContain("teamcity.agent.name", "ec2")
-            // US region agents have name "EC2-XXX"
-            doesNotContain("teamcity.agent.name", "EC2")
-        }
-    }
-
     applyTestDefaults(
         model, this, testTasks,
         dependsOnQuickFeedbackLinux = !testCoverage.withoutDependencies && stage.stageName > StageName.PULL_REQUEST_FEEDBACK,


### PR DESCRIPTION
Closes https://github.com/gradle/dev-infrastructure/issues/383 

It seems no longer necessary.
