### PR TITLE
Introduce `AtomicHashSet`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProjectStateRegistry.java
@@ -28,6 +28,7 @@ import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.build.BuildProjectRegistry;
 import org.gradle.internal.build.BuildState;
+import org.gradle.internal.collect.AtomicHashSet;
 import org.gradle.internal.model.CalculatedModelValue;
 import org.gradle.internal.model.ModelContainer;
 import org.gradle.internal.model.StateTransitionControllerFactory;
@@ -43,7 +44,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -229,7 +229,7 @@ public class DefaultProjectStateRegistry implements ProjectStateRegistry {
         private final ResourceLock allProjectsLock;
         private final ResourceLock projectLock;
         private final ResourceLock taskLock;
-        private final Set<Thread> canDoAnythingToThisProject = new CopyOnWriteArraySet<>();
+        private final AtomicHashSet<Thread> canDoAnythingToThisProject = new AtomicHashSet<>();
         private final ProjectLifecycleController controller;
 
         ProjectStateImpl(

--- a/subprojects/functional/build.gradle.kts
+++ b/subprojects/functional/build.gradle.kts
@@ -1,10 +1,14 @@
 plugins {
     id("gradlebuild.distribution.implementation-java")
     id("gradlebuild.publish-public-libraries")
+    id("gradlebuild.jmh")
 }
 
 description = "Tools to work with functional code, including data structures"
 
 dependencies {
     implementation(project(":base-annotations"))
+    implementation(libs.capsule)
 }
+
+jmh.includes.set(listOf("AtomicHashSetBenchmark"))

--- a/subprojects/functional/src/jmh/java/org/gradle/internal/collect/AtomicHashSetBenchmark.java
+++ b/subprojects/functional/src/jmh/java/org/gradle/internal/collect/AtomicHashSetBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+
+@Fork(1)
+@Threads(4)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@State(Scope.Benchmark)
+public class AtomicHashSetBenchmark {
+
+    @Param({"1", "4", "16", "512", "1024", "65536"})
+    int setSize;
+
+    CopyOnWriteArraySet<Integer> cowSet;
+    AtomicHashSet<Integer> atomicHashSet;
+
+    @Setup(Level.Iteration)
+    public void setup() throws CloneNotSupportedException {
+        cowSet = cowOf(setSize);
+        atomicHashSet = atomicSetOf(setSize);
+    }
+
+    @Benchmark
+    public void atomicSetContains(Blackhole blackhole) {
+        forEach(1, 1000, i -> blackhole.consume(atomicHashSet.contains(i)));
+    }
+
+    @Benchmark
+    public void cowSetContains(Blackhole blackhole) {
+        forEach(1, 1000, i -> blackhole.consume(cowSet.contains(i)));
+    }
+
+    @Benchmark
+    public void atomicSetAdd(Blackhole blackhole) {
+        blackhole.consume(atomicSetOf(setSize));
+    }
+
+    @Benchmark
+    public void cowSetAdd(Blackhole blackhole) {
+        blackhole.consume(cowOf(setSize));
+    }
+
+    private static AtomicHashSet<Integer> atomicSetOf(int count) {
+        AtomicHashSet<Integer> set = new AtomicHashSet<>();
+        forEach(1, count, set::add);
+        return set;
+    }
+
+    private static CopyOnWriteArraySet<Integer> cowOf(int count) {
+        CopyOnWriteArraySet<Integer> set = new CopyOnWriteArraySet<>();
+        forEach(1, count, set::add);
+        return set;
+    }
+
+    private static void forEach(int from, int to, Consumer<Integer> action) {
+        assert from <= to;
+        for (int i = from; i <= to; ++i) {
+            action.accept(i);
+        }
+    }
+}

--- a/subprojects/functional/src/main/java/org/gradle/internal/collect/AtomicHashSet.java
+++ b/subprojects/functional/src/main/java/org/gradle/internal/collect/AtomicHashSet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.collect;
+
+import io.usethesource.capsule.Set;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AtomicHashSet<T> implements Iterable<T> {
+
+    private AtomicReference<Set.Immutable<T>> set = new AtomicReference<>(Set.Immutable.of());
+
+    public boolean add(T value) {
+        boolean[] added = new boolean[1];
+        set.updateAndGet(set -> {
+            Set.Immutable<T> result = set.__insert(value);
+            added[0] = result != set;
+            return result;
+        });
+        return added[0];
+    }
+
+    public boolean contains(T value) {
+        return set.get().contains(value);
+    }
+
+    public void remove(T value) {
+        set.updateAndGet(set -> set.__remove(value));
+    }
+
+    public void clear() {
+        set.set(Set.Immutable.of());
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return set.get().iterator();
+    }
+
+}

--- a/subprojects/persistent-cache/build.gradle.kts
+++ b/subprojects/persistent-cache/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":messaging"))
     implementation(project(":native"))
     implementation(project(":files"))
+    implementation(project(":functional"))
     implementation(project(":resources"))
     implementation(project(":logging"))
 

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -35,6 +35,7 @@ import org.gradle.cache.internal.filelock.Version1LockStateSerializer;
 import org.gradle.cache.internal.locklistener.FileLockContentionHandler;
 import org.gradle.internal.Factory;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.collect.AtomicHashSet;
 import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.id.IdGenerator;
@@ -47,8 +48,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -63,7 +62,7 @@ public class DefaultFileLockManager implements FileLockManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFileLockManager.class);
     public static final int DEFAULT_LOCK_TIMEOUT = 60000;
 
-    private final Set<File> lockedFiles = new CopyOnWriteArraySet<>();
+    private final AtomicHashSet<File> lockedFiles = new AtomicHashSet<>();
     private final ProcessMetaDataProvider metaDataProvider;
     private final int lockTimeoutMs;
     private final IdGenerator<Long> generator;


### PR DESCRIPTION
A fast and scalable replacement for `CopyOnWriteArraySet`.