### PR TITLE
Refactor tests to run with both Groovy 3 and Groovy 4

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/GroovyGradlePluginInitIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.util.internal.VersionNumber
 import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.GROOVY
 
+@IgnoreIf({ VersionNumber.parse(GroovySystem.version).major >= 4}) // FIXME if Groovy 4 is bundled, cannot run without regenerating library-versions.properties
 class GroovyGradlePluginInitIntegrationTest extends AbstractInitIntegrationSpec {
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -41,9 +41,11 @@ import org.gradle.test.fixtures.ivy.IvyFileRepository
 import org.gradle.test.fixtures.maven.M2Installation
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.maven.MavenLocalRepository
+import org.gradle.util.internal.VersionNumber
 import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.intellij.lang.annotations.Language
+import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Specification
 
@@ -62,7 +64,7 @@ import static org.gradle.util.Matchers.normalizedLineSeparators
 @CleanupTestDirectory
 @SuppressWarnings("IntegrationTestFixtures")
 @IntegrationTestTimeout(DEFAULT_TIMEOUT_SECONDS)
-class AbstractIntegrationSpec extends Specification {
+abstract class AbstractIntegrationSpec extends Specification {
 
     @Rule
     public final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider(getClass())
@@ -97,6 +99,8 @@ class AbstractIntegrationSpec extends Specification {
 
     protected int maxHttpRetries = 1
     protected Integer maxUploadAttempts
+
+    @Lazy private isAtLeastGroovy4 = VersionNumber.parse(GroovySystem.version).major >= 4
 
     def setup() {
         // Verify that the previous test (or fixtures) has cleaned up state correctly
@@ -669,4 +673,13 @@ tmpdir is currently ${System.getProperty("java.io.tmpdir")}""")
         this.ignoreCleanupAssertions = false
         recreateExecuter()
     }
+
+    void assumeGroovy3() {
+        Assume.assumeFalse('Requires Groovy 3', isAtLeastGroovy4)
+    }
+
+    void assumeGroovy4() {
+        Assume.assumeTrue('Requires Groovy 4', isAtLeastGroovy4)
+    }
+
 }

--- a/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
+++ b/subprojects/model-groovy/src/integTest/groovy/org/gradle/model/dsl/ModelMapDslIntegrationTest.groovy
@@ -242,7 +242,8 @@ configure test
         outputContains("value = 12")
     }
 
-    def "nested rule cannot reference method of delegate of outer closure"() {
+    def "nested rule cannot reference method of delegate of outer closure with Groovy 3"() {
+        assumeGroovy3()
         buildFile << '''
 model {
     things {
@@ -257,6 +258,24 @@ model {
         failure.assertHasLineNumber(18)
         failure.assertHasCause('Exception thrown while executing model rule: create(main) { ... } @ build.gradle line 17, column 9')
         failure.assertHasCause('No signature of method: org.gradle.api.Project.create() is applicable for argument types:')
+    }
+
+    def "nested rule cannot reference method of delegate of outer closure with Groovy 4"() {
+        assumeGroovy4()
+        buildFile << '''
+model {
+    things {
+        create('main') {
+            create('test') { println "no" }
+        }
+    }
+}
+'''
+        expect:
+        fails "model"
+        failure.assertHasLineNumber(18)
+        failure.assertHasCause('Exception thrown while executing model rule: create(main) { ... } @ build.gradle line 17, column 9')
+        failure.assertHasCause('No signature of method: Thing.create() is applicable for argument types')
     }
 
     def "nested rule can reference vars defined in outer closure"() {


### PR DESCRIPTION
Extracted from #20038 

Certain test logic differs too broadly between Groovy 3 and 4.  I've added some assumption convenience methods to test fixtures, and in most cases copy/pasted test logic when it differs between major Groovy versions.