### PR TITLE
Update Sentry Android plugin and use AGP 7.3.0 in samples and Android perf tests

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -397,13 +397,13 @@ performanceTest.registerTestProject("bigSwiftApp", BuildBuilderGenerator) {
 performanceTest.registerAndroidTestProject("largeAndroidBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large.git'
     // From android-73 branch
-    ref = "ba684f8f6015d86f117e5839dec0986d7e9ef5d0"
+    ref = "54eef7cc87e9eb1e89fce0d2de8d12e60c694080"
 }
 
 performanceTest.registerAndroidTestProject("largeAndroidBuild2", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-android-large-2.git'
     // Pinned from android-73-kotlin-16 branch
-    ref = "f5c8e98e9f577e419a0d7c84fd555004bc383c5f"
+    ref = "a67ceb08a7b4e4a71e3c151a3abd72a9abe5d703"
 }
 
 performanceTest.registerAndroidTestProject("santaTrackerAndroidBuild", RemoteProject) {

--- a/subprojects/docs/src/samples/android-application/groovy/app/build.gradle
+++ b/subprojects/docs/src/samples/android-application/groovy/app/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id('com.android.application') version '7.3.0-rc01'
+    id('com.android.application') version '7.3.0'
 }
 
 repositories {

--- a/subprojects/docs/src/samples/android-application/kotlin/app/build.gradle.kts
+++ b/subprojects/docs/src/samples/android-application/kotlin/app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.android.application") version "7.3.0-rc01"
+    id("com.android.application") version "7.3.0"
 }
 
 repositories {

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/groovy/platforms/plugins-platform/build.gradle
@@ -6,7 +6,7 @@ group = 'com.example.platform'
 
 dependencies {
     constraints {
-        api('com.android.tools.build:gradle:7.3.0-rc01')
+        api('com.android.tools.build:gradle:7.3.0')
         api('org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:1.7.10')
         api('org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.7.10')
         api('org.springframework.boot:org.springframework.boot.gradle.plugin:2.4.0')

--- a/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
+++ b/subprojects/docs/src/samples/build-organization/structuring-software-projects/kotlin/platforms/plugins-platform/build.gradle.kts
@@ -6,7 +6,7 @@ group = "com.example.platform"
 
 dependencies {
     constraints {
-        api("com.android.tools.build:gradle:7.3.0-rc01")
+        api("com.android.tools.build:gradle:7.3.0")
         api("org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin:1.7.10")
         api("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.7.10")
         api("org.springframework.boot:org.springframework.boot.gradle.plugin:2.4.0")

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -214,22 +214,6 @@ abstract class AbstractSmokeTest extends Specification {
             }
         }
 
-        /**
-         * Since Android 7.3.0 is not yet stable we have to use that.
-         * One stable version is released we should remove this.
-         */
-        String latestStableOrRc() {
-            def stableVersion = latestStable()
-            if (stableVersion != null) {
-                return stableVersion
-            }
-            return versions.reverse().find { version ->
-                    !version.containsIgnoreCase("beta") &&
-                    !version.containsIgnoreCase("alpha") &&
-                    !version.containsIgnoreCase("milestone")
-            }
-        }
-
         String latestStartsWith(String prefix) {
             return versions.reverse().find { it.startsWith(prefix) }
         }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AndroidCommunityPluginsSmokeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.smoketests
 
-import org.gradle.internal.reflect.validation.Severity
+
 import org.gradle.internal.reflect.validation.ValidationMessageChecker
 
 class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest implements ValidationMessageChecker {
@@ -44,7 +44,7 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
             (TRIPLET_PLAY_PLUGIN_ID): Versions.of('3.7.0'),
             (SAFEARGS_PLUGIN_ID): Versions.of('2.5.1'),
             (DAGGER_HILT_ANDROID_PLUGIN_ID): Versions.of('2.43.2'),
-            (SENTRY_PLUGIN_ID): Versions.of('3.1.4'),
+            (SENTRY_PLUGIN_ID): Versions.of('3.1.6'),
         ]
     }
 
@@ -54,24 +54,8 @@ class AndroidCommunityPluginsSmokeTest extends AbstractPluginValidatingSmokeTest
         configureAndroidProject(testedPluginId)
 
         validatePlugins {
-            switch (testedPluginId) {
-                case SENTRY_PLUGIN_ID:
-                    passing {
-                        it !in [SENTRY_PLUGIN_ID]
-                    }
-                    onPlugins([SENTRY_PLUGIN_ID]) {
-                        // https://github.com/getsentry/sentry-android-gradle-plugin/issues/370
-                        failsWith([
-                            (incorrectUseOfInputAnnotation { type('io.sentry.android.gradle.tasks.SentryUploadNativeSymbolsTask').property('buildDir').propertyType('DirectoryProperty').includeLink() }): Severity.ERROR,
-                            (incorrectUseOfInputAnnotation { type('io.sentry.android.gradle.tasks.SentryUploadProguardMappingsTask').property('uuidDirectory').propertyType('DirectoryProperty').includeLink() }): Severity.ERROR
-                        ])
-                    }
-                    break
-                default:
-                    passing {
-                        true
-                    }
-                    break
+            passing {
+                true
             }
         }
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -198,8 +198,7 @@ class KotlinPluginSmokeTest extends AbstractPluginValidatingSmokeTest implements
 
     @Override
     Map<String, String> getExtraPluginsRequiredForValidation(String testedPluginId, String version) {
-        // We should use TestedVersions.androidGradle.latestStable() once AGP 7.3.0 stable version is released
-        def androidVersion = TestedVersions.androidGradle.latestStableOrRc()
+        def androidVersion = TestedVersions.androidGradle.latestStable()
         if (testedPluginId in ['org.jetbrains.kotlin.kapt', 'org.jetbrains.kotlin.plugin.scripting']) {
             return ['org.jetbrains.kotlin.jvm': version]
         }


### PR DESCRIPTION
This relates to removal of IncrementalTaskInputs: https://github.com/gradle/gradle/pull/21731.

Sentry plugin was updated for 8.0: https://github.com/getsentry/sentry-android-gradle-plugin/issues/370.
Also, there are some leftovers after upgrading AGP to 7.3.0 in samples and performance tests.

Performance test changes: 
- https://github.com/gradle/perf-android-large/commit/54eef7cc87e9eb1e89fce0d2de8d12e60c694080
- https://github.com/gradle/perf-android-large-2/commit/a67ceb08a7b4e4a71e3c151a3abd72a9abe5d703