### PR TITLE
Add task to automatically sort accepted-public-api-changes.json file

### DIFF
--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTask.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTask.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+import com.google.common.annotations.VisibleForTesting
+import com.google.gson.Gson
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+
+
+/**
+ * Abstract base class for [Task][org.gradle.api.Task]s that verify and manipulate the given accepted API changes file.
+ */
+@CacheableTask
+abstract class AbstractAcceptedApiChangesMaintenanceTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val apiChangesFile: RegularFileProperty
+
+    protected
+    fun loadChanges(): List<AcceptedApiChange> {
+        val jsonString = apiChangesFile.get().asFile.readText()
+        val json = Gson().fromJson(jsonString, AcceptedApiChanges::class.java)
+        return json.acceptedApiChanges!!
+    }
+
+    protected
+    fun sortChanges(originalChanges: List<AcceptedApiChange>) = originalChanges.toMutableList().sortedBy { it.type + '#' + it.member }
+
+    @VisibleForTesting
+    data class AcceptedApiChange(
+        val type: String?,
+        val member: String?,
+        val acceptation: String?,
+        val changes: List<String>?
+    ) {
+        override fun toString(): String = "Type: '$type', Member: '$member'"
+    }
+
+    @VisibleForTesting
+    data class AcceptedApiChanges(
+        val acceptedApiChanges: List<AcceptedApiChange>?
+    )
+}

--- a/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/SortAcceptedApiChangesTask.kt
+++ b/build-logic/binary-compatibility/src/main/kotlin/gradlebuild/binarycompatibility/SortAcceptedApiChangesTask.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.TaskAction
+
+
+/**
+ * This [Task][org.gradle.api.Task] reorders the changes in an accepted API changes file
+ * so that they are alphabetically sorted (by type, then member).
+ */
+@CacheableTask
+abstract class SortAcceptedApiChangesTask : AbstractAcceptedApiChangesMaintenanceTask() {
+
+    @TaskAction
+    fun execute() {
+        val sortedChanges = sortChanges(loadChanges())
+        val json = formatChanges(sortedChanges)
+        apiChangesFile.asFile.get().bufferedWriter().use { out -> out.write(json) }
+    }
+
+    private
+    fun formatChanges(changes: List<AbstractAcceptedApiChangesMaintenanceTask.AcceptedApiChange>): String {
+        val gson: Gson = GsonBuilder().setPrettyPrinting().create()
+        val initialString = gson.toJson(AcceptedApiChanges(changes))
+        return adjustIndentation(initialString) + "\n"
+    }
+
+    /**
+     * It appears there is no way to configure Gson to use 4 spaces instead of 2 for indentation.
+     *
+     * See: https://github.com/google/gson/blob/master/UserGuide.md#TOC-Compact-Vs.-Pretty-Printing-for-JSON-Output-Format
+     */
+    private
+    fun adjustIndentation(initalJsonString: String): String {
+        val indentationRegex = """^\s+""".toRegex(RegexOption.MULTILINE)
+        return indentationRegex.replace(initalJsonString) { m ->
+            " ".repeat(m.value.length * 2)
+        }
+    }
+}

