### PR TITLE
Separate promoteMilestone and promoteReleaseMilestone

### DIFF
--- a/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
+++ b/.teamcity/src/main/kotlin/common/VersionedSettingsBranch.kt
@@ -39,6 +39,11 @@ data class VersionedSettingsBranch(val branchName: String, val enableTriggers: B
     fun promoteNightlyTaskName() = nightlyTaskName("promote")
     fun prepNightlyTaskName() = nightlyTaskName("prep")
 
+    fun promoteMilestoneTaskName(): String = when {
+        isRelease -> "promoteReleaseMilestone"
+        else -> "promoteMilestone"
+    }
+
     private fun nightlyTaskName(prefix: String): String = when {
         isMaster -> "${prefix}Nightly"
         isRelease -> "${prefix}ReleaseNightly"

--- a/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
+++ b/.teamcity/src/main/kotlin/promotion/PublishRelease.kt
@@ -97,11 +97,11 @@ class PublishReleaseCandidate(branch: VersionedSettingsBranch) : PublishRelease(
 class PublishMilestone(branch: VersionedSettingsBranch) : PublishRelease(
     promotedBranch = branch.branchName,
     prepTask = "prepMilestone",
-    promoteTask = "promoteMilestone",
+    promoteTask = branch.promoteMilestoneTaskName(),
     requiredConfirmationCode = "milestone",
     init = {
         id("Promotion_Milestone")
         name = "Release - Milestone"
-        description = "Promotes the latest successful change on 'release' as a new milestone"
+        description = "Promotes the latest successful change on '${branch.branchName}' as a new milestone"
     }
 )

--- a/.teamcity/src/test/kotlin/PromotionProjectTests.kt
+++ b/.teamcity/src/test/kotlin/PromotionProjectTests.kt
@@ -15,6 +15,7 @@
  */
 
 import common.VersionedSettingsBranch
+import common.toCapitalized
 import jetbrains.buildServer.configs.kotlin.v2019_2.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2019_2.BuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
@@ -22,6 +23,8 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.GradleBuildStep
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import promotion.PromotionProject
 
 class PromotionProjectTests {
@@ -69,15 +72,15 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
         promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforNightly_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
@@ -90,7 +93,7 @@ class PromotionProjectTests {
 
         val step = gradleStep(steps, 0)
         step.assertTasks("clean promoteStartReleaseCycle")
-        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" """, step.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_ReadyforNightly_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" """, step.gradleParams)
     }
 
     @Test
@@ -116,15 +119,15 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
         promote.assertTasks("prepReleaseNightly promoteReleaseNightly")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
@@ -137,15 +140,15 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepSnapshot checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepSnapshot uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
         promote.assertTasks("prepSnapshot promoteSnapshot")
-        assertEquals("""-PcommitId=%dep.Gradle_master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Master_Check_Stage_QuickFeedback_Trigger.build.vcs.number% -PpromotedBranch=%branch.qualifier%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
@@ -158,11 +161,11 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     @Test
@@ -175,11 +178,11 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepReleaseNightly checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepReleaseNightly promoteReleaseNightly")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_QuickFeedback_Trigger.build.vcs.number%  "-PgitUserName=bot-teamcity" "-PgitUserEmail=bot-teamcity@gradle.com" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     @Test
@@ -192,15 +195,15 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepFinalRelease checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepFinalRelease uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
         promote.assertTasks("prepFinalRelease promoteFinalRelease")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, promote.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, promote.gradleParams)
     }
 
     @Test
@@ -213,20 +216,26 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepRc checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepRc uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
         promote.assertTasks("prepRc promoteRc")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_Release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
-    @Test
-    fun `publish milestone build type runs three gradle invocations`() {
-        val model = setupModelFor("release")
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "master,  promoteMilestone",
+            "release, promoteReleaseMilestone"
+        ]
+    )
+    fun `publish milestone build type runs three gradle invocations`(branch: String, promoteTaskName: String) {
+        val model = setupModelFor(branch)
         val nightlySnapshot = model.findBuildTypeByName("Release - Milestone")
 
         val steps = nightlySnapshot.steps.items
@@ -234,20 +243,20 @@ class PromotionProjectTests {
 
         val checkReady = gradleStep(steps, 0)
         checkReady.assertTasks("prepMilestone checkNeedToPromote")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_${branch.toCapitalized()}_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, checkReady.gradleParams)
 
         val upload = gradleStep(steps, 1)
         upload.assertTasks("prepMilestone uploadAll")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+        assertEquals("""-PcommitId=%dep.Gradle_${branch.toCapitalized()}_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
 
         val promote = gradleStep(steps, 2)
-        promote.assertTasks("prepMilestone promoteMilestone")
-        assertEquals("""-PcommitId=%dep.Gradle_release_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
+        promote.assertTasks("prepMilestone $promoteTaskName")
+        assertEquals("""-PcommitId=%dep.Gradle_${branch.toCapitalized()}_Check_Stage_ReadyforRelease_Trigger.build.vcs.number% -PconfirmationCode=%confirmationCode% "-PgitUserName=%gitUserName%" "-PgitUserEmail=%gitUserEmail%" %additional.gradle.parameters% """, upload.gradleParams)
     }
 
     private fun setupModelFor(branchName: String): PromotionProject {
         // Set the project id here, so we can use methods on the DslContext
-        DslContext.projectId = AbsoluteId("Gradle_$branchName")
+        DslContext.projectId = AbsoluteId("Gradle_${branchName.toCapitalized()}")
         DslContext.addParameters("Branch" to branchName)
         val model = PromotionProject(VersionedSettingsBranch(branchName, true))
         return model


### PR DESCRIPTION
Previously, `promoteMilestone` didn't distinguish `master` and `release`, which caused some problems: for example, milestone release on master shouldn't trigger updating `released-versions.json`.

See https://github.com/gradle/gradle-promote/pull/97