### PR TITLE
Deprecate old groovy workaround behavior

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NestedConfigureDslIntegrationTest.groovy
@@ -225,7 +225,42 @@ assert repositories.size() == 1
 """
 
         expect:
+        executer.expectDocumentedDeprecationWarning("Referencing 'repositories' in this block is deprecated. Fully qualify your reference to this API or access it in another block. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#referencing_script_configure_method_from_container_configure_closure_deprecated")
         succeeds()
+    }
+
+    // NOTE: Documents actual behaviour, for backwards compatibility purposes, not desired behaviour
+    def "can reference script level configure method from async closure in named container configure closure when that closure would fail with MME if applied to a new element"() {
+        buildFile << """
+plugins {
+    id 'distribution'
+}
+${mavenCentralRepository()}
+
+configurations {
+    conf.incoming.afterResolve {
+        distributions {
+            myDist {
+                contents {}
+            }
+        }
+    }
+}
+
+task resolve {
+    dependsOn configurations.conf
+    doFirst {
+        configurations.conf.files() // Trigger `afterResolve`
+        assert distributions*.name.contains('myDist')
+    }
+}
+
+assert configurations*.name.contains('conf')
+"""
+
+        expect:
+        executer.expectDocumentedDeprecationWarning("Referencing 'distributions' in this block is deprecated. Fully qualify your reference to this API or access it in another block. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. Consult the upgrading guide for further information: https://docs.gradle.org/current/userguide/upgrading_version_7.html#referencing_script_configure_method_from_container_configure_closure_deprecated")
+        succeeds "resolve"
     }
 
     def "reports missing method from inside configure closure"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesIntegrationTest.groovy
@@ -665,7 +665,7 @@ class LoggingRule implements ComponentMetadataRule {
 configurations {
     ruleDownloader.incoming.afterResolve {
         println "Adding rules"
-        dependencies {
+        project.dependencies {
             components {
                 all(LoggingRule)
             }

--- a/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
+++ b/subprojects/docs/src/docs/userguide/migration/upgrading_version_7.adoc
@@ -66,38 +66,6 @@ This can be achieved persistently in the `gradle.properties` file in your build 
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 ```
 
-[[invalid_toolchain_specification_deprecation]]
-=== Usage of invalid Java toolchain specifications is now deprecated
-
-Along with the Java language version, the <<toolchains#toolchains, Java toolchain>> DSL allows configuring other criteria such as specific vendors or VM implementations.
-Starting with Gradle 7.6, toolchain specifications that configure other properties without specifying the language version are considered _invalid_.
-Invalid specifications are deprecated and will become build errors in Gradle 8.0.
-
-See more details about toolchain configuration in the <<toolchains#sec:configuring_toolchain_specifications,user manual>>.
-
-[[org_gradle_util_reports_deprecations]]
-=== Deprecated members of the `org.gradle.util` package now report their deprecation
-
-These members will be removed in Gradle 9.0.
-
-* `ClosureBackedAction`
-* `CollectionUtils`
-* `ConfigureUtil`
-* `DistributionLocator`
-* `GFileUtils`
-* `GradleVersion.getBuildTime()`
-* `GradleVersion.getNextMajor()`
-* `GradleVersion.getRevision()`
-* `GradleVersion.isValid()`
-* `GUtil`
-* `NameMatcher`
-* `NameValidator`
-* `RelativePathUtil`
-* `TextUtil`
-* `SingleMessageLogger`
-* `VersionNumber`
-* `WrapUtil`
-
 === Potential breaking changes
 
 [[kotlin_1_7_10]]
@@ -157,9 +125,120 @@ In the past, the task would be executed with the default toolchain or JVM runnin
 
 === Deprecations
 
+[[invalid_toolchain_specification_deprecation]]
+==== Usage of invalid Java toolchain specifications is now deprecated
+
+Along with the Java language version, the <<toolchains#toolchains, Java toolchain>> DSL allows configuring other criteria such as specific vendors or VM implementations.
+Starting with Gradle 7.6, toolchain specifications that configure other properties without specifying the language version are considered _invalid_.
+Invalid specifications are deprecated and will become build errors in Gradle 8.0.
+
+See more details about toolchain configuration in the <<toolchains#sec:configuring_toolchain_specifications,user manual>>.
+
+[[org_gradle_util_reports_deprecations]]
+==== Deprecated members of the `org.gradle.util` package now report their deprecation
+
+These members will be removed in Gradle 9.0.
+
+* `ClosureBackedAction`
+* `CollectionUtils`
+* `ConfigureUtil`
+* `DistributionLocator`
+* `GFileUtils`
+* `GradleVersion.getBuildTime()`
+* `GradleVersion.getNextMajor()`
+* `GradleVersion.getRevision()`
+* `GradleVersion.isValid()`
+* `GUtil`
+* `NameMatcher`
+* `NameValidator`
+* `RelativePathUtil`
+* `TextUtil`
+* `SingleMessageLogger`
+* `VersionNumber`
+* `WrapUtil`
+
 [[dependency_factory_renamed]]
 ==== Internal DependencyFactory was renamed
 The internal `org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory` type was renamed to `org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactoryInternal`. As an internal type, it should not be used, but for compatibility reasons the inner `ClassPathNotation` type is still available. This name for the type is deprecated and will be removed in Gradle 8.0. The public API for this is on `DependencyHandler`, with methods such as `localGroovy()` providing the same functionality.
+
+[[referencing_script_configure_method_from_container_configure_closure_deprecated]]
+==== Implicitly referencing outer scope methods in some configuration blocks in Groovy DSL is now deprecated
+
+Prior to Gradle 7.6, Groovy scripts would permit accessing root project-level configure methods from
+within named container configure methods, as long as that container configure method would otherwise
+fail with a `MissingMethodException`. Consider the following snippets for examples of this behavior:
+
+Accessing the top-level `repositories` block from within the `configurations` block is permitted
+as long as the provided closure is otherwise an invalid configure closure for a Configuration.
+In this case, the `repositories` closure is executed as if it were called at the script-level, _and_
+an unconfigured `repositories` Configuration is created.
+```groovy
+configurations {
+    repositories {
+        mavenCentral()
+    }
+    someConf {
+        canBeConsumed = false
+        canBeResolved = false
+    }
+}
+```
+
+The behavior also applies in closures which are not immediately executed. In this case, `afterResolve`
+is only executed when the `resolve` task runs. Regardless, the `distributions` closure is an otherwise
+invalid configure closure for a Configuration, though it is a valid top-level script closure. In this
+case, the `conf` Configuration is created immediately, and during the execution of the `resolve` task,
+the `distributions` block is executed as if it were declared at the script-level.
+
+```groovy
+configurations {
+    conf.incoming.afterResolve {
+        distributions {
+            myDist {
+                contents {}
+            }
+        }
+    }
+}
+
+task resolve {
+    dependsOn configurations.conf
+    doFirst {
+        configurations.conf.files() // Trigger `afterResolve`
+    }
+}
+```
+
+As of Gradle 7.6, this behavior is deprecated. Starting with Gradle 8.0, this behavior will be removed and instead
+the underlying `MissingMethodException` will be thrown. To mitigate this change, consider the following solutions:
+
+```groovy
+configurations {
+    conf.incoming.afterResolve {
+        // Fully qualify the reference.
+        project.distributions {
+            myDist {
+                contents {}
+            }
+        }
+    }
+}
+```
+
+```groovy
+configurations {
+    conf
+}
+
+// Extract the script-level closure to the script root scope.
+configurations.conf.incoming.afterResolve {
+    distributions {
+        myDist {
+            contents {}
+        }
+    }
+}
+```
 
 [[changes_7.5]]
 == Upgrading from 7.4 and earlier

--- a/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/metaobject/ConfigureDelegate.java
@@ -19,6 +19,7 @@ package org.gradle.internal.metaobject;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingMethodException;
+import org.gradle.internal.deprecation.DeprecationLogger;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -76,6 +77,12 @@ public class ConfigureDelegate extends GroovyObjectSupport {
             // try the owner
             result = _owner.tryInvokeMethod(name, params);
             if (result.isFound()) {
+                if (failure != null) {
+                    DeprecationLogger.deprecateBehaviour("Referencing '" + name + "' in this block is deprecated. Fully qualify your reference to this API or access it in another block.")
+                        .willBeRemovedInGradle8()
+                        .withUpgradeGuideSection(7, "referencing_script_configure_method_from_container_configure_closure_deprecated")
+                        .nagUser();
+                }
                 return result.getValue();
             }
 


### PR DESCRIPTION
This behavior dates back to at least Gradle 2.14. At the time, we already had the intention to remove this behavior but
we never ended up doing so. See: https://github.com/gradle/gradle/commit/79d084e16050b02cc566f71df3c3ad7a342b9c5a

This behavior is blocking us from updating the Task container to a Polymorphic container.

* Add deprecation for this behavior, to be removed in 8.0
* Add additional test verifying existing behavior
* Add upgrade guide section explaining existing behavior
* Move existing deprecation docs into deprecation section in upgrade guide.