### PR TITLE
Switch Spock-using integ tests to test suites

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -77,6 +77,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
 
         and:
         buildFile << spockBasedBuildScript()
+        buildFile << addOpens()
 
         expect:
         succeeds("test")
@@ -108,24 +109,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
 
         and:
         buildFile << junitBasedBuildScript()
-        buildFile << """
-            // Needed when using ProjectBuilder
-            class AddOpensArgProvider implements CommandLineArgumentProvider {
-                private final Test test;
-                public AddOpensArgProvider(Test test) {
-                    this.test = test;
-                }
-                @Override
-                Iterable<String> asArguments() {
-                    return test.javaVersion.isCompatibleWith(JavaVersion.VERSION_1_9)
-                        ? ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
-                        : []
-                }
-            }
-            tasks.withType(Test).configureEach {
-                jvmArgumentProviders.add(new AddOpensArgProvider(it))
-            }
-        """
+        buildFile << addOpens()
 
         expect:
         executer.withArgument("--info")
@@ -176,6 +160,7 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
 
         and:
         buildFile << spockBasedBuildScript()
+        buildFile << addOpens()
 
         expect:
         succeeds('test')
@@ -204,6 +189,31 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
                     }
                 }
             }
+        """
+    }
+
+    /**
+     * Configures tests to include open access to java.base/java.lang modules
+     * ProjectBuilder usages will fail without this
+     */
+    static String addOpens() {
+        """
+        // Needed when using ProjectBuilder
+        class AddOpensArgProvider implements CommandLineArgumentProvider {
+            private final Test test;
+            public AddOpensArgProvider(Test test) {
+                this.test = test;
+            }
+            @Override
+            Iterable<String> asArguments() {
+                return test.javaVersion.isCompatibleWith(JavaVersion.VERSION_1_9)
+                    ? ["--add-opens=java.base/java.lang=ALL-UNNAMED"]
+                    : []
+            }
+        }
+        tasks.withType(Test).configureEach {
+            jvmArgumentProviders.add(new AddOpensArgProvider(it))
+        }
         """
     }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ApplyPluginIntegSpec.groovy
@@ -193,7 +193,6 @@ class ApplyPluginIntegSpec extends AbstractIntegrationSpec {
 
     static String spockBasedBuildScript() {
         """
-            apply plugin: 'jvm-test-suite'
             ${basicBuildScript()}
 
             configurations.all { exclude group: 'org.codehaus.groovy' }

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
@@ -29,18 +29,23 @@ class ProjectBuilderEndUserIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """
         apply plugin: 'groovy'
+        apply plugin: 'jvm-test-suite'
 
         dependencies {
             implementation localGroovy()
             implementation gradleApi()
-            testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
-            testImplementation("org.spockframework:spock-core")
         }
 
         ${mavenCentralRepository()}
 
+        testing {
+            suites {
+                test {
+                    useSpock()
+                }
+            }
+        }
         test {
-            useJUnitPlatform()
             testLogging.exceptionFormat = 'full'
         }
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/testfixtures/ProjectBuilderEndUserIntegrationTest.groovy
@@ -29,7 +29,6 @@ class ProjectBuilderEndUserIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
         buildFile << """
         apply plugin: 'groovy'
