### PR TITLE
Add build operation for IdentifyStep

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ systemProp.gradle.internal.testdistribution.writeTraceFile=true
 systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 
 # Default performance baseline
-defaultPerformanceBaselines=8.1-commit-e739dfad
+defaultPerformanceBaselines=8.1-commit-2be346c7ab7
 
 # Disable Test Retry in GE plugin as long as Test Retry Gradle plugin is in use
 systemProp.gradle.enterprise.testretry.enabled=false

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
@@ -125,6 +125,21 @@ class BuildOperationNotificationFixture {
 
                 def ops = [:]
 
+                private jsonGenerator = new groovy.json.JsonGenerator.Options()
+                    .addConverter(new groovy.json.JsonGenerator.Converter() {
+                        @Override
+                        public boolean handles(Class<?> type) {
+                            return Class.class.equals(type);
+                        }
+
+                        @Override
+                        public Object convert(Object value, String key) {
+                            Class<?> clazz = (Class<?>) value;
+                            return clazz.getName();
+                        }
+                    }).build()
+
+
                 @Override
                 synchronized void started(${BuildOperationStartedNotification.name} startedNotification) {
 
@@ -160,7 +175,7 @@ class BuildOperationNotificationFixture {
 
                 synchronized void store(File target){
                     target.withPrintWriter { pw ->
-                        String json = groovy.json.JsonOutput.toJson(ops.values())
+                        String json = jsonGenerator.toJson(ops.values())
                         pw.append(json)
                     }
                 }
@@ -184,6 +199,4 @@ class BuildOperationNotificationFixture {
     private TestFile jsonFile() {
         dir.file('buildOpNotifications.json')
     }
-
-
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGradleServices.java
@@ -136,7 +136,7 @@ public class ExecutionGradleServices {
         Supplier<OutputsCleaner> skipEmptyWorkOutputsCleanerSupplier = () -> new OutputsCleaner(deleter, buildOutputCleanupRegistry::isOutputOwnedByBuild, buildOutputCleanupRegistry::isOutputOwnedByBuild);
         // @formatter:off
         return new DefaultExecutionEngine(documentationRegistry,
-            new IdentifyStep<>(
+            new IdentifyStep<>(buildOperationExecutor,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new CleanupStaleOutputsStep<>(buildOperationExecutor, buildOutputCleanupRegistry,  deleter, outputChangeListener, outputFilesRepository,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -167,7 +167,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
 
     // @formatter:off
     def executionEngine = new DefaultExecutionEngine(documentationRegistry,
-        new IdentifyStep<>(
+        new IdentifyStep<>(buildOperationExecutor,
         new IdentityCacheStep<>(
         new AssignWorkspaceStep<>(
         new LoadPreviousExecutionStateStep<>(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -691,7 +691,7 @@ class DependencyManagementBuildScopeServices {
         UniqueId fixedUniqueId = UniqueId.from("dhwwyv4tqrd43cbxmdsf24wquu");
         // @formatter:off
         return new DefaultExecutionEngine(documentationRegistry,
-            new IdentifyStep<>(
+            new IdentifyStep<>(buildOperationExecutor,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadPreviousExecutionStateStep<>(

--- a/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
+++ b/subprojects/execution/src/integTest/groovy/org/gradle/internal/execution/IncrementalExecutionIntegrationTest.groovy
@@ -136,7 +136,7 @@ class IncrementalExecutionIntegrationTest extends Specification implements Valid
     ExecutionEngine getExecutor() {
         // @formatter:off
         new DefaultExecutionEngine(documentationRegistry,
-            new IdentifyStep<>(
+            new IdentifyStep<>(buildOperationExecutor,
             new IdentityCacheStep<>(
             new AssignWorkspaceStep<>(
             new LoadPreviousExecutionStateStep<>(

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/steps/ExecuteStep.java
@@ -51,6 +51,8 @@ public class ExecuteStep<C extends ChangingOutputsContext> implements Step<C, Re
 
     @Override
     public Result execute(UnitOfWork work, C context) {
+        Class<? extends UnitOfWork> workType = work.getClass();
+        UnitOfWork.Identity identity = context.getIdentity();
         return buildOperationExecutor.call(new CallableBuildOperation<Result>() {
             @Override
             public Result call(BuildOperationContext operationContext) {
@@ -63,7 +65,17 @@ public class ExecuteStep<C extends ChangingOutputsContext> implements Step<C, Re
             public BuildOperationDescriptor.Builder description() {
                 return BuildOperationDescriptor
                     .displayName("Executing " + work.getDisplayName())
-                    .details(Operation.Details.INSTANCE);
+                    .details(new Operation.Details() {
+                        @Override
+                        public Class<?> getWorkType() {
+                            return workType;
+                        }
+
+                        @Override
+                        public UnitOfWork.Identity getIdentity() {
+                            return identity;
+                        }
+                    });
             }
         });
     }
@@ -120,8 +132,8 @@ public class ExecuteStep<C extends ChangingOutputsContext> implements Step<C, Re
      */
     public interface Operation extends BuildOperationType<Operation.Details, Operation.Result> {
         interface Details {
-            Operation.Details INSTANCE = new Operation.Details() {
-            };
+            Class<?> getWorkType();
+            UnitOfWork.Identity getIdentity();
         }
 
         interface Result {

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/steps/IdentifyStepTest.groovy
@@ -27,7 +27,7 @@ import org.gradle.internal.snapshot.ValueSnapshot
 class IdentifyStepTest extends StepSpec<ExecutionRequestContext> {
     def delegateResult = Mock(Result)
     def inputFingerprinter = Mock(InputFingerprinter)
-    def step = new IdentifyStep<>(delegate)
+    def step = new IdentifyStep<>(buildOperationExecutor, delegate)
 
 
     def "delegates with assigned workspace"() {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -100,6 +100,7 @@ class ProgressEvents implements ProgressListener {
                             || descriptor.displayName.startsWith('Configure project ')
                             || descriptor.displayName.startsWith('Cross-configure project ')
                             || descriptor.displayName.startsWith('Resolve files of')
+                            || descriptor.displayName.startsWith('Identifying ')
                             || descriptor.displayName.startsWith('Executing ')
                             || descriptor.displayName.startsWith('Execute container callback action')
                             || descriptor.displayName.startsWith('Resolving ')


### PR DESCRIPTION
Add a build operation for the `IdentifyStep` allowing to track in the build operation trace all the work that goes through the execution engine. Additionally, the `Details` of the `ExecuteStep` build operation have been extended to allow correlating the requested and actually executed work in the build operations trace.