### PR TITLE
Fix ParallelDownloadsPerformanceTest

### DIFF
--- a/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
+++ b/build-logic/performance-testing/src/main/groovy/gradlebuild.performance-templates.gradle
@@ -537,7 +537,7 @@ performanceTest.registerTestProject("excludeRuleMergingBuild", RemoteProject) {
 performanceTest.registerTestProject("springBootApp", RemoteProject) {
     remoteUri = 'https://github.com/gradle/performance-comparisons.git'
     // From master branch
-    ref = "f93d2e6d7057f4cdf379a817bdf036e85e97429a"
+    ref = "5b586d729eedf0cf36238c15c5deed64d43a8742"
     subdirectory = 'parallel-downloads'
 }
 


### PR DESCRIPTION
the test project was still using AbstractArchiveTask.{baseName,version}. Fixed this in the project via https://github.com/gradle/performance-comparisons/pull/208.

See #17123 where the removal happened.