### PR TITLE
Upgrade to Spock 2.3 to simplify AbstractMultiTestInterceptor

### DIFF
--- a/subprojects/distributions-dependencies/build.gradle.kts
+++ b/subprojects/distributions-dependencies/build.gradle.kts
@@ -176,8 +176,8 @@ dependencies {
         api(libs.samplesCheck)          { version { strictly("1.0.0") }}
         api(libs.snappy)                { version { strictly("0.4") }}
         api(libs.socksProxy)            { version { strictly("2.0.0") }}
-        api(libs.spock)                 { version { strictly("2.2-M2-groovy-3.0") }}
-        api(libs.spockJUnit4)           { version { strictly("2.2-M2-groovy-3.0") }}
+        api(libs.spock)                 { version { strictly("2.3-groovy-3.0") }}
+        api(libs.spockJUnit4)           { version { strictly("2.3-groovy-3.0") }}
         api(libs.sshdCore)              { version { strictly(sshdVersion) }}
         api(libs.sshdScp)               { version { strictly(sshdVersion) }}
         api(libs.sshdSftp)              { version { strictly(sshdVersion) }}


### PR DESCRIPTION
We can now remove hacks to parameterize a non-parameterized Spock test, since Spock has this capability out of the box.