### PR TITLE
Improve output of integration tests failing check for "output contains string" tests

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -540,7 +540,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         then: // name has changed, should run
         result.assertTasksNotSkipped(":b:producer", ":a:resolve")
         transformed("b-blue")
-        outputContains("result = [b-blue.green, c-dir.green]")
+        outputContains("resxult = [b-blue.green, c-dir.green]")
 
         when:
         executer.withArguments("-DbOutputDir=out", "-DbDirName=b-blue", "-DbContent=new")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -540,7 +540,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         then: // name has changed, should run
         result.assertTasksNotSkipped(":b:producer", ":a:resolve")
         transformed("b-blue")
-        outputContains("resxult = [b-blue.green, c-dir.green]")
+        outputContains("result = [b-blue.green, c-dir.green]")
 
         when:
         executer.withArguments("-DbOutputDir=out", "-DbDirName=b-blue", "-DbContent=new")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -17,6 +17,7 @@ package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.integtests.fixtures.logging.GroupedOutputFixture;
 import org.gradle.internal.Pair;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
@@ -25,10 +26,13 @@ import org.gradle.launcher.daemon.server.DaemonStateCoordinator;
 import org.gradle.launcher.daemon.server.health.LowHeapSpaceDaemonExpirationStrategy;
 import org.gradle.util.internal.CollectionUtils;
 import org.gradle.util.internal.GUtil;
+import org.spockframework.runtime.SpockAssertionError;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -220,10 +224,39 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
         return this;
     }
 
