### PR TITLE
Use a version range when auto-applying GE plugin

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -41,6 +41,7 @@ class PluginBuilder {
     String packageName = "org.gradle.test"
 
     final Map<String, String> pluginIds = [:]
+    final List<Map<String, String>> pluginDependencies = []
 
     PluginBuilder(TestFile projectDir) {
         this.projectDir = projectDir
@@ -110,6 +111,9 @@ class PluginBuilder {
 
         // The implementation jar module.
         def module = mavenRepo.module(group, artifact, version)
+        pluginDependencies.each { dep ->
+            module.dependsOn(dep['group'], dep['name'], dep['version'])
+        }
         def pluginModule = module.publish()
         def artifactFile = module.getArtifactFile()
 
@@ -132,6 +136,9 @@ class PluginBuilder {
 
         // The implementation jar module.
         def module = ivyRepo.module(omr.get(0), omr.get(1), omr.get(2))
+        pluginDependencies.each { dep ->
+            module.dependsOn(dep['group'], dep['name'], dep['version'])
+        }
         def artifactFile = module.artifact([:]).getJarFile()
         module.publish()
 
@@ -164,6 +171,11 @@ class PluginBuilder {
                 }
             }
         """
+    }
+
+    PluginBuilder addPluginDependency(String group, String name, String version) {
+        pluginDependencies << [group: group, name: name, version: version]
+        this
     }
 
     PluginBuilder addPluginSource(String id, String className, String impl) {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -72,9 +72,13 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
     }
 
     private static PluginRequestInternal createGradleEnterprisePluginRequest() {
+        // We use a version range here so that a user-provided version will be preferred (as long as it falls in the range).
+        // Without this, adding `--scan` to the command line can result in a different GE plugin being used.
+        String gePluginVersionRange = "(," + AutoAppliedGradleEnterprisePlugin.VERSION + "]";
+
         ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(AutoAppliedGradleEnterprisePlugin.GROUP, AutoAppliedGradleEnterprisePlugin.NAME);
-        ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(moduleIdentifier, AutoAppliedGradleEnterprisePlugin.VERSION);
-        return new DefaultPluginRequest(AutoAppliedGradleEnterprisePlugin.ID, AutoAppliedGradleEnterprisePlugin.VERSION, true, null, getScriptDisplayName(), artifact);
+        ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(moduleIdentifier, gePluginVersionRange);
+        return new DefaultPluginRequest(AutoAppliedGradleEnterprisePlugin.ID, gePluginVersionRange, true, null, getScriptDisplayName(), artifact);
     }
 
     private static String getScriptDisplayName() {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #22272 

### Context
When the `--scan` option is provided at the command-line, Gradle auto-applies the GE plugin to enable publishing of build scans to scans.gradle.com. But by auto-applying a fixed version of the plugin, this option could be newer than a version specified within the build. While some attempt was made to avoid auto-applying the plugin when it is not required, this check did not detect the case where the GE plugin is brought in transitively by a user plugin.

This PR changes the auto-apply behaviour to use an upper-bounded version range instead ofa fixed version for the GE plugin. By doing this:
- If the user specifies an older plugin version, this will be used as long as it falls within the range.
- If the user specifies a newer plugin version, then the newer version will be chosen by conflict resolution.

This fixes the issue where adding `--scan` to the command line could cause a different GE plugin version to be used.