### PR TITLE
Store `IntersectionPatternSet` to the configuration cache fully

### DIFF
--- a/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProcessResourcesIntegrationTest.groovy
+++ b/subprojects/configuration-cache/src/integTest/groovy/org/gradle/configurationcache/ConfigurationCacheProcessResourcesIntegrationTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configurationcache
+
+import spock.lang.Issue
+
+class ConfigurationCacheProcessResourcesIntegrationTest extends AbstractConfigurationCacheIntegrationTest {
+
+    @Issue('https://github.com/gradle/gradle/issues/16423')
+    def 'java source files are excluded by default'() {
+        given:
+        buildFile '''
+            plugins {
+                id 'java'
+            }
+            sourceSets {
+                main.resources.srcDir 'src/main/java'
+                main.resources.exclude '**/*.kt' // Forces an intersection pattern set to be created behind the scenes
+            }
+        '''
+        createDir('src/main') {
+            dir('java') {
+                file('Test.java') << 'class Test {}'
+            }
+            dir('resources') {
+                file('data.txt') << '42'
+            }
+        }
+        def configurationCache = newConfigurationCacheFixture()
+
+        when: ':processResources is executed twice'
+        configurationCacheRun 'processResources'
+        configurationCacheRun 'processResources'
+
+        then: 'the 2nd time it is loaded from the cache'
+        configurationCache.assertStateLoaded()
+
+        and: 'the task is up-to-date'
+        result.assertTaskSkipped ':processResources'
+    }
+}

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/Codecs.kt
@@ -264,7 +264,7 @@ class Codecs(
         val fileCollectionCodec = FileCollectionCodec(fileCollectionFactory, artifactSetConverter)
         bind(ConfigurableFileCollectionCodec(fileCollectionCodec, fileCollectionFactory))
         bind(fileCollectionCodec)
-        bind(IntersectPatternSetCodec)
+        bind(IntersectionPatternSetCodec)
         bind(PatternSetCodec(patternSetFactory))
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/PatternSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/PatternSetCodec.kt
@@ -34,40 +34,51 @@ import org.gradle.internal.Factory
 class PatternSetCodec(private val patternSetFactory: Factory<PatternSet>) : Codec<PatternSet> {
 
     override suspend fun WriteContext.encode(value: PatternSet) {
-        writeBoolean(value.isCaseSensitive)
-        writeStrings(value.includes)
-        writeStrings(value.excludes)
-        writeCollection(value.includeSpecs)
-        writeCollection(value.excludeSpecs)
+        writePatternSet(value)
     }
 
     override suspend fun ReadContext.decode() =
         patternSetFactory.create()!!.apply {
-            isCaseSensitive = readBoolean()
-            setIncludes(readStrings())
-            setExcludes(readStrings())
-            readCollection {
-                include(readNonNull<Spec<FileTreeElement>>())
-            }
-            readCollection {
-                exclude(readNonNull<Spec<FileTreeElement>>())
-            }
+            readPatternSet(this)
         }
 }
 
 
 object IntersectPatternSetCodec : Codec<IntersectionPatternSet> {
+
     override suspend fun WriteContext.encode(value: IntersectionPatternSet) {
         write(value.other)
-        writeStrings(value.includes)
-        writeStrings(value.excludes)
+        writePatternSet(value)
     }
 
-    override suspend fun ReadContext.decode(): IntersectionPatternSet? {
+    override suspend fun ReadContext.decode(): IntersectionPatternSet {
         val other = read() as PatternSet
         return IntersectionPatternSet(other).apply {
-            setIncludes(readStrings())
-            setExcludes(readStrings())
+            readPatternSet(this)
         }
+    }
+}
+
+
+private
+suspend fun WriteContext.writePatternSet(value: PatternSet) {
+    writeBoolean(value.isCaseSensitive)
+    writeStrings(value.includes)
+    writeStrings(value.excludes)
+    writeCollection(value.includeSpecs)
+    writeCollection(value.excludeSpecs)
+}
+
+
+private
+suspend fun ReadContext.readPatternSet(value: PatternSet) {
+    value.isCaseSensitive = readBoolean()
+    value.setIncludes(readStrings())
+    value.setExcludes(readStrings())
+    readCollection {
+        value.include(readNonNull<Spec<FileTreeElement>>())
+    }
+    readCollection {
+        value.exclude(readNonNull<Spec<FileTreeElement>>())
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/PatternSetCodec.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/serialization/codecs/PatternSetCodec.kt
@@ -44,7 +44,7 @@ class PatternSetCodec(private val patternSetFactory: Factory<PatternSet>) : Code
 }
 
 
-object IntersectPatternSetCodec : Codec<IntersectionPatternSet> {
+object IntersectionPatternSetCodec : Codec<IntersectionPatternSet> {
 
     override suspend fun WriteContext.encode(value: IntersectionPatternSet) {
         write(value.other)


### PR DESCRIPTION
It was missing the include and exclude specs.

See https://github.com/gradle/gradle/issues/16423