### PR TITLE
More Groovy 4 safe changes

### DIFF
--- a/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
+++ b/subprojects/code-quality/src/testFixtures/groovy/org/gradle/quality/integtest/fixtures/CodeNarcCoverage.groovy
@@ -21,7 +21,12 @@ import org.gradle.api.plugins.quality.CodeNarcPlugin
 import org.gradle.util.internal.VersionNumber
 
 class CodeNarcCoverage {
-    private static final List<String> ALL = [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "0.17", "0.21", "0.23", "0.24.1", "0.25.2", "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1", "3.1.0"].asImmutable()
+    private static boolean isAtLeastGroovy4() {
+        return VersionNumber.parse(GroovySystem.version).major >= 4
+    }
+
+    private static final List<String> ALL = isAtLeastGroovy4() ? [CodeNarcPlugin.DEFAULT_CODENARC_VERSION].asImmutable()
+                                                               : [CodeNarcPlugin.DEFAULT_CODENARC_VERSION, "0.17", "0.21", "0.23", "0.24.1", "0.25.2", "1.0", "1.6.1", "2.0.0", "2.2.0", "3.0.1"].asImmutable()
 
     private static final List<String> JDK11_SUPPORTED = versionsAboveInclusive(ALL, "0.23")
     private static final List<String> JDK14_SUPPORTED = JDK11_SUPPORTED - ['1.6.1', '1.0']

--- a/subprojects/docs/src/snippets/codeQuality/codeQuality/groovy/build.gradle
+++ b/subprojects/docs/src/snippets/codeQuality/codeQuality/groovy/build.gradle
@@ -21,10 +21,6 @@ plugins {
 // end::use-codenarc-plugin[]
 // end::use-pmd-plugin[]
 
-codenarc {
-    toolVersion = "3.1.0"
-}
-
 repositories {
     mavenCentral()
 }

--- a/subprojects/docs/src/snippets/codeQuality/codeQuality/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/snippets/codeQuality/codeQuality/kotlin/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
 // end::use-codenarc-plugin[]
 // end::use-pmd-plugin[]
 
-codenarc {
-    toolVersion = "3.1.0"
-}
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
Extracted from #20038 

These changes will allow CodeNarc tests to run with either Groovy 3 or Groovy 4.

The two templates affected are not wrapped in templating tags and therefore do not show up in our documentation.