### PR TITLE
Eagerly compute task graph representation for build scans

### DIFF
--- a/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
+++ b/.teamcity/src/main/kotlin/configurations/FunctionalTest.kt
@@ -6,7 +6,6 @@ import model.CIBuildModel
 import model.Stage
 import model.StageName
 import model.TestCoverage
-import model.TestType
 
 const val functionalTestTag = "FunctionalTest"
 
@@ -53,12 +52,11 @@ class FunctionalTest(
         preSteps = preBuildSteps
     )
 
-    if (testCoverage.testType == TestType.soak || testTasks.contains("plugins:")) {
-        failureConditions {
-            // JavaExecDebugIntegrationTest.debug session fails without debugger might cause JVM crash
-            // Some soak tests produce OOM exceptions
-            javaCrash = false
-        }
+    failureConditions {
+        // JavaExecDebugIntegrationTest.debug session fails without debugger might cause JVM crash
+        // Some soak tests produce OOM exceptions
+        // There are also random worker crashes for some tests.
+        javaCrash = false
     }
 })
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -76,7 +76,7 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractCrossVersionPerformanc
         'help'                                       | null       | null
         'assembleDebug'                              | null       | null
         'clean phthalic:assembleDebug'               | 2          | 8
-        // ':module21:module02:assembleDebug --dry-run' | 8          | 20
+        ':module21:module02:assembleDebug --dry-run' | 8          | 20
     }
 
     @RunFor([


### PR DESCRIPTION
to avoid ConcurrentModificationException on publishing build scans.