### PR TITLE
Control Test task framework dependencies without suite interaction

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/test/fixtures/AbstractProjectBuilderSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.test.fixtures
 
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
@@ -64,9 +65,13 @@ abstract class AbstractProjectBuilderSpec extends Specification {
     ProjectExecutionServices executionServices
 
     def setup() {
-        project = TestUtil.createRootProject(temporaryFolder.testDirectory)
-        executionServices = new ProjectExecutionServices(project)
         System.setProperty("user.dir", temporaryFolder.testDirectory.absolutePath)
+        project = (ProjectInternal) createRootProject()
+        executionServices = new ProjectExecutionServices(project)
+    }
+
+    Project createRootProject() {
+        TestUtil.createRootProject(temporaryFolder.testDirectory)
     }
 
     def cleanup() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -70,6 +70,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
+        configuration.runDependencyActions();
         if (configuration.getAllDependencies().isEmpty()) {
             emptyGraph(configuration, result, false);
         } else {
@@ -79,6 +80,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
 
     @Override
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
+        configuration.runDependencyActions();
         if (configuration.getAllDependencies().isEmpty()) {
             emptyGraph(configuration, results, true);
         } else {

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleProjectBuilderTest.groovy
@@ -16,16 +16,20 @@
 
 package org.gradle.plugins.ide.internal.tooling
 
-
+import org.gradle.api.Project
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class GradleProjectBuilderTest extends AbstractProjectBuilderSpec {
     def builder = new GradleProjectBuilder()
 
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder).withName("test").build()
+    }
+
     def "builds basics for project"() {
         def buildFile = temporaryFolder.file("build.gradle") << "//empty"
-        def project = TestUtil.builder(temporaryFolder).withName("test").build()
         project.description = 'a test project'
 
         when:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/ProjectPublicationsBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/ProjectPublicationsBuilderTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugins.ide.internal.tooling
 
+import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectComponentPublication
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectPublicationRegistry
@@ -37,8 +38,12 @@ class ProjectPublicationsBuilderTest extends AbstractProjectBuilderSpec {
     }
     def builder = new PublicationsBuilder(publicationRegistry)
 
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder).withName("test").build()
+    }
+
     def "builds basics for project"() {
-        def project = TestUtil.builder(temporaryFolder).withName("test").build()
         project.description = 'a test project'
 
         when:

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -41,10 +41,14 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
     Project child3
     Project child4
 
-    def setup() {
+    @Override
+    Project createRootProject() {
         // Without this file, the build layout finds the one from Gradle itself and causes dependency verification to be enabled
         temporaryFolder.testDirectory.createFile("settings.gradle")
-        project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+        TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+    }
+
+    def setup() {
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
         child3 = ProjectBuilder.builder().withName("child3").withParent(project).build()

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -45,8 +45,12 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
     Project child1
     Project child2
 
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+    }
+
     def setup() {
-        project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
         [project, child1, child2].each { it.pluginManager.apply(EclipsePlugin.class) }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/RunBuildDependenciesTaskBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/RunBuildDependenciesTaskBuilderTest.groovy
@@ -35,8 +35,12 @@ class RunBuildDependenciesTaskBuilderTest extends AbstractProjectBuilderSpec {
     Project child1
     Project child2
 
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+    }
+
     def setup() {
-        project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/distribution/plugins/DistributionPluginTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.api.distribution.plugins
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.distribution.DistributionContainer
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskDependencyMatchers
 import org.gradle.api.tasks.bundling.Tar
@@ -27,7 +27,11 @@ import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class DistributionPluginTest extends AbstractProjectBuilderSpec {
-    ProjectInternal project = TestUtil.builder(temporaryFolder).withName("test-project").build()
+
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder).withName("test-project").build()
+    }
 
     def "adds convention object and a main distribution"() {
         when:

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaLibraryDistributionPluginTest.groovy
@@ -15,16 +15,19 @@
  */
 package org.gradle.api.plugins
 
-
+import org.gradle.api.Project
 import org.gradle.api.distribution.DistributionContainer
 import org.gradle.api.distribution.plugins.DistributionPlugin
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.util.TestUtil
 
 class JavaLibraryDistributionPluginTest extends AbstractProjectBuilderSpec {
-    ProjectInternal project = TestUtil.builder(temporaryFolder).withName("test-project").build()
+
+    @Override
+    Project createRootProject() {
+        TestUtil.builder(temporaryFolder).withName("test-project").build()
+    }
 
     def "applies JavaLibraryPlugin and adds convention object with default values"() {
         when:

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest.groovy
@@ -41,6 +41,11 @@ class TestNGFailurePolicyIntegrationTest extends AbstractTestNGVersionIntegratio
                     }
                 }
             }
+            test {
+                options {
+                    useDefaultListeners = true
+                }
+            }
         """
     }
 

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest/shared/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/testng/TestNGFailurePolicyIntegrationTest/shared/build.gradle
@@ -19,9 +19,3 @@ apply plugin: "java"
 repositories {
     mavenCentral()
 }
-
-test {
-    useTestNG {
-        useDefaultListeners = true
-    }
-}


### PR DESCRIPTION
Updates test suites to listen to the test framework on a test. We base our `VersionedTestingFramework` on the `TestFramework` of the Test task. However, if the user chooses a test framework via test suites, we override the `TestFramework` on the Test task itself with our new framework.

This allows us to add dependencies of test frameworks to the test classpath even when users don't interact with test suites directly