--- a/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
+++ b/build-logic/binary-compatibility/src/test/kotlin/gradlebuild/binarycompatibility/AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gradlebuild.binarycompatibility
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.StringWriter
+
+
+abstract class AbstractAcceptedApiChangesMaintenanceTaskIntegrationTest {
+    @TempDir
+    lateinit var projectDir: File
+    lateinit var acceptedApiChangesFile: File
+
+    @BeforeEach
+    fun setUp() {
+        projectDir.resolve("src").resolve("changes").mkdirs()
+        acceptedApiChangesFile = projectDir.resolve("src/changes/accepted-public-api-changes.json")
+
+        projectDir.resolve("build.gradle.kts")
+            .writeText(
+                """
+                    plugins {
+                        id("gradlebuild.binary-compatibility")
+                    }
+
+                    val verifyAcceptedApiChangesOrdering = tasks.register<gradlebuild.binarycompatibility.AlphabeticalAcceptedApiChangesTask>("verifyAcceptedApiChangesOrdering") {
+                        group = "verification"
+                        description = "Ensures the accepted api changes file is kept alphabetically ordered to make merging changes to it easier"
+                        apiChangesFile.set(layout.projectDirectory.file("${acceptedApiChangesFile.absolutePath}"))
+                    }
+
+                    val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.SortAcceptedApiChangesTask>("sortAcceptedApiChanges") {
+                        group = "verification"
+                        description = "Sort the accepted api changes file alphabetically"
+                        apiChangesFile.set(layout.projectDirectory.file("${acceptedApiChangesFile.absolutePath}"))
+                    }
+                """.trimIndent()
+            )
+
+        setupPluginRequirements()
+    }
+
+    /**
+     * Create projects and files required for plugins applied to the project (including transitively applied plugins).
+     * These files are not required to run the task itself, but are required to apply the binary-compatibility plugin.
+     */
+    protected
+    fun setupPluginRequirements() {
+        projectDir.resolve("version.txt").writeText("9999999.0") // All released versions should be lower than this
+        projectDir.resolve("released-versions.json").writeText(
+            """
+                {
+                  "latestReleaseSnapshot": {
+                    "version": "7.6-20220831090819+0000",
+                    "buildTime": "20220831090819+0000"
+                  },
+                  "latestRc": {
+                    "version": "7.5-rc-5",
+                    "buildTime": "20220712114039+0000"
+                  },
+                  "finalReleases": [
+                    {
+                      "version": "7.5.1",
+                      "buildTime": "20220805211756+0000"
+                    },
+                    {
+                      "version": "7.5",
+                      "buildTime": "20220714124815+0000"
+                    },
+                    {
+                      "version": "7.4.2",
+                      "buildTime": "20220331152529+0000"
+                    },
+                    {
+                      "version": "6.9.2",
+                      "buildTime": "20211221172537+0000"
+                    }
+                  ]
+                }
+            """.trimIndent()
+        )
+    }
+
+    protected
+    fun run(vararg args: String) = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withTestKitDir(projectDir.resolve("test-kit"))
+        .withPluginClasspath()
+        .forwardOutput()
+        .withArguments(*args)
+
+
+    protected
+    fun assertChangesProperlyOrdered() {
+        val result = run(":verifyAcceptedApiChangesOrdering").build()
+        Assertions.assertEquals(TaskOutcome.SUCCESS, result.task(":verifyAcceptedApiChangesOrdering")!!.outcome)
+    }
+
+    protected
+    fun assertHasMisorderedChanges(changes: List<Change>? = null) {
+        val standardError = StringWriter()
+        run(":verifyAcceptedApiChangesOrdering")
+            .forwardStdError(standardError)
+            .buildAndFail()
+
+        val expectedOutput = "API changes in file '${acceptedApiChangesFile.name}' should be in alphabetical order (by type and member), yet these changes were not:\n"
+        val cleanupHint = "To automatically alphabetize these changes run: 'gradlew :architecture-test:sortAcceptedApiChanges'"
+        with(standardError) {
+            assertContains(expectedOutput)
+            changes?.forEach { assertContains(it.toString()) }
+            assertContains(cleanupHint)
+        }
+    }
+
+    private
+    fun StringWriter.assertContains(text: String) {
+        Assertions.assertTrue(toString().contains(text)) {
+            "Did not find expected error message in $this"
+        }
+    }
+
+    protected
+    data class Change(val type: String, val member: String) {
+        override fun toString(): String = "Type: '$type', Member: '$member'"
+    }
+}

--- a/subprojects/architecture-test/build.gradle.kts
+++ b/subprojects/architecture-test/build.gradle.kts
@@ -27,10 +27,18 @@ dependencies {
     testRuntimeOnly(project(":distributions-full"))
 }
 
+val acceptedApiChangesFile = layout.projectDirectory.file("src/changes/accepted-public-api-changes.json")
+
 val verifyAcceptedApiChangesOrdering = tasks.register<gradlebuild.binarycompatibility.AlphabeticalAcceptedApiChangesTask>("verifyAcceptedApiChangesOrdering") {
     group = "verification"
     description = "Ensures the accepted api changes file is kept alphabetically ordered to make merging changes to it easier"
-    apiChangesFile.set(layout.projectDirectory.file("src/changes/accepted-public-api-changes.json"))
+    apiChangesFile.set(acceptedApiChangesFile)
+}
+
+val sortAcceptedApiChanges = tasks.register<gradlebuild.binarycompatibility.SortAcceptedApiChangesTask>("sortAcceptedApiChanges") {
+    group = "verification"
+    description = "Sort the accepted api changes file alphabetically"
+    apiChangesFile.set(acceptedApiChangesFile)
 }
 
 tasks.test {


### PR DESCRIPTION
Fixes #22278 

- Notifies about task upon failure to verify.
- Extracted common base class for verification and sorting tasks.
- Maintained existing formatting of changes file.
