### PR TITLE
Various fixes for restoring build tree state when loading from configuration cache after storing

### DIFF
--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/BuildEventListenerRegistryInternal.java
@@ -34,4 +34,9 @@ public interface BuildEventListenerRegistryInternal extends BuildEventsListenerR
     void subscribe(Provider<?> provider);
 
     List<Provider<?>> getSubscriptions();
+
+    /**
+     * Discards all subscriptions.
+     */
+    void unsubscribeAll();
 }

--- a/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
+++ b/subprojects/build-events/src/main/java/org/gradle/internal/build/event/DefaultBuildEventsListenerRegistry.java
@@ -128,6 +128,22 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
         }
     }
 
+    @Override
+    public void unsubscribeAll() {
+        try {
+            for (Object listener : listeners) {
+                listenerManager.removeListener(listener);
+                if (listener instanceof BuildOperationListener) {
+                    buildOperationListenerManager.removeListener((BuildOperationListener) listener);
+                }
+            }
+            CompositeStoppable.stoppable(subscriptions.values()).stop();
+        } finally {
+            listeners.clear();
+            subscriptions.clear();
+        }
+    }
+
     private static abstract class AbstractListener<T> implements Closeable {
         private static final Object END = new Object();
         private final ManagedExecutor executor;
@@ -245,18 +261,7 @@ public class DefaultBuildEventsListenerRegistry implements BuildEventsListenerRe
                 // Stop only when the root build completes
                 return;
             }
-            try {
-                for (Object listener : listeners) {
-                    listenerManager.removeListener(listener);
-                    if (listener instanceof BuildOperationListener) {
-                        buildOperationListenerManager.removeListener((BuildOperationListener) listener);
-                    }
-                }
-                CompositeStoppable.stoppable(subscriptions.values()).stop();
-            } finally {
-                listeners.clear();
-                subscriptions.clear();
-            }
+            unsubscribeAll();
         }
     }
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/BuildTreeConfigurationCache.kt
@@ -75,5 +75,5 @@ interface BuildTreeConfigurationCache {
     // This is a temporary method to allow migration from a root build scoped cache to a build tree scoped cache
     fun attachRootBuild(host: DefaultConfigurationCache.Host)
 
-    class WorkGraphResult(val graph: BuildTreeWorkGraph.FinalizedGraph, val wasLoadedFromCache: Boolean)
+    class WorkGraphResult(val graph: BuildTreeWorkGraph.FinalizedGraph, val wasLoadedFromCache: Boolean, val entryDiscarded: Boolean)
 }

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -21,6 +21,7 @@ import org.gradle.configurationcache.initialization.ConfigurationCacheStartParam
 import org.gradle.execution.EntryTaskSelector
 import org.gradle.internal.build.BuildStateRegistry
 import org.gradle.internal.build.ExecutionResult
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.buildtree.BuildTreeWorkController
 import org.gradle.internal.buildtree.BuildTreeWorkExecutor
 import org.gradle.internal.buildtree.BuildTreeWorkPreparer
@@ -32,6 +33,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
     private val workGraph: BuildTreeWorkGraphController,
     private val cache: BuildTreeConfigurationCache,
     private val buildRegistry: BuildStateRegistry,