-        apply plugin: 'jvm-test-suite'
 
         dependencies {
             implementation localGroovy()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -18,6 +18,8 @@ package org.gradle.test.fixtures.junitplatform
 
 import groovy.io.FileType
 
+import java.util.regex.Pattern
+
 class JUnitPlatformTestRewriter {
 
     private static final Map REPLACEMENTS = Collections.unmodifiableMap([

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -18,8 +18,6 @@ package org.gradle.test.fixtures.junitplatform
 
 import groovy.io.FileType
 
-import java.util.regex.Pattern
-
 class JUnitPlatformTestRewriter {
 
     private static final Map REPLACEMENTS = Collections.unmodifiableMap([

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -48,24 +48,6 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
         """
     }
 
-    static String junitDependency() {
-        """
-            dependencies {
-                testImplementation 'junit:junit:4.13.1'
-            }
-        """
-    }
-
-    static String spockDependency() {
-        """
-            dependencies {
-                testImplementation('org.spockframework:spock-core:2.1-groovy-3.0') {
-                    exclude group: 'org.codehaus.groovy'
-                }
-            }
-        """
-    }
-
     static String customGroovyPlugin() {
         """
             import org.gradle.api.Plugin
@@ -81,10 +63,17 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
     }
     static String testablePluginProject(List<String> plugins = ['groovy-gradle-plugin']) {
         StringBuilder buildFile = new StringBuilder()
-        buildFile << applyPlugins(plugins)
+        buildFile << applyPlugins(plugins + ['jvm-test-suite'])
         buildFile << mavenCentralRepository()
-        buildFile << junitDependency()
         buildFile << """
+            testing {
+                suites {
+                    test {
+                        useJUnit()
+                    }
+                }
+            }
+
             gradlePlugin {
                 plugins {
                     plugin {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -40,6 +40,10 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
         """
     }
 
+    static String excludeGroovy() {
+        applyPlugins(['groovy'])
+    }
+
     static String gradleApiDependency() {
         """
             dependencies {
@@ -63,7 +67,7 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
     }
     static String testablePluginProject(List<String> plugins = ['groovy-gradle-plugin']) {
         StringBuilder buildFile = new StringBuilder()
-        buildFile << applyPlugins(plugins + ['jvm-test-suite'])
+        buildFile << applyPlugins(plugins)
         buildFile << mavenCentralRepository()
         buildFile << """
             testing {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
@@ -104,7 +104,7 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
 
     def "Gradle API and TestKit are compatible regardless of order #dependencyPermutations"() {
         when:
-        buildFile << applyPlugins(['groovy', 'jvm-test-suite'])
+        buildFile << applyGroovyPlugin()
         buildFile << mavenCentralRepository()
         buildFile << """
             testing {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsCompatibilityIntegrationTest.groovy
@@ -104,11 +104,17 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
 
     def "Gradle API and TestKit are compatible regardless of order #dependencyPermutations"() {
         when:
-        buildFile << applyGroovyPlugin()
+        buildFile << applyPlugins(['groovy', 'jvm-test-suite'])
         buildFile << mavenCentralRepository()
-        buildFile << spockDependency()
-        buildFile << junitDependency()
         buildFile << """
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
+            }
+
             repositories {
                 maven { url '${buildContext.localRepository.toURI().toURL()}' }
             }
@@ -128,16 +134,15 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
         file('src/test/groovy/BuildLogicFunctionalTest.groovy') << """
             import org.gradle.testkit.runner.GradleRunner
             import static org.gradle.testkit.runner.TaskOutcome.*
-            import org.junit.Rule
-            import org.junit.rules.TemporaryFolder
             import spock.lang.Specification
+            import spock.lang.TempDir
 
             class BuildLogicFunctionalTest extends Specification {
-                @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+                @TempDir File testProjectDir
                 File buildFile
 
                 def setup() {
-                    buildFile = testProjectDir.newFile('build.gradle')
+                    buildFile = new File(testProjectDir, 'build.gradle')
                 }
 
                 def "hello world task prints hello world"() {
@@ -152,7 +157,7 @@ class GradleImplDepsCompatibilityIntegrationTest extends BaseGradleImplDepsInteg
 
                     when:
                     def result = GradleRunner.create()
-                        .withProjectDir(testProjectDir.root)
+                        .withProjectDir(testProjectDir)
                         .withArguments('helloWorld')
                         .withTestKitDir(new java.io.File("${TextUtil.normaliseFileSeparators(executer.gradleUserHomeDir.absolutePath)}"))
                         .build()

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
@@ -65,6 +65,7 @@ class JavaGradlePluginRelocationTest extends AbstractProjectRelocationIntegratio
             file("build.gradle") << """
                 apply plugin: "java-gradle-plugin"
                 apply plugin: "groovy"
+                apply plugin: "jvm-test-suite"
 
                 gradlePlugin {
                     plugins {
@@ -77,9 +78,11 @@ class JavaGradlePluginRelocationTest extends AbstractProjectRelocationIntegratio
 
                 ${mavenCentralRepository()}
 
-                dependencies {
-                    testImplementation('org.spockframework:spock-core:2.1-groovy-3.0') {
-                        exclude group: 'org.codehaus.groovy'
+                testing {
+                    suites {
+                        test {
+                            useSpock()
+                        }
                     }
                 }
             """

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginRelocationTest.groovy
@@ -65,7 +65,6 @@ class JavaGradlePluginRelocationTest extends AbstractProjectRelocationIntegratio
             file("build.gradle") << """
                 apply plugin: "java-gradle-plugin"
                 apply plugin: "groovy"
-                apply plugin: "jvm-test-suite"
 
                 gradlePlugin {
                     plugins {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -822,10 +822,17 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             plugins {
                 id 'groovy-gradle-plugin'
+                id 'jvm-test-suite'
             }
+
             ${mavenCentralRepository()}
-            dependencies {
-                testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0'
+
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
             }
         """
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/plugins/PrecompiledGroovyPluginsIntegrationTest.groovy
@@ -822,7 +822,6 @@ class PrecompiledGroovyPluginsIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             plugins {
                 id 'groovy-gradle-plugin'
-                id 'jvm-test-suite'
             }
 
             ${mavenCentralRepository()}

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -33,7 +33,6 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
     def setup() {
         buildFile << """
             apply plugin: 'groovy'
-            apply plugin: 'jvm-test-suite'
 
             dependencies {
                 testImplementation localGroovy()

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConsoleInputEndUserIntegrationTest.groovy
@@ -33,15 +33,20 @@ class GradleRunnerConsoleInputEndUserIntegrationTest extends BaseTestKitEndUserI
     def setup() {
         buildFile << """
             apply plugin: 'groovy'
+            apply plugin: 'jvm-test-suite'
 
             dependencies {
                 testImplementation localGroovy()
                 testImplementation gradleTestKit()
-                testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
-                testImplementation("org.spockframework:spock-core")
             }
 
-            test.useJUnitPlatform()
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
+            }
 
             ${mavenCentralRepository()}
         """

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -31,13 +31,16 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
             plugins {
                 id "org.gradle.java-gradle-plugin"
                 id "org.gradle.groovy"
+                id "org.gradle.jvm-test-suite"
             }
             ${mavenCentralRepository()}
-            dependencies {
-                testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
-                testImplementation("org.spockframework:spock-core")
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
             }
-            test.useJUnitPlatform()
         """
 
         plugin.writeSourceFiles()

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -31,7 +31,6 @@ class GradleRunnerConventionalPluginClasspathInjectionEndUserIntegrationTest ext
             plugins {
                 id "org.gradle.java-gradle-plugin"
                 id "org.gradle.groovy"
-                id "org.gradle.jvm-test-suite"
             }
             ${mavenCentralRepository()}
             testing {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
@@ -44,17 +44,23 @@ class GradleRunnerDefaultTestKitDirIntegrationTest extends BaseGradleRunnerInteg
 
         buildFile << """
             apply plugin: 'groovy'
+            apply plugin: 'jvm-test-suite'
 
             dependencies {
                 implementation localGroovy()
-                testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
-                testImplementation("org.spockframework:spock-core")
             }
 
             ${mavenCentralRepository()}
 
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
+            }
+
             tasks.withType(Test).configureEach {
-                useJUnitPlatform()
                 testLogging.exceptionFormat = 'full'
                 testLogging.showStandardStreams = true
                 testLogging.events "started", "skipped", "failed", "passed", "standard_out", "standard_error"

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerDefaultTestKitDirIntegrationTest.groovy
@@ -44,7 +44,6 @@ class GradleRunnerDefaultTestKitDirIntegrationTest extends BaseGradleRunnerInteg
 
         buildFile << """
             apply plugin: 'groovy'
-            apply plugin: 'jvm-test-suite'
 
             dependencies {
                 implementation localGroovy()

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
@@ -34,7 +34,6 @@ class GradleRunnerMiscEndUserIntegrationTest extends BaseTestKitEndUserIntegrati
     def setup() {
         buildFile << """
             apply plugin: 'groovy'
-            apply plugin: 'jvm-test-suite'
 
             ${mavenCentralRepository()}
 

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerMiscEndUserIntegrationTest.groovy
@@ -34,19 +34,20 @@ class GradleRunnerMiscEndUserIntegrationTest extends BaseTestKitEndUserIntegrati
     def setup() {
         buildFile << """
             apply plugin: 'groovy'
-
-            dependencies {
-                implementation localGroovy()
-                testImplementation('org.spockframework:spock-core:2.1-groovy-3.0') {
-                    exclude group: 'org.codehaus.groovy'
-                }
-            }
+            apply plugin: 'jvm-test-suite'
 
             ${mavenCentralRepository()}
 
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
+            }
+
             test {
                 testLogging.exceptionFormat = 'full'
-                useJUnitPlatform()
             }
         """
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -48,7 +48,6 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
                 testImplementation files(createClasspathManifest)
             }
 
-            apply plugin: 'jvm-test-suite'
             testing {
                 suites {
                     test {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerPluginClasspathInjectionEndUserIntegrationTest.groovy
@@ -44,14 +44,17 @@ class GradleRunnerPluginClasspathInjectionEndUserIntegrationTest extends BaseTes
 
             dependencies {
                 implementation localGroovy()
-                testImplementation(platform("org.spockframework:spock-bom:2.1-groovy-3.0"))
-                testImplementation("org.spockframework:spock-core")
                 testImplementation gradleTestKit()
                 testImplementation files(createClasspathManifest)
             }
 
-            test {
-                useJUnitPlatform()
+            apply plugin: 'jvm-test-suite'
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
             }
 
             ${mavenCentralRepository()}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
@@ -92,13 +92,13 @@ abstract class JUnitMultiVersionIntegrationSpec extends MultiVersionIntegrationS
         }
     }
 
-    protected getDependencyNotation() {
+    protected List<String> getDependencyNotation() {
         if (isJupiter()) {
-            return "org.junit.jupiter:junit-jupiter-api:${dependencyVersion}','org.junit.jupiter:junit-jupiter-engine:${dependencyVersion}"
+            return ["org.junit.jupiter:junit-jupiter-api:${dependencyVersion}", "org.junit.jupiter:junit-jupiter-engine:${dependencyVersion}"]
         } else if (isVintage()) {
-            return "org.junit.vintage:junit-vintage-engine:${dependencyVersion}','junit:junit:4.13"
+            return ["org.junit.vintage:junit-vintage-engine:${dependencyVersion}","junit:junit:4.13"]
         } else {
-            return "junit:junit:${version}"
+            return ["junit:junit:${version}"]
         }
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -29,6 +29,7 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         file("build.gradle") << """
             plugins {
                 id("groovy")
+                id("jvm-test-suite")
             }
 
             ${mavenCentralRepository()}
@@ -36,9 +37,20 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             dependencies {
                 implementation gradleApi()
                 implementation localGroovy()
+            }
 
-                testImplementation '$dependencyNotation',
-                    'org.spockframework:spock-core:2.1-groovy-3.0'
+            testing {
+                suites {
+                    // Must explicitly use `named` to avoid being rewritten by JUnitPlatformTestRewriter.rewriteBuildFile
+                    named('test') {
+                        useSpock()
+                        dependencies {
+                            ${dependencyNotation.collect { "implementation '$it'" }.join('\n')}
+                            // Required to use Spock mocking
+                            runtimeOnly 'net.bytebuddy:byte-buddy:1.12.17'
+                        }
+                    }
+                }
             }
         """
         file("src/main/groovy/MockIt.groovy") << """
@@ -83,12 +95,21 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     private void writeSpockDependencies() {
         file("build.gradle") << """
             apply plugin: 'groovy'
+            apply plugin: 'jvm-test-suite'
 
             ${mavenCentralRepository()}
 
-            dependencies {
-                testImplementation localGroovy()
-                testImplementation '$dependencyNotation', 'org.spockframework:spock-core:2.1-groovy-3.0@jar'
+            testing {
+                suites {
+                    // Must explicitly use `named` to avoid being rewritten by JUnitPlatformTestRewriter.rewriteBuildFile
+                    named('test') {
+                        useSpock()
+                        dependencies {
+                            implementation localGroovy()
+                            ${dependencyNotation.collect { "implementation '$it'" }.join('\n')}
+                        }
+                    }
+                }
             }
         """
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/BuildSrcSpockIntegrationTest.groovy
@@ -29,7 +29,6 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         file("build.gradle") << """
             plugins {
                 id("groovy")
-                id("jvm-test-suite")
             }
 
             ${mavenCentralRepository()}
@@ -95,7 +94,6 @@ class BuildSrcSpockIntegrationTest extends JUnitMultiVersionIntegrationSpec {
     private void writeSpockDependencies() {
         file("build.gradle") << """
             apply plugin: 'groovy'
-            apply plugin: 'jvm-test-suite'
 
             ${mavenCentralRepository()}
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnit3FilteringIntegrationTest.groovy
@@ -30,7 +30,7 @@ class JUnit3FilteringIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
-            dependencies { testImplementation '${dependencyNotation}' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
         """
 
         file("src/test/java/FooTest.java") << """

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest.groovy
@@ -37,7 +37,7 @@ class JUnitAbortedTestClassIntegrationTest extends JUnitMultiVersionIntegrationS
         executer.noExtraLogging()
         buildFile << """
 dependencies {
-    testImplementation '$dependencyNotation'
+    ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
 }
 """
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAssumptionsIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAssumptionsIntegrationTest.groovy
@@ -34,7 +34,7 @@ class JUnitAssumptionsIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         executer.noExtraLogging()
         buildFile << """
 dependencies {
-    testImplementation '$dependencyNotation'
+    ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
 }
 """
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
@@ -32,7 +32,7 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
 
     def setup() {
         executer.noExtraLogging()
-        buildFile << "dependencies { testImplementation '$dependencyNotation' }"
+        buildFile << "dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }"
     }
 
     def canSpecifyIncludeAndExcludeCategories() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassDetectionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassDetectionIntegrationTest.groovy
@@ -30,7 +30,7 @@ class JUnitClassDetectionIntegrationTest extends JUnitMultiVersionIntegrationSpe
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
-            dependencies { testImplementation '${dependencyNotation}' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassInJarDetectionIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassInJarDetectionIntegrationTest.groovy
@@ -36,7 +36,7 @@ class JUnitClassInJarDetectionIntegrationTest extends JUnitMultiVersionIntegrati
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
-            dependencies { testImplementation '${dependencyNotation}' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
         """.stripIndent()
     }
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitClassLevelFilteringIntegrationTest.groovy
@@ -31,7 +31,7 @@ class JUnitClassLevelFilteringIntegrationTest extends JUnitMultiVersionIntegrati
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
-            dependencies { testImplementation '${dependencyNotation}' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
             test { use${testFramework}() }
         """
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitEnclosedRunnerIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitEnclosedRunnerIntegrationTest.groovy
@@ -30,7 +30,7 @@ class JUnitEnclosedRunnerIntegrationTest extends JUnitMultiVersionIntegrationSpe
         buildFile << """
             apply plugin: 'java'
             ${mavenCentralRepository()}
-            dependencies { testImplementation '${dependencyNotation}' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
         """.stripIndent()
     }
 
@@ -109,10 +109,10 @@ public class EnclosedTest {
       outer = 1;
   }
 
-  @Category(Fast.class) 
+  @Category(Fast.class)
   public static class InnerClass {
     private int inner;
-    
+
     @Before
     public void setUp() {
        inner = 2;
@@ -122,7 +122,7 @@ public class EnclosedTest {
     public void test() {
        Assert.assertTrue(outer==1 && inner==2);
     }
-  } 
+  }
 }
 '''
         file('src/test/java/Fast.java') << 'public interface Fast {}'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIgnoreClassMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIgnoreClassMultiVersionIntegrationSpec.groovy
@@ -33,7 +33,7 @@ class JUnitIgnoreClassMultiVersionIntegrationSpec extends JUnitMultiVersionInteg
     def canHandleClassLevelIgnoredTests() {
         executer.noExtraLogging()
         buildFile << """
-            dependencies { testImplementation '$dependencyNotation' }
+            dependencies { ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')} }
         """
 
         when:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitIntegrationTest.groovy
@@ -468,7 +468,7 @@ class JUnitIntegrationTest extends JUnitMultiVersionIntegrationSpec {
             apply plugin: 'java'
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation '$dependencyNotation'
+                ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
             }
         """
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitLoggingOutputCaptureIntegrationTest.groovy
@@ -38,7 +38,7 @@ class JUnitLoggingOutputCaptureIntegrationTest extends JUnitMultiVersionIntegrat
             apply plugin: "java"
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation '$dependencyNotation'
+                ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
             }
             test {
                 reports.junitXml.outputPerTestCase = true

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitSmokeMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitSmokeMultiVersionIntegrationSpec.groovy
@@ -38,8 +38,8 @@ class JUnitSmokeMultiVersionIntegrationSpec extends JUnitMultiVersionIntegration
         buildFile << """
         apply plugin: 'java'
         ${mavenCentralRepository()}
-        dependencies { 
-            testImplementation '$dependencyNotation' 
+        dependencies {
+            ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
         }"""
 
         when:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/Specs2IntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/Specs2IntegrationTest.groovy
@@ -33,9 +33,7 @@ class Specs2IntegrationTest extends JUnitMultiVersionIntegrationSpec {
                 id("scala")
             }
 
-            repositories {
-                 mavenCentral()
-            }
+            ${mavenCentralRepository()}
 
             dependencies {
                 implementation 'org.scala-lang:scala-library:2.11.8'

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/Specs2IntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/Specs2IntegrationTest.groovy
@@ -36,19 +36,19 @@ class Specs2IntegrationTest extends JUnitMultiVersionIntegrationSpec {
             repositories {
                  mavenCentral()
             }
-            
+
             dependencies {
                 implementation 'org.scala-lang:scala-library:2.11.8'
-                testImplementation 'org.specs2:specs2_2.11:3.7' 
-                testImplementation 'org.specs2:specs2-junit_2.11:4.7.0' 
-                testImplementation '$dependencyNotation'
+                testImplementation 'org.specs2:specs2_2.11:3.7'
+                testImplementation 'org.specs2:specs2-junit_2.11:4.7.0'
+                ${dependencyNotation.collect { "testImplementation '$it'" }.join('\n')}
             }
         """
         file('src/test/scala/BasicSpec.scala') << '''
             import org.junit.runner.RunWith
             import org.specs2.runner.JUnitRunner
             import org.specs2.mutable.Specification
-            
+
             @RunWith(classOf[JUnitRunner])
             class BasicSpec extends Specification {
               "Basic Math" >> {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
@@ -20,26 +20,28 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.testing.fixture.GroovyCoverage
 
 class Spock2IntegrationSpec extends AbstractIntegrationSpec {
-    private static final String SPOCK_VERSION = "2.2-groovy-3.0"
-
     def setup() {
         buildScript("""
             plugins {
                 id("groovy")
+                id("jvm-test-suite")
             }
 
             ${mavenCentralRepository()}
             dependencies {
-                testImplementation("org.spockframework:spock-core:$SPOCK_VERSION")
-
                 constraints {
                     implementation("org.codehaus.groovy:groovy:${GroovyCoverage.MINIMAL_GROOVY_3}") {
                         because("need a version of Groovy that supports the current JDK")
                     }
                 }
             }
-            test {
-                useJUnitPlatform()
+
+            testing {
+                suites {
+                    test {
+                        useSpock()
+                    }
+                }
             }
         """)
     }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/spock/Spock2IntegrationSpec.groovy
@@ -24,7 +24,6 @@ class Spock2IntegrationSpec extends AbstractIntegrationSpec {
         buildScript("""
             plugins {
                 id("groovy")
-                id("jvm-test-suite")
             }
 
             ${mavenCentralRepository()}


### PR DESCRIPTION
Separated from #20038, this changes tests that depended on an explicit version of Spock to instead `useSpock()` from test suites.