### PR TITLE
Rebaseline performance tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ systemProp.gradle.internal.testdistribution.queryResponseTimeout=PT20S
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 # Default performance baseline
-defaultPerformanceBaselines=8.0-commit-56c251a4
+defaultPerformanceBaselines=8.0-commit-6d0169890d7


### PR DESCRIPTION
It looks like we have an 4% performance regression in assemble for abi change | largeGroovyMultiProject | JavaIncrementalExecutionPerformanceTest on master.

This PR rebaselines to unblock `master`.

See gradle/gradle-private#3601