+    private val eventListenerRegistry: BuildEventListenerRegistryInternal,
     private val startParameter: ConfigurationCacheStartParameter
 ) : BuildTreeWorkController {
 
@@ -50,7 +52,10 @@ class ConfigurationCacheAwareBuildTreeWorkController(
         if (executionResult != null) {
             return executionResult
         }
+
+        eventListenerRegistry.unsubscribeAll()
         buildRegistry.resetStateForAllBuilds()
+
         return workGraph.withNewWorkGraph { graph ->
             val finalizedGraph = cache.loadRequestedTasks(graph)
             workExecutor.execute(finalizedGraph)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheAwareBuildTreeWorkController.kt
@@ -40,7 +40,7 @@ class ConfigurationCacheAwareBuildTreeWorkController(
             val result = cache.loadOrScheduleRequestedTasks(graph) {
                 workPreparer.scheduleRequestedTasks(graph, taskSelector)
             }
-            if (!result.wasLoadedFromCache && startParameter.loadAfterStore) {
+            if (!result.wasLoadedFromCache && !result.entryDiscarded && startParameter.loadAfterStore) {
                 // Load the work graph from cache instead
                 null
             } else {

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheBuildTreeLifecycleControllerFactory.kt
@@ -21,6 +21,7 @@ import org.gradle.configurationcache.extensions.get
 import org.gradle.configurationcache.initialization.ConfigurationCacheStartParameter
 import org.gradle.internal.build.BuildLifecycleController
 import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.build.event.BuildEventListenerRegistryInternal
 import org.gradle.internal.buildtree.BuildModelParameters
 import org.gradle.internal.buildtree.BuildTreeFinishExecutor
 import org.gradle.internal.buildtree.BuildTreeLifecycleController
@@ -39,8 +40,9 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
     private val cache: BuildTreeConfigurationCache,
     private val taskGraph: BuildTreeWorkGraphController,
     private val stateTransitionControllerFactory: StateTransitionControllerFactory,
+    private val eventListenerRegistry: BuildEventListenerRegistryInternal,
     private val startParameter: ConfigurationCacheStartParameter,
-    private val buildStateRegistry: BuildStateRegistry
+    private val buildStateRegistry: BuildStateRegistry,
 ) : BuildTreeLifecycleControllerFactory {
     private
     val vintageFactory = VintageBuildTreeLifecycleControllerFactory(buildModelParameters, taskGraph, buildOperationExecutor, projectLeaseRegistry, stateTransitionControllerFactory)
@@ -66,7 +68,7 @@ class ConfigurationCacheBuildTreeLifecycleControllerFactory(
         }
 
         val workPreparer = vintageFactory.createWorkPreparer(targetBuild)
-        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, startParameter)
+        val workController = ConfigurationCacheAwareBuildTreeWorkController(workPreparer, workExecutor, taskGraph, cache, buildStateRegistry, eventListenerRegistry, startParameter)
 
         val defaultModelCreator = vintageFactory.createModelCreator(targetBuild)
         val modelCreator = ConfigurationCacheAwareBuildTreeModelCreator(defaultModelCreator, cache)

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/ConfigurationCacheState.kt
@@ -623,9 +623,12 @@ class ConfigurationCacheState(
     suspend fun DefaultReadContext.readGradleEnterprisePluginManager(gradle: GradleInternal) {
         val adapter = read() as GradleEnterprisePluginAdapter?
         if (adapter != null) {
-            adapter.onLoadFromConfigurationCache()
             val manager = gradle.serviceOf<GradleEnterprisePluginManager>()
-            manager.registerAdapter(adapter)
+            if (manager.adapter == null) {
+                // Don't replace the existing adapter. The adapter will be present if the current Gradle invocation wrote this entry.
+                adapter.onLoadFromConfigurationCache()
+                manager.registerAdapter(adapter)
+            }
         }
     }
 

--- a/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
+++ b/subprojects/configuration-cache/src/main/kotlin/org/gradle/configurationcache/DefaultConfigurationCache.kt
@@ -112,11 +112,7 @@ class DefaultConfigurationCache internal constructor(
 
     override fun initializeCacheEntry() {
         cacheAction = determineCacheAction()
-        problems.action(cacheAction) {
-            store.useForStore { layout ->
-                invalidateConfigurationCacheState(layout)
-            }
-        }
+        problems.action(cacheAction)
     }
 
     override fun attachRootBuild(host: Host) {
@@ -126,12 +122,12 @@ class DefaultConfigurationCache internal constructor(
     override fun loadOrScheduleRequestedTasks(graph: BuildTreeWorkGraph, scheduler: (BuildTreeWorkGraph) -> BuildTreeWorkGraph.FinalizedGraph): BuildTreeConfigurationCache.WorkGraphResult {
         return if (isLoaded) {
             val finalizedGraph = loadWorkGraph(graph)
-            BuildTreeConfigurationCache.WorkGraphResult(finalizedGraph, true)
+            BuildTreeConfigurationCache.WorkGraphResult(finalizedGraph, true, false)
         } else {
             runWorkThatContributesToCacheEntry {
                 val finalizedGraph = scheduler(graph)
                 saveWorkGraph()
-                BuildTreeConfigurationCache.WorkGraphResult(finalizedGraph, false)
+                BuildTreeConfigurationCache.WorkGraphResult(finalizedGraph, false, problems.shouldDiscardEntry)
             }
         }
     }
@@ -169,7 +165,11 @@ class DefaultConfigurationCache internal constructor(
     }
 
     override fun finalizeCacheEntry() {
-        if (hasSavedValues) {
+        if (problems.shouldDiscardEntry) {
+            store.useForStore { layout ->
+                layout.fileFor(StateType.Entry).delete()
+            }
+        } else if (hasSavedValues) {
             val reusedProjects = mutableSetOf<Path>()
             val updatedProjects = mutableSetOf<Path>()
             intermediateModels.value.visitProjects(reusedProjects::add, updatedProjects::add)
@@ -500,11 +500,6 @@ class DefaultConfigurationCache internal constructor(
     private
     fun unloadGradleProperties() {
         gradlePropertiesController.unloadGradleProperties()
-    }
-
-    private
-    fun invalidateConfigurationCacheState(layout: ConfigurationCacheRepository.Layout) {
-        layout.fileFor(StateType.Entry).delete()
     }
 
     private

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/BuildServiceRegistryInternal.java
@@ -34,4 +34,9 @@ public interface BuildServiceRegistryInternal extends BuildServiceRegistry {
     BuildServiceProvider<?, ?> register(String name, Class<? extends BuildService<?>> implementationType, @Nullable BuildServiceParameters parameters, int maxUsages);
 
     SharedResource forService(Provider<? extends BuildService<?>> service);
+
+    /**
+     * Discards all registered services.
+     */
+    void discardAll();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/services/internal/DefaultBuildServicesRegistry.java
@@ -193,6 +193,20 @@ public class DefaultBuildServicesRegistry implements BuildServiceRegistryInterna
         return provider;
     }
 
+    @Override
+    public void discardAll() {
+        withRegistrations(registrations -> {
+            try {
+                for (BuildServiceRegistration<?, ?> registration : registrations) {
+                    ((DefaultServiceRegistration<?, ?>) registration).provider.maybeStop();
+                }
+            } finally {
+                registrations.clear();
+            }
+            return null;
+        });
+    }
+
     private static class ServiceBackedSharedResource implements SharedResource {
         private final String name;
         private final int maxUsages;

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -19,6 +19,7 @@ package org.gradle.internal.build;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.api.services.internal.BuildServiceRegistryInternal;
 import org.gradle.initialization.IncludedBuildSpec;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -75,6 +76,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
         projectStateRegistry.get().resetState(this);
         workGraphController.get().resetState();
         buildLifecycleController.get().resetState();
+        buildLifecycleController.get().getGradle().getServices().get(BuildServiceRegistryInternal.class).discardAll();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/AbstractBuildState.java
@@ -73,6 +73,7 @@ public abstract class AbstractBuildState implements BuildState, Closeable {
     @Override
     public void resetState() {
         projectStateRegistry.get().resetState(this);
+        workGraphController.get().resetState();
         buildLifecycleController.get().resetState();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/BuildWorkGraphController.java
@@ -41,4 +41,9 @@ public interface BuildWorkGraphController {
      * Eventually, this constraint should be removed, so that it is possible to populate and run multiple work graphs concurrently.
      */
     BuildWorkGraph newWorkGraph();
+
+    /**
+     * Discards all work state.
+     */
+    void resetState();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/build/DefaultBuildWorkGraphController.java
@@ -59,6 +59,17 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
     }
 
     @Override
+    public void resetState() {
+        synchronized (lock) {
+            if (currentOwner != null) {
+                throw new IllegalStateException("Cannot reset work graph state as another thread is currently using the work graph.");
+            }
+            nodesByPath.clear();
+        }
+        taskNodeFactory.clear();
+    }
+
+    @Override
     public ExportedTaskNode locateTask(TaskIdentifier taskIdentifier) {
         DefaultExportedTaskNode node = doLocate(taskIdentifier);
         if (taskIdentifier instanceof TaskIdentifier.TaskBasedTaskIdentifier) {
@@ -112,6 +123,14 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
         public void stop() {
             if (plan != null) {
                 plan.stop();
+            }
+            synchronized (lock) {
+                assert currentOwner == Thread.currentThread();
+                pendingGraphs.remove(this);
+                if (pendingGraphs.isEmpty()) {
+                    currentOwner = null;
+                    lock.notifyAll();
+                }
             }
         }
 
@@ -194,11 +213,6 @@ public class DefaultBuildWorkGraphController implements BuildWorkGraphController
             } finally {
                 synchronized (lock) {
                     currentlyRunning = null;
-                    pendingGraphs.remove(this);
-                    if (pendingGraphs.isEmpty()) {
-                        currentOwner = null;
-                        lock.notifyAll();
-                    }
                 }
             }
         }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #?

### Context

This PR fixes various issues when the (currently) internal feature to load the work graph from the cache after storing it is enabled.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Make sure all contributed code can be distributed under the terms of the [Apache License 2.0](https://github.com/gradle/gradle/blob/master/LICENSE), e.g. the code was written by yourself or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass sanity check: `./gradlew sanityCheck`
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:quickTest`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
