### PR TITLE
Disambiguate extra attributes with remaining candidates

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeDisambiguationRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeDisambiguationRule.java
@@ -19,7 +19,7 @@ package org.gradle.api.attributes;
 import org.gradle.api.Action;
 
 /**
- * A rule that selects the best value out of a set of two or more candidates.
+ * A rule that selects the best value out of a set of candidates.
  *
  * @since 4.0
  * @param <T> The attribute value type.

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/MultipleCandidatesDetails.java
@@ -46,7 +46,7 @@ public interface MultipleCandidatesDetails<T> {
      * Calling this method indicates that the candidate is the closest match. It is allowed to call this method several times with
      * different values, in which case it indicates that multiple candidates are equally compatible.
      *
-     * @param candidate the closest match
+     * @param candidate The closest match. Must be present in {@link #getCandidateValues()}.
      */
     void closestMatch(T candidate);
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ExtraAttributeDisambiguationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ExtraAttributeDisambiguationIntegrationTest.groovy
@@ -81,12 +81,12 @@ class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpe
         file("other/build.gradle") << text
     }
 
-    def configurationResolved(String name) {
+    void assertConfigurationResolved(String name) {
         succeeds "consumeConfiguration"
         if (name == "runtimeElements") {
-            return outputContains("Resolved: [other.jar]")
+            outputContains("Resolved: [other.jar]")
         } else {
-            return outputContains("Resolved: [$name]")
+            outputContains("Resolved: [$name]")
         }
     }
 
@@ -143,7 +143,7 @@ class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpe
         """)
 
         expect:
-        configurationResolved("runtimeElements")
+        assertConfigurationResolved("runtimeElements")
     }
 
     def "Disambiguating on attribute defined after CompileView in precedence order succeeds -- with non-empty request attributes"() {
@@ -175,7 +175,7 @@ class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpe
         """)
 
         expect:
-        configurationResolved("another")
+        assertConfigurationResolved("another")
     }
 
     def "Disambiguating on custom attribute succeeds when both variants have identical ordered attributes"() {
@@ -217,7 +217,7 @@ class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpe
         """)
 
         expect:
-        configurationResolved("another")
+        assertConfigurationResolved("another")
     }
 
     def "Disambiguating on custom attribute succeeds when both variants have identical ordered attributes -- with non-empty request attributes"() {
@@ -273,6 +273,6 @@ class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpe
         """)
 
         expect:
-        configurationResolved("another")
+        assertConfigurationResolved("another")
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ExtraAttributeDisambiguationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ExtraAttributeDisambiguationIntegrationTest.groovy
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.GroovyBuildScriptLanguage
+
+/**
+ * A regression test which verifies consistent behavior after the addition of the {@code CompileView} attribute
+ * and the associated {@code compileElements} configuration. Specifically tests behavior of the
+ * {@code disambiguateWithExtraAttributes} step with {@code MultipleCandidateMatcher}.
+ *
+ * Each test in this class succeeds before the introduction of the new configuration, fails after introduction,
+ * then succeeds again after applying the necessary changes to restore the initial behavior.
+ */
+class ExtraAttributeDisambiguationIntegrationTest extends AbstractIntegrationSpec {
+
+    //region setup
+
+    def setup() {
+        // We define a base file which will consume another project, named "other".
+
+        // By default, we consume the other project without any request attributes in order to best
+        // stress test attribute disambiguation. If we requested more attributes, we run the chance
+        // of finding a variant match before disambiguation, thus not testing the disambiguation process
+        // at all. Or, our pre-disambiguation calculations would otherwise reduce the set of `compatible`
+        // candidates, thus reducing the complexity of disambiguation. All steps run before disambiguation
+        // can only reduce the number of `compatible` candidates, and thus `remaining` candidates,
+        // therefore making disambiguation easier and less complex.
+        buildFile("""
+            plugins {
+                id 'java-library'
+            }
+
+            configurations {
+                resolvable {
+                    canBeConsumed = false
+                    canBeResolved = true
+                }
+            }
+
+            dependencies {
+                resolvable project(':other')
+            }
+
+            tasks.register("consumeConfiguration") {
+                dependsOn configurations.resolvable
+                doFirst {
+                    println("Resolved: " + configurations.resolvable.files*.name)
+                }
+            }
+        """)
+
+        settingsFile << "include 'other'"
+        otherBuildFile("""
+            plugins {
+                id 'java-library'
+            }
+        """)
+        file("other/src/main/java/com/example/Example.java") << """
+            package com.example;
+            public class Example {}
+        """
+    }
+
+    def otherBuildFile(@GroovyBuildScriptLanguage String text) {
+        file("other/build.gradle") << text
+    }
+
+    def configurationResolved(String name) {
+        succeeds "consumeConfiguration"
+        if (name == "runtimeElements") {
+            return outputContains("Resolved: [other.jar]")
+        } else {
+            return outputContains("Resolved: [$name]")
+        }
+    }
+
+    /**
+     * Executes the given attributes code block against the root project's resolvable configuration.
+     */
+    def withRequestAttributes(String block) {
+        buildFile << """
+            configurations {
+                resolvable {
+                    attributes {
+                        ${block}
+                    }
+                }
+            }
+        """
+    }
+
+    /**
+     * Defines a new consumable configuration with a single file dependency of the same name of as the configuration.
+     */
+    def createConfiguration(String name, attributes = "") {
+        otherBuildFile("""
+            configurations {
+                ${name} {
+                    canBeConsumed = true
+                    canBeResolved = false
+                    attributes {
+                        ${attributes}
+                    }
+                }
+            }
+
+            // Add a dummy file so when we resolve this configuration, we can tell it apart from the others
+            dependencies {
+                ${name} files("$name")
+            }
+        """)
+    }
+
+    //endregion
+
+    def "Disambiguating on attribute defined after CompileView in precedence order succeeds"() {
+        given:
+        createConfiguration("another", """
+            // Different value than runtimeElements -- not preferred according to jvm-ecosystem disambiguation rule.
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.SHADOWED))
+
+            // Same as runtimeElements
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+
+        expect:
+        configurationResolved("runtimeElements")
+    }
+
+    def "Disambiguating on attribute defined after CompileView in precedence order succeeds -- with non-empty request attributes"() {
+        given:
+        createConfiguration("another", """
+            // We add the default TargetJvmEnvironment so this variant is preferred over runtimeElements and another2
+            attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.objects.named(TargetJvmEnvironment, TargetJvmEnvironment.STANDARD_JVM))
+
+            // Same as runtimeElements, except with bundling omitted
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+        createConfiguration("another2", """
+            // Same as above but with non-default target environment. Used to ensure we have at two compatible values with target environment.
+            attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, project.objects.named(TargetJvmEnvironment, TargetJvmEnvironment.ANDROID))
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+        // Whatever we request, we need to make sure two `CompileView` values remain in the `compatible` set.
+        withRequestAttributes("""
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+        """)
+
+        expect:
+        configurationResolved("another")
+    }
+
+    def "Disambiguating on custom attribute succeeds when both variants have identical ordered attributes"() {
+        given:
+        createConfiguration("another", """
+            attribute(Attribute.of("custom-attribute", String), "another-value")
+
+            // Same as runtimeElements
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+        createConfiguration("another2", """
+            attribute(Attribute.of("custom-attribute", String), "custom-value")
+        """)
+        otherBuildFile("""
+            // When no `custom` attribute is requested, prefer `another-value`.
+            abstract class CustomDisambiguationRule implements AttributeDisambiguationRule<String>, org.gradle.api.internal.ReusableAction {
+                @Inject
+                protected abstract ObjectFactory getObjectFactory()
+                @Override
+                void execute(MultipleCandidatesDetails<String> details) {
+                    String consumerValue = details.getConsumerValue()
+                    Set<String> candidateValues = details.getCandidateValues()
+                    if (consumerValue == null) {
+                        // Default to custom-value
+                        if (candidateValues.contains("another-value")) {
+                            details.closestMatch("another-value")
+                        }
+                        // Otherwise, use the selected value
+                    } else if (candidateValues.contains(consumerValue)) {
+                        details.closestMatch(consumerValue)
+                    }
+                }
+            }
+            dependencies.getAttributesSchema().attribute(Attribute.of("custom-attribute", String)).getDisambiguationRules().add(CustomDisambiguationRule.class)
+        """)
+
+        expect:
+        configurationResolved("another")
+    }
+
+    def "Disambiguating on custom attribute succeeds when both variants have identical ordered attributes -- with non-empty request attributes"() {
+        given:
+        createConfiguration("another", """
+            attribute(Attribute.of("custom-attribute", String), "another-value")
+
+            // Same as runtimeElements
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+        createConfiguration("another2", """
+            attribute(Attribute.of("custom-attribute", String), "custom-value")
+
+            // Same as runtimeElements
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+            attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        """)
+        otherBuildFile("""
+            // When no `custom` attribute is requested, prefer `another-value`.
+            abstract class CustomDisambiguationRule implements AttributeDisambiguationRule<String>, org.gradle.api.internal.ReusableAction {
+                @Inject
+                protected abstract ObjectFactory getObjectFactory()
+                @Override
+                void execute(MultipleCandidatesDetails<String> details) {
+                    String consumerValue = details.getConsumerValue()
+                    Set<String> candidateValues = details.getCandidateValues()
+                    if (consumerValue == null) {
+                        // Default to custom-value
+                        if (candidateValues.contains("another-value")) {
+                            details.closestMatch("another-value")
+                        }
+                        // Otherwise, use the selected value
+                    } else if (candidateValues.contains(consumerValue)) {
+                        details.closestMatch(consumerValue)
+                    }
+                }
+            }
+            dependencies.getAttributesSchema().attribute(Attribute.of("custom-attribute", String)).getDisambiguationRules().add(CustomDisambiguationRule.class)
+        """)
+        withRequestAttributes("""
+            // Same as runtimeElements
+            attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
+            attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.parseInt(JavaVersion.current().getMajorVersion()))
+            attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.objects.named(LibraryElements, LibraryElements.JAR))
+        """)
+
+        expect:
+        configurationResolved("another")
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -240,7 +240,7 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
                 return Collections.singleton(requested);
             }
 
-            return candidates;
+            return null;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionSchema.java
@@ -28,6 +28,18 @@ import java.util.Set;
 public interface AttributeSelectionSchema {
     boolean hasAttribute(Attribute<?> attribute);
 
+    /**
+     * Given a set of {@code candidate} attribute values for a given {@code attribute}, produce
+     * a set of matching values from within the candidate set based on the provided {@code requested} value.
+     *
+     * @param attribute The attribute being disambiguated.
+     * @param requested The requested attribute. If null, {@code attribute} is an extra attribute.
+     * @param candidates All candidate values. If a remaining candidates does not include a value
+     *      for {@code attribute}, null is not included in this set.
+     *
+     * @return A subset of {@code candidates} which contain matched attribute values. Or, null if no matches were found.
+     */
+    @Nullable
     Set<Object> disambiguate(Attribute<?> attribute, @Nullable Object requested, Set<Object> candidates);
 
     boolean matchValue(Attribute<?> attribute, Object requested, Object candidate);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultMultipleCandidateResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultMultipleCandidateResult.java
@@ -32,10 +32,15 @@ public class DefaultMultipleCandidateResult<T> implements MultipleCandidatesResu
     private Set<T> multipleMatches;
 
     public DefaultMultipleCandidateResult(@Nullable T consumerValue, Set<T> candidateValues) {
-        assert candidateValues.size() > 1;
-        for (T candidateValue : candidateValues) {
-            assert candidateValue != null;
+        if (candidateValues.isEmpty() || (consumerValue != null && candidateValues.size() == 1)) {
+            throw new IllegalArgumentException("Insufficient number of candidate values: " + candidateValues.size());
         }
+        for (T candidateValue : candidateValues) {
+            if (candidateValue == null)  {
+                throw new IllegalArgumentException("candidateValues cannot contain null elements");
+            }
+        }
+
         this.candidateValues = candidateValues;
         this.consumerValue = consumerValue;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -306,7 +306,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         }
 
         Set<Object> matches = schema.disambiguate(requestedAttributes.get(a), requestedAttributeValues[a], candidateValues);
-        if (matches.size() < candidateValues.size()) {
+        if (matches != null && matches.size() < candidateValues.size()) {
             // Remove any candidates which do not satisfy the disambiguation rule.
             for (int c = remaining.nextSetBit(0); c >= 0; c = remaining.nextSetBit(c + 1)) {
                 if (!matches.contains(getCandidateValue(c, a))) {
@@ -316,14 +316,23 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         }
     }
 
-    private void disambiguateExtraAttribute(Attribute<?> attribute) {
-        Set<Object> candidateValues = getCandidateValues(compatible, c -> getCandidateValue(c, attribute));
-        if (candidateValues.size() <= 1) {
+    /**
+     * @param attribute The attribute to disambiguate.
+     * @param candidates The set of candidate attribute sets to extract values from during disambiguation.
+     */
+    private void disambiguateExtraAttribute(Attribute<?> attribute, BitSet candidates) {
+        Set<Object> candidateValues = getCandidateValues(candidates, c -> getCandidateValue(c, attribute));
+
+        // We continue disambiguation for attributes with only one value since we may have some candidates with
+        // no value for this attribute in addition to those with a value. Since we do not include `null` in the
+        // candidate values, we must continue to execute the disambiguation rule in case the rule specifies a
+        // default value and thus removes the candidates which do not have a value for this attribute.
+        if (candidateValues.size() < 1) {
             return;
         }
 
         Set<Object> matches = schema.disambiguate(attribute, null, candidateValues);
-        if (matches.size() < candidateValues.size()) {
+        if (matches != null) {
             // Remove any candidates which do not satisfy the disambiguation rule.
             for (int c = remaining.nextSetBit(0); c >= 0; c = remaining.nextSetBit(c + 1)) {
                 if (!matches.contains(getCandidateValue(c, attribute))) {
@@ -380,7 +389,7 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         final AttributeSelectionSchema.PrecedenceResult precedenceResult = schema.orderByPrecedence(Arrays.asList(extraAttributes));
 
         for (int a : precedenceResult.getSortedOrder()) {
-            disambiguateExtraAttribute(extraAttributes[a]);
+            disambiguateExtraAttribute(extraAttributes[a], remaining);
             if (remaining.cardinality() == 0) {
                 return;
             } else if (remaining.cardinality() == 1) {
@@ -390,10 +399,15 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
             }
         }
 
+        // When disambiguating in unknown precedence order, we always use the same set of candidates
+        // so that this step is not affected by the order in which we iterate.
+        BitSet candidates = new BitSet();
+        candidates.or(remaining);
+
         // If the attribute does not have a known precedence, then we cannot stop
         // until we've disambiguated all of the attributes.
         for (int a : precedenceResult.getUnsortedOrder()) {
-            disambiguateExtraAttribute(extraAttributes[a]);
+            disambiguateExtraAttribute(extraAttributes[a], candidates);
             if (remaining.cardinality() == 0) {
                 return;
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/attributes/DefaultAttributesSchemaTest.groovy
@@ -234,7 +234,7 @@ class DefaultAttributesSchemaTest extends Specification {
         best == ["bar"] as Set
     }
 
-    def "selects all candidates when no disambiguation rules and requested is not one of the candidate values"() {
+    def "returns null when no disambiguation rules and requested is not one of the candidate values"() {
         def attr = Attribute.of(String)
 
         given:
@@ -245,10 +245,10 @@ class DefaultAttributesSchemaTest extends Specification {
         def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "other", candidates)
 
         then:
-        best == candidates
+        best == null
     }
 
-    def "selects all candidates when no rule expresses an opinion and requested is not one of the candidate values"() {
+    def "returns null when no rule expresses an opinion and requested is not one of the candidate values"() {
         def attr = Attribute.of(String)
 
         given:
@@ -259,7 +259,7 @@ class DefaultAttributesSchemaTest extends Specification {
         def best = schema.mergeWith(EmptySchema.INSTANCE).disambiguate(attr, "other", candidates)
 
         then:
-        best == candidates
+        best == null
     }
 
     def "custom rule can select best match"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributePrecedenceSchemaAttributeMatcherTest.groovy
@@ -59,7 +59,9 @@ class AttributePrecedenceSchemaAttributeMatcherTest extends Specification {
         @Override
         void execute(MultipleCandidatesDetails<String> details) {
             if (details.consumerValue == null) {
-                details.closestMatch("best")
+                if (details.candidateValues.contains("best")) {
+                    details.closestMatch("best")
+                }
             } else {
                 if (details.candidateValues.contains("best")) {
                     details.closestMatch("best")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/ComponentAttributeMatcherTest.groovy
@@ -652,7 +652,7 @@ class ComponentAttributeMatcherTest extends Specification {
                 return [preferred]
             }
 
-            candidates
+            null
         }
 
         @Override


### PR DESCRIPTION
Includes changes to attribute matching to eliminate breaking change after the introduction of `compileElements`. Spec is in-progress. 

Additionally includes a regression test to ensure the introduction of compileElements does not change the behavior. 