### PR TITLE
Ignore archetecture-test:test when -PflakyTests=only

### DIFF
--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -1,3 +1,7 @@
+import gradlebuild.basics.flakyTestStrategy
+import gradlebuild.basics.FlakyTestStrategy
+import gradlebuild.basics.PublicApi
+
 plugins {
     id("gradlebuild.internal.java")
     id("gradlebuild.binary-compatibility")
@@ -30,12 +34,14 @@ tasks.test {
     // Only use one fork, so freezing doesn't have concurrency issues
     maxParallelForks = 1
 
-    systemProperty("org.gradle.public.api.includes", gradlebuild.basics.PublicApi.includes.joinToString(":"))
-    systemProperty("org.gradle.public.api.excludes", gradlebuild.basics.PublicApi.excludes.joinToString(":"))
+    systemProperty("org.gradle.public.api.includes", PublicApi.includes.joinToString(":"))
+    systemProperty("org.gradle.public.api.excludes", PublicApi.excludes.joinToString(":"))
     jvmArgumentProviders.add(ArchUnitFreezeConfiguration(
         project.file("src/changes/archunit_store"),
         providers.gradleProperty("archunitRefreeze").map { true })
     )
+
+    enabled = flakyTestStrategy !=  FlakyTestStrategy.ONLY
 }
 
 class ArchUnitFreezeConfiguration(


### PR DESCRIPTION
Because we have no flaky tests there.