+    private static class LineWithDistance {
+        private final String line;
+        private final int distance;
+
+        public LineWithDistance(String line, int distance) {
+            this.line = line;
+            this.distance = distance;
+        }
+
+        public String getLine() {
+            return line;
+        }
+
+        public int getDistance() {
+            return distance;
+        }
+    }
+
     @Override
     public ExecutionResult assertContentContains(String actualText, String expectedOutput, String label) {
         String expectedText = LogContent.of(expectedOutput).withNormalizedEol();
         if (!actualText.contains(expectedText)) {
+            if (!expectedText.contains("\n")) {
+                Arrays.stream(actualText.split("\n"))
+                    // Measure Levenshtein distance for each line
+                    .map(line -> new LineWithDistance(line, StringUtils.getLevenshteinDistance(line, expectedText)))
+                    // Filter out lines that need more edits than half the length of the line
+                    .filter(pair -> pair.getDistance() < pair.getLine().length() / 2)
+                    // Find the closest match
+                    .min(Comparator.comparingInt(LineWithDistance::getDistance))
+                    .map(LineWithDistance::getLine)
+                    .ifPresent(similarLine -> failOnDifferentLine("Did not find expected text in " + label.toLowerCase() + ", found similar line.", expectedOutput, similarLine));
+            }
             failOnMissingOutput("Did not find expected text in " + label.toLowerCase() + ".", label, expectedOutput, actualText);
         }
         return this;
@@ -392,6 +425,10 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
 
     private void failOnMissingOutput(String message, String type, String expected, String actual) {
         throw new AssertionError(String.format("%s%nExpected: %s%n%n%s:%n=======%n%s", message, expected, type, actual));
+    }
+
+    private void failOnDifferentLine(String message, String expected, String actual) {
+        throw new SpockAssertionError(String.format("%nExpected: \"%s\"%n but: was \"%s\"", expected, actual));
     }
 
     protected void failureOnUnexpectedOutput(String message) {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResultTest.groovy
@@ -161,11 +161,21 @@ post build
             '''))
 
         when:
-        result.assertOutputContains("message\n\n")
+        result.assertOutputContains("message 3")
 
         then:
         def e6 = thrown(AssertionError)
-        error(e6).startsWith(error('''
+        error(e6).trim().startsWith(error('''
+            Expected: "message 3"
+             but: was "message 2"
+            '''))
+
+        when:
+        result.assertOutputContains("message\n\n")
+
+        then:
+        def e7 = thrown(AssertionError)
+        error(e7).startsWith(error('''
             Did not find expected text in build output.
             Expected: message
 


### PR DESCRIPTION
When integration test fails checking for presence of line in output, show only difference with most similar line.

The format is picked explicitly to match IntelliJ's pattern for detecting comparison failures here:

https://github.com/JetBrains/intellij-community/blob/3f97400071e1a0b6a21a6bbd2af1fa27c47467c0/plugins/gradle/java/src/execution/GradleRunnerUtil.java#L97-L116

Output after the changes (17 lines, only non-matching line is shown):

```text
Expected: "result = [b-dir.green, c-dir.red]"
 but: was "result = [b-dir.green, c-dir.green]"
Expected :result = [b-dir.green, c-dir.red]
Actual   :result = [b-dir.green, c-dir.green]
<Click to see difference>


Expected: "result = [b-dir.green, c-dir.red]"
 but: was "result = [b-dir.green, c-dir.green]"
	at app//org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.failOnDifferentLine(OutputScrapingExecutionResult.java:431)
	at app//org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.lambda$assertContentContains$2(OutputScrapingExecutionResult.java:258)
	at java.base@11.0.14/java.util.Optional.ifPresent(Optional.java:183)
	at app//org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertContentContains(OutputScrapingExecutionResult.java:258)
	at app//org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertOutputContains(OutputScrapingExecutionResult.java:267)
	at app//org.gradle.integtests.fixtures.executer.InProcessGradleExecuter$InProcessExecutionResult.assertOutputContains(InProcessGradleExecuter.java:533)
	at app//org.gradle.integtests.fixtures.AbstractIntegrationSpec.outputContains(AbstractIntegrationSpec.groovy:633)
	at org.gradle.integtests.resolve.transform.ArtifactTransformInputArtifactIntegrationTest.honors @PathSensitive(#sensitivity) to input artifact property for project artifact directory when caching(ArtifactTransformInputArtifactIntegrationTest.groovy:534)
```

Output before the changes (65 lines, full build output repeated three times):

```text
Condition failed with Exception:

outputContains("result = [b-dir.green, c-dir.red]")
|
java.lang.AssertionError: Did not find expected text in build output.
Expected: result = [b-dir.green, c-dir.red]
 
Build output:
=======
> Task :b:producer
> Task :c:producer UP-TO-DATE
 
> Task :a:resolve
result = [b-dir.green, c-dir.green]
 
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.failOnMissingOutput(OutputScrapingExecutionResult.java:394)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertContentContains(OutputScrapingExecutionResult.java:227)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertOutputContains(OutputScrapingExecutionResult.java:234)
	at org.gradle.integtests.fixtures.executer.InProcessGradleExecuter$InProcessExecutionResult.assertOutputContains(InProcessGradleExecuter.java:533)
	at org.gradle.integtests.fixtures.AbstractIntegrationSpec.outputContains(AbstractIntegrationSpec.groovy:633)
	at org.gradle.integtests.resolve.transform.ArtifactTransformInputArtifactIntegrationTest.honors @PathSensitive(#sensitivity) to input artifact property for project artifact directory when caching(ArtifactTransformInputArtifactIntegrationTest.groovy:534)

Condition failed with Exception:

outputContains("result = [b-dir.green, c-dir.red]")
|
java.lang.AssertionError: Did not find expected text in build output.
Expected: result = [b-dir.green, c-dir.red]
 
Build output:
=======
> Task :b:producer
> Task :c:producer UP-TO-DATE
 
> Task :a:resolve
result = [b-dir.green, c-dir.green]
 
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.failOnMissingOutput(OutputScrapingExecutionResult.java:394)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertContentContains(OutputScrapingExecutionResult.java:227)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertOutputContains(OutputScrapingExecutionResult.java:234)
	at org.gradle.integtests.fixtures.executer.InProcessGradleExecuter$InProcessExecutionResult.assertOutputContains(InProcessGradleExecuter.java:533)
	at org.gradle.integtests.fixtures.AbstractIntegrationSpec.outputContains(AbstractIntegrationSpec.groovy:633)
	at org.gradle.integtests.resolve.transform.ArtifactTransformInputArtifactIntegrationTest.honors @PathSensitive(#sensitivity) to input artifact property for project artifact directory when caching(ArtifactTransformInputArtifactIntegrationTest.groovy:534)

	at org.gradle.integtests.resolve.transform.ArtifactTransformInputArtifactIntegrationTest.honors @PathSensitive(#sensitivity) to input artifact property for project artifact directory when caching(ArtifactTransformInputArtifactIntegrationTest.groovy:534)
Caused by: java.lang.AssertionError: Did not find expected text in build output.
Expected: result = [b-dir.green, c-dir.red]

Build output:
=======
> Task :b:producer
> Task :c:producer UP-TO-DATE

> Task :a:resolve
result = [b-dir.green, c-dir.green]

	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.failOnMissingOutput(OutputScrapingExecutionResult.java:394)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertContentContains(OutputScrapingExecutionResult.java:227)
	at org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult.assertOutputContains(OutputScrapingExecutionResult.java:234)
	at org.gradle.integtests.fixtures.executer.InProcessGradleExecuter$InProcessExecutionResult.assertOutputContains(InProcessGradleExecuter.java:533)
	at org.gradle.integtests.fixtures.AbstractIntegrationSpec.outputContains(AbstractIntegrationSpec.groovy:633)
	... 1 more
```

This is far from perfect, as the new output still shows the expected/actual values three times for some reason in IntelliJ (only twice in TeamCity), but I think it's still a significant improvement in how readable the output is.