### PR TITLE
Allow selecting more testJavaVendors

### DIFF
--- a/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
+++ b/build-logic/basics/src/main/kotlin/gradlebuild/basics/BuildParams.kt
@@ -134,7 +134,11 @@ object BuildParams {
     const val RUN_BROKEN_CONFIGURATION_CACHE_DOCS_TESTS = "runBrokenConfigurationCacheDocsTests"
 
     internal
-    val VENDOR_MAPPING = mapOf("oracle" to JvmVendorSpec.ORACLE, "openjdk" to JvmVendorSpec.ADOPTIUM)
+    val VENDOR_MAPPING = mapOf(
+        "oracle" to JvmVendorSpec.ORACLE,
+        "openjdk" to JvmVendorSpec.ADOPTIUM,
+        "zulu" to JvmVendorSpec.AZUL
+    )
 }
 
 
@@ -313,7 +317,7 @@ val Project.rerunAllTests: Provider<Boolean>
 
 
 val Project.testJavaVendor: Provider<JvmVendorSpec>
-    get() = propertyFromAnySource(TEST_JAVA_VENDOR).map { VENDOR_MAPPING.getValue(it) }
+    get() = propertyFromAnySource(TEST_JAVA_VENDOR).map { vendorName -> VENDOR_MAPPING.getOrElse(vendorName) { -> JvmVendorSpec.matching(vendorName) } }
 
 
 val Project.testJavaVersion: String

--- a/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/gradlebuild.unittest-and-compile.gradle.kts
@@ -59,10 +59,7 @@ tasks.registerCITestDistributionLifecycleTasks()
 fun configureCompile() {
     java.toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
-        // Do not force Adoptium vendor for M1 Macs
-        if (System.getProperty("os.arch") != "aarch64") {
-            vendor.set(JvmVendorSpec.ADOPTIUM)
-        }
+        vendor.set(JvmVendorSpec.ADOPTIUM)
     }
 
     tasks.withType<JavaCompile>().configureEach {


### PR DESCRIPTION
by using a matching spec if we don't have a pre-defined spec.

This also enforces Adoptium JDK 11 for building Gradle on M1 macs, given that Temurin has been released now